### PR TITLE
Initial implementation of the Wanaku operator

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,6 +66,7 @@
         <jna.version>5.17.0</jna.version>
         <commons-logging.version>1.3.5</commons-logging.version>
         <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
+        <quarkus-operator-sdk.version>7.2.2</quarkus-operator-sdk.version>
 
         <assembly.descriptor>src/main/assembly/assembly.xml</assembly.descriptor>
         <dist.final.name>${project.artifactId}-${project.version}</dist.final.name>
@@ -77,6 +78,14 @@
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-operator-sdk-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <module>api</module>
         <module>core</module>
         <module>wanaku-router</module>
+        <module>wanaku-operator</module>
         <module>cli</module>
         <module>capabilities</module>
         <module>archetypes</module>

--- a/wanaku-operator/README.md
+++ b/wanaku-operator/README.md
@@ -1,0 +1,16 @@
+# Wanaku Operator
+
+This module contains the Wanaku Operator implementation.
+
+
+### Running the operator
+
+The operator uses the [Java Operator SDK](https://javaoperatorsdk.io/). This SDK will resolve the
+Kubernetes cluster by inspecting the local configuration for the `kubectl` command. This process is
+described in more detail in the [Getting Started section of the documentation](https://javaoperatorsdk.io/docs/getting-started/#getting-started).
+
+**NOTE**: Podman Desktop can manage the Kubernetes contexts for you. You can set it using the tray icon or the Dashboard.
+
+With the Kind cluster up and running, the `kubectl` command installed and the Kubernetes context set. Then you can launch the
+operator. At this moment, the recommended way is by running the `main` method on `WanakuOperator` class
+directly via the IDE or by running `mvn quarkus:dev`.

--- a/wanaku-operator/pom.xml
+++ b/wanaku-operator/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ai.wanaku</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.9-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wanaku-operator</artifactId>
+    <name>Wanaku :: Operator</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.operatorsdk</groupId>
+            <artifactId>quarkus-operator-sdk</artifactId>
+            <version>${quarkus-operator-sdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkiverse.operatorsdk</groupId>
+            <artifactId>quarkus-operator-sdk-annotations</artifactId>
+            <version>${quarkus-operator-sdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*ManualTest.java</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*ManualTest.java</exclude>
+                            </excludes>
+                            <systemPropertyVariables>
+                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <maven.home>${maven.home}</maven.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wanaku-operator/samples/router.yaml
+++ b/wanaku-operator/samples/router.yaml
@@ -1,0 +1,26 @@
+apiVersion: "wanaku.ai/v1alpha1"
+kind: Wanaku
+metadata:
+  name: wanaku-dev
+spec:
+  auth:
+    authServer: http://keycloak-addr
+    authProxy: http://keycloak-addr
+  secrets:
+    oidcCredentialsSecret: fjgE1vkb0x5UhXj8yrecwyOmRlYR9tR6
+# Router settings are optional
+#  router:
+#    port: 8080
+#    image: quay.io/wanaku/wanaku-router-backend:latest # Optional
+  services:
+    - name: employee-system
+      image: quay.io/wanaku/camel-integration-capability:latest
+    - name: finance-system
+      image: quay.io/wanaku/camel-integration-capability:latest
+#      env:
+#        - name: ABC
+#          value: xyz
+#        - name: CONFIG_DDDE
+#          value: why
+    - name: wanaku-http
+      image: quay.io/wanaku/wanaku-tool-service-http:latest

--- a/wanaku-operator/samples/sample-deployment.yaml
+++ b/wanaku-operator/samples/sample-deployment.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1
+data:
+  AUTH_PROXY: http://wanaku-router-backend-orp-wanaku.camel-dev-eu-de-1-bx2-4x1-b0521fcfdb6f3f868b0758fbda095bbe-0000.eu-de.containers.appdomain.cloud
+  AUTH_SERVER: http://keycloak-orp-wanaku.camel-dev-eu-de-1-bx2-4x1-b0521fcfdb6f3f868b0758fbda095bbe-0000.eu-de.containers.appdomain.cloud
+  QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED: "true"
+  QUARKUS_OIDC_CREDENTIALS_SECRET: aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-config
+---
+apiVersion: v1
+data:
+  AUTH_SERVER: http://keycloak-orp-wanaku.camel-dev-eu-de-1-bx2-4x1-b0521fcfdb6f3f868b0758fbda095bbe-0000.eu-de.containers.appdomain.cloud
+  WANAKU_SERVICE_REGISTRATION_URI: http://wanaku-router-backend:8080/
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-services-config
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-service-credentials
+stringData:
+  QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: fjgE1vkb0x5UhXj8yrecwyOmRlYR9tR6
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: wanaku-router-backend
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-router-backend
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: wanaku-router-backend
+    app.kubernetes.io/part-of: wanaku
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: wanaku-tool-service-http
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-tool-service-http
+spec:
+  ports:
+  - name: 9000-tcp
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: wanaku-tool-service-http
+    app.kubernetes.io/part-of: wanaku
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: wanaku-tool-service-tavily
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-tool-service-tavily
+spec:
+  ports:
+  - name: 9000-tcp
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: wanaku-tool-service-tavily
+    app.kubernetes.io/part-of: wanaku
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: wanaku-router-backend
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-router-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wanaku-router-backend
+      app.kubernetes.io/part-of: wanaku
+  template:
+    metadata:
+      labels:
+        app: wanaku-router-backend
+        app.kubernetes.io/part-of: wanaku
+    spec:
+      containers:
+      - env:
+        - name: AUTH_SERVER
+          valueFrom:
+            configMapKeyRef:
+              key: AUTH_SERVER
+              name: wanaku-config
+        - name: AUTH_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: AUTH_PROXY
+              name: wanaku-config
+        - name: QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED
+          valueFrom:
+            configMapKeyRef:
+              key: QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED
+              name: wanaku-config
+        image: quay.io/orpiske/wanaku-router-backend:main
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /api/v1/management/info/version
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 10
+        name: wanaku-router-backend
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /api/v1/management/info/version
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /home/default/.wanaku/router
+          name: router-volume
+      volumes:
+      - emptyDir: {}
+        name: router-volume
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: wanaku-tool-service-http
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-tool-service-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wanaku-tool-service-http
+      app.kubernetes.io/part-of: wanaku
+  template:
+    metadata:
+      labels:
+        app: wanaku-tool-service-http
+        app.kubernetes.io/part-of: wanaku
+    spec:
+      containers:
+      - env:
+        - name: AUTH_SERVER
+          valueFrom:
+            configMapKeyRef:
+              key: AUTH_SERVER
+              name: wanaku-services-config
+        - name: WANAKU_SERVICE_REGISTRATION_URI
+          valueFrom:
+            configMapKeyRef:
+              key: WANAKU_SERVICE_REGISTRATION_URI
+              name: wanaku-services-config
+        - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+              name: wanaku-service-credentials
+        image: quay.io/orpiske/wanaku-tool-service-http:main
+        imagePullPolicy: Always
+        name: wanaku-tool-service-http
+        ports:
+        - containerPort: 9000
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /home/default/.wanaku/services
+          name: services-volume
+      volumes:
+      - emptyDir: {}
+        name: services-volume
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: wanaku-tool-service-tavily
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-tool-service-tavily
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wanaku-tool-service-tavily
+      app.kubernetes.io/part-of: wanaku
+  template:
+    metadata:
+      labels:
+        app: wanaku-tool-service-tavily
+        app.kubernetes.io/part-of: wanaku
+    spec:
+      containers:
+      - env:
+        - name: AUTH_SERVER
+          valueFrom:
+            configMapKeyRef:
+              key: AUTH_SERVER
+              name: wanaku-services-config
+        - name: WANAKU_SERVICE_REGISTRATION_URI
+          valueFrom:
+            configMapKeyRef:
+              key: WANAKU_SERVICE_REGISTRATION_URI
+              name: wanaku-services-config
+        - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+              name: wanaku-service-credentials
+        image: quay.io/orpiske/wanaku-tool-service-tavily:main
+        imagePullPolicy: Always
+        name: wanaku-tool-service-tavily
+        ports:
+        - containerPort: 9000
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /home/default/.wanaku/services
+          name: services-volume
+      volumes:
+      - emptyDir: {}
+        name: services-volume
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: wanaku-router-backend
+    app.kubernetes.io/part-of: wanaku
+  name: wanaku-router-backend
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: wanaku-router-backend
+    weight: 100
+  wildcardPolicy: None

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/WanakuOperator.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/WanakuOperator.java
@@ -1,0 +1,22 @@
+package ai.wanaku.operator;
+
+import io.javaoperatorsdk.operator.Operator;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.QuarkusApplication;
+import jakarta.inject.Inject;
+
+public class WanakuOperator implements QuarkusApplication {
+    @Inject
+    Operator operator;
+
+    public static void main(String... args) {
+        Quarkus.run(WanakuOperator.class, args);
+    }
+
+    @Override
+    public int run(String... args) {
+        operator.start();
+        Quarkus.waitForExit();
+        return 0;
+    }
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariables.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariables.java
@@ -1,0 +1,12 @@
+package ai.wanaku.operator.util;
+
+public final class EnvironmentVariables {
+    public static final String AUTH_SERVER = "AUTH_SERVER";
+    public static final String AUTH_PROXY = "AUTH_PROXY";
+    public static final String QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED =
+            "QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED";
+    public static final String WANAKU_SERVICE_REGISTRATION_URI = "WANAKU_SERVICE_REGISTRATION_URI";
+    public static final String QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET = "QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET";
+
+    private EnvironmentVariables() {}
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
@@ -1,0 +1,82 @@
+package ai.wanaku.operator.util;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.openshift.api.model.Route;
+
+/**
+ * Matching utilities to check if the desired resource matches the existing resource
+ */
+public final class Matchers {
+
+    private Matchers() {}
+
+    public static boolean match(Job desired, Job existing) {
+        if (existing == null) {
+            return false;
+        } else {
+            return desired.getSpec()
+                            .getTemplate()
+                            .getMetadata()
+                            .getName()
+                            .equals(existing.getSpec()
+                                    .getTemplate()
+                                    .getMetadata()
+                                    .getName())
+                    && desired.getSpec()
+                            .getTemplate()
+                            .getSpec()
+                            .getContainers()
+                            .get(0)
+                            .getImage()
+                            .equals(existing.getSpec()
+                                    .getTemplate()
+                                    .getSpec()
+                                    .getContainers()
+                                    .get(0)
+                                    .getImage());
+        }
+    }
+
+    public static boolean match(Deployment desired, Deployment existing) {
+        if (existing == null) {
+            return false;
+        } else {
+            return desired.getSpec().getReplicas().equals(existing.getSpec().getReplicas())
+                    && desired.getSpec()
+                            .getTemplate()
+                            .getSpec()
+                            .getContainers()
+                            .get(0)
+                            .getImage()
+                            .equals(existing.getSpec()
+                                    .getTemplate()
+                                    .getSpec()
+                                    .getContainers()
+                                    .get(0)
+                                    .getImage());
+        }
+    }
+
+    public static boolean match(Service desired, Service existing) {
+        if (existing == null) {
+            return false;
+        }
+
+        final ServiceSpec existingSpec = existing.getSpec();
+        final ServiceSpec desiredSpec = desired.getSpec();
+
+        return existingSpec.getExternalName().equals(desiredSpec.getExternalName())
+                && existingSpec.getPorts().equals(desiredSpec.getPorts());
+    }
+
+    public static boolean match(Route desiredRoute, Route existingRoute) {
+        if (existingRoute == null) {
+            return false;
+        }
+
+        return desiredRoute.getFullResourceName().equals(existingRoute.getFullResourceName());
+    }
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -1,0 +1,213 @@
+package ai.wanaku.operator.util;
+
+import ai.wanaku.operator.wanaku.Wanaku;
+import ai.wanaku.operator.wanaku.WanakuReconciler;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.ReconcilerUtils;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import java.util.List;
+import java.util.Map;
+import org.jboss.logging.Logger;
+
+public final class OperatorUtil {
+    private static final Logger LOG = Logger.getLogger(OperatorUtil.class);
+    public static final String ROUTER_BACKEND_DEPLOYMENT_FILE = "wanaku-router-deployment.yaml";
+    public static final String ROUTER_BACKEND_INTERNAL_SERVICE_FILE = "wanaku-router-service-internal.yaml";
+    public static final String ROUTER_BACKEND_EXTERNAL_SERVICE_FILE = "wanaku-router-service-external.yaml";
+    public static final String CAPABILITY_DEPLOYMENT_FILE = "wanaku-capability-deployment.yaml";
+    public static final String CAPABILITY_INTERNAL_SERVICE_FILE = "wanaku-capability-service-internal.yaml";
+
+    private OperatorUtil() {}
+
+    private static void setupBackendContainer(Wanaku resource, DeploymentSpec spec) {
+        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
+
+        final Container service = containers.stream()
+                .filter(c -> c.getName().equals("wanaku-mcp-router"))
+                .findFirst()
+                .get();
+
+        final String authServer = resource.getSpec().getAuth().getAuthServer();
+        final String authProxy = resource.getSpec().getAuth().getAuthProxy();
+
+        EnvVar authServerEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_SERVER)
+                .withValue(authServer)
+                .build();
+        EnvVar authProxyEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_PROXY)
+                .withValue(authProxy)
+                .build();
+
+        service.setEnv(List.of(authServerEnv, authProxyEnv));
+    }
+
+    public static Deployment makeDesiredRouterBackendDeployment(Wanaku resource, Context<Wanaku> context) {
+        Deployment desiredDeployment =
+                ReconcilerUtils.loadYaml(Deployment.class, WanakuReconciler.class, ROUTER_BACKEND_DEPLOYMENT_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        desiredDeployment.getMetadata().setName(deploymentName);
+        desiredDeployment.getMetadata().setNamespace(ns);
+
+        final DeploymentSpec serviceSpec = desiredDeployment.getSpec();
+
+        serviceSpec.getSelector().getMatchLabels().put("app", deploymentName);
+        serviceSpec.getSelector().getMatchLabels().put("component", "wanaku-router-backend");
+        serviceSpec.getTemplate().getMetadata().getLabels().put("app", deploymentName);
+        serviceSpec.getTemplate().getMetadata().getLabels().put("component", "wanaku-router-backend");
+
+        setupBackendContainer(resource, serviceSpec);
+        desiredDeployment.addOwnerReference(resource);
+        return desiredDeployment;
+    }
+
+    public static Service makeRouterInternalService(Wanaku resource) {
+        Service service =
+                ReconcilerUtils.loadYaml(Service.class, WanakuReconciler.class, ROUTER_BACKEND_INTERNAL_SERVICE_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating new external service for deployment: %s", deploymentName);
+        service.getMetadata().setName("internal-" + deploymentName);
+        service.getMetadata().setNamespace(ns);
+        service.getMetadata().getLabels().put("app", deploymentName);
+        service.getMetadata().getLabels().put("component", "wanaku-router-backend");
+        service.getSpec().getSelector().put("app", deploymentName);
+
+        ServiceSpec serviceSpec = service.getSpec();
+        serviceSpec.setSelector(Map.of("app", deploymentName, "component", "wanaku-router-backend"));
+
+        service.addOwnerReference(resource);
+
+        return service;
+    }
+
+    public static Route makeRouterExternalService(Wanaku resource) {
+        Route route =
+                ReconcilerUtils.loadYaml(Route.class, WanakuReconciler.class, ROUTER_BACKEND_EXTERNAL_SERVICE_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating new external service for deployment: %s", deploymentName);
+        route.getMetadata().setName(deploymentName);
+        route.getMetadata().setNamespace(ns);
+        route.getMetadata().getLabels().put("app", deploymentName);
+        route.getMetadata().getLabels().put("component", "wanaku-router-backend");
+        route.getSpec().getTo().setName("internal-" + deploymentName);
+
+        route.addOwnerReference(resource);
+
+        return route;
+    }
+
+    private static void setupCapabilityContainer(
+            Wanaku resource,
+            DeploymentSpec spec,
+            String serviceName,
+            String serviceImage,
+            List<ai.wanaku.operator.wanaku.WanakuSpec.EnvVar> customEnv) {
+        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
+
+        final Container service = containers.get(0);
+        service.setName(serviceName);
+        service.setImage(serviceImage);
+
+        final String authServer = resource.getSpec().getAuth().getAuthServer();
+        final String oidcSecret = resource.getSpec().getSecrets().getOidcCredentialsSecret();
+
+        // Build the registration URI - use the internal service name
+        String registrationUri = "http://internal-" + resource.getMetadata().getName() + ":8080/";
+
+        EnvVar authServerEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_SERVER)
+                .withValue(authServer)
+                .build();
+        EnvVar registrationUriEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.WANAKU_SERVICE_REGISTRATION_URI)
+                .withValue(registrationUri)
+                .build();
+        EnvVar oidcSecretEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET)
+                .withValue(oidcSecret)
+                .build();
+
+        List<EnvVar> envVars = new java.util.ArrayList<>();
+        envVars.add(authServerEnv);
+        envVars.add(registrationUriEnv);
+        envVars.add(oidcSecretEnv);
+
+        // Add custom environment variables if provided
+        if (customEnv != null && !customEnv.isEmpty()) {
+            for (ai.wanaku.operator.wanaku.WanakuSpec.EnvVar env : customEnv) {
+                EnvVar customEnvVar = new EnvVarBuilder()
+                        .withName(env.getName())
+                        .withValue(env.getValue())
+                        .build();
+                envVars.add(customEnvVar);
+            }
+        }
+
+        service.setEnv(envVars);
+    }
+
+    public static Deployment makeDesiredCapabilityDeployment(
+            Wanaku resource, Context<Wanaku> context, ai.wanaku.operator.wanaku.WanakuSpec.ServiceSpec serviceSpec) {
+        Deployment desiredDeployment =
+                ReconcilerUtils.loadYaml(Deployment.class, WanakuReconciler.class, CAPABILITY_DEPLOYMENT_FILE);
+
+        String serviceName = serviceSpec.getName();
+        String ns = resource.getMetadata().getNamespace();
+        String parentName = resource.getMetadata().getName();
+
+        desiredDeployment.getMetadata().setName(serviceName);
+        desiredDeployment.getMetadata().setNamespace(ns);
+        desiredDeployment.getMetadata().getLabels().put("app", parentName);
+        desiredDeployment.getMetadata().getLabels().put("component", serviceName);
+
+        final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
+
+        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
+        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
+
+        setupCapabilityContainer(resource, deploymentSpec, serviceName, serviceSpec.getImage(), serviceSpec.getEnv());
+        desiredDeployment.addOwnerReference(resource);
+        return desiredDeployment;
+    }
+
+    public static Service makeCapabilityInternalService(
+            Wanaku resource, ai.wanaku.operator.wanaku.WanakuSpec.ServiceSpec serviceSpec) {
+        Service service =
+                ReconcilerUtils.loadYaml(Service.class, WanakuReconciler.class, CAPABILITY_INTERNAL_SERVICE_FILE);
+
+        String serviceName = serviceSpec.getName();
+        String ns = resource.getMetadata().getNamespace();
+        String parentName = resource.getMetadata().getName();
+
+        LOG.infof("Creating internal service for capability: %s", serviceName);
+        service.getMetadata().setName(serviceName);
+        service.getMetadata().setNamespace(ns);
+        service.getMetadata().getLabels().put("app", parentName);
+        service.getMetadata().getLabels().put("component", serviceName);
+
+        ServiceSpec serviceSpec2 = service.getSpec();
+        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
+
+        service.addOwnerReference(resource);
+
+        return service;
+    }
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/Wanaku.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/Wanaku.java
@@ -1,0 +1,10 @@
+package ai.wanaku.operator.wanaku;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Version("v1alpha1")
+@Group("wanaku.ai")
+public class Wanaku extends CustomResource<WanakuSpec, WanakuStatus> implements Namespaced {}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuReconciler.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuReconciler.java
@@ -1,0 +1,161 @@
+package ai.wanaku.operator.wanaku;
+
+import static ai.wanaku.operator.util.Matchers.match;
+import static ai.wanaku.operator.util.OperatorUtil.makeCapabilityInternalService;
+import static ai.wanaku.operator.util.OperatorUtil.makeDesiredCapabilityDeployment;
+import static ai.wanaku.operator.util.OperatorUtil.makeRouterExternalService;
+import static ai.wanaku.operator.util.OperatorUtil.makeRouterInternalService;
+
+import ai.wanaku.operator.util.OperatorUtil;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Replaceable;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+public class WanakuReconciler implements Reconciler<Wanaku> {
+    private static final Logger LOG = Logger.getLogger(WanakuReconciler.class);
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Override
+    public UpdateControl<Wanaku> reconcile(Wanaku resource, Context<Wanaku> context) throws Exception {
+        LOG.infof("Starting reconciliation for %s", resource.getMetadata().getName());
+
+        final String namespace = resource.getMetadata().getNamespace();
+
+        deployRouter(resource, context, namespace);
+        deployCapabilities(resource, context, namespace);
+
+        return UpdateControl.noUpdate();
+    }
+
+    private void deployRouter(Wanaku resource, Context<Wanaku> context, String namespace) {
+        // Create the router deployment
+        final Deployment desiredDeployment = OperatorUtil.makeDesiredRouterBackendDeployment(resource, context);
+
+        Deployment existingDeployment;
+        try {
+            existingDeployment = context.getSecondaryResource(Deployment.class).orElse(null);
+        } catch (Exception e) {
+            LOG.warnf("There is no existing deployment");
+            existingDeployment = null;
+        }
+
+        if (!match(desiredDeployment, existingDeployment)) {
+            String ns = resource.getMetadata().getNamespace();
+            LOG.infof(
+                    "Creating or updating Deployment %s in %s",
+                    desiredDeployment.getMetadata().getName(), ns);
+
+            kubernetesClient
+                    .apps()
+                    .deployments()
+                    .inNamespace(ns)
+                    .resource(desiredDeployment)
+                    .createOr(Replaceable::update);
+        }
+
+        // Create the internal service (cluster IP)
+        final Service desiredExternalService = makeRouterInternalService(resource);
+        Service existingExternalService;
+        try {
+            existingExternalService =
+                    context.getSecondaryResource(Service.class).orElse(null);
+        } catch (Exception e) {
+            LOG.warnf("There is no existing service");
+            existingExternalService = null;
+        }
+        if (!match(desiredExternalService, existingExternalService)) {
+            String ns = resource.getMetadata().getNamespace();
+            LOG.infof(
+                    "Creating or updating Service %s in %s",
+                    desiredExternalService.getMetadata().getName(), ns);
+
+            kubernetesClient
+                    .services()
+                    .inNamespace(ns)
+                    .resource(desiredExternalService)
+                    .createOr(Replaceable::update);
+        }
+
+        // Create the external service (cluster IP)
+        final OpenShiftClient openShiftClient = kubernetesClient.adapt(OpenShiftClient.class);
+
+        final Route desiredRoute = makeRouterExternalService(resource);
+        Route existingRoute;
+        try {
+            existingRoute = context.getSecondaryResource(Route.class).orElse(null);
+        } catch (Exception e) {
+            LOG.warnf("There is no existing service");
+            existingRoute = null;
+        }
+        if (!match(desiredRoute, existingRoute)) {
+            String ns = resource.getMetadata().getNamespace();
+            LOG.infof(
+                    "Creating or updating Service %s in %s",
+                    desiredRoute.getMetadata().getName(), ns);
+
+            openShiftClient.routes().inNamespace(ns).resource(desiredRoute).createOr(Replaceable::update);
+        }
+    }
+
+    private void deployCapabilities(Wanaku resource, Context<Wanaku> context, String namespace) {
+        if (resource.getSpec().getServices() == null
+                || resource.getSpec().getServices().isEmpty()) {
+            LOG.infof("No capabilities to deploy for %s", resource.getMetadata().getName());
+            return;
+        }
+
+        for (WanakuSpec.ServiceSpec serviceSpec : resource.getSpec().getServices()) {
+            String serviceName = serviceSpec.getName();
+            LOG.infof("Deploying capability: %s", serviceName);
+
+            // Create the capability deployment
+            final Deployment desiredDeployment = makeDesiredCapabilityDeployment(resource, context, serviceSpec);
+
+            String deploymentName = serviceName;
+            Deployment existingDeployment = kubernetesClient
+                    .apps()
+                    .deployments()
+                    .inNamespace(namespace)
+                    .withName(deploymentName)
+                    .get();
+
+            if (!match(desiredDeployment, existingDeployment)) {
+                LOG.infof("Creating or updating Deployment %s in %s", deploymentName, namespace);
+                kubernetesClient
+                        .apps()
+                        .deployments()
+                        .inNamespace(namespace)
+                        .resource(desiredDeployment)
+                        .createOr(Replaceable::update);
+            }
+
+            // Create the internal service for the capability
+            final Service desiredService = makeCapabilityInternalService(resource, serviceSpec);
+
+            Service existingService = kubernetesClient
+                    .services()
+                    .inNamespace(namespace)
+                    .withName(serviceName)
+                    .get();
+
+            if (!match(desiredService, existingService)) {
+                LOG.infof("Creating or updating Service %s in %s", serviceName, namespace);
+                kubernetesClient
+                        .services()
+                        .inNamespace(namespace)
+                        .resource(desiredService)
+                        .createOr(Replaceable::update);
+            }
+        }
+    }
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuSpec.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuSpec.java
@@ -1,0 +1,147 @@
+package ai.wanaku.operator.wanaku;
+
+import java.util.List;
+
+public class WanakuSpec {
+    private AuthSpec auth;
+    private SecretsSpec secrets;
+    private RouterSpec router;
+    private List<ServiceSpec> services;
+
+    public AuthSpec getAuth() {
+        return auth;
+    }
+
+    public void setAuth(AuthSpec auth) {
+        this.auth = auth;
+    }
+
+    public SecretsSpec getSecrets() {
+        return secrets;
+    }
+
+    public void setSecrets(SecretsSpec secrets) {
+        this.secrets = secrets;
+    }
+
+    public RouterSpec getRouter() {
+        return router;
+    }
+
+    public void setRouter(RouterSpec router) {
+        this.router = router;
+    }
+
+    public List<ServiceSpec> getServices() {
+        return services;
+    }
+
+    public void setServices(List<ServiceSpec> services) {
+        this.services = services;
+    }
+
+    public static class AuthSpec {
+        private String authServer;
+        private String authProxy;
+
+        public String getAuthServer() {
+            return authServer;
+        }
+
+        public void setAuthServer(String authServer) {
+            this.authServer = authServer;
+        }
+
+        public String getAuthProxy() {
+            return authProxy;
+        }
+
+        public void setAuthProxy(String authProxy) {
+            this.authProxy = authProxy;
+        }
+    }
+
+    public static class SecretsSpec {
+        private String oidcCredentialsSecret;
+
+        public String getOidcCredentialsSecret() {
+            return oidcCredentialsSecret;
+        }
+
+        public void setOidcCredentialsSecret(String oidcCredentialsSecret) {
+            this.oidcCredentialsSecret = oidcCredentialsSecret;
+        }
+    }
+
+    public static class RouterSpec {
+        private Integer port;
+        private String image;
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
+        }
+
+        public String getImage() {
+            return image;
+        }
+
+        public void setImage(String image) {
+            this.image = image;
+        }
+    }
+
+    public static class ServiceSpec {
+        private String name;
+        private String image;
+        private List<EnvVar> env;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getImage() {
+            return image;
+        }
+
+        public void setImage(String image) {
+            this.image = image;
+        }
+
+        public List<EnvVar> getEnv() {
+            return env;
+        }
+
+        public void setEnv(List<EnvVar> env) {
+            this.env = env;
+        }
+    }
+
+    public static class EnvVar {
+        private String name;
+        private String value;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuStatus.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuStatus.java
@@ -1,0 +1,3 @@
+package ai.wanaku.operator.wanaku;
+
+public class WanakuStatus {}

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ""
+  name: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ""
+  template:
+    metadata:
+      labels:
+        app: ""
+    spec:
+      containers:
+        - env:
+            - name: AUTH_SERVER
+              value: ""
+            - name: WANAKU_SERVICE_REGISTRATION_URI
+              # Comes from Wanaku route
+              value: ""
+            - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+              value: ""
+          image: ""
+          imagePullPolicy: Always
+          name: wanaku-tool-service-http
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /home/default/.wanaku/services
+              name: services-volume
+      volumes:
+        - emptyDir: {}
+          name: services-volume

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-service-internal.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-service-internal.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ""
+  name: ""
+spec:
+  ports:
+    - name: 9000-tcp
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app: ""
+  sessionAffinity: None
+  type: ClusterIP

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ""
+      component: ""
+  template:
+    metadata:
+      labels:
+        app: ""
+    spec:
+      containers:
+        - name: "wanaku-mcp-router"
+          image: quay.io/wanaku/wanaku-router-backend:0.0.8
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: AUTH_SERVER
+              value: ""
+            - name: AUTH_PROXY
+              value: ""
+            - name: QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED
+              value: "true"
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /api/v1/management/info/version
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 10
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/v1/management/info/version
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /home/default/.wanaku/router
+              name: router-volume
+      volumes:
+        - emptyDir: {}
+          name: router-volume

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-service-external.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-service-external.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: ""
+  name: ""
+spec:
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: ""
+  wildcardPolicy: None

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-service-internal.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-service-internal.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ""
+    component: ""
+  name: ""
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: ""
+  sessionAffinity: None
+  type: ClusterIP

--- a/wanaku-operator/src/main/resources/application.properties
+++ b/wanaku-operator/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Wanaku Operator Configuration
+
+# HTTP Configuration
+quarkus.http.port=8081
+
+# Logging Configuration
+quarkus.log.console.enable=true
+quarkus.log.console.level=INFO
+quarkus.log.category."ai.wanaku".level=DEBUG
+
+quarkus.operator-sdk.crd.apply=true


### PR DESCRIPTION
Brings an initial implementation of an operator capable of deploying Wanaku on OpenShift

This solves issue #28

## Summary by Sourcery

Introduce an initial implementation of the Wanaku Operator using Quarkus Operator SDK, including CRD definitions, reconciliation logic for router and capability deployments, resource templates, and sample configurations.

New Features:
- Add wanaku-operator Maven module with initial Quarkus Operator SDK setup
- Define Wanaku CustomResource and spec/status classes for the CRD
- Implement WanakuReconciler to manage router and service capabilities as Deployments, Services, and OpenShift Routes
- Provide OperatorUtil and Matchers utilities for loading templates and comparing resources
- Include Kubernetes/OpenShift YAML templates and sample manifests for operator-driven deployments

Build:
- Import quarkus-operator-sdk BOM and add its dependency in the parent POM
- Register wanaku-operator module in the project’s parent POM

Documentation:
- Add README with instructions for running the Wanaku operator