### PR TITLE
Add partial release automation via GitHub Actions

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,80 @@
+name: release-artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      currentDevelopmentVersion:
+        description: 'The current development version'
+        required: true
+
+jobs:
+  pre-release-build:
+    name: Release artifacts
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        experimental: [ false ]
+        include:
+          - os: [ macos-latest ]
+            experimental: true
+      fail-fast: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
+
+      - uses: graalvm/setup-graalvm@v1.3.4
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          cache: maven
+
+      - name: Login to Container Registry
+        if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/wanaku'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Create a snapshot build (with container push)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mvn -Dnative -Pdist \
+          -Dquarkus.container-image.build=true \
+          -Dquarkus.container-image.push=true \
+          -Dquarkus.container-image.additional-tags=${{ github.event.inputs.currentDevelopmentVersion }} \
+          clean package
+      - name: Create a snapshot build
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+          mvn -Dnative -Pdist clean package
+
+      - name: Run JReleaser
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
+          JRELEASER_SELECT_CURRENT_PLATFORM: true
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      # Persist logs
+
+      - name: JReleaser release output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release-${{ matrix.os }}
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      previousDevelopmentVersion:
+        description: 'The previous development version'
+        required: true
+      currentDevelopmentVersion:
+        description: 'The current development version'
+        required: true
+      nextDevelopmentVersion:
+        description: 'The next development version'
+        required: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Configure build steps as you'd normally do
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'zulu'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: maven
+
+      - name: Create release
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: |
+          export GPG_TTY=$(tty)
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+#         We need to do this because there are some files that are auto-generated/auto-updated during the build.
+#         When creating the release, we want to make sure that any version referenced in there is actually related to
+#         the version being released.
+
+#         Prepare the release
+          mvn --batch-mode -Dtag=wanaku-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare
+               
+#         Adjust the docker-compose files
+          sed -i -e "s/wanaku-${{ github.event.inputs.previousDevelopmentVersion }}/wanaku-${{ github.event.inputs.currentDevelopmentVersion }}/g" docker-compose.yml
+          sed -i -e "s/wanaku-${{ github.event.inputs.previousDevelopmentVersion }}/wanaku-${{ github.event.inputs.currentDevelopmentVersion }}/g" docker-compose-prod.yml
+               
+#         Adjust the Jbang catalog file
+          sed -i -e "s/${{ github.event.inputs.previousDevelopmentVersion }}/${{ github.event.inputs.currentDevelopmentVersion }}/g" jbang-catalog.json
+               
+#         Commit the auto-generated UI files and the other version-specific files
+          mvn -PcommitFiles scm:checkin
+               
+#         Erase the tag created incorrectly by Maven
+          git tag -d wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
+               
+#         Recreate the release tag by marking tagging at exactly two commits before HEAD (i.: ignoring the version bumps from maven)      
+          git tag wanaku-${{ github.event.inputs.currentDevelopmentVersion }} HEAD~2
+          
+#         Continue the release
+          mvn -Pdist release:perform
+      # Create a release
+
+      - name: Run JReleaser
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
+          JRELEASER_SELECT_CURRENT_PLATFORM: true
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      # Persist logs
+
+      - name: JReleaser release output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties


### PR DESCRIPTION
## Summary by Sourcery

Introduce two GitHub Actions workflows to partially automate the release process, including Maven release preparation, multi-platform artifact builds, and JReleaser execution.

New Features:
- Add release.yml workflow to handle Maven release:prepare/perform steps, dynamic version bumps, tagging, and JReleaser invocation.
- Add release-artifacts.yml workflow to perform multi-OS native builds with GraalVM, conditional container pushes, and artifact uploads.

Enhancements:
- Accept workflow inputs for previous, current, and next development versions to drive automated tagging and version updates.
- Automatically adjust Docker Compose and JBang catalog files and commit generated artifacts during release preparation.
- Persist JReleaser logs as workflow artifacts for traceability.

CI:
- Configure Java and GraalVM setup with caching, secrets, and permissions in release workflows.
- Include matrix strategy for cross-platform builds in release-artifacts.yml and conditional steps for container registry login.