### PR TITLE
(chores) Code cleanups

### DIFF
--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ConfigResourceLoader.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ConfigResourceLoader.java
@@ -9,7 +9,6 @@ import ai.wanaku.core.config.provider.file.SecretFileStore;
 import ai.wanaku.core.exchange.ResourceRequest;
 import ai.wanaku.core.exchange.ToolInvokeRequest;
 import java.net.URI;
-import java.util.List;
 
 public final class ConfigResourceLoader {
     private ConfigResourceLoader() {}

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
@@ -7,7 +7,6 @@ import ai.wanaku.core.capabilities.discovery.DefaultRegistrationManager;
 import ai.wanaku.core.capabilities.discovery.RegistrationManager;
 import ai.wanaku.core.exchange.PropertySchema;
 import ai.wanaku.core.service.discovery.client.DiscoveryService;
-import ai.wanaku.core.util.discovery.DiscoveryUtil;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import java.io.File;
 import java.net.URI;

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -17,9 +17,9 @@ import ai.wanaku.core.exchange.ProvisionRequest;
 import ai.wanaku.core.exchange.ResourceAcquirerDelegate;
 import ai.wanaku.core.exchange.ResourceReply;
 import ai.wanaku.core.exchange.ResourceRequest;
-import java.util.HashMap;
+
 import java.util.List;
-import java.util.Map;
+
 import org.jboss.logging.Logger;
 
 /**

--- a/core/core-config-provider/core-config-provider-file/src/main/java/ai/wanaku/core/config/provider/file/PropertyFileProvider.java
+++ b/core/core-config-provider/core-config-provider-file/src/main/java/ai/wanaku/core/config/provider/file/PropertyFileProvider.java
@@ -4,7 +4,6 @@ import ai.wanaku.api.exceptions.WanakuException;
 import ai.wanaku.core.config.provider.api.PropertyProvider;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Properties;

--- a/core/core-exchange/src/main/java/ai/wanaku/core/exchange/ProvisionAware.java
+++ b/core/core-exchange/src/main/java/ai/wanaku/core/exchange/ProvisionAware.java
@@ -1,7 +1,5 @@
 package ai.wanaku.core.exchange;
 
-import java.util.Map;
-
 /**
  * Interface used by delegates that can provide access to exchange-related properties.
  * <p>

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceConfiguration.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceConfiguration.java
@@ -5,7 +5,6 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import ai.wanaku.core.mcp.providers.ServiceRegistry;
-import io.quarkus.arc.lookup.LookupIfProperty;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/protostream/marshaller/ServiceTargetMarshaller.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/protostream/marshaller/ServiceTargetMarshaller.java
@@ -5,8 +5,6 @@ import ai.wanaku.api.types.providers.ServiceType;
 import org.infinispan.protostream.MessageMarshaller;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ServiceTargetMarshaller implements MessageMarshaller<ServiceTarget> {
 

--- a/core/core-persistence/core-persistence-infinispan/src/test/java/ai/wanaku/core/persistence/infinispan/NamespaceRepositoryTest.java
+++ b/core/core-persistence/core-persistence-infinispan/src/test/java/ai/wanaku/core/persistence/infinispan/NamespaceRepositoryTest.java
@@ -25,7 +25,7 @@ public class NamespaceRepositoryTest {
     @Inject
     NamespaceRepository namespaceRepository;
 
-    private int maxNamespaces = 10;
+    private final int maxNamespaces = 10;
 
     @BeforeAll
     void setup() {

--- a/core/core-runtimes/core-runtime-camel/src/main/java/ai/wanaku/core/runtime/camel/CamelQueryParameterBuilder.java
+++ b/core/core-runtimes/core-runtime-camel/src/main/java/ai/wanaku/core/runtime/camel/CamelQueryParameterBuilder.java
@@ -4,7 +4,6 @@ import ai.wanaku.core.config.provider.api.ConfigResource;
 import ai.wanaku.core.config.provider.api.ReservedConfigs;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class CamelQueryParameterBuilder {
     private final ConfigResource configResource;

--- a/core/core-runtimes/core-runtime-camel/src/test/java/ai/wanaku/core/runtime/camel/CamelUriTest.java
+++ b/core/core-runtimes/core-runtime-camel/src/test/java/ai/wanaku/core/runtime/camel/CamelUriTest.java
@@ -4,7 +4,7 @@ import ai.wanaku.core.capabilities.common.ParsedToolInvokeRequest;
 import ai.wanaku.core.exchange.ToolInvokeRequest;
 import java.net.URISyntaxException;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/forwards/ForwardsBean.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/forwards/ForwardsBean.java
@@ -28,7 +28,6 @@ import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkus.runtime.StartupEvent;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/namespaces/NamespacesBean.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/namespaces/NamespacesBean.java
@@ -19,7 +19,7 @@ public class NamespacesBean {
 
     private NamespaceRepository namespaceRepository;
 
-    private int maxNamespaces = 10;
+    private final int maxNamespaces = 10;
 
     @PostConstruct
     void init() {

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/EventType.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/EventType.java
@@ -7,7 +7,7 @@ public enum EventType {
     UPDATE("update"),
     PING("ping");
 
-    private String value;
+    private final String value;
 
     EventType(String value) {
         this.value = value;

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/ToolsHelper.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/ToolsHelper.java
@@ -56,16 +56,6 @@ public class ToolsHelper {
      * @param handler       A BiFunction that takes ToolArguments and ToolReference as input,
      *                      and returns a ToolResponse. This function will be applied to invoke the tool's functionality.
      */
-
-    /**
-     * Registers a tool with the given tool manager by applying the provided handler function
-     * to expose the tool's functionality.
-     *
-     * @param toolReference The reference to the tool being registered
-     * @param toolManager   The tool manager instance responsible for managing tools
-     * @param handler       A BiFunction that takes ToolArguments and ToolReference as input,
-     *                      and returns a ToolResponse. This function will be applied to invoke the tool's functionality.
-     */
     public static void registerTool(
             CallableReference toolReference, ToolManager toolManager,
             BiFunction<ToolManager.ToolArguments, CallableReference, ToolResponse> handler) {


### PR DESCRIPTION
- Use final when possible
- removed dangling javadoc comment
- cleanup unused imports

## Summary by Sourcery

Apply code cleanups across the codebase by enforcing final immutability on fields, removing unused imports, and deleting a redundant Javadoc comment.

Enhancements:
- Add final modifiers to fields and enum properties where possible
- Remove unused import statements in various modules
- Delete a dangling Javadoc comment in ToolsHelper