### PR TITLE
Fix moving the files unnecessarily

### DIFF
--- a/capabilities/providers/wanaku-provider-file/src/main/java/ai/wanaku/provider/ftp/file/FileResourceDelegate.java
+++ b/capabilities/providers/wanaku-provider-file/src/main/java/ai/wanaku/provider/ftp/file/FileResourceDelegate.java
@@ -28,7 +28,10 @@ public class FileResourceDelegate extends AbstractResourceDelegate {
 
     @Override
     protected String getEndpointUri(ResourceRequest request, ConfigResource configResource) {
-        Map<String, String> parameters = CamelQueryParameterBuilder.build(configResource);
+        final Map<String, String> parameters = config.service().defaults();
+
+        Map<String, String> toolsParameters = CamelQueryParameterBuilder.build(configResource);
+        parameters.putAll(toolsParameters);
 
         File file = new File(request.getLocation());
         String path;


### PR DESCRIPTION
This fixes issue #429

## Summary by Sourcery

Bug Fixes:
- Merge default service parameters with config-specific parameters in FileResourceDelegate.getEndpointUri to fix unnecessary file moves