### PR TITLE
Upgrade to Langchain4j 1.7.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,7 +49,7 @@
         <quarkus-mcp-server.version>1.6.1</quarkus-mcp-server.version>
         <camel.version>4.12.0</camel.version>
         <picocli.version>4.7.7</picocli.version>
-        <langchain4j.version>1.3.0</langchain4j.version>
+        <langchain4j.version>1.7.1</langchain4j.version>
         <langchain4j-mcp.version>1.7.1-beta14</langchain4j-mcp.version>
         <quarkus-quinoa.version>2.6.2</quarkus-quinoa.version>
         <test-containers.version>1.21.3</test-containers.version>

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/resolvers/WanakuForwardResolver.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/resolvers/WanakuForwardResolver.java
@@ -24,6 +24,7 @@ import dev.langchain4j.mcp.client.McpResourceContents;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import io.quarkiverse.mcp.server.ResourceContents;
 import io.quarkiverse.mcp.server.ResourceManager;
 import io.quarkiverse.mcp.server.TextResourceContents;
@@ -180,8 +181,12 @@ public class WanakuForwardResolver implements ForwardResolver {
                         .arguments(serializeArguments(toolArguments.args()))
                         .build();
                 try (McpClient client = ClientUtil.createClient(forwardReference.getAddress())) {
-                    String status = client.executeTool(request);
-                    return ToolResponse.success(status);
+                    ToolExecutionResult result = client.executeTool(request);
+                    if (result.isError()) {
+                        return ToolResponse.error(result.resultText());
+                    }
+
+                    return ToolResponse.success(result.resultText());
                 }
             } catch (Exception e) {
                 LOG.errorf(


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Langchain4j dependency to 1.7.1 and adapt tool execution logic to use the new ToolExecutionResult API with proper error handling.

Enhancements:
- Adapt tool execution call to return ToolExecutionResult and differentiate between success and error responses.

Build:
- Bump langchain4j version from 1.3.0 to 1.7.1 in the parent POM.