### PR TITLE
Fix incorrect removal of tools and resources

### DIFF
--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
@@ -1,6 +1,7 @@
 package ai.wanaku.core.persistence.api;
 
 import ai.wanaku.api.types.ResourceReference;
+import java.util.List;
 
 /**
  * Repository interface for managing ResourceReference entities.
@@ -10,5 +11,5 @@ import ai.wanaku.api.types.ResourceReference;
  * between model and entity representations.</p>
  */
 public interface ResourceReferenceRepository extends WanakuRepository<ResourceReference, String> {
-
+    List<ResourceReference> findByName(String name);
 }

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/InfinispanResourceReferenceRepository.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/InfinispanResourceReferenceRepository.java
@@ -2,7 +2,9 @@ package ai.wanaku.core.persistence.infinispan;
 
 import ai.wanaku.api.types.ResourceReference;
 import ai.wanaku.core.persistence.api.ResourceReferenceRepository;
+import java.util.List;
 import java.util.UUID;
+import org.infinispan.commons.api.query.Query;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
 
@@ -26,5 +28,12 @@ public class InfinispanResourceReferenceRepository extends AbstractInfinispanRep
     @Override
     protected String newId() {
         return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<ResourceReference> findByName(String name) {
+        Query<ResourceReference> query = cacheManager.getCache(entityName()).query("from ai.wanaku.api.types.ResourceReference t where t.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
     }
 }

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/resources/ResourcesResource.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/resources/ResourcesResource.java
@@ -54,7 +54,7 @@ public class ResourcesResource {
     @Path("/remove")
     @PUT
     public Response remove(@QueryParam("resource") String resource) throws WanakuException {
-        int deleteCount = resourcesBean.removeByName(resource);
+        int deleteCount = resourcesBean.remove(resource);
         if (deleteCount > 0) {
             return Response.ok().build();
         }else{

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/tools/ToolsBean.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/tools/ToolsBean.java
@@ -1,5 +1,6 @@
 package ai.wanaku.server.quarkus.api.v1.tools;
 
+import ai.wanaku.api.exceptions.WanakuException;
 import ai.wanaku.core.persistence.api.WanakuRepository;
 import ai.wanaku.server.quarkus.common.AbstractBean;
 import jakarta.annotation.PostConstruct;
@@ -89,18 +90,17 @@ public class ToolsBean extends AbstractBean<ToolReference> {
         }
     }
 
-    private boolean removeReference(String name, ToolReference toolReference) {
-        if (toolReference.getName().equals(name)) {
-            try {
+    public int remove(String name) throws WanakuException {
+        int removed = 0;
+        try {
+             removed = removeByName(name);
+        } finally {
+            if (removed > 0) {
                 toolManager.removeTool(name);
-            } finally {
-                toolReferenceRepository.deleteById(toolReference.getId());
             }
-
-            return true;
         }
 
-        return false;
+        return removed;
     }
 
     public void update(ToolReference resource) {
@@ -110,10 +110,6 @@ public class ToolsBean extends AbstractBean<ToolReference> {
     public ToolReference getByName(String name) {
         List<ToolReference> tools =  toolReferenceRepository.findByName(name);
         return tools.isEmpty() ? null : tools.getFirst();
-    }
-
-    public ToolReference getById(String id) {
-        return toolReferenceRepository.findById(id);
     }
 
     @Override

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/tools/ToolsResource.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/api/v1/tools/ToolsResource.java
@@ -63,7 +63,7 @@ public class ToolsResource {
     @Path("/remove")
     @PUT
     public Response remove(@QueryParam("tool") String tool) throws WanakuException {
-        int deleteCount = toolsBean.removeByName(tool);
+        int deleteCount = toolsBean.remove(tool);
         if (deleteCount > 0) {
             return Response.ok().build();
         }else{

--- a/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/AbstractBean.java
+++ b/core/core-server/src/main/java/ai/wanaku/server/quarkus/common/AbstractBean.java
@@ -13,46 +13,22 @@ public abstract class AbstractBean<R extends WanakuEntity> {
      *
      * <p>This method performs a bulk removal operation for all entities
      * where the name field matches the specified value. If no entities
-     * are found with the given name, a warning is logged.</p>
+     * are found with the given name, a warning is logged.
+     * This is meant for internal use, as it only removes from the repositories
+     * but not from the tool/resource managers that actually contain the
+     * references</p>
      *
      * @param name the name of the entity/entities to remove, must not be null
      * @return the number of entities removed from the repository
      * @throws IllegalArgumentException if name is null or blank
      * @throws RuntimeException if the repository operation fails
      */
-
-    public int removeByName(String name) {
-
+    protected int removeByName(String name) {
         int removedCount = getRepository().removeByField("name", name);
         if (removedCount == 0) {
             LOG.warnf("No entities named '%s' were found for removal", name);
         } else {
             LOG.infof("Successfully removed %d entity(ies) with name '%s'", removedCount, name);
-        }
-
-        return removedCount;
-    }
-
-
-    /**
-     * Removes an entity from the repository by its unique identifier.
-     *
-     * <p>This method removes a single entity matching the specified ID.
-     * If no entity is found with the given ID, a warning is logged.</p>
-     *
-     * @param id the unique identifier of the entity to remove, must not be null
-     * @return the number of entities removed (0 or 1)
-     * @throws IllegalArgumentException if id is null or blank
-     * @throws RuntimeException if the repository operation fails
-     */
-    public int removeById(String id) {
-        LOG.debugf("Attempting to remove entity with id: %s", id);
-        int removedCount = getRepository().removeByField("id", id);
-
-        if (removedCount == 0) {
-            LOG.warnf("No entity with id '%s' was found for removal", id);
-        } else {
-            LOG.infof("Successfully removed entity with id '%s'", id);
         }
 
         return removedCount;
@@ -70,7 +46,4 @@ public abstract class AbstractBean<R extends WanakuEntity> {
      * @return the repository instance for type R with identifier type I
      */
     protected abstract <I> WanakuRepository<R,I> getRepository();
-
-
-
 }


### PR DESCRIPTION
Tools and resources were only removed from the inventory, but not from the respective tools/resource managers, which caused them to be dangling until the server is restarted.

This fixes issue #408

## Summary by Sourcery

Fix the removal logic for tools and resources so that entities are purged from both the persistence layer and their respective managers to avoid dangling references.

Bug Fixes:
- Ensure tools and resources are removed from both repository and manager layers to prevent stale references until server restart.

Enhancements:
- Expose public remove(name) methods in ToolsBean and ResourcesBean that return the number of removals.
- Add findByName support to the ResourceReferenceRepository and its Infinispan implementation.
- Restrict AbstractBean.removeByName to protected and update its documentation to reflect internal use.

Chores:
- Remove deprecated removeById and unused getById methods.
- Update REST endpoints in ToolsResource and ResourcesResource to invoke the new remove methods.