### PR TITLE
More deployment fixes

### DIFF
--- a/deploy/auth/configure-auth.sh
+++ b/deploy/auth/configure-auth.sh
@@ -1,0 +1,16 @@
+wanaku_service_client_id=wanaku-service
+wanaku_service_client_uuid=102929ec-264a-4acb-8111-970d62a112fb
+
+# Get the admin token
+TOKEN=$(curl -s -d 'client_id=admin-cli' -d 'username=admin' -d "password=$WANAKU_KEYCLOAK_PASS" -d 'grant_type=password' "http://${WANAKU_KEYCLOAK_HOST}/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
+
+echo "Creating the realm"
+curl -X POST "http://${WANAKU_KEYCLOAK_HOST}/admin/realms" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d @auth/wanaku-config.json
+
+echo "Regenerating secret"
+NEW_SECRET=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "http://${WANAKU_KEYCLOAK_HOST}/admin/realms/wanaku/clients/${wanaku_service_client_uuid}/client-secret")
+
+echo $NEW_SECRET | jq -r .value

--- a/deploy/auth/keycloak.yaml
+++ b/deploy/auth/keycloak.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.3.1
+          image: quay.io/keycloak/keycloak:26.3.4
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary by Sourcery

Update Keycloak deployment and automate realm setup

Deployment:
- Bump Keycloak image to v26.3.4 in deploy/auth/keycloak.yaml
- Add configure-auth.sh script to automate Keycloak realm creation and client secret regeneration