### PR TITLE
Add support for multi capability services

### DIFF
--- a/api/src/main/java/ai/wanaku/api/types/providers/ServiceType.java
+++ b/api/src/main/java/ai/wanaku/api/types/providers/ServiceType.java
@@ -12,7 +12,12 @@ public enum ServiceType {
     /**
      * Invokes tools
      */
-    TOOL_INVOKER("tool-invoker", 2);
+    TOOL_INVOKER("tool-invoker", 2),
+
+    /**
+     * This can do both: invoke tools and provide resources
+     */
+    MULTI_CAPABILITY("multi-capability", 3);
 
     private final String value;
     private final int intValue;
@@ -40,6 +45,10 @@ public enum ServiceType {
         }
         if (value == 2) {
             return TOOL_INVOKER;
+        }
+
+        if (value == 3) {
+            return MULTI_CAPABILITY;
         }
 
         throw new IllegalArgumentException("Invalid service type: " + value);

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/io/FileHeader.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/io/FileHeader.java
@@ -16,6 +16,8 @@ public class FileHeader {
             new FileHeader(FORMAT_NAME, ServiceType.TOOL_INVOKER, CURRENT_FILE_VERSION);
     public static final FileHeader RESOURCE_PROVIDER =
             new FileHeader(FORMAT_NAME, ServiceType.RESOURCE_PROVIDER, CURRENT_FILE_VERSION);
+    public static final FileHeader MULTI_CAPABILITY =
+            new FileHeader(FORMAT_NAME, ServiceType.MULTI_CAPABILITY, CURRENT_FILE_VERSION);
 
     static {
         // The underlying header size is format + file version + service type;

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/io/InstanceDataManager.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/io/InstanceDataManager.java
@@ -1,7 +1,6 @@
 package ai.wanaku.core.capabilities.io;
 
 import ai.wanaku.api.types.providers.ServiceTarget;
-import ai.wanaku.api.types.providers.ServiceType;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,10 +57,10 @@ public class InstanceDataManager {
     }
 
     private static FileHeader newFileHeader(ServiceTarget serviceTarget) {
-        if (serviceTarget.getServiceType() == ServiceType.RESOURCE_PROVIDER) {
-            return FileHeader.RESOURCE_PROVIDER;
-        } else {
-            return FileHeader.TOOL_INVOKER;
-        }
+        return switch (serviceTarget.getServiceType()) {
+            case TOOL_INVOKER -> FileHeader.TOOL_INVOKER;
+            case RESOURCE_PROVIDER -> FileHeader.RESOURCE_PROVIDER;
+            case MULTI_CAPABILITY -> FileHeader.MULTI_CAPABILITY;
+        };
     }
 }

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanCapabilitiesRepository.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanCapabilitiesRepository.java
@@ -42,21 +42,28 @@ public class InfinispanCapabilitiesRepository extends AbstractInfinispanReposito
         final Cache<Object, ServiceTarget> cache = cacheManager.getCache(entityName());
 
         Query<ServiceTarget> query = cache.query(
-                "from ai.wanaku.api.types.providers.ServiceTarget t where t.service = :service and t.serviceType = :serviceType");
+                "from ai.wanaku.api.types.providers.ServiceTarget t where t.service = :service and (t.serviceType = :serviceType or t.serviceType = :multi)");
 
         query.setParameter("service", serviceName);
         query.setParameter("serviceType", serviceType);
+        query.setParameter("multi", ServiceType.MULTI_CAPABILITY);
 
         return query.maxResults(1).execute().list();
     }
 
-    public List<ServiceTarget> listByType(ServiceType serviceType) {
+    /**
+     * List all services capable of serving resources of the given type
+     * @param serviceType the service type
+     * @return a list of service targets capable of service the given type
+     */
+    public List<ServiceTarget> listCapable(ServiceType serviceType) {
         final Cache<Object, ServiceTarget> cache = cacheManager.getCache(entityName());
 
-        Query<ServiceTarget> query =
-                cache.query("from ai.wanaku.api.types.providers.ServiceTarget t where t.serviceType = :serviceType");
+        Query<ServiceTarget> query = cache.query(
+                "from ai.wanaku.api.types.providers.ServiceTarget t where (t.serviceType = :serviceType or t.serviceType = :multi)");
 
         query.setParameter("serviceType", serviceType);
+        query.setParameter("multi", ServiceType.MULTI_CAPABILITY);
 
         return query.maxResults(1).execute().list();
     }

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
@@ -73,7 +73,7 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
 
     @Override
     public List<ServiceTarget> getEntries(ServiceType serviceType) {
-        return capabilitiesRepository.listByType(serviceType);
+        return capabilitiesRepository.listCapable(serviceType);
     }
 
     @Override

--- a/core/core-persistence/core-persistence-infinispan/src/main/resources/proto/providers.proto
+++ b/core/core-persistence/core-persistence-infinispan/src/main/resources/proto/providers.proto
@@ -17,6 +17,11 @@ enum ServiceType {
    * Invokes tools
    */
   TOOL_INVOKER = 2;
+
+  /**
+   * Has both capabilities
+   */
+  MULTI_CAPABILITY = 3;
 }
 
 /*

--- a/wanaku-router/ui/src/models/serviceType.ts
+++ b/wanaku-router/ui/src/models/serviceType.ts
@@ -11,4 +11,5 @@ export type ServiceType = (typeof ServiceType)[keyof typeof ServiceType];
 export const ServiceType = {
   RESOURCE_PROVIDER: "RESOURCE_PROVIDER",
   TOOL_INVOKER: "TOOL_INVOKER",
+  MULTI_CAPABILITY: "MULTI_CAPABILITY",
 } as const;

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
@@ -267,7 +267,7 @@
       },
       "ServiceType" : {
         "type" : "string",
-        "enum" : [ "RESOURCE_PROVIDER", "TOOL_INVOKER" ]
+        "enum" : [ "RESOURCE_PROVIDER", "TOOL_INVOKER", "MULTI_CAPABILITY" ]
       },
       "ToolPayload" : {
         "type" : "object",

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -181,6 +181,7 @@ components:
       enum:
       - RESOURCE_PROVIDER
       - TOOL_INVOKER
+      - MULTI_CAPABILITY
     ToolPayload:
       type: object
       properties:


### PR DESCRIPTION
This solves issue #509

## Summary by Sourcery

Add support for multi-capability services by introducing a new ServiceType, updating persistence queries and serialization, and exposing the new type in the UI and API specs

New Features:
- Introduce MULTI_CAPABILITY service type for services that handle both tool invocation and resource provisioning
- Extend persistence repository queries to include MULTI_CAPABILITY services in findByService and listCapable
- Add serialization support for MULTI_CAPABILITY via FileHeader and InstanceDataManager
- Expose MULTI_CAPABILITY in the frontend serviceType model and backend OpenAPI spec

Enhancements:
- Rename listByType to listCapable and update the service registry accordingly