### PR TITLE
Partial fix for HTTP capabilities

### DIFF
--- a/capabilities/tools/wanaku-tool-service-http/README.md
+++ b/capabilities/tools/wanaku-tool-service-http/README.md
@@ -1,3 +1,32 @@
 # Wanaku Tools - HTTP Service
 
 Provides access to HTTP endpoints as tools to Wanaku.
+
+
+Headers can be configured using properties, such as: 
+
+```properties
+header.CamelHttpMethod=GET
+```
+
+
+Query can be configured using properties, such as:
+
+```properties
+query.key=value
+```
+
+As such, a file consisting of: 
+
+```properties
+header.CamelHttpMethod=GET
+query.key=value
+```
+
+If configured for a tool such as: 
+
+```shell
+wanaku tools add -n "some-tool" --description "Description" --uri "http://host:9096/api/" --type http --configure-from-file /path/to/some-tool-configuration.properties
+```
+
+Will generate a GET request to an endpoint consisted of `http://host:9096/api?key=value` when invoked.

--- a/core/core-config-provider/core-config-provider-api/src/main/java/ai/wanaku/core/config/provider/api/ReservedConfigs.java
+++ b/core/core-config-provider/core-config-provider-api/src/main/java/ai/wanaku/core/config/provider/api/ReservedConfigs.java
@@ -10,6 +10,11 @@ public final class ReservedConfigs {
      */
     public static final String CONFIG_QUERY_PARAMETERS_PREFIX = "query.";
 
+    /**
+     * Configurations that modify the headers when building URI-based addresses
+     */
+    public static final String CONFIG_HEADER_PARAMETERS_PREFIX = "header.";
+
     private ReservedConfigs() {}
 
 

--- a/core/core-util/src/main/java/ai/wanaku/core/util/CollectionsHelper.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/CollectionsHelper.java
@@ -2,6 +2,7 @@ package ai.wanaku.core.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,6 +23,16 @@ public class CollectionsHelper {
         return map.entrySet().stream()
                 .filter(e -> e.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+    }
+
+    /**
+     * Convert a map of String keys and unspecified type to String (value must be
+     * convertible to String using toString())
+     * @param map the map of String keys and unspecified type
+     * @return A Map of String keys and String values
+     */
+    public static Map<String, Object> toStringObjectMap(Map<String, String> map) {
+        return new HashMap<>(map);
     }
 
     /**


### PR DESCRIPTION
## Summary by Sourcery

Add support for configuring HTTP headers and query parameters via properties and update HttpClient to source headers accordingly.

New Features:
- Support configuring HTTP headers and query parameters via properties using `header.` and `query.` prefixes.

Enhancements:
- Add `toStringObjectMap` method to CollectionsHelper for converting String maps to Object maps.
- Refactor HttpClient to load headers from configuration using the new header prefix.
- Introduce `CONFIG_HEADER_PARAMETERS_PREFIX` constant for header configuration.

Documentation:
- Enhance HTTP service README with examples for header and query parameter configuration and tool setup.