### PR TITLE
Reduce incidence of unauthorized errors

### DIFF
--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -17,7 +17,6 @@ import ai.wanaku.core.exchange.ProvisionRequest;
 import ai.wanaku.core.exchange.ResourceAcquirerDelegate;
 import ai.wanaku.core.exchange.ResourceReply;
 import ai.wanaku.core.exchange.ResourceRequest;
-import ai.wanaku.core.security.SecurityHelper;
 import io.quarkus.oidc.client.Tokens;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.inject.Instance;
@@ -44,17 +43,7 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
 
     @PostConstruct
     public void init() {
-        final String accessToken = retrieveAccessToken();
-
-        registrationManager = ServicesHelper.newRegistrationManager(config, ServiceType.RESOURCE_PROVIDER, accessToken);
-    }
-
-    private String retrieveAccessToken() {
-        if (SecurityHelper.isAuthEnabled()) {
-            return ServicesHelper.retrieveAccessToken(tokensInstance);
-        } else {
-            return null;
-        }
+        registrationManager = ServicesHelper.newRegistrationManager(config, ServiceType.RESOURCE_PROVIDER, tokensInstance.get());
     }
 
     /**

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
@@ -16,7 +16,6 @@ import ai.wanaku.core.exchange.ProvisionReply;
 import ai.wanaku.core.exchange.ProvisionRequest;
 import ai.wanaku.core.exchange.ToolInvokeReply;
 import ai.wanaku.core.exchange.ToolInvokeRequest;
-import ai.wanaku.core.security.SecurityHelper;
 import io.quarkus.oidc.client.Tokens;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.inject.Instance;
@@ -43,17 +42,7 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
 
     @PostConstruct
     public void init() {
-        final String accessToken = retrieveAccessToken();
-
-        registrationManager = ServicesHelper.newRegistrationManager(config, ServiceType.TOOL_INVOKER, accessToken);
-    }
-
-    private String retrieveAccessToken() {
-        if (SecurityHelper.isAuthEnabled()) {
-            return ServicesHelper.retrieveAccessToken(tokensInstance);
-        } else {
-            return null;
-        }
+        registrationManager = ServicesHelper.newRegistrationManager(config, ServiceType.TOOL_INVOKER, tokensInstance.get());
     }
 
     /**

--- a/core/core-capabilities-base/src/main/resources/application.properties
+++ b/core/core-capabilities-base/src/main/resources/application.properties
@@ -12,6 +12,7 @@ quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
 
 # Client identifier configured in KeyCloak for capability services
 quarkus.oidc-client.client-id=wanaku-service
+quarkus.oidc-client.refresh-token-time-skew=1m
 
 # Client secret from KeyCloak for service authentication - replace with your actual secret
 quarkus.oidc-client.credentials.secret=<insert key here>


### PR DESCRIPTION
Try to force the renewal of the token before it expires and that the renewed token gets used in subsequent calls

## Summary by Sourcery

Improve token management by switching to Tokens objects for registration, adding expiration checks and warning logs, removing outdated retrieval methods, and configuring a refresh skew to reduce unauthorized errors

Enhancements:
- Change ServicesHelper to accept Tokens instead of raw token strings
- Update ServiceClientHeadersFactory to check token expiration, log warnings, and use dynamic token retrieval
- Remove deprecated retrieveAccessToken methods and directly pass Tokens in delegates' init methods
- Add OIDC client refresh-token-time-skew configuration to renew tokens before expiry