### PR TITLE
fix(UI): Add @carbon/react/styles

### DIFF
--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -1,6 +1,31 @@
 // Bring in all the styles for Carbon
-@use '@carbon/react' with (
-  $font-path: '@ibm/plex'
+@use "@carbon/react" with (
+  $font-path: "@ibm/plex"
 );
 
-@import '@carbon/styles';
+@use "@carbon/react/scss/reset";
+@use "@carbon/react/scss/grid";
+@use "@carbon/react/scss/layer";
+@use "@carbon/react/scss/themes";
+@use "@carbon/react/scss/theme";
+
+@include grid.flex-grid();
+
+:root[data-carbon-theme="g10"] {
+  @include theme.theme(themes.$g10);
+}
+
+:root[data-carbon-theme="g100"] {
+  @include theme.theme(themes.$g100);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include theme.theme(themes.$g100);
+  }
+}
+
+body {
+  background: theme.$background;
+  color: theme.$text-primary;
+}


### PR DESCRIPTION
### Context
After introducing the UI router, the pages cannot be seen because styles are missing, so this PR adds them.

#### Light mode
![image](https://github.com/user-attachments/assets/f035d2d8-93b3-4f2f-8d1f-99670fc0c249)

#### Dark mode
![image](https://github.com/user-attachments/assets/6eaf6835-fb6c-460e-ba2b-7a995e88010f)
