### PR TITLE
Added support for using the integration tests locally

### DIFF
--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -63,6 +63,9 @@
                             <systemPropertyVariables>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             </systemPropertyVariables>
+                            <excludes>
+                                <exclude>**ManualIT**</exclude>
+                            </excludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/integration/src/test/java/ai/wanaku/mcp/CLIHelper.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/CLIHelper.java
@@ -1,0 +1,56 @@
+package ai.wanaku.mcp;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+public class CLIHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(CLIHelper.class);
+
+    private CLIHelper() {}
+
+    /**
+     * Executes a command using the Wanaku CLI.
+     *
+     * @param command The command to execute, as a list of strings.
+     * @param host The host running the Wanaku MCP Router
+     * @return The exit code of the command.
+     */
+    public static int executeWanakuCliCommand(List<String> command, String host) {
+        List<String> executableCommand = new ArrayList<>(command);
+        if ("wanaku".equals(executableCommand.get(0))) {
+            executableCommand.remove(0);
+        }
+
+        if (host != null) {
+            executableCommand.add(String.format("--host=%s", host));
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintWriter printOut = new PrintWriter(out);
+        PrintWriter printErr = new PrintWriter(err);
+
+        CommandLine cmd = new CommandLine(WanakuIntegrationBase.cliMain)
+                .setOut(printOut)
+                .setErr(printErr);
+
+        LOG.debug("Executing command via wanaku CLI: {}", executableCommand);
+
+        int result = cmd.execute(executableCommand.toArray(new String[0]));
+
+        LOG.info("Wanaku command out: {}", out);
+        LOG.error("Wanaku command err: {}", err);
+
+        Assertions.assertThat(result)
+                .as("The command: " + executableCommand + " didn't run successfully")
+                .isEqualTo(0);
+
+        return result;
+    }
+}

--- a/tests/integration/src/test/java/ai/wanaku/mcp/WanakuFileResourceIT.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/WanakuFileResourceIT.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static ai.wanaku.mcp.CLIHelper.executeWanakuCliCommand;
+
 @QuarkusTest
 public class WanakuFileResourceIT extends WanakuIntegrationBase {
 
@@ -18,6 +20,8 @@ public class WanakuFileResourceIT extends WanakuIntegrationBase {
                 .getJsonObject("result")
                 .getJsonArray("resources")).isEmpty();
 
+        String host = String.format("http://localhost:%d", router.getMappedPort(8080));
+
         executeWanakuCliCommand(List.of("wanaku",
                 "resources",
                 "expose",
@@ -25,7 +29,7 @@ public class WanakuFileResourceIT extends WanakuIntegrationBase {
                 "--mimeType=text/plain",
                 "--description=\"Sample test resource added via CLI\"",
                 "--name=test-file-resource",
-                "--type=file"));
+                "--type=file"), host);
 
         response = mcpExtension.listResources();
 

--- a/tests/integration/src/test/java/ai/wanaku/mcp/WanakuHttpToolIT.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/WanakuHttpToolIT.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static ai.wanaku.mcp.CLIHelper.*;
+
 @QuarkusTest
 public class WanakuHttpToolIT extends WanakuIntegrationBase {
 
@@ -16,10 +18,11 @@ public class WanakuHttpToolIT extends WanakuIntegrationBase {
 
         Assertions.assertThat(response.getJsonObject("result").getJsonArray("tools")).isEmpty();
 
+        String host = String.format("http://localhost:%d", router.getMappedPort(8080));
         executeWanakuCliCommand(List.of("wanaku",
                 "tools",
                 "import",
-                "https://raw.githubusercontent.com/wanaku-ai/wanaku-toolsets/refs/heads/main/toolsets/currency.json"));
+                "https://raw.githubusercontent.com/wanaku-ai/wanaku-toolsets/refs/heads/main/toolsets/currency.json"), host);
 
         response = mcpExtension.listTools();
 

--- a/tests/integration/src/test/java/ai/wanaku/mcp/WanakuHttpToolManualIT.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/WanakuHttpToolManualIT.java
@@ -1,0 +1,51 @@
+package ai.wanaku.mcp;
+
+import ai.wanaku.mcp.inspector.ModelContextProtocolExtension;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static ai.wanaku.mcp.CLIHelper.executeWanakuCliCommand;
+
+@QuarkusTest
+public class WanakuHttpToolManualIT {
+
+
+    @Test
+    void manuTest() {
+        try {
+            testInvocation();
+        } finally {
+            executeWanakuCliCommand(List.of("wanaku", "tools", "remove", "-n", "providence"), "http://localhost:8080");
+        }
+    }
+
+    private static void testInvocation() {
+        ModelContextProtocolExtension mcpExtension = new ModelContextProtocolExtension(8080);
+
+        executeWanakuCliCommand(List.of("wanaku",
+                "tools",
+                "add",
+                "-n",
+                "providence",
+                "--description",
+                "Retrieve reading content from yesterday",
+                "--uri",
+                "http://192.168.1.12:9096/api/curated/yesterday",
+                "--type",
+                "http"), "http://localhost:8080");
+
+        JsonObject response = mcpExtension.callTool(new JsonObject()
+                .put("name", "providence"));
+
+        Assertions.assertThat(response.getJsonObject("result").getBoolean("isError"))
+                .isFalse();
+        Assertions.assertThat(response
+                        .getJsonObject("result")
+                        .getJsonArray("content")
+                        .getJsonObject(0))
+                .isNotNull();
+    }
+}

--- a/tests/integration/src/test/java/ai/wanaku/mcp/WanakuIntegrationBase.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/WanakuIntegrationBase.java
@@ -2,7 +2,6 @@ package ai.wanaku.mcp;
 
 import ai.wanaku.cli.main.CliMain;
 import ai.wanaku.mcp.inspector.ModelContextProtocolExtension;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,9 +14,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import picocli.CommandLine;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -109,43 +105,6 @@ public abstract class WanakuIntegrationBase {
      * @return A list of {@link WanakuContainerDownstreamService}s to be started.
      */
     public abstract List<WanakuContainerDownstreamService> activeWanakuDownstreamServices();
-
-    /**
-     * Executes a command using the Wanaku CLI.
-     *
-     * @param command The command to execute, as a list of strings.
-     * @return The exit code of the command.
-     */
-    public int executeWanakuCliCommand(List<String> command) {
-        List<String> executableCommand = new ArrayList<>(command);
-        if ("wanaku".equals(executableCommand.get(0))) {
-            executableCommand.remove(0);
-        }
-
-        executableCommand.add(String.format("--host=http://localhost:%d", router.getMappedPort(8080)));
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        PrintWriter printOut = new PrintWriter(out);
-        PrintWriter printErr = new PrintWriter(err);
-
-        CommandLine cmd = new CommandLine(cliMain)
-                .setOut(printOut)
-                .setErr(printErr);
-
-        LOG.debug("Executing command via wanaku CLI: {}", executableCommand);
-
-        int result = cmd.execute(executableCommand.toArray(new String[0]));
-
-        LOG.info("Wanaku command out: {}", out);
-        LOG.error("Wanaku command err: {}", err);
-
-        Assertions.assertThat(result)
-                .as("The command: " + executableCommand + " didn't run successfully")
-                .isEqualTo(0);
-
-        return result;
-    }
 
     /**
      * Stops all running containers after all tests have completed.


### PR DESCRIPTION
This makes it possible to run manual tests with the builtin infrastructure

## Summary by Sourcery

Enable local execution of integration tests by extracting CLI invocation logic into a helper class, updating existing tests to use it, and adding manual-only integration tests with exclusion from default test runs.

New Features:
- Introduce CLIHelper to execute Wanaku CLI commands with a configurable host parameter
- Add WanakuHttpToolManualIT for manual local integration testing

Enhancements:
- Refactor executeWanakuCliCommand out of the base test class and update integration tests to use the new helper

Build:
- Exclude **ManualIT** tests from the default Maven test execution in the integration pom

Tests:
- Update WanakuFileResourceIT and WanakuHttpToolIT to call CLIHelper.executeWanakuCliCommand with the host argument