### PR TITLE
Align camel bom version with the one used in CEQ

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
         <jackson.version>2.19.1</jackson.version>
         <junit-jupiter.version>5.13.2</junit-jupiter.version>
         <quarkus-mcp-server.version>1.3.1</quarkus-mcp-server.version>
-        <camel.version>4.10.0</camel.version>
+        <camel.version>4.12.0</camel.version>
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.1.0</langchain4j.version>
         <langchain4j-mcp.version>1.1.0-beta7</langchain4j-mcp.version>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Upgrade Camel BOM version from 4.10.0 to 4.12.0 in parent POM