### PR TITLE
Add support for the Quarkus OIDC Proxy

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,6 +47,7 @@
         <jackson.version>2.20.0</jackson.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <quarkus-mcp-server.version>1.6.1</quarkus-mcp-server.version>
+        <quarkus-oidc-proxy.version>0.3.2</quarkus-oidc-proxy.version>
         <camel.version>4.12.0</camel.version>
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.3.0</langchain4j.version>

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -97,6 +97,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.oidc-proxy</groupId>
+            <artifactId>quarkus-oidc-proxy</artifactId>
+            <version>${quarkus-oidc-proxy.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>

--- a/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
+++ b/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
@@ -60,6 +60,12 @@ quarkus.http.auth.permission.web.paths=/*
 ## Policy requiring users to be authenticated to access protected paths
 quarkus.http.auth.permission.web.policy=authenticated
 
+
+quarkus.oidc-proxy.enabled=false
+quarkus.oidc-proxy.root-path=/q/oidc
+quarkus.http.auth.permission.oidcproxy.paths=/q/oidc/*
+quarkus.http.auth.permission.oidcproxy.policy=permit
+
 quarkus.oidc.tls.verification=none
 
 # URL path where users can logout from the application


### PR DESCRIPTION
This solves issue #520

## Summary by Sourcery

Add support for Quarkus OIDC Proxy by adding the quarkus-oidc-proxy dependency and exposing related configuration properties

New Features:
- Add quarkus-oidc-proxy dependency in backend module and declare its version in the parent POM
- Introduce application.properties settings to enable/disable the OIDC proxy, configure its root path, and define security permissions for its endpoints