### PR TITLE
Generate a sources package by default

### DIFF
--- a/core/core-exchange/pom.xml
+++ b/core/core-exchange/pom.xml
@@ -24,6 +24,11 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/proto</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
@@ -36,6 +41,19 @@
                             <goal>build</goal>
                             <goal>generate-code</goal>
                             <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This simplifies using the proto files

## Summary by Sourcery

Include protocol buffer definitions in the build resources and automatically generate and attach a sources JAR during packaging for the core-exchange module.

Enhancements:
- Add src/main/proto as a Maven resource to bundle proto files in the build output
- Configure the Maven Source Plugin to produce and attach a sources JAR by default during the package phase