### PR TITLE
Consolidate and simplify resolving the service to use

### DIFF
--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/providers/ServiceRegistry.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/providers/ServiceRegistry.java
@@ -31,7 +31,7 @@ public interface ServiceRegistry {
      * @param serviceType the service type
      * @return the service instance or null if not found
      */
-    ServiceTarget getServiceByName(String service, ServiceType serviceType);
+    List<ServiceTarget> getServiceByName(String service, ServiceType serviceType);
 
     /**
      * Gets the state of the given service

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
@@ -48,13 +48,8 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
     }
 
     @Override
-    public ServiceTarget getServiceByName(String serviceName, ServiceType serviceType) {
-        List<ServiceTarget> targets = capabilitiesRepository.findByService(serviceName, serviceType);
-        if (!targets.isEmpty()) {
-            return targets.getFirst();
-        }
-
-        return null;
+    public List<ServiceTarget> getServiceByName(String serviceName, ServiceType serviceType) {
+        return capabilitiesRepository.findByService(serviceName, serviceType);
     }
 
     @Override

--- a/core/core-persistence/core-persistence-infinispan/src/test/java/ai/wanaku/core/persistence/infinispan/discovery/ServiceRegistryTest.java
+++ b/core/core-persistence/core-persistence-infinispan/src/test/java/ai/wanaku/core/persistence/infinispan/discovery/ServiceRegistryTest.java
@@ -49,8 +49,9 @@ public class ServiceRegistryTest {
     @Test
     @Order(2)
     public void getServiceByName() {
-        ServiceTarget service = serviceRegistry.getServiceByName(TEST_SERVICE_NAME, ServiceType.TOOL_INVOKER);
-
+        List<ServiceTarget> services = serviceRegistry.getServiceByName(TEST_SERVICE_NAME, ServiceType.TOOL_INVOKER);
+        assertFalse(services.isEmpty());
+        ServiceTarget service = services.getFirst();
         assertEquals("localhost", service.getHost());
         assertEquals(8081, service.getPort());
     }

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -116,6 +116,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ResourcesProvider.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ResourcesProvider.java
@@ -2,6 +2,8 @@ package ai.wanaku.backend.providers;
 
 import ai.wanaku.backend.proxies.ResourceAcquirerProxy;
 import ai.wanaku.backend.resolvers.WanakuResourceResolver;
+import ai.wanaku.backend.service.support.FirstAvailable;
+import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.core.mcp.common.resolvers.ResourceResolver;
 import ai.wanaku.core.mcp.common.resolvers.util.NoopResourceResolver;
 import ai.wanaku.core.mcp.providers.ServiceRegistry;
@@ -37,6 +39,7 @@ public class ResourcesProvider extends AbstractProvider<ResourceResolver> {
             return new NoopResourceResolver();
         }
 
-        return new WanakuResourceResolver(new ResourceAcquirerProxy(serviceRegistry));
+        ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+        return new WanakuResourceResolver(new ResourceAcquirerProxy(resolver));
     }
 }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
@@ -2,6 +2,8 @@ package ai.wanaku.backend.providers;
 
 import ai.wanaku.backend.proxies.InvokerProxy;
 import ai.wanaku.backend.resolvers.WanakuToolsResolver;
+import ai.wanaku.backend.service.support.FirstAvailable;
+import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.core.mcp.common.resolvers.ToolsResolver;
 import ai.wanaku.core.mcp.common.resolvers.util.NoopToolsResolver;
 import ai.wanaku.core.mcp.providers.ServiceRegistry;
@@ -44,6 +46,7 @@ public class ToolsProvider extends AbstractProvider<ToolsResolver> {
         }
 
         LOG.infof("Wanaku version %s is starting", VersionHelper.VERSION);
-        return new WanakuToolsResolver(new InvokerProxy(serviceRegistry));
+        ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+        return new WanakuToolsResolver(new InvokerProxy(resolver));
     }
 }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/proxies/InvokerProxy.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/proxies/InvokerProxy.java
@@ -12,6 +12,7 @@ import ai.wanaku.api.types.ToolReference;
 import ai.wanaku.api.types.io.ToolPayload;
 import ai.wanaku.api.types.providers.ServiceTarget;
 import ai.wanaku.api.types.providers.ServiceType;
+import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.backend.support.ProvisioningReference;
 import ai.wanaku.core.exchange.Configuration;
 import ai.wanaku.core.exchange.PayloadType;
@@ -23,7 +24,6 @@ import ai.wanaku.core.exchange.Secret;
 import ai.wanaku.core.exchange.ToolInvokeReply;
 import ai.wanaku.core.exchange.ToolInvokeRequest;
 import ai.wanaku.core.exchange.ToolInvokerGrpc;
-import ai.wanaku.core.mcp.providers.ServiceRegistry;
 import ai.wanaku.core.util.CollectionsHelper;
 import com.google.protobuf.ProtocolStringList;
 import io.grpc.ManagedChannel;
@@ -47,10 +47,10 @@ public class InvokerProxy implements ToolsProxy {
     private static final String EMPTY_BODY = "";
     private static final String EMPTY_ARGUMENT = "";
 
-    private final ServiceRegistry serviceRegistry;
+    private final ServiceResolver serviceResolver;
 
-    public InvokerProxy(ServiceRegistry serviceRegistry) {
-        this.serviceRegistry = serviceRegistry;
+    public InvokerProxy(ServiceResolver serviceResolver) {
+        this.serviceResolver = serviceResolver;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class InvokerProxy implements ToolsProxy {
     }
 
     private ToolResponse call(ToolManager.ToolArguments toolArguments, ToolReference toolReference) {
-        ServiceTarget service = serviceRegistry.getServiceByName(toolReference.getType(), ServiceType.TOOL_INVOKER);
+        ServiceTarget service = serviceResolver.resolve(toolReference.getType(), ServiceType.TOOL_INVOKER);
         if (service == null) {
             return ToolResponse.error("There is no host registered for service " + toolReference.getType());
         }
@@ -164,7 +164,7 @@ public class InvokerProxy implements ToolsProxy {
     public ProvisioningReference provision(ToolPayload toolPayload) {
         ToolReference toolReference = toolPayload.getPayload();
 
-        ServiceTarget service = serviceRegistry.getServiceByName(toolReference.getType(), ServiceType.TOOL_INVOKER);
+        ServiceTarget service = serviceResolver.resolve(toolReference.getType(), ServiceType.TOOL_INVOKER);
         if (service == null) {
             throw new ServiceNotFoundException("There is no host registered for service " + toolReference.getType());
         }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/service/support/FirstAvailable.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/service/support/FirstAvailable.java
@@ -1,0 +1,39 @@
+package ai.wanaku.backend.service.support;
+
+import ai.wanaku.api.types.providers.ServiceTarget;
+import ai.wanaku.api.types.providers.ServiceType;
+import ai.wanaku.core.mcp.providers.ServiceRegistry;
+import java.util.List;
+
+/**
+ * A service resolver that returns the first available service from the registry.
+ */
+public class FirstAvailable implements ServiceResolver {
+
+    private final ServiceRegistry serviceRegistry;
+
+    /**
+     * Creates a new FirstAvailable service resolver.
+     *
+     * @param serviceRegistry the service registry to use for resolving services.
+     */
+    public FirstAvailable(ServiceRegistry serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    /**
+     * Resolves a service by returning the first available service from the registry that matches the given name and type.
+     *
+     * @param serviceName the name of the service to resolve.
+     * @param serviceType the type of the service to resolve.
+     * @return the first available service target, or null if no service could be resolved.
+     */
+    @Override
+    public ServiceTarget resolve(String serviceName, ServiceType serviceType) {
+        List<ServiceTarget> services = serviceRegistry.getServiceByName(serviceName, serviceType);
+        if (services != null && !services.isEmpty()) {
+            return services.getFirst();
+        }
+        return null;
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/service/support/ServiceResolver.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/service/support/ServiceResolver.java
@@ -1,0 +1,19 @@
+package ai.wanaku.backend.service.support;
+
+import ai.wanaku.api.types.providers.ServiceTarget;
+import ai.wanaku.api.types.providers.ServiceType;
+
+/**
+ * An interface for resolving services.
+ */
+public interface ServiceResolver {
+
+    /**
+     * Resolves a service based on its name and type.
+     *
+     * @param serviceName the name of the service to resolve.
+     * @param serviceType the type of the service to resolve.
+     * @return the resolved service target, or null if no service could be resolved.
+     */
+    ServiceTarget resolve(String serviceName, ServiceType serviceType);
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/service/support/FirstAvailableTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/service/support/FirstAvailableTest.java
@@ -1,0 +1,58 @@
+package ai.wanaku.backend.service.support;
+
+import ai.wanaku.api.types.providers.ServiceTarget;
+import ai.wanaku.api.types.providers.ServiceType;
+import ai.wanaku.core.mcp.providers.ServiceRegistry;
+import io.quarkus.test.junit.QuarkusTest;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+public class FirstAvailableTest {
+
+    FirstAvailable firstAvailable;
+
+    ServiceRegistry mockRegistry;
+
+    @BeforeEach
+    public void setup() {
+        mockRegistry = Mockito.mock(ServiceRegistry.class);
+        firstAvailable = new FirstAvailable(mockRegistry);
+    }
+
+    @Test
+    public void testResolveService() {
+        ServiceTarget service1 = new ServiceTarget("id1", "service-a", "localhost", 8080, ServiceType.TOOL_INVOKER);
+        ServiceTarget service2 = new ServiceTarget("id2", "service-a", "localhost", 8081, ServiceType.TOOL_INVOKER);
+        List<ServiceTarget> targets = List.of(service1, service2);
+
+        Mockito.when(mockRegistry.getServiceByName("service-a", ServiceType.TOOL_INVOKER))
+                .thenReturn(targets);
+
+        ServiceTarget resolved = firstAvailable.resolve("service-a", ServiceType.TOOL_INVOKER);
+        Assertions.assertNotNull(resolved);
+        Assertions.assertEquals("id1", resolved.getId());
+    }
+
+    @Test
+    public void testResolveServiceNotFound() {
+        Mockito.when(mockRegistry.getServiceByName("service-b", ServiceType.TOOL_INVOKER))
+                .thenReturn(Collections.emptyList());
+
+        ServiceTarget resolved = firstAvailable.resolve("service-b", ServiceType.TOOL_INVOKER);
+        Assertions.assertNull(resolved);
+    }
+
+    @Test
+    public void testResolveServiceNull() {
+        Mockito.when(mockRegistry.getServiceByName("service-c", ServiceType.TOOL_INVOKER))
+                .thenReturn(null);
+
+        ServiceTarget resolved = firstAvailable.resolve("service-c", ServiceType.TOOL_INVOKER);
+        Assertions.assertNull(resolved);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a ServiceResolver abstraction and simplify service lookup by refactoring proxies and registry implementations to use it

New Features:
- Define ServiceResolver interface for decoupling service resolution
- Implement FirstAvailable resolver that returns the first registered service

Enhancements:
- Refactor ResourceAcquirerProxy and InvokerProxy to use ServiceResolver.resolve instead of ServiceRegistry.getServiceByName
- Update ServiceRegistry interface and InfinispanServiceRegistry to return lists of ServiceTarget

Build:
- Add quarkus-junit5-mockito test dependency in router backend pom.xml

Tests:
- Update ServiceRegistryTest to assert list-based registry lookup
- Add FirstAvailableTest to cover resolver behavior