### PR TITLE
Add support for Streamable HTTP in MCP forwards

### DIFF
--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
@@ -4,15 +4,25 @@ import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 
 public class ClientUtil {
 
     public static McpClient createClient(String address) {
-        McpTransport transport = new HttpMcpTransport.Builder()
-                .sseUrl(address)
-                .logRequests(true)
-                .logResponses(true)
-                .build();
+        McpTransport transport;
+        if (address.endsWith("sse") || address.endsWith("sse/")) {
+            transport = new HttpMcpTransport.Builder()
+                    .sseUrl(address)
+                    .logRequests(true)
+                    .logResponses(true)
+                    .build();
+        } else {
+            transport = new StreamableHttpMcpTransport.Builder()
+                    .url(address)
+                    .logRequests(true)
+                    .logResponses(true)
+                    .build();
+        }
 
         return new DefaultMcpClient.Builder().transport(transport).build();
     }


### PR DESCRIPTION
This fixes issue #569

## Summary by Sourcery

Introduce StreamableHttpMcpTransport and update ClientUtil to choose between SSE and streamable HTTP transports based on the provided address

New Features:
- Add support for StreamableHttpMcpTransport in the MCP client

Enhancements:
- Select between SSE-based and streamable HTTP transports in ClientUtil based on the address suffix