### PR TITLE
Newer JNA versions (dependency from Jline) prevents native builds fro…

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -215,6 +215,20 @@
                 <skipITs>false</skipITs>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
                 <quarkus.native.additional-build-args>
+                    <!-- initialize at build time -->
+                    --initialize-at-build-time=com.sun.jna.internal.Cleaner,
+                    --initialize-at-build-time=com.sun.jna.internal.Cleaner$CleanerThread,
+                    <!-- trace object instantiation -->
+                    --trace-object-instantiation=com.sun.jna.internal.Cleaner$CleanerThread,
+                    <!-- initialize at run time -->
+                    --initialize-at-run-time=org.jline.nativ.Kernel32,
+                    --initialize-at-run-time=com.sun.jna.Native,
+                    --initialize-at-run-time=com.sun.jna.Structure$FFIType,
+                    --initialize-at-run-time=org.jline.terminal.impl.jna.osx.OsXNativePty,
+                    --initialize-at-run-time=org.jline.terminal.impl.jna.linux.LinuxNativePty,
+                    --initialize-at-run-time=org.jline.terminal.impl.jna.linux.LinuxNativePty$UtilLibrary,
+                    --initialize-at-run-time=org.jline.terminal.impl.jna.freebsd.FreeBsdNativePty,
+                    --initialize-at-run-time=org.jline.terminal.impl.jna.solaris.SolarisNativePty,
                     --initialize-at-run-time=org.jline.nativ.Kernel32,
                     --initialize-at-run-time=org.jline.nativ.Kernel32$CONSOLE_SCREEN_BUFFER_INFO,
                     --initialize-at-run-time=org.jline.nativ.Kernel32$CHAR_INFO,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
         <assertj-version>3.27.3</assertj-version>
         <juniversalchardet-version>1.0.3</juniversalchardet-version>
         <jansi-version>2.4.2</jansi-version>
-        <jna.version>5.11.0</jna.version>
+        <jna.version>5.17.0</jna.version>
         <awssdk.version>2.31.68</awssdk.version>
         <commons-logging.version>1.3.5</commons-logging.version>
 


### PR DESCRIPTION
…m working.

resolve #406

## Summary by Sourcery

Enable GraalVM native-image builds with updated JNA by bumping the JNA dependency and adding initialization flags for JNA and JLine native classes

Bug Fixes:
- Fix GraalVM native build failures caused by newer JNA versions

Enhancements:
- Add GraalVM native-image --initialize-at-build-time and --initialize-at-run-time flags for JNA and JLine classes in the CLI module

Build:
- Bump JNA version to 5.17.0 in the parent POM