### PR TITLE
Skip tagging as it is done by Maven

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -37,6 +37,7 @@ release:
       enabled: true
     update:
       enabled: true
+    skipTag: true
 
 distributions:
   cli:


### PR DESCRIPTION
## Summary by Sourcery

Update the release process documentation to include automated GitHub Actions workflows and disable JReleaser tagging in favor of Maven release plugin.

Enhancements:
- Add skipTag configuration in jreleaser.yml to prevent JReleaser from creating Git tags
- Refactor release-guide.md to introduce an automated release process with gh workflow commands

Documentation:
- Document steps for triggering release and artifact workflows via GitHub CLI
- Restructure manual release section under revised headings and update commands
- Update early-access workflow invocation to read the current development version from build output