### PR TITLE
Use Smallrye Health for liveness/readiness probes

### DIFF
--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           livenessProbe:
             failureThreshold: 5
             httpGet:
-              path: /api/v1/management/info/version
+              path: /q/health/live
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 20
@@ -37,7 +37,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /api/v1/management/info/version
+              path: /q/health/ready
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -71,6 +71,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary by Sourcery

Switch Kubernetes liveness and readiness probes to Smallrye Health endpoints and include the corresponding health dependency in the backend pom.

Enhancements:
- Switch Kubernetes liveness probe path to /q/health/live and readiness probe path to /q/health/ready using Smallrye Health

Build:
- Add quarkus-smallrye-health dependency to the backend pom.xml