### PR TITLE
Add support for a public namespace

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1134,7 +1134,9 @@ Each namespace acts as a separate logical container, ensuring that the LLM conte
 interfere with tools in another.
 This is particularly useful when you have a large number of tools or when different sets of tools are used for distinct purposes.
 
-Wanaku provides a fixed set of 10 available slots for namespaces, named from `ns-0` to `ns-9`.
+Wanaku provides a fixed set of 10 available slots for namespaces, named from `ns-0` to `ns-9`. 
+It also provides a `default` namespace, 
+which is used if none is specified and a special `public` namespace that can be accessed without any authentication.
 
 ### Using Namespaces
 
@@ -1158,18 +1160,19 @@ This command will display a list of all active namespaces, their unique IDs, and
 The output will look similar to this:
 
 ```shell
-id                                   name path
-381d4276-c824-4bbe-9094-a962c6e8fc46 test http://localhost:8080/ns-9/mcp/sse
-4b7a5ec7-c1f3-4311-8067-10148daf3a10      http://localhost:8080/ns-3/mcp/sse
-dcf97b5e-8ff7-4d04-944c-194379f2e0e4      http://localhost:8080/ns-2/mcp/sse
-dd6f75ac-7b32-4f3b-b965-99040f4af6c2      http://localhost:8080/ns-8/mcp/sse
-59e92c00-04d5-4673-a631-d9244c3e07c1      http://localhost:8080/ns-0/mcp/sse
-e3ff6cd0-e73d-431f-96c9-327b3a498265      http://localhost:8080/ns-1/mcp/sse
-ffe8d322-6ebe-46f2-b913-ac792571fadc      http://localhost:8080/ns-7/mcp/sse
-82434059-45b4-442c-b945-385ae36f158d      http://localhost:8080/ns-6/mcp/sse
-901ea4d6-8e08-4e8b-8171-ce23ae1380d4      http://localhost:8080/ns-5/mcp/sse
-4b2403ca-1acd-419f-9e83-102bbf631536      http://localhost:8080/ns-4/mcp/sse
-<default>                                 http://localhost:8080//mcp/sse
+id                                   name   path
+28560e66-d94c-44a2-b032-779b5542132a        http://localhost:8080/ns-4/mcp/sse
+43b5d7a7-4e7d-4109-960b-ac7695b6f2d3 public http://localhost:8080/public/mcp/sse
+93c5bfdf-0e09-4da5-82fa-4eec3bf6b1b4        http://localhost:8080/ns-3/mcp/sse
+bfd112d2-32cb-475a-9f55-63301519152b        http://localhost:8080/ns-7/mcp/sse
+f5915650-4daa-4616-95c6-5aafceffb026        http://localhost:8080/ns-1/mcp/sse
+db89fedd-ffe6-4dee-b051-bcd5285bb9c9        http://localhost:8080/ns-2/mcp/sse
+d4249e11-9368-4c5b-bb66-981d2d2e69c7        http://localhost:8080/ns-0/mcp/sse
+8898fab6-3774-427f-8400-8c6f6fd9a97e        http://localhost:8080/ns-6/mcp/sse
+fe8cc1f2-2355-4009-ba68-4faeefe937f7        http://localhost:8080/ns-5/mcp/sse
+a3dfaaf6-3655-4bcc-8c48-3d183b6d675b        http://localhost:8080/ns-8/mcp/sse
+8832e2c7-3bd9-4f9b-88ba-982cc20a43de        http://localhost:8080/ns-9/mcp/sse
+<default>                                   http://localhost:8080//mcp/sse
 ```
 
 In this output, you can see the mapping of internal namespace IDs to their corresponding ns-X paths.

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -41,21 +41,36 @@ public class NamespacesBean {
         } else {
             LOG.infof("This instance already has %d namespaces allocated", namespaceRepository.size());
         }
+
+        List<Namespace> publicList = namespaceRepository.findByName("public");
+        if (publicList.isEmpty()) {
+            // Register the public namespace
+            Namespace publicNs = new Namespace();
+            publicNs.setPath("public");
+            publicNs.setName("public");
+
+            namespaceRepository.persist(publicNs);
+        }
     }
 
     public Namespace alocateNamespace(String name) {
-        final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(name);
-        Namespace namespace = namespaces.getFirst();
+        List<Namespace> byName = namespaceRepository.findByName(name);
+        if (byName.isEmpty()) {
+            final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(name);
+            Namespace namespace = namespaces.getFirst();
 
-        if (namespace.getName() == null) {
-            LOG.debugf("Allocating namespace with path %s for %s", namespace.getPath(), name);
-            namespace.setName(name);
-            return namespaceRepository.persist(namespace);
-        } else {
-            LOG.debugf("Reusing namespace with path %s for %s", namespace.getPath(), name);
+            if (namespace.getName() == null) {
+                LOG.debugf("Allocating namespace with path %s for %s", namespace.getPath(), name);
+                namespace.setName(name);
+                return namespaceRepository.persist(namespace);
+            } else {
+                LOG.debugf("Reusing namespace with path %s for %s", namespace.getPath(), name);
+            }
+
+            return namespace;
         }
 
-        return namespace;
+        return byName.getFirst();
     }
 
     public List<Namespace> list() {

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -62,8 +62,10 @@ public class ToolsBean extends AbstractBean<ToolReference> {
     }
 
     private void registerTool(ToolReference toolReference) throws ToolNotFoundException {
+        //        Namespace ns = namespacesBean.
 
         if (!StringHelper.isEmpty(toolReference.getNamespace())) {
+
             final Namespace namespace = namespacesBean.alocateNamespace(toolReference.getNamespace());
 
             Tool tool = toolsResolver.resolve(toolReference);

--- a/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
+++ b/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
@@ -19,6 +19,9 @@ quarkus.mcp.server.ns-8.sse.root-path=/ns-8/mcp
 quarkus.mcp.server.ns-9.sse.root-path=/ns-9/mcp
 quarkus.mcp.server.ns-10.sse.root-path=/ns-10/mcp
 
+# Public NS
+quarkus.mcp.server.public.sse.root-path=/public/mcp
+
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:8080,http://127.0.0.1:8080,http://localhost:5173,http://localhost:6274
 


### PR DESCRIPTION
## Summary by Sourcery

Support a public namespace by auto-creating it in preload, reusing named namespaces during allocation, and exposing a public SSE root-path in configuration.

New Features:
- Add automatic registration of a default public namespace on startup

Enhancements:
- Update namespace allocation to first return existing namespaces by name before allocating new ones

Build:
- Add configuration for public namespace SSE root-path in application.properties