### PR TITLE
Move the registration manager to the API

### DIFF
--- a/api/src/main/java/ai/wanaku/api/discovery/RegistrationManager.java
+++ b/api/src/main/java/ai/wanaku/api/discovery/RegistrationManager.java
@@ -1,4 +1,4 @@
-package ai.wanaku.core.capabilities.discovery;
+package ai.wanaku.api.discovery;
 
 /**
  * The `RegistrationManager` interface defines the contract for a class responsible for managing the lifecycle

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
@@ -4,7 +4,7 @@ import ai.wanaku.api.types.providers.ServiceTarget;
 import ai.wanaku.api.types.providers.ServiceType;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.capabilities.discovery.DefaultRegistrationManager;
-import ai.wanaku.core.capabilities.discovery.RegistrationManager;
+import ai.wanaku.api.discovery.RegistrationManager;
 import ai.wanaku.core.exchange.PropertySchema;
 import ai.wanaku.core.service.discovery.client.DiscoveryService;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/discovery/DefaultRegistrationManager.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/discovery/DefaultRegistrationManager.java
@@ -3,6 +3,7 @@ package ai.wanaku.core.capabilities.discovery;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
+import ai.wanaku.api.discovery.RegistrationManager;
 import ai.wanaku.api.exceptions.WanakuException;
 import ai.wanaku.api.types.WanakuResponse;
 import ai.wanaku.api.types.discovery.ServiceState;

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -10,7 +10,7 @@ import ai.wanaku.api.types.providers.ServiceType;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
 import ai.wanaku.core.capabilities.common.ServicesHelper;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
-import ai.wanaku.core.capabilities.discovery.RegistrationManager;
+import ai.wanaku.api.discovery.RegistrationManager;
 import ai.wanaku.core.config.provider.api.ConfigResource;
 import ai.wanaku.core.exchange.ProvisionReply;
 import ai.wanaku.core.exchange.ProvisionRequest;

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
@@ -10,7 +10,7 @@ import ai.wanaku.core.capabilities.common.ConfigProvisionerLoader;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
 import ai.wanaku.core.capabilities.common.ServicesHelper;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
-import ai.wanaku.core.capabilities.discovery.RegistrationManager;
+import ai.wanaku.api.discovery.RegistrationManager;
 import ai.wanaku.core.config.provider.api.ConfigProvisioner;
 import ai.wanaku.core.config.provider.api.ConfigResource;
 import ai.wanaku.core.config.provider.api.ProvisionedConfig;


### PR DESCRIPTION
It can be useful when implementing new services

## Summary by Sourcery

Enhancements:
- Relocate `RegistrationManager` interface to `ai.wanaku.api.discovery` package in the API module