### PR TITLE
Remove the jreleaser part from the Maven release bits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,22 +58,3 @@ jobs:
           git tag wanaku-${{ github.event.inputs.currentDevelopmentVersion }} HEAD~2
           git push origin wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
           mvn -Pdist release:perform
-
-      - name: Run JReleaser
-        uses: jreleaser/release-action@v2
-        env:
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
-          JRELEASER_SELECT_CURRENT_PLATFORM: true
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-
-      - name: JReleaser release output
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jreleaser-release
-          path: |
-            out/jreleaser/trace.log
-            out/jreleaser/output.properties


### PR DESCRIPTION
## Summary by Sourcery

Remove JReleaser invocation and related artifact upload from the GitHub Actions release workflow

CI:
- Remove Run JReleaser step from release.yml
- Remove JReleaser release output artifact upload step from release.yml