### PR TITLE
Update PropertyBasedStore.java

### DIFF
--- a/core/core-config-provider/core-config-provider-api/src/main/java/ai/wanaku/core/config/provider/api/PropertyBasedStore.java
+++ b/core/core-config-provider/core-config-provider-api/src/main/java/ai/wanaku/core/config/provider/api/PropertyBasedStore.java
@@ -39,7 +39,7 @@ public abstract class PropertyBasedStore implements ConfigStore {
     @Override
     public Map<String, String> getEntries(String prefix) {
         final Map<String, String> configs = properties.entrySet().stream()
-                .filter(e -> e.getKey().toString().startsWith(CONFIG_QUERY_PARAMETERS_PREFIX))
+                .filter(e -> e.getKey().toString().startsWith(prefix))
                 .collect(Collectors.toMap(
                         e -> e.getKey().toString(), e -> e.getValue().toString()));
         return configs;


### PR DESCRIPTION
HTTP type Capability tool does not support "header." configuration properties. It does only support "query." configuration parameters due to this bug.

this means that adding "header.CamelHttpMethod=POST" via --configuration-from-file capabilities.properties when the tool is created will be ignored and default to "header.CamelHttpMethod=GET" meaning posting to Restful API can't be achieved.

This code change will fix the bug

## Summary by Sourcery

Bug Fixes:
- Change filtering logic in getEntries to use the provided prefix rather than a hardcoded query parameter prefix, restoring support for header.* properties