### PR TITLE
Added missing JavaDoc

### DIFF
--- a/api/src/main/java/ai/wanaku/api/types/CallableReference.java
+++ b/api/src/main/java/ai/wanaku/api/types/CallableReference.java
@@ -1,45 +1,69 @@
 package ai.wanaku.api.types;
 
 /**
- * Represents a reference that can be called, providing metadata and input schema information.
+ * Represents a reference to a callable entity that can be invoked with arguments.
+ * <p>
+ * A callable reference is an abstraction for any object or function that can be invoked,
+ * potentially with arguments. This interface provides metadata about the callable entity
+ * including its name, description, type, input schema, and namespace.
+ * </p>
+ * <p>
+ * This interface is implemented by various tool and capability reference types to provide
+ * a common contract for invocable entities in the Wanaku system.
+ * </p>
  *
- * A callable reference is an abstraction of an object or function that can be invoked,
- * potentially with arguments. This interface provides methods to retrieve its name, description,
- * data type, and input schema.
- *
+ * @see ToolReference
+ * @see RemoteToolReference
  */
 public interface CallableReference {
     /**
-     * Returns the name of this callable reference.
+     * Gets the name of this callable reference.
      *
-     * @return The name of this callable reference.
+     * @return the name of this callable reference
      */
     String getName();
 
     /**
-     * Returns a human-readable description of this callable reference.
+     * Gets the human-readable description of this callable reference.
+     * <p>
+     * The description provides information about what this callable does,
+     * its purpose, and how it should be used.
+     * </p>
      *
-     * @return A human-readable description of this callable reference.
+     * @return a human-readable description of this callable reference
      */
     String getDescription();
 
     /**
-     * Returns the data type associated with this callable reference.
+     * Gets the type associated with this callable reference.
+     * <p>
+     * The type typically indicates the category or implementation mechanism
+     * of the callable (e.g., "http", "function", "tool").
+     * </p>
      *
-     * @return The data type associated with this callable reference.
+     * @return the type associated with this callable reference
      */
     String getType();
 
     /**
-     * Returns the input schema for this callable reference, describing its expected input structure and format.
+     * Gets the input schema for this callable reference.
+     * <p>
+     * The input schema describes the expected structure, format, and validation
+     * rules for arguments that can be passed to this callable.
+     * </p>
      *
-     * @return The input schema for this callable reference.
+     * @return the input schema for this callable reference
      */
     InputSchema getInputSchema();
 
     /**
-     * Sets the namespace associated with this reference
-     * @return
+     * Gets the namespace in which this callable reference is registered.
+     * <p>
+     * The namespace provides logical grouping and isolation for callable
+     * references within the Wanaku system.
+     * </p>
+     *
+     * @return the namespace identifier
      */
     String getNamespace();
 }

--- a/api/src/main/java/ai/wanaku/api/types/NameNamespacePair.java
+++ b/api/src/main/java/ai/wanaku/api/types/NameNamespacePair.java
@@ -1,3 +1,14 @@
 package ai.wanaku.api.types;
 
+/**
+ * A record representing a name and namespace pair for identifying Wanaku entities.
+ * <p>
+ * This immutable record is used throughout the Wanaku system to uniquely identify
+ * capabilities, tools, and resources by combining their name with their namespace.
+ * The combination of name and namespace provides a fully qualified identifier.
+ * </p>
+ *
+ * @param name the entity name
+ * @param namespace the namespace in which the entity resides
+ */
 public record NameNamespacePair(String name, String namespace) {}

--- a/api/src/main/java/ai/wanaku/api/types/Namespace.java
+++ b/api/src/main/java/ai/wanaku/api/types/Namespace.java
@@ -1,32 +1,74 @@
 package ai.wanaku.api.types;
 
+/**
+ * Represents a namespace within the Wanaku system.
+ * <p>
+ * Namespaces provide logical grouping and isolation for capabilities, tools, and resources.
+ * Each namespace has a unique identifier, a human-readable name, and a path that defines
+ * its location within the namespace hierarchy.
+ * </p>
+ */
 public class Namespace implements WanakuEntity<String> {
     private String id;
     private String name;
     private String path;
 
+    /**
+     * Gets the unique identifier for this namespace.
+     *
+     * @return the namespace identifier
+     */
     @Override
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the unique identifier for this namespace.
+     *
+     * @param id the namespace identifier to set
+     */
     @Override
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Gets the human-readable name of this namespace.
+     *
+     * @return the namespace name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the human-readable name of this namespace.
+     *
+     * @param name the namespace name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets the hierarchical path of this namespace.
+     * <p>
+     * The path defines the location of this namespace within the namespace hierarchy
+     * and is used for namespace resolution and organization.
+     * </p>
+     *
+     * @return the namespace path
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * Sets the hierarchical path of this namespace.
+     *
+     * @param path the namespace path to set
+     */
     public void setPath(String path) {
         this.path = path;
     }

--- a/api/src/main/java/ai/wanaku/api/types/RemoteToolReference.java
+++ b/api/src/main/java/ai/wanaku/api/types/RemoteToolReference.java
@@ -3,7 +3,21 @@ package ai.wanaku.api.types;
 import java.util.Objects;
 
 /**
- * This class represents a reference to a tool with various attributes such as name, description, URI, type, and input schema.
+ * Represents a reference to a tool capability available on a remote MCP server.
+ * <p>
+ * A remote tool reference contains metadata about a tool that is provided by an
+ * external service or remote MCP server, rather than being locally implemented.
+ * This class is used when tools are discovered through forward proxies or when
+ * integrating with remote capability providers.
+ * </p>
+ * <p>
+ * Remote tool references can be converted to standard {@link ToolReference}
+ * instances using the {@link #asToolReference(RemoteToolReference)} method,
+ * which assigns a placeholder URI to indicate the remote nature of the tool.
+ * </p>
+ *
+ * @see ToolReference
+ * @see CallableReference
  */
 public class RemoteToolReference implements CallableReference, WanakuEntity<String> {
     private String id;
@@ -127,6 +141,17 @@ public class RemoteToolReference implements CallableReference, WanakuEntity<Stri
                 + inputSchema + '}';
     }
 
+    /**
+     * Converts a remote tool reference to a standard tool reference.
+     * <p>
+     * This utility method creates a {@link ToolReference} from a {@link RemoteToolReference}
+     * by copying all metadata and assigning a placeholder URI {@code "<remote>"} to indicate
+     * that the tool is provided by a remote service.
+     * </p>
+     *
+     * @param ref the remote tool reference to convert
+     * @return a tool reference with the same metadata and a placeholder remote URI
+     */
     public static ToolReference asToolReference(RemoteToolReference ref) {
         ToolReference ret = new ToolReference();
 
@@ -140,11 +165,21 @@ public class RemoteToolReference implements CallableReference, WanakuEntity<Stri
         return ret;
     }
 
+    /**
+     * Gets the namespace in which this remote tool is registered.
+     *
+     * @return the namespace identifier
+     */
     @Override
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Sets the namespace in which this remote tool is registered.
+     *
+     * @param namespace the namespace identifier to set
+     */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }

--- a/api/src/main/java/ai/wanaku/api/types/ResourceReference.java
+++ b/api/src/main/java/ai/wanaku/api/types/ResourceReference.java
@@ -43,6 +43,11 @@ public class ResourceReference implements WanakuEntity<String> {
     private String secretsURI;
     private String namespace;
 
+    /**
+     * Gets the location of the resource.
+     *
+     * @return the resource location (e.g., URL, file path)
+     */
     public String getLocation() {
         return location;
     }
@@ -56,6 +61,11 @@ public class ResourceReference implements WanakuEntity<String> {
         this.location = location;
     }
 
+    /**
+     * Gets the type of the resource.
+     *
+     * @return the resource type (e.g., image, text, binary)
+     */
     public String getType() {
         return type;
     }
@@ -69,6 +79,11 @@ public class ResourceReference implements WanakuEntity<String> {
         this.type = type;
     }
 
+    /**
+     * Gets the brief name of the resource.
+     *
+     * @return the resource name
+     */
     public String getName() {
         return name;
     }
@@ -82,6 +97,11 @@ public class ResourceReference implements WanakuEntity<String> {
         this.name = name;
     }
 
+    /**
+     * Gets the longer description of the resource.
+     *
+     * @return the resource description
+     */
     public String getDescription() {
         return description;
     }
@@ -95,6 +115,11 @@ public class ResourceReference implements WanakuEntity<String> {
         this.description = description;
     }
 
+    /**
+     * Gets the MIME type of the resource.
+     *
+     * @return the MIME type (e.g., image/jpeg, text/plain)
+     */
     public String getMimeType() {
         return mimeType;
     }
@@ -108,6 +133,11 @@ public class ResourceReference implements WanakuEntity<String> {
         this.mimeType = mimeType;
     }
 
+    /**
+     * Gets the list of parameters associated with the resource.
+     *
+     * @return the list of resource parameters
+     */
     public List<Param> getParams() {
         return params;
     }
@@ -121,26 +151,64 @@ public class ResourceReference implements WanakuEntity<String> {
         this.params = params;
     }
 
+    /**
+     * Gets the URI location for the resource configuration.
+     * <p>
+     * The configuration URI points to the location where non-sensitive
+     * configuration data for this resource is stored.
+     * </p>
+     *
+     * @return the configuration URI, or {@code null} if not configured
+     */
     public String getConfigurationURI() {
         return configurationURI;
     }
 
+    /**
+     * Sets the URI location for the resource configuration.
+     *
+     * @param configurationURI the configuration URI to set
+     */
     public void setConfigurationURI(String configurationURI) {
         this.configurationURI = configurationURI;
     }
 
+    /**
+     * Gets the URI location for the secrets associated with this resource.
+     * <p>
+     * The secrets URI points to the location where sensitive data such as
+     * credentials, API keys, or tokens for this resource are stored.
+     * </p>
+     *
+     * @return the secrets URI, or {@code null} if not configured
+     */
     public String getSecretsURI() {
         return secretsURI;
     }
 
+    /**
+     * Sets the URI location for the secrets associated with this resource.
+     *
+     * @param secretsURI the secrets URI to set
+     */
     public void setSecretsURI(String secretsURI) {
         this.secretsURI = secretsURI;
     }
 
+    /**
+     * Gets the namespace in which this resource is registered.
+     *
+     * @return the namespace identifier
+     */
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Sets the namespace in which this resource is registered.
+     *
+     * @param namespace the namespace identifier to set
+     */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
@@ -159,6 +227,11 @@ public class ResourceReference implements WanakuEntity<String> {
          */
         private String value;
 
+        /**
+         * Gets the name of the parameter.
+         *
+         * @return the parameter name
+         */
         public String getName() {
             return name;
         }
@@ -172,6 +245,11 @@ public class ResourceReference implements WanakuEntity<String> {
             this.name = name;
         }
 
+        /**
+         * Gets the value of the parameter.
+         *
+         * @return the parameter value
+         */
         public String getValue() {
             return value;
         }

--- a/api/src/main/java/ai/wanaku/api/types/ToolReference.java
+++ b/api/src/main/java/ai/wanaku/api/types/ToolReference.java
@@ -114,35 +114,65 @@ public class ToolReference implements CallableReference, WanakuEntity<String> {
         this.inputSchema = inputSchema;
     }
 
+    /**
+     * Gets the namespace in which this tool is registered.
+     *
+     * @return the namespace identifier
+     */
     @Override
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Sets the namespace in which this tool is registered.
+     *
+     * @param namespace the namespace identifier to set
+     */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
     /**
-     * Gets the location for the tool configuration
-     * @return
+     * Gets the URI location for the tool configuration.
+     * <p>
+     * The configuration URI points to the location where non-sensitive
+     * configuration data for this tool is stored.
+     * </p>
+     *
+     * @return the configuration URI, or {@code null} if not configured
      */
     public String getConfigurationURI() {
         return configurationURI;
     }
 
+    /**
+     * Sets the URI location for the tool configuration.
+     *
+     * @param configurationURI the configuration URI to set
+     */
     public void setConfigurationURI(String configurationURI) {
         this.configurationURI = configurationURI;
     }
 
     /**
-     * Gets the location for the secrets associated with this tool
-     * @return
+     * Gets the URI location for the secrets associated with this tool.
+     * <p>
+     * The secrets URI points to the location where sensitive data such as
+     * credentials, API keys, or tokens for this tool are stored.
+     * </p>
+     *
+     * @return the secrets URI, or {@code null} if not configured
      */
     public String getSecretsURI() {
         return secretsURI;
     }
 
+    /**
+     * Sets the URI location for the secrets associated with this tool.
+     *
+     * @param secretsURI the secrets URI to set
+     */
     public void setSecretsURI(String secretsURI) {
         this.secretsURI = secretsURI;
     }

--- a/api/src/main/java/ai/wanaku/api/types/WanakuEntity.java
+++ b/api/src/main/java/ai/wanaku/api/types/WanakuEntity.java
@@ -1,8 +1,28 @@
 package ai.wanaku.api.types;
 
+/**
+ * Base interface for all Wanaku entity types.
+ * <p>
+ * This interface provides a common contract for entities that require identity management
+ * within the Wanaku system. All entities implementing this interface must provide an
+ * identifier of type {@code K}.
+ * </p>
+ *
+ * @param <K> the type of the entity identifier
+ */
 public interface WanakuEntity<K> {
 
+    /**
+     * Gets the unique identifier for this entity.
+     *
+     * @return the entity identifier, or {@code null} if not yet assigned
+     */
     K getId();
 
+    /**
+     * Sets the unique identifier for this entity.
+     *
+     * @param id the entity identifier to set
+     */
     void setId(K id);
 }

--- a/api/src/main/java/ai/wanaku/api/types/WanakuError.java
+++ b/api/src/main/java/ai/wanaku/api/types/WanakuError.java
@@ -1,13 +1,27 @@
 package ai.wanaku.api.types;
 
 /**
- * Represents an error response from a WANAKU API or service. This class encapsulates an error message.
- * @param message the error message
+ * Represents an error response from the Wanaku API or services.
+ * <p>
+ * This immutable record encapsulates error information that is returned to clients
+ * when API operations fail or encounter errors. It provides a simple, standardized
+ * way to communicate error details across the Wanaku system.
+ * </p>
+ * <p>
+ * The error message should be descriptive and provide enough context for clients
+ * to understand what went wrong and potentially take corrective action.
+ * </p>
+ *
+ * @param message the error message describing what went wrong, or {@code null} if no message is available
  */
 public record WanakuError(String message) {
 
     /**
-     * Default constructor that initializes a {@link WanakuError} with no message.
+     * Default constructor that creates a {@link WanakuError} with no message.
+     * <p>
+     * This constructor is provided for cases where an error indicator is needed
+     * but no specific message is available at the time of creation.
+     * </p>
      */
     public WanakuError() {
         this(null);

--- a/api/src/main/java/ai/wanaku/api/types/discovery/ActivityRecord.java
+++ b/api/src/main/java/ai/wanaku/api/types/discovery/ActivityRecord.java
@@ -6,42 +6,94 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Records the activity and health status of a service in the Wanaku system.
+ * <p>
+ * This entity tracks service lifecycle information including when the service was last
+ * observed, its current active status, and a history of state transitions. Activity records
+ * are used by the service discovery mechanism to monitor service health and availability.
+ * </p>
+ */
 public class ActivityRecord implements WanakuEntity<String> {
     private String id;
     private Instant lastSeen;
     private boolean active;
     private List<ServiceState> states = new ArrayList<>();
 
+    /**
+     * Gets the unique identifier for this activity record.
+     *
+     * @return the activity record identifier
+     */
     @Override
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the unique identifier for this activity record.
+     *
+     * @param id the activity record identifier to set
+     */
     @Override
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Gets the timestamp when this service was last observed as active.
+     *
+     * @return the last seen timestamp, or {@code null} if never observed
+     */
     public Instant getLastSeen() {
         return lastSeen;
     }
 
+    /**
+     * Sets the timestamp when this service was last observed as active.
+     *
+     * @param lastSeen the last seen timestamp to set
+     */
     public void setLastSeen(Instant lastSeen) {
         this.lastSeen = lastSeen;
     }
 
+    /**
+     * Checks whether the service is currently active.
+     *
+     * @return {@code true} if the service is active, {@code false} otherwise
+     */
     public boolean isActive() {
         return active;
     }
 
+    /**
+     * Sets the active status of the service.
+     *
+     * @param active {@code true} to mark the service as active, {@code false} otherwise
+     */
     public void setActive(boolean active) {
         this.active = active;
     }
 
+    /**
+     * Gets the list of state transitions for this service.
+     * <p>
+     * The states list maintains a history of service state changes, allowing
+     * tracking of service health and availability over time.
+     * </p>
+     *
+     * @return the list of service states
+     */
     public List<ServiceState> getStates() {
         return states;
     }
 
+    /**
+     * Sets the list of state transitions for this service.
+     *
+     * @param states the list of service states to set
+     */
     public void setStates(List<ServiceState> states) {
         this.states = states;
     }

--- a/api/src/main/java/ai/wanaku/api/types/discovery/StandardMessages.java
+++ b/api/src/main/java/ai/wanaku/api/types/discovery/StandardMessages.java
@@ -1,8 +1,28 @@
 package ai.wanaku.api.types.discovery;
 
+/**
+ * Standard status messages used in the service discovery and health monitoring system.
+ * <p>
+ * This utility class defines constant messages that represent common service states
+ * within the Wanaku discovery mechanism. These messages are used to communicate
+ * service health and availability status.
+ * </p>
+ */
 public final class StandardMessages {
+    /**
+     * Message indicating that a service is operating normally and is healthy.
+     */
     public static final String HEALTHY = "healthy";
+
+    /**
+     * Message indicating that a service has not been observed within the expected timeframe
+     * and may be unavailable.
+     */
     public static final String MISSING_IN_ACTION = "missing in action";
+
+    /**
+     * Message indicating that a service has been automatically deregistered due to inactivity.
+     */
     public static final String AUTO_DEREGISTRATION = "inactive due to service auto-deregistration";
 
     private StandardMessages() {}

--- a/api/src/main/java/ai/wanaku/api/types/io/ProvisionAwarePayload.java
+++ b/api/src/main/java/ai/wanaku/api/types/io/ProvisionAwarePayload.java
@@ -1,10 +1,54 @@
 package ai.wanaku.api.types.io;
 
+/**
+ * Interface for payloads that carry provisioning information.
+ * <p>
+ * This interface defines the contract for payloads that bundle together a primary
+ * payload object (such as a tool or resource reference) along with associated
+ * configuration and secrets data needed for provisioning and deployment.
+ * </p>
+ * <p>
+ * Implementations of this interface are used during capability provisioning to
+ * ensure that all necessary configuration and sensitive data are transmitted
+ * together with the capability reference.
+ * </p>
+ *
+ * @param <T> the type of the primary payload object
+ */
 public interface ProvisionAwarePayload<T> {
 
+    /**
+     * Gets the primary payload object.
+     * <p>
+     * This typically contains the reference to a tool, resource, or other capability
+     * being provisioned.
+     * </p>
+     *
+     * @return the payload object
+     */
     T getPayload();
 
+    /**
+     * Gets the configuration data associated with this payload.
+     * <p>
+     * Configuration data contains non-sensitive settings and parameters required
+     * for provisioning the capability. The format and content are specific to the
+     * type of capability being provisioned.
+     * </p>
+     *
+     * @return the configuration data as a string, or {@code null} if no configuration is provided
+     */
     String getConfigurationData();
 
+    /**
+     * Gets the secrets data associated with this payload.
+     * <p>
+     * Secrets data contains sensitive information such as credentials, API keys,
+     * or tokens required for provisioning the capability. This data should be
+     * handled securely and not logged or persisted in plain text.
+     * </p>
+     *
+     * @return the secrets data as a string, or {@code null} if no secrets are provided
+     */
     String getSecretsData();
 }

--- a/api/src/main/java/ai/wanaku/api/types/io/ResourcePayload.java
+++ b/api/src/main/java/ai/wanaku/api/types/io/ResourcePayload.java
@@ -2,34 +2,80 @@ package ai.wanaku.api.types.io;
 
 import ai.wanaku.api.types.ResourceReference;
 
+/**
+ * Payload for provisioning resource capabilities with associated configuration and secrets.
+ * <p>
+ * This class bundles a {@link ResourceReference} with its corresponding configuration
+ * and secrets data, facilitating the complete provisioning of a resource capability
+ * within the Wanaku system.
+ * </p>
+ * <p>
+ * The payload includes:
+ * <ul>
+ *   <li>A resource reference that identifies and describes the resource</li>
+ *   <li>Configuration data with non-sensitive settings</li>
+ *   <li>Secrets data with sensitive credentials or tokens</li>
+ * </ul>
+ * </p>
+ */
 public class ResourcePayload implements ProvisionAwarePayload<ResourceReference> {
     private ResourceReference resourceReference;
     private String configurationData;
     private String secretsData;
 
+    /**
+     * Gets the resource reference contained in this payload.
+     *
+     * @return the resource reference
+     */
     @Override
     public ResourceReference getPayload() {
         return resourceReference;
     }
 
+    /**
+     * Sets the resource reference for this payload.
+     *
+     * @param resourceReference the resource reference to set
+     */
     public void setPayload(ResourceReference resourceReference) {
         this.resourceReference = resourceReference;
     }
 
+    /**
+     * Gets the configuration data for provisioning this resource.
+     *
+     * @return the configuration data, or {@code null} if not provided
+     */
     @Override
     public String getConfigurationData() {
         return configurationData;
     }
 
+    /**
+     * Sets the configuration data for provisioning this resource.
+     *
+     * @param configurationData the configuration data to set
+     */
     public void setConfigurationData(String configurationData) {
         this.configurationData = configurationData;
     }
 
+    /**
+     * Gets the secrets data required for provisioning this resource.
+     *
+     * @return the secrets data, or {@code null} if not provided
+     */
     @Override
     public String getSecretsData() {
         return secretsData;
     }
 
+    /**
+     * Sets the secrets data required for provisioning this resource.
+     *
+     * @param secretsData the secrets data to set
+     */
     public void setSecretsData(String secretsData) {
         this.secretsData = secretsData;
     }

--- a/api/src/main/java/ai/wanaku/api/types/io/ToolPayload.java
+++ b/api/src/main/java/ai/wanaku/api/types/io/ToolPayload.java
@@ -2,34 +2,80 @@ package ai.wanaku.api.types.io;
 
 import ai.wanaku.api.types.ToolReference;
 
+/**
+ * Payload for provisioning tool capabilities with associated configuration and secrets.
+ * <p>
+ * This class bundles a {@link ToolReference} with its corresponding configuration
+ * and secrets data, facilitating the complete provisioning of a tool capability
+ * within the Wanaku system.
+ * </p>
+ * <p>
+ * The payload includes:
+ * <ul>
+ *   <li>A tool reference that identifies and describes the tool</li>
+ *   <li>Configuration data with non-sensitive settings</li>
+ *   <li>Secrets data with sensitive credentials or tokens</li>
+ * </ul>
+ * </p>
+ */
 public final class ToolPayload implements ProvisionAwarePayload<ToolReference> {
     private ToolReference toolReference;
     private String configurationData;
     private String secretsData;
 
+    /**
+     * Gets the tool reference contained in this payload.
+     *
+     * @return the tool reference
+     */
     @Override
     public ToolReference getPayload() {
         return toolReference;
     }
 
+    /**
+     * Sets the tool reference for this payload.
+     *
+     * @param toolReference the tool reference to set
+     */
     public void setPayload(ToolReference toolReference) {
         this.toolReference = toolReference;
     }
 
+    /**
+     * Gets the configuration data for provisioning this tool.
+     *
+     * @return the configuration data, or {@code null} if not provided
+     */
     @Override
     public String getConfigurationData() {
         return configurationData;
     }
 
+    /**
+     * Sets the configuration data for provisioning this tool.
+     *
+     * @param configurationData the configuration data to set
+     */
     public void setConfigurationData(String configurationData) {
         this.configurationData = configurationData;
     }
 
+    /**
+     * Gets the secrets data required for provisioning this tool.
+     *
+     * @return the secrets data, or {@code null} if not provided
+     */
     @Override
     public String getSecretsData() {
         return secretsData;
     }
 
+    /**
+     * Sets the secrets data required for provisioning this tool.
+     *
+     * @param secretsData the secrets data to set
+     */
     public void setSecretsData(String secretsData) {
         this.secretsData = secretsData;
     }

--- a/cli/src/main/java/ai/wanaku/cli/main/Main.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/Main.java
@@ -3,9 +3,36 @@ package ai.wanaku.cli.main;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.annotations.QuarkusMain;
 
+/**
+ * Main entry point for the Wanaku CLI application.
+ * <p>
+ * This class bootstraps the Quarkus-based command-line interface for managing
+ * the Wanaku router and its capabilities. The CLI provides commands for:
+ * <ul>
+ *   <li>Managing tool and resource capabilities</li>
+ *   <li>Configuring namespaces and forwards</li>
+ *   <li>Monitoring service health and activity</li>
+ *   <li>Interacting with the Wanaku router API</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The actual CLI command implementation is delegated to {@link CliMain},
+ * which is executed within the Quarkus runtime environment.
+ * </p>
+ *
+ * @see CliMain
+ */
 @QuarkusMain
 public class Main {
 
+    /**
+     * Application entry point.
+     * <p>
+     * Initializes the Quarkus runtime and executes the CLI application.
+     * </p>
+     *
+     * @param args command-line arguments passed to the application
+     */
     public static void main(String[] args) {
         Quarkus.run(CliMain.class, args);
     }

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/ResourceConsumer.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/ResourceConsumer.java
@@ -3,14 +3,42 @@ package ai.wanaku.core.capabilities.provider;
 import ai.wanaku.core.exchange.ResourceRequest;
 
 /**
- * Consumes a resource from a service providing it
+ * Interface for consuming resources from capability provider services.
+ * <p>
+ * A resource consumer handles the retrieval and consumption of resource content
+ * from services that provide them. This interface abstracts the mechanism of
+ * accessing resources, allowing different implementations for various transport
+ * protocols and service types.
+ * </p>
+ * <p>
+ * Resource consumers are responsible for:
+ * <ul>
+ *   <li>Connecting to resource provider services</li>
+ *   <li>Translating resource requests into service-specific calls</li>
+ *   <li>Retrieving resource content from the provider</li>
+ *   <li>Converting provider responses into a standard format</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Different implementations may support various protocols such as HTTP, file system,
+ * database connections, or other custom resource providers.
+ * </p>
  */
 public interface ResourceConsumer {
     /**
-     * Consume the resource
-     * @param uri The URI pointing to the service to consume
-     * @param request The resource request as received by the MCP router
-     * @return Whatever response was obtained by calling the server (it must be convertible to a String)
+     * Consumes a resource from the specified service provider.
+     * <p>
+     * This method connects to the resource provider service at the given URI
+     * and retrieves the requested resource content. The response format depends
+     * on the resource type and provider implementation, but must be convertible
+     * to a String representation.
+     * </p>
+     *
+     * @param uri the URI pointing to the service provider that hosts the resource
+     * @param request the resource request as received by the MCP router, containing
+     *                resource identification and any parameters needed for retrieval
+     * @return the resource content obtained from the provider service, in a format
+     *         that can be converted to a String
      */
     Object consume(String uri, ResourceRequest request);
 }

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/Tool.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/Tool.java
@@ -5,14 +5,43 @@ import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
 
 /**
- * Represents a tool that can be called and executed.
+ * Interface for executable tool implementations in the MCP system.
+ * <p>
+ * A tool represents an executable capability that can be invoked by AI agents
+ * through the Model Context Protocol (MCP). Tools encapsulate specific functionality
+ * and can accept arguments to customize their behavior during execution.
+ * </p>
+ * <p>
+ * Implementations of this interface handle the actual execution logic for tools,
+ * processing arguments and returning results in a standardized format. Tools may
+ * interact with external services, perform computations, or execute any other
+ * programmatic task.
+ * </p>
+ * <p>
+ * Example tool types include:
+ * <ul>
+ *   <li>HTTP-based tools that call REST APIs</li>
+ *   <li>Command execution tools that run system commands</li>
+ *   <li>Search tools that query external data sources</li>
+ *   <li>Computation tools that perform calculations</li>
+ * </ul>
+ * </p>
+ *
+ * @see CallableReference
  */
 public interface Tool {
     /**
-     * Call a tool
-     * @param toolReference the tool reference
-     * @param toolArguments the arguments to the tool
-     * @return The tool response instance containing details about its execution
+     * Invokes this tool with the specified arguments.
+     * <p>
+     * This method executes the tool's logic using the provided arguments and
+     * returns a response containing the execution results. The tool reference
+     * provides metadata about the tool being invoked, while the arguments contain
+     * the actual parameter values for this specific invocation.
+     * </p>
+     *
+     * @param toolArguments the arguments to pass to the tool, containing parameter values
+     * @param toolReference the reference to the tool being called, providing metadata and schema information
+     * @return a tool response containing the execution results, status, and any output or error information
      */
     ToolResponse call(ToolManager.ToolArguments toolArguments, CallableReference toolReference);
 }

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/Resolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/Resolver.java
@@ -1,7 +1,25 @@
 package ai.wanaku.core.mcp.common.resolvers;
 
 /**
- * A resolver that consumes MCP requests and resolves what type of tool or resource acquirer
- * should handle it
+ * Base interface for resolvers in the MCP (Model Context Protocol) system.
+ * <p>
+ * Resolvers are responsible for consuming MCP requests and determining which
+ * service provider (tool acquirer or resource acquirer) should handle them.
+ * This interface serves as a marker interface for all resolver types within
+ * the Wanaku MCP infrastructure.
+ * </p>
+ * <p>
+ * Specialized resolver interfaces extend this base interface to provide
+ * specific resolution strategies for different capability types:
+ * <ul>
+ *   <li>{@link ToolsResolver} - Resolves tool capability requests</li>
+ *   <li>{@link ResourceResolver} - Resolves resource capability requests</li>
+ *   <li>{@link ForwardResolver} - Resolves forward proxy requests</li>
+ * </ul>
+ * </p>
+ *
+ * @see ToolsResolver
+ * @see ResourceResolver
+ * @see ForwardResolver
  */
 public interface Resolver {}

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/ResourceResolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/ResourceResolver.java
@@ -8,23 +8,50 @@ import io.quarkiverse.mcp.server.ResourceManager;
 import java.util.List;
 
 /**
- * A resolver that consumes MCP requests and resolves what type of resource acquirer
- * should handle it
+ * Resolver interface for resource capability requests in the MCP system.
+ * <p>
+ * This resolver processes MCP resource requests and determines which resource provider
+ * service should handle them. It supports both resource provisioning (registering
+ * resources with their configuration) and resource reading (accessing resource content
+ * through the appropriate provider).
+ * </p>
+ * <p>
+ * Implementations of this interface are responsible for:
+ * <ul>
+ *   <li>Provisioning resources by loading their properties from remote services</li>
+ *   <li>Reading resource contents through the appropriate resource acquirer</li>
+ *   <li>Managing the lifecycle of resource capabilities</li>
+ * </ul>
+ * </p>
+ *
+ * @see Resolver
  */
 public interface ResourceResolver extends Resolver {
 
     /**
-     * Given a reference, load properties (arguments) defined on the remote service capable of handling it
-     * @param resourcePayload the resource payload
-     * @throws ServiceNotFoundException if a service capable of handling such a resource cannot be found
+     * Provisions a resource by loading its properties from the remote service capable of handling it.
+     * <p>
+     * This method registers the resource with the system and retrieves any necessary
+     * configuration or metadata from the service provider that will handle resource
+     * access requests.
+     * </p>
+     *
+     * @param resourcePayload the resource payload containing the resource reference and provisioning data
+     * @throws ServiceNotFoundException if a service capable of handling the resource cannot be found
      */
     void provision(ResourcePayload resourcePayload) throws ServiceNotFoundException;
 
     /**
-     * Read resources
-     * @param arguments the resource request arguments
-     * @param mcpResource the resource to read
-     * @return the resource contents in a format specific to the content that had been read
+     * Reads the contents of a resource.
+     * <p>
+     * This method retrieves the actual content of a resource by delegating to the
+     * appropriate resource acquirer. The content format is specific to the type of
+     * resource being read (e.g., text, binary, structured data).
+     * </p>
+     *
+     * @param arguments the resource request arguments containing any parameters needed to read the resource
+     * @param mcpResource the resource reference identifying which resource to read
+     * @return a list of resource contents, where each entry represents a portion or variant of the resource
      */
     List<ResourceContents> read(ResourceManager.ResourceArguments arguments, ResourceReference mcpResource);
 }

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/ToolsResolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/ToolsResolver.java
@@ -7,23 +7,51 @@ import ai.wanaku.api.types.io.ToolPayload;
 import ai.wanaku.core.mcp.common.Tool;
 
 /**
- * A resolver that consumes MCP requests and resolves what type of tool
- * should handle it
+ * Resolver interface for tool capability requests in the MCP system.
+ * <p>
+ * This resolver processes MCP tool requests and determines which tool provider
+ * service should handle them. It supports both tool provisioning (registering
+ * tools with their configuration) and tool resolution (finding the appropriate
+ * tool implementation for a given reference).
+ * </p>
+ * <p>
+ * Implementations of this interface are responsible for:
+ * <ul>
+ *   <li>Provisioning tools by loading their properties from remote services</li>
+ *   <li>Resolving tool references to concrete {@link Tool} implementations</li>
+ *   <li>Managing the lifecycle of tool capabilities</li>
+ * </ul>
+ * </p>
+ *
+ * @see Resolver
+ * @see Tool
  */
 public interface ToolsResolver extends Resolver {
 
     /**
-     * Given a reference, load properties (arguments) defined on the remote service capable of handling it
-     * @param toolPayload the tool payload
-     * @throws ServiceNotFoundException if a service capable of handling such a tool cannot be found
+     * Provisions a tool by loading its properties from the remote service capable of handling it.
+     * <p>
+     * This method registers the tool with the system and retrieves any necessary
+     * configuration or metadata from the service provider that will handle tool
+     * invocations.
+     * </p>
+     *
+     * @param toolPayload the tool payload containing the tool reference and provisioning data
+     * @throws ServiceNotFoundException if a service capable of handling the tool cannot be found
      */
     void provision(ToolPayload toolPayload) throws ServiceNotFoundException;
 
     /**
-     * Given a reference, resolves what tool would call it
-     * @param toolReference the reference to the tool
-     * @return An instance of the requested tool
-     * @throws ToolNotFoundException if the tools cannot be found
+     * Resolves a tool reference to a concrete tool implementation.
+     * <p>
+     * Given a tool reference, this method determines which {@link Tool} instance
+     * should be used to handle invocations of that tool. The resolved tool is
+     * ready to be called with appropriate arguments.
+     * </p>
+     *
+     * @param toolReference the reference to the tool to resolve
+     * @return an instance of the requested tool
+     * @throws ToolNotFoundException if the tool cannot be found or resolved
      */
     Tool resolve(ToolReference toolReference) throws ToolNotFoundException;
 }

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopForwardResolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopForwardResolver.java
@@ -12,25 +12,74 @@ import io.quarkiverse.mcp.server.ResourceContents;
 import io.quarkiverse.mcp.server.ResourceManager;
 import java.util.List;
 
+/**
+ * No-operation implementation of {@link ForwardResolver} for testing and default behavior.
+ * <p>
+ * This resolver provides empty implementations of all {@link ForwardResolver} methods,
+ * making it useful for testing scenarios where actual forward resolution is not needed,
+ * or as a default/fallback resolver when no real resolver is configured.
+ * </p>
+ * <p>
+ * The noop resolver:
+ * <ul>
+ *   <li>Returns {@code null} for tool resolution</li>
+ *   <li>Returns empty lists for all listing operations</li>
+ *   <li>Does not perform any provisioning operations</li>
+ *   <li>Returns an empty list for resource read operations</li>
+ * </ul>
+ * </p>
+ *
+ * @see ForwardResolver
+ */
 public class NoopForwardResolver implements ForwardResolver {
+    /**
+     * Returns {@code null} indicating no tool is resolved.
+     *
+     * @param toolReference the tool reference (ignored)
+     * @return {@code null}
+     * @throws ToolNotFoundException never thrown by this implementation
+     */
     @Override
     public Tool resolve(CallableReference toolReference) throws ToolNotFoundException {
         return null;
     }
 
+    /**
+     * Returns an empty list of resources.
+     *
+     * @return an empty list
+     */
     @Override
     public List<ResourceReference> listResources() {
         return List.of();
     }
 
+    /**
+     * Returns an empty list of remote tools.
+     *
+     * @return an empty list
+     */
     @Override
     public List<RemoteToolReference> listTools() {
         return List.of();
     }
 
+    /**
+     * No-operation provisioning that does nothing.
+     *
+     * @param resourcePayload the resource payload (ignored)
+     * @throws ServiceNotFoundException never thrown by this implementation
+     */
     @Override
     public void provision(ResourcePayload resourcePayload) throws ServiceNotFoundException {}
 
+    /**
+     * Returns an empty list of resource contents.
+     *
+     * @param arguments the resource request arguments (ignored)
+     * @param mcpResource the resource reference (ignored)
+     * @return an empty list
+     */
     @Override
     public List<ResourceContents> read(ResourceManager.ResourceArguments arguments, ResourceReference mcpResource) {
         return List.of();

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopResourceResolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopResourceResolver.java
@@ -9,13 +9,48 @@ import io.quarkiverse.mcp.server.ResourceManager;
 import java.util.List;
 
 /**
- * A resolver that does not to anything (mostly used for testing)
+ * No-operation implementation of {@link ResourceResolver} for testing and default behavior.
+ * <p>
+ * This resolver provides empty implementations of all {@link ResourceResolver} methods,
+ * making it useful for testing scenarios where actual resource resolution is not needed,
+ * or as a default/fallback resolver when no real resolver is configured.
+ * </p>
+ * <p>
+ * The noop resolver:
+ * <ul>
+ *   <li>Does not perform any provisioning operations</li>
+ *   <li>Returns an empty list for all resource read operations</li>
+ *   <li>Never throws exceptions during normal operation</li>
+ * </ul>
+ * </p>
+ *
+ * @see ResourceResolver
  */
 public class NoopResourceResolver implements ResourceResolver {
 
+    /**
+     * No-operation provisioning that does nothing.
+     * <p>
+     * This method accepts the resource payload but performs no actual provisioning.
+     * </p>
+     *
+     * @param resourcePayload the resource payload (ignored)
+     * @throws ServiceNotFoundException never thrown by this implementation
+     */
     @Override
     public void provision(ResourcePayload resourcePayload) throws ServiceNotFoundException {}
 
+    /**
+     * Returns an empty list of resource contents.
+     * <p>
+     * This method always returns an empty list, indicating that no resource
+     * content is available.
+     * </p>
+     *
+     * @param arguments the resource request arguments (ignored)
+     * @param mcpResource the resource reference (ignored)
+     * @return an empty list
+     */
     @Override
     public List<ResourceContents> read(ResourceManager.ResourceArguments arguments, ResourceReference mcpResource) {
         return List.of();

--- a/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopToolsResolver.java
+++ b/core/core-mcp/src/main/java/ai/wanaku/core/mcp/common/resolvers/util/NoopToolsResolver.java
@@ -11,12 +11,46 @@ import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
 
 /**
- * A resolver that does not to anything (mostly used for testing)
+ * No-operation implementation of {@link ToolsResolver} for testing and default behavior.
+ * <p>
+ * This resolver provides empty implementations of all {@link ToolsResolver} methods,
+ * making it useful for testing scenarios where actual tool resolution is not needed,
+ * or as a default/fallback resolver when no real resolver is configured.
+ * </p>
+ * <p>
+ * The noop resolver:
+ * <ul>
+ *   <li>Does not perform any provisioning operations</li>
+ *   <li>Returns a stub tool implementation that returns {@code null} for all calls</li>
+ *   <li>Never throws exceptions during normal operation</li>
+ * </ul>
+ * </p>
+ *
+ * @see ToolsResolver
  */
 public class NoopToolsResolver implements ToolsResolver {
+    /**
+     * No-operation provisioning that does nothing.
+     * <p>
+     * This method accepts the tool payload but performs no actual provisioning.
+     * </p>
+     *
+     * @param toolPayload the tool payload (ignored)
+     * @throws ServiceNotFoundException never thrown by this implementation
+     */
     @Override
     public void provision(ToolPayload toolPayload) throws ServiceNotFoundException {}
 
+    /**
+     * Returns a stub tool implementation that does nothing.
+     * <p>
+     * The returned tool's {@code call} method will always return {@code null}.
+     * </p>
+     *
+     * @param toolReference the tool reference (ignored)
+     * @return a stub tool implementation
+     * @throws ToolNotFoundException never thrown by this implementation
+     */
     @Override
     public Tool resolve(ToolReference toolReference) throws ToolNotFoundException {
         return new Tool() {

--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ForwardReferenceRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ForwardReferenceRepository.java
@@ -3,6 +3,24 @@ package ai.wanaku.core.persistence.api;
 import ai.wanaku.api.types.ForwardReference;
 import java.util.List;
 
+/**
+ * Repository interface for managing {@link ForwardReference} entities.
+ * <p>
+ * This interface extends {@link WanakuRepository} to provide persistence operations
+ * for forward references, which configure the router to proxy requests to remote
+ * MCP servers or external capability providers.
+ * </p>
+ */
 public interface ForwardReferenceRepository extends WanakuRepository<ForwardReference, String> {
+    /**
+     * Finds all forward references with the specified name.
+     * <p>
+     * Multiple forward references may share the same name but differ in other
+     * attributes such as namespace or target URI.
+     * </p>
+     *
+     * @param name the name of the forward references to find
+     * @return a list of matching forward references, or an empty list if none found
+     */
     List<ForwardReference> findByName(String name);
 }

--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/NamespaceRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/NamespaceRepository.java
@@ -3,9 +3,37 @@ package ai.wanaku.core.persistence.api;
 import ai.wanaku.api.types.Namespace;
 import java.util.List;
 
+/**
+ * Repository interface for managing {@link Namespace} entities.
+ * <p>
+ * This interface extends {@link WanakuRepository} to provide persistence operations
+ * for namespaces, which provide logical grouping and isolation for capabilities,
+ * tools, and resources within the Wanaku system.
+ * </p>
+ */
 public interface NamespaceRepository extends WanakuRepository<Namespace, String> {
 
+    /**
+     * Finds all namespaces with the specified name.
+     * <p>
+     * While namespace names are typically unique, this method returns a list
+     * to support potential future use cases or naming conflicts.
+     * </p>
+     *
+     * @param name the name of the namespaces to find
+     * @return a list of matching namespaces, or an empty list if none found
+     */
     List<Namespace> findByName(String name);
 
+    /**
+     * Finds the first available namespace with the specified name.
+     * <p>
+     * This method is optimized for the common case where only one namespace
+     * with a given name is expected. It returns the first match found.
+     * </p>
+     *
+     * @param name the name of the namespace to find
+     * @return a list containing the first available namespace, or an empty list if not found
+     */
     List<Namespace> findFirstAvailable(String name);
 }

--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
@@ -4,12 +4,23 @@ import ai.wanaku.api.types.ResourceReference;
 import java.util.List;
 
 /**
- * Repository interface for managing ResourceReference entities.
- *
- * <p>This interface extends WanakuRepository to provide specific operations
- * for ResourceReference objects, with default implementations for converting
- * between model and entity representations.</p>
+ * Repository interface for managing {@link ResourceReference} entities.
+ * <p>
+ * This interface extends {@link WanakuRepository} to provide persistence operations
+ * for resource references, which represent data sources or content that can be
+ * accessed by AI agents, such as files, databases, or external data sources.
+ * </p>
  */
 public interface ResourceReferenceRepository extends WanakuRepository<ResourceReference, String> {
+    /**
+     * Finds all resource references with the specified name.
+     * <p>
+     * Multiple resource references may share the same name but exist in different
+     * namespaces or have different configurations.
+     * </p>
+     *
+     * @param name the name of the resource references to find
+     * @return a list of matching resource references, or an empty list if none found
+     */
     List<ResourceReference> findByName(String name);
 }

--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ToolReferenceRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ToolReferenceRepository.java
@@ -4,13 +4,24 @@ import ai.wanaku.api.types.ToolReference;
 import java.util.List;
 
 /**
- * Repository interface for managing ToolReference entities.
- *
- * <p>This interface extends WanakuRepository to provide specific operations
- * for ToolReference objects, with default implementations for converting
- * between model and entity representations.</p>
+ * Repository interface for managing {@link ToolReference} entities.
+ * <p>
+ * This interface extends {@link WanakuRepository} to provide persistence operations
+ * for tool references, which represent executable capabilities that can be invoked
+ * by AI agents to perform specific tasks.
+ * </p>
  */
 public interface ToolReferenceRepository extends WanakuRepository<ToolReference, String> {
 
+    /**
+     * Finds all tool references with the specified name.
+     * <p>
+     * Multiple tool references may share the same name but exist in different
+     * namespaces or have different configurations.
+     * </p>
+     *
+     * @param name the name of the tool references to find
+     * @return a list of matching tool references, or an empty list if none found
+     */
     List<ToolReference> findByName(String name);
 }

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/CapabilitiesService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/CapabilitiesService.java
@@ -15,20 +15,54 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * JAX-RS service interface for managing and monitoring capabilities in the Wanaku system.
+ * <p>
+ * This service provides REST endpoints for discovering available capability providers
+ * (both tools and resources), monitoring their health and activity state, and configuring
+ * their runtime settings. It acts as a central point for capability lifecycle management
+ * and service discovery.
+ * </p>
+ * <p>
+ * All endpoints are available under the {@code /api/v1/capabilities} base path.
+ * </p>
+ */
 @Path("/api/v1/capabilities")
 public interface CapabilitiesService {
 
+    /**
+     * Lists all available tool capability providers.
+     *
+     * @return a {@link WanakuResponse} containing a list of tool service targets
+     */
     @Path("/tools/list")
     @GET
     @Consumes(MediaType.TEXT_PLAIN)
     WanakuResponse<List<ServiceTarget>> toolsList();
 
+    /**
+     * Retrieves the health and activity state of all tool providers.
+     * <p>
+     * Returns a map where keys are service identifiers and values are lists of
+     * activity records tracking the health and availability of each tool provider.
+     * </p>
+     *
+     * @return a {@link WanakuResponse} containing the state map of tool providers
+     */
     @Path("/tools/state")
     @GET
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
     WanakuResponse<Map<String, List<ActivityRecord>>> toolsState();
 
+    /**
+     * Configures runtime settings for a specific tool provider service.
+     *
+     * @param service the identifier of the service to configure
+     * @param option the configuration option name
+     * @param value the configuration value to set
+     * @return a {@link Response} indicating the result of the configuration operation
+     */
     @Path("/tools/configure/{service}")
     @PUT
     @Consumes(MediaType.TEXT_PLAIN)
@@ -37,11 +71,24 @@ public interface CapabilitiesService {
             @QueryParam("option") String option,
             @QueryParam("value") String value);
 
+    /**
+     * Lists all available resource capability providers.
+     *
+     * @return a {@link WanakuResponse} containing a list of resource service targets
+     */
     @Path("/resources/list")
     @GET
     @Consumes(MediaType.TEXT_PLAIN)
     WanakuResponse<List<ServiceTarget>> resourcesList();
 
+    /**
+     * Configures runtime settings for a specific resource provider service.
+     *
+     * @param service the identifier of the service to configure
+     * @param option the configuration option name
+     * @param value the configuration value to set
+     * @return a {@link Response} indicating the result of the configuration operation
+     */
     @Path("/resources/configure/{service}")
     @PUT
     @Consumes(MediaType.TEXT_PLAIN)
@@ -50,6 +97,15 @@ public interface CapabilitiesService {
             @QueryParam("option") String option,
             @QueryParam("value") String value);
 
+    /**
+     * Retrieves the health and activity state of all resource providers.
+     * <p>
+     * Returns a map where keys are service identifiers and values are lists of
+     * activity records tracking the health and availability of each resource provider.
+     * </p>
+     *
+     * @return a {@link WanakuResponse} containing the state map of resource providers
+     */
     @Path("/resources/state")
     @GET
     @Consumes(MediaType.TEXT_PLAIN)

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ForwardsService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ForwardsService.java
@@ -12,19 +12,51 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 
+/**
+ * JAX-RS service interface for managing forward references in the Wanaku system.
+ * <p>
+ * This service provides REST endpoints for managing forwards, which enable the
+ * Wanaku router to proxy requests to remote MCP (Model Context Protocol) servers
+ * or other external capability providers.
+ * </p>
+ * <p>
+ * All endpoints are available under the {@code /api/v1/forwards} base path.
+ * </p>
+ */
 @Path("/api/v1/forwards")
 public interface ForwardsService {
+    /**
+     * Registers a new forward reference in the system.
+     * <p>
+     * A forward reference configures the router to proxy requests for specific
+     * capabilities to a remote server or service.
+     * </p>
+     *
+     * @param reference the forward reference to register
+     * @return a {@link Response} indicating the result of the add operation
+     */
     @Path("/add")
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     Response addForward(ForwardReference reference);
 
+    /**
+     * Removes a forward reference from the system.
+     *
+     * @param reference the forward reference to remove
+     * @return a {@link Response} indicating the result of the remove operation
+     */
     @Path("/remove")
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     Response removeForward(ForwardReference reference);
 
+    /**
+     * Lists all registered forward references.
+     *
+     * @return a {@link WanakuResponse} containing a list of all forward references
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/NamespacesService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/NamespacesService.java
@@ -8,9 +8,25 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 
+/**
+ * JAX-RS service interface for managing namespaces in the Wanaku system.
+ * <p>
+ * This service provides REST endpoints for working with namespaces. Namespaces
+ * provide logical grouping and isolation for capabilities, tools, and resources
+ * within the Wanaku system.
+ * </p>
+ * <p>
+ * All endpoints are available under the {@code /api/v1/namespaces} base path.
+ * </p>
+ */
 @Path("/api/v1/namespaces")
 public interface NamespacesService {
 
+    /**
+     * Lists all registered namespaces in the system.
+     *
+     * @return a {@link WanakuResponse} containing a list of all namespaces
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ResourcesService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ResourcesService.java
@@ -14,26 +14,64 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 
+/**
+ * JAX-RS service interface for managing resource capabilities in the Wanaku system.
+ * <p>
+ * This service provides REST endpoints for exposing, listing, and removing resource
+ * capabilities. Resources are data sources or content that can be accessed by AI agents,
+ * such as files, databases, or external data sources.
+ * </p>
+ * <p>
+ * All endpoints are available under the {@code /api/v1/resources} base path.
+ * </p>
+ */
 @Path("/api/v1/resources")
 public interface ResourcesService {
 
+    /**
+     * Exposes a new resource capability with configuration and secrets payload.
+     * <p>
+     * This endpoint allows exposing a resource along with its provisioning data,
+     * including configuration settings and secrets required for resource access.
+     * </p>
+     *
+     * @param resourceReference the resource payload containing the resource reference and provisioning data
+     * @return a {@link Response} indicating the result of the expose operation
+     */
     @Path("/exposeWithPayload")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     Response exposeWithPayload(ResourcePayload resourceReference);
 
+    /**
+     * Exposes a new resource capability in the system.
+     *
+     * @param resourceReference the resource reference containing resource metadata
+     * @return a {@link Response} indicating the result of the expose operation
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/expose")
     Response expose(ResourceReference resourceReference);
 
+    /**
+     * Lists all exposed resource capabilities.
+     *
+     * @return a {@link WanakuResponse} containing a list of all resource references
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     WanakuResponse<List<ResourceReference>> list();
 
+    /**
+     * Removes a resource capability from the system.
+     *
+     * @param resource the name of the resource to remove
+     * @return a {@link Response} indicating the result of the removal operation
+     */
     @Path("/remove")
     @PUT
     Response remove(@QueryParam("resource") String resource);

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsService.java
@@ -15,35 +15,88 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 
+/**
+ * JAX-RS service interface for managing tool capabilities in the Wanaku system.
+ * <p>
+ * This service provides REST endpoints for registering, listing, updating, and removing
+ * tool capabilities. Tools are executable capabilities that can be invoked by AI agents
+ * to perform specific tasks.
+ * </p>
+ * <p>
+ * All endpoints are available under the {@code /api/v1/tools} base path.
+ * </p>
+ */
 @Path("/api/v1/tools")
 public interface ToolsService {
 
+    /**
+     * Registers a new tool capability in the system.
+     *
+     * @param toolReference the tool reference containing tool metadata
+     * @return a {@link WanakuResponse} containing the registered tool reference
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/add")
     WanakuResponse<ToolReference> add(ToolReference toolReference);
 
+    /**
+     * Registers a new tool capability with configuration and secrets payload.
+     * <p>
+     * This endpoint allows registering a tool along with its provisioning data,
+     * including configuration settings and secrets required for tool operation.
+     * </p>
+     *
+     * @param resource the tool payload containing the tool reference and provisioning data
+     * @return a {@link WanakuResponse} containing the registered tool reference
+     * @throws WanakuException if registration fails
+     */
     @Path("/addWithPayload")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     WanakuResponse<ToolReference> addWithPayload(ToolPayload resource) throws WanakuException;
 
+    /**
+     * Lists all registered tool capabilities.
+     *
+     * @return a {@link WanakuResponse} containing a list of all tool references
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     WanakuResponse<List<ToolReference>> list();
 
+    /**
+     * Removes a tool capability from the system.
+     *
+     * @param tool the name of the tool to remove
+     * @return a {@link Response} indicating the result of the removal operation
+     */
     @Path("/remove")
     @PUT
     Response remove(@QueryParam("tool") String tool);
 
+    /**
+     * Updates an existing tool capability.
+     *
+     * @param resource the updated tool reference
+     * @return a {@link Response} indicating the result of the update operation
+     * @throws WanakuException if the update fails
+     */
     @Path("/update")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     Response update(ToolReference resource) throws WanakuException;
 
+    /**
+     * Retrieves a tool capability by its name.
+     *
+     * @param name the name of the tool to retrieve
+     * @return a {@link WanakuResponse} containing the tool reference
+     * @throws WanakuException if the tool is not found
+     */
     @Path("/")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/core/core-util/src/main/java/ai/wanaku/core/util/StringHelper.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/StringHelper.java
@@ -1,13 +1,44 @@
 package ai.wanaku.core.util;
 
+/**
+ * Utility class providing helper methods for String operations.
+ * <p>
+ * This class contains common string validation and manipulation utilities
+ * used throughout the Wanaku system. All methods are static and the class
+ * cannot be instantiated.
+ * </p>
+ */
 public final class StringHelper {
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private StringHelper() {}
 
+    /**
+     * Checks if a string is null or empty.
+     * <p>
+     * A string is considered empty if it is {@code null} or has zero length
+     * after trimming is NOT performed. This means strings containing only
+     * whitespace are considered non-empty.
+     * </p>
+     *
+     * @param str the string to check
+     * @return {@code true} if the string is null or empty, {@code false} otherwise
+     */
     public static boolean isEmpty(String str) {
         return str == null || str.isEmpty();
     }
 
+    /**
+     * Checks if a string is not null and not empty.
+     * <p>
+     * This is the logical inverse of {@link #isEmpty(String)}.
+     * </p>
+     *
+     * @param str the string to check
+     * @return {@code true} if the string is not null and not empty, {@code false} otherwise
+     */
     public static boolean isNotEmpty(String str) {
         return !isEmpty(str);
     }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -20,6 +20,22 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 
+/**
+ * JAX-RS REST resource implementation for resource management endpoints.
+ * <p>
+ * This class implements the {@code /api/v1/resources} endpoints for managing
+ * resource capabilities in the Wanaku router. It delegates business logic to
+ * {@link ResourcesBean} and integrates with {@link ForwardsBean} to provide
+ * a unified view of both locally exposed resources and resources available
+ * through forward proxies.
+ * </p>
+ * <p>
+ * This is an application-scoped CDI bean that serves as the entry point for
+ * HTTP requests related to resource management.
+ * </p>
+ *
+ * @see ai.wanaku.core.services.api.ResourcesService
+ */
 @ApplicationScoped
 @Path("/api/v1/resources")
 public class ResourcesResource {
@@ -30,6 +46,17 @@ public class ResourcesResource {
     @Inject
     ForwardsBean forwardsBean;
 
+    /**
+     * Exposes a new resource capability with provisioning payload.
+     * <p>
+     * This endpoint accepts a resource reference along with configuration and secrets
+     * data, enabling complete provisioning of the resource capability.
+     * </p>
+     *
+     * @param resource the resource payload containing the resource reference and provisioning data
+     * @return a response containing the exposed resource reference
+     * @throws WanakuException if exposure fails or payload validation fails
+     */
     @Path("/exposeWithPayload")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -40,6 +67,12 @@ public class ResourcesResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Validates that a provision-aware payload is not null and contains a payload object.
+     *
+     * @param resource the payload to validate
+     * @throws WanakuException if the payload or its nested payload object is null
+     */
     private void validatePayload(ProvisionAwarePayload<?> resource) throws WanakuException {
         if (resource == null) {
             throw new WanakuException("The request itself must not be null");
@@ -49,6 +82,13 @@ public class ResourcesResource {
         }
     }
 
+    /**
+     * Exposes a new resource capability.
+     *
+     * @param resource the resource reference to expose
+     * @return a response containing the exposed resource reference
+     * @throws WanakuException if exposure fails
+     */
     @Path("/expose")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -58,6 +98,16 @@ public class ResourcesResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Lists all available resource capabilities.
+     * <p>
+     * This endpoint returns a combined list of both locally exposed resources
+     * and resources available through forward proxies to remote MCP servers.
+     * </p>
+     *
+     * @return a response containing a list of all resource references
+     * @throws WanakuException if listing fails
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -70,6 +120,13 @@ public class ResourcesResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Removes a resource capability by name.
+     *
+     * @param resource the name of the resource to remove
+     * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the resource doesn't exist
+     * @throws WanakuException if removal fails
+     */
     @Path("/remove")
     @PUT
     public Response remove(@QueryParam("resource") String resource) throws WanakuException {
@@ -81,6 +138,13 @@ public class ResourcesResource {
         }
     }
 
+    /**
+     * Updates an existing resource capability.
+     *
+     * @param resource the updated resource reference
+     * @return HTTP 200 OK if updated successfully
+     * @throws WanakuException if update fails
+     */
     @Path("/update")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -21,6 +21,21 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 
+/**
+ * JAX-RS REST resource implementation for tool management endpoints.
+ * <p>
+ * This class implements the {@code /api/v1/tools} endpoints for managing tool
+ * capabilities in the Wanaku router. It delegates business logic to {@link ToolsBean}
+ * and integrates with {@link ForwardsBean} to provide a unified view of both
+ * locally registered tools and tools available through forward proxies.
+ * </p>
+ * <p>
+ * This is an application-scoped CDI bean that serves as the entry point for
+ * HTTP requests related to tool management.
+ * </p>
+ *
+ * @see ai.wanaku.core.services.api.ToolsService
+ */
 @ApplicationScoped
 @Path("/api/v1/tools")
 public class ToolsResource {
@@ -30,6 +45,13 @@ public class ToolsResource {
     @Inject
     ForwardsBean forwardsBean;
 
+    /**
+     * Registers a new tool capability.
+     *
+     * @param resource the tool reference to register
+     * @return a response containing the registered tool reference
+     * @throws WanakuException if registration fails
+     */
     @Path("/add")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -39,6 +61,17 @@ public class ToolsResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Registers a new tool capability with provisioning payload.
+     * <p>
+     * This endpoint accepts a tool reference along with configuration and secrets
+     * data, enabling complete provisioning of the tool capability.
+     * </p>
+     *
+     * @param resource the tool payload containing the tool reference and provisioning data
+     * @return a response containing the registered tool reference
+     * @throws WanakuException if registration fails or payload validation fails
+     */
     @Path("/addWithPayload")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -49,6 +82,12 @@ public class ToolsResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Validates that a provision-aware payload is not null and contains a payload object.
+     *
+     * @param resource the payload to validate
+     * @throws WanakuException if the payload or its nested payload object is null
+     */
     private void validatePayload(ProvisionAwarePayload<?> resource) throws WanakuException {
         if (resource == null) {
             throw new WanakuException("The request itself must not be null");
@@ -58,6 +97,16 @@ public class ToolsResource {
         }
     }
 
+    /**
+     * Lists all available tool capabilities.
+     * <p>
+     * This endpoint returns a combined list of both locally registered tools
+     * and tools available through forward proxies to remote MCP servers.
+     * </p>
+     *
+     * @return a response containing a list of all tool references
+     * @throws WanakuException if listing fails
+     */
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -70,6 +119,13 @@ public class ToolsResource {
         return new WanakuResponse<>(ret);
     }
 
+    /**
+     * Removes a tool capability by name.
+     *
+     * @param tool the name of the tool to remove
+     * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the tool doesn't exist
+     * @throws WanakuException if removal fails
+     */
     @Path("/remove")
     @PUT
     public Response remove(@QueryParam("tool") String tool) throws WanakuException {
@@ -81,6 +137,13 @@ public class ToolsResource {
         }
     }
 
+    /**
+     * Updates an existing tool capability.
+     *
+     * @param resource the updated tool reference
+     * @return HTTP 200 OK if updated successfully
+     * @throws WanakuException if update fails
+     */
     @Path("/update")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -89,6 +152,14 @@ public class ToolsResource {
         return Response.ok().build();
     }
 
+    /**
+     * Retrieves a tool capability by name.
+     *
+     * @param name the name of the tool to retrieve
+     * @return a response containing the tool reference
+     * @throws ToolNotFoundException if the tool is not found
+     * @throws WanakuException if retrieval fails
+     */
     @Path("/")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/proxies/Proxy.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/proxies/Proxy.java
@@ -1,12 +1,31 @@
 package ai.wanaku.backend.proxies;
 
 /**
- * Proxies between MCP URIs and services capable of handling them
+ * Interface for proxy implementations that mediate between MCP URIs and backend services.
+ * <p>
+ * Proxies in the Wanaku system handle the routing and translation of requests from
+ * Model Context Protocol (MCP) URIs to the appropriate backend services that can
+ * process them. Different proxy implementations may support different transport
+ * mechanisms, protocols, or service types.
+ * </p>
+ * <p>
+ * Common proxy implementations include:
+ * <ul>
+ *   <li>HTTP/REST proxies for web-based MCP servers</li>
+ *   <li>SSE (Server-Sent Events) proxies for streaming MCP servers</li>
+ *   <li>STDIO proxies for process-based MCP servers</li>
+ * </ul>
+ * </p>
  */
 public interface Proxy {
     /**
-     * The name of the proxy
-     * @return the name of the proxy
+     * Gets the name identifier for this proxy implementation.
+     * <p>
+     * The name typically indicates the transport mechanism or protocol
+     * that this proxy handles (e.g., "http", "sse", "stdio").
+     * </p>
+     *
+     * @return the proxy name identifier
      */
     String name();
 }


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive JavaDoc comments across modules to document public APIs, service endpoints, payloads, resolvers, and utility classes.

Documentation:
- Add JavaDoc to API model types and entities to describe properties and behavior.
- Document JAX-RS resource classes and service interface methods for tools, resources, capabilities, forwards, and namespaces.
- Annotate resolver interfaces and no-op implementations (ToolsResolver, ResourceResolver, ForwardResolver) with usage details.
- Add documentation to payload classes (ToolPayload, ResourcePayload, ProvisionAwarePayload) and repository interfaces.
- Document utility classes (StringHelper), CLI entry point, and core MCP Tool and Resource consumer interfaces.