### PR TITLE
Add support for authentication in the CLI

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -96,6 +96,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-security</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>

--- a/cli/src/main/java/ai/wanaku/cli/main/CliMain.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/CliMain.java
@@ -1,6 +1,7 @@
 package ai.wanaku.cli.main;
 
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.commands.auth.Auth;
 import ai.wanaku.cli.main.commands.capabilities.Capabilities;
 import ai.wanaku.cli.main.commands.completion.Completion;
 import ai.wanaku.cli.main.commands.datastores.DataStores;
@@ -24,6 +25,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "wanaku",
         subcommands = {
+            Auth.class,
             Forwards.class,
             Resources.class,
             Prompts.class,

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/Auth.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/Auth.java
@@ -1,0 +1,19 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "auth",
+        description = "Authentication management commands",
+        subcommands = {AuthLogin.class, AuthLogout.class, AuthStatus.class, AuthToken.class})
+public class Auth extends BaseCommand {
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        CommandLine.usage(this, System.out);
+        return EXIT_ERROR;
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -1,0 +1,103 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.security.auth.OidcTokenException;
+import ai.wanaku.core.security.auth.OidcTokenService;
+import ai.wanaku.core.security.auth.TokenResponse;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "login", description = "Interactive authentication login")
+public class AuthLogin extends BaseCommand {
+
+    private static final String DEFAULT_AUTH_SERVER = "http://localhost:8543";
+    private static final String DEFAULT_REALM = "wanaku";
+    private static final String DEFAULT_CLIENT_ID = "admin-cli";
+    private static final String DEFAULT_AUTH_MODE = "token";
+
+    @CommandLine.Option(
+            names = {"--api-token"},
+            description = "API token for authentication")
+    private String apiToken;
+
+    @CommandLine.Option(
+            names = {"--auth-server"},
+            description = "Authentication server URL")
+    private String authServerUrl;
+
+    @CommandLine.Option(
+            names = {"--username"},
+            description = "Username for authentication")
+    private String username;
+
+    @CommandLine.Option(
+            names = {"--password"},
+            description = "Password for authentication",
+            interactive = true)
+    private String password;
+
+    @CommandLine.Option(
+            names = {"--realm"},
+            description = "Authentication realm",
+            defaultValue = DEFAULT_REALM)
+    private String realm;
+
+    @CommandLine.Option(
+            names = {"--client-id"},
+            description = "OAuth2 client ID",
+            defaultValue = DEFAULT_CLIENT_ID)
+    private String clientId;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        AuthCredentialStore credentialStore = new AuthCredentialStore();
+
+        // Handle direct API token authentication
+        if (apiToken != null) {
+            credentialStore.storeApiToken(apiToken);
+            credentialStore.storeAuthMode(DEFAULT_AUTH_MODE);
+
+            if (authServerUrl != null) {
+                credentialStore.storeAuthServerUrl(authServerUrl);
+            }
+
+            printer.printSuccessMessage("Successfully stored authentication credentials");
+            return EXIT_OK;
+        }
+
+        // Handle username/password authentication
+        if (username != null && password != null) {
+            String serverUrl = authServerUrl != null ? authServerUrl : DEFAULT_AUTH_SERVER;
+
+            try {
+                printer.printInfoMessage("Authenticating with username and password...");
+                OidcTokenService tokenService = new OidcTokenService();
+                TokenResponse tokenResponse =
+                        tokenService.retrieveToken(serverUrl, realm, clientId, username, password);
+
+                credentialStore.storeApiToken(tokenResponse.getAccessToken());
+                if (tokenResponse.getRefreshToken() != null) {
+                    credentialStore.storeRefreshToken(tokenResponse.getRefreshToken());
+                }
+                credentialStore.storeAuthMode("token");
+                credentialStore.storeAuthServerUrl(serverUrl);
+
+                printer.printSuccessMessage("Successfully authenticated and stored credentials");
+                return EXIT_OK;
+            } catch (OidcTokenException e) {
+                printer.printErrorMessage("Authentication failed: " + e.getMessage());
+                return EXIT_ERROR;
+            }
+        }
+
+        // Interactive mode - show help
+        printer.printInfoMessage("Interactive login mode");
+        printer.printInfoMessage("To login with an API token, use: wanaku auth login --api-token <your-token>");
+        printer.printInfoMessage(
+                "To login with username/password, use: wanaku auth login --username <user> --password <pass>");
+
+        return EXIT_OK;
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogout.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogout.java
@@ -1,0 +1,35 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "logout", description = "Clear stored authentication credentials")
+public class AuthLogout extends BaseCommand {
+
+    private AuthCredentialStore credentialStore;
+
+    public AuthLogout() {
+        this(new AuthCredentialStore());
+    }
+
+    public AuthLogout(AuthCredentialStore credentialStore) {
+        this.credentialStore = credentialStore;
+    }
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+
+        if (!credentialStore.hasCredentials()) {
+            printer.printInfoMessage("No authentication credentials found");
+            return EXIT_OK;
+        }
+
+        credentialStore.clearCredentials();
+        printer.printSuccessMessage("Successfully cleared authentication credentials");
+
+        return EXIT_OK;
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthStatus.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthStatus.java
@@ -1,0 +1,63 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "status", description = "Show current authentication status")
+public class AuthStatus extends BaseCommand {
+
+    private AuthCredentialStore credentialStore;
+
+    public AuthStatus() {
+        this(new AuthCredentialStore());
+    }
+
+    public AuthStatus(AuthCredentialStore credentialStore) {
+        this.credentialStore = credentialStore;
+    }
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+
+        printer.printInfoMessage("Authentication Status:");
+        printer.printInfoMessage("=====================");
+
+        String authMode = credentialStore.getAuthMode();
+        printer.printInfoMessage("Mode: " + authMode);
+
+        String apiToken = credentialStore.getApiToken();
+        if (apiToken != null) {
+            String maskedToken = maskToken(apiToken);
+            printer.printInfoMessage("API Token: " + maskedToken);
+        } else {
+            printer.printInfoMessage("API Token: Not set");
+        }
+
+        String authServerUrl = credentialStore.getAuthServerUrl();
+        if (authServerUrl != null) {
+            printer.printInfoMessage("Auth Server: " + authServerUrl);
+        }
+
+        String refreshToken = credentialStore.getRefreshToken();
+        if (refreshToken != null) {
+            String maskedRefreshToken = maskToken(refreshToken);
+            printer.printInfoMessage("Refresh Token: " + maskedRefreshToken);
+        }
+
+        printer.printInfoMessage(
+                "Credentials File: " + credentialStore.getCredentialsFile().getPath());
+        printer.printInfoMessage("Has Credentials: " + credentialStore.hasCredentials());
+
+        return EXIT_OK;
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() <= 8) {
+            return "***";
+        }
+        return token.substring(0, 4) + "***" + token.substring(token.length() - 4);
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -1,0 +1,70 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "token", description = "Manage API tokens")
+public class AuthToken extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--set"},
+            description = "Set the API token")
+    private String setToken;
+
+    @CommandLine.Option(
+            names = {"--get"},
+            description = "Get the current API token (masked)")
+    private boolean getToken;
+
+    @CommandLine.Option(
+            names = {"--clear"},
+            description = "Clear the API token")
+    private boolean clearToken;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        AuthCredentialStore credentialStore = new AuthCredentialStore();
+
+        if (setToken != null) {
+            credentialStore.storeApiToken(setToken);
+            credentialStore.storeAuthMode("token");
+            printer.printSuccessMessage("API token has been set");
+            return EXIT_OK;
+        }
+
+        if (getToken) {
+            String apiToken = credentialStore.getApiToken();
+            if (apiToken != null) {
+                String maskedToken = maskToken(apiToken);
+                printer.printInfoMessage("Current API token: " + maskedToken);
+            } else {
+                printer.printInfoMessage("No API token is currently set");
+            }
+            return EXIT_OK;
+        }
+
+        if (clearToken) {
+            String currentToken = credentialStore.getApiToken();
+            if (currentToken != null) {
+                credentialStore.storeApiToken("");
+                printer.printSuccessMessage("API token has been cleared");
+            } else {
+                printer.printInfoMessage("No API token was set");
+            }
+            return EXIT_OK;
+        }
+
+        CommandLine.usage(this, System.out);
+        return EXIT_ERROR;
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() <= 8) {
+            return "***";
+        }
+        return token.substring(0, 4) + "***" + token.substring(token.length() - 4);
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -1,0 +1,192 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+/**
+ * A credential store specifically designed for CLI authentication.
+ * Handles secure storage and retrieval of authentication credentials
+ * such as API tokens, refresh tokens, and authentication configuration.
+ */
+public class AuthCredentialStore {
+
+    private static final String DEFAULT_CREDENTIALS_FILE = "~/.wanaku/credentials";
+    private static final String API_TOKEN_KEY = "api.token";
+    private static final String REFRESH_TOKEN_KEY = "refresh.token";
+    private static final String AUTH_MODE_KEY = "auth.mode";
+    private static final String AUTH_SERVER_URL_KEY = "auth.server.url";
+
+    private final URI credentialsUri;
+
+    public AuthCredentialStore() {
+        this(resolveCredentialsPath(DEFAULT_CREDENTIALS_FILE));
+    }
+
+    public AuthCredentialStore(String credentialsPath) {
+        this(resolveCredentialsPath(credentialsPath));
+    }
+
+    public AuthCredentialStore(URI credentialsUri) {
+        this.credentialsUri = credentialsUri;
+        ensureCredentialsDirectoryExists();
+    }
+
+    private String get(String name) {
+        Properties props = loadProperties();
+        return props.getProperty(name);
+    }
+
+    /**
+     * Stores an API token for authentication.
+     *
+     * @param token the API token to store
+     */
+    public void storeApiToken(String token) {
+        storeCredential(API_TOKEN_KEY, token);
+    }
+
+    /**
+     * Retrieves the stored API token.
+     *
+     * @return the API token, or null if not found
+     */
+    public String getApiToken() {
+        return get(API_TOKEN_KEY);
+    }
+
+    /**
+     * Stores a refresh token for token renewal.
+     *
+     * @param refreshToken the refresh token to store
+     */
+    public void storeRefreshToken(String refreshToken) {
+        storeCredential(REFRESH_TOKEN_KEY, refreshToken);
+    }
+
+    /**
+     * Retrieves the stored refresh token.
+     *
+     * @return the refresh token, or null if not found
+     */
+    public String getRefreshToken() {
+        return get(REFRESH_TOKEN_KEY);
+    }
+
+    /**
+     * Stores the authentication mode.
+     *
+     * @param authMode the authentication mode (e.g., "token", "oauth2")
+     */
+    public void storeAuthMode(String authMode) {
+        storeCredential(AUTH_MODE_KEY, authMode);
+    }
+
+    /**
+     * Retrieves the authentication mode.
+     *
+     * @return the authentication mode, or "none" if not found
+     */
+    public String getAuthMode() {
+        String mode = get(AUTH_MODE_KEY);
+        return mode != null ? mode : "none";
+    }
+
+    /**
+     * Stores the authentication server URL.
+     *
+     * @param serverUrl the authentication server URL
+     */
+    public void storeAuthServerUrl(String serverUrl) {
+        storeCredential(AUTH_SERVER_URL_KEY, serverUrl);
+    }
+
+    /**
+     * Retrieves the authentication server URL.
+     *
+     * @return the authentication server URL, or null if not found
+     */
+    public String getAuthServerUrl() {
+        return get(AUTH_SERVER_URL_KEY);
+    }
+
+    /**
+     * Clears all stored credentials.
+     */
+    public void clearCredentials() {
+        try {
+            Path credentialsPath = Paths.get(getCredentialsFile().getPath());
+            if (Files.exists(credentialsPath)) {
+                Files.delete(credentialsPath);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to clear credentials", e);
+        }
+    }
+
+    /**
+     * Checks if any credentials are stored.
+     *
+     * @return true if credentials exist, false otherwise
+     */
+    public boolean hasCredentials() {
+        return getApiToken() != null || getRefreshToken() != null;
+    }
+
+    /**
+     * Gets the credentials file URI.
+     *
+     * @return the URI of the credentials file
+     */
+    public URI getCredentialsFile() {
+        return credentialsUri;
+    }
+
+    private Properties loadProperties() {
+        Properties props = new Properties();
+        try {
+            Path credentialsPath = Paths.get(getCredentialsFile().getPath());
+            if (Files.exists(credentialsPath)) {
+                props.load(Files.newInputStream(credentialsPath));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load credentials", e);
+        }
+        return props;
+    }
+
+    private void storeCredential(String key, String value) {
+        try {
+            Path credentialsPath = Paths.get(getCredentialsFile().getPath());
+            Properties props = loadProperties();
+
+            props.setProperty(key, value);
+            props.store(Files.newOutputStream(credentialsPath), "Wanaku CLI Authentication Credentials");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store credential: " + key, e);
+        }
+    }
+
+    private void ensureCredentialsDirectoryExists() {
+        try {
+            Path credentialsPath = Paths.get(getCredentialsFile().getPath());
+            Path parentDir = credentialsPath.getParent();
+            if (parentDir != null && !Files.exists(parentDir)) {
+                Files.createDirectories(parentDir);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create credentials directory", e);
+        }
+    }
+
+    private static URI resolveCredentialsPath(String credentialsPath) {
+        String resolvedPath = credentialsPath;
+        if (resolvedPath.startsWith("~/")) {
+            resolvedPath = System.getProperty("user.home") + resolvedPath.substring(1);
+        }
+        return Paths.get(resolvedPath).toUri();
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -1,0 +1,37 @@
+package ai.wanaku.cli.main.support;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+/**
+ * A JAX-RS client request filter that automatically adds authentication headers
+ * to outgoing requests based on stored credentials.
+ */
+public class AuthenticationInterceptor implements ClientRequestFilter {
+
+    private final AuthCredentialStore credentialStore;
+
+    public AuthenticationInterceptor() {
+        this.credentialStore = new AuthCredentialStore();
+    }
+
+    public AuthenticationInterceptor(AuthCredentialStore credentialStore) {
+        this.credentialStore = credentialStore;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String authMode = credentialStore.getAuthMode();
+
+        if ("none".equals(authMode) || !credentialStore.hasCredentials()) {
+            return;
+        }
+
+        String apiToken = credentialStore.getApiToken();
+        if (apiToken != null && !apiToken.trim().isEmpty()) {
+            requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + apiToken);
+        }
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -21,11 +21,24 @@ public interface WanakuCliConfig extends WanakuConfig {
         String createCmd();
     }
 
+    interface Auth {
+        @WithDefault("none")
+        String mode();
+
+        @WithDefault("~/.wanaku/credentials")
+        String credentialsFile();
+
+        @WithDefault("false")
+        boolean enabled();
+    }
+
     Tool tool();
 
     Resource resource();
 
     Mcp mcp();
+
+    Auth auth();
 
     @WithDefault("early-access")
     String earlyAccessTag();

--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -10,6 +10,11 @@ wanaku.cli.components.service-http=https://github.com/wanaku-ai/wanaku/releases/
 wanaku.cli.components.service-tavily=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-tavily-%s.zip
 wanaku.cli.default-services=provider-file,service-http
 
+# Authentication Configuration
+wanaku.cli.auth.enabled=false
+wanaku.cli.auth.mode=none
+wanaku.cli.auth.credentials-file=~/.wanaku/credentials
+
 # If needed
 # wanaku.cli.initial-grpc-port=9000
 #quarkus.native.resources.includes=nano/**

--- a/cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
@@ -1,0 +1,73 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import static ai.wanaku.cli.main.commands.BaseCommand.EXIT_OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import java.nio.file.Path;
+import org.jline.terminal.Terminal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AuthCommandsTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private Terminal terminal;
+
+    @Mock
+    private WanakuPrinter printer;
+
+    private Path credentialsFile;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        credentialsFile = tempDir.resolve("test-credentials");
+    }
+
+    @Test
+    void authLogoutShouldClearCredentials() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        store.storeApiToken("test-token");
+
+        AuthLogout authLogout = new AuthLogout(store);
+        int result = authLogout.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer).printSuccessMessage("Successfully cleared authentication credentials");
+    }
+
+    @Test
+    void authLogoutShouldHandleNoCredentials() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        AuthLogout authLogout = new AuthLogout(store);
+        int result = authLogout.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer).printInfoMessage("No authentication credentials found");
+    }
+
+    @Test
+    void authStatusShouldDisplayStatus() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        store.storeApiToken("test-token-123456789");
+        store.storeAuthMode("token");
+
+        AuthStatus authStatus = new AuthStatus(store);
+        int result = authStatus.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer).printInfoMessage("Authentication Status:");
+        verify(printer).printInfoMessage("Mode: token");
+        verify(printer).printInfoMessage(contains("API Token: test***6789"));
+        verify(printer).printInfoMessage("Has Credentials: true");
+    }
+}

--- a/cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
@@ -1,0 +1,122 @@
+package ai.wanaku.cli.main.support;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AuthCredentialStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private AuthCredentialStore credentialStore;
+
+    @BeforeEach
+    void setUp() {
+        Path credentialsFile = tempDir.resolve("test-credentials");
+        URI credentialsUri = credentialsFile.toUri();
+        credentialStore = new AuthCredentialStore(credentialsUri);
+    }
+
+    @Test
+    void shouldStoreAndRetrieveApiToken() {
+        String token = "test-api-token-12345";
+
+        credentialStore.storeApiToken(token);
+        String retrievedToken = credentialStore.getApiToken();
+
+        assertEquals(token, retrievedToken);
+    }
+
+    @Test
+    void shouldStoreAndRetrieveRefreshToken() {
+        String refreshToken = "test-refresh-token-67890";
+
+        credentialStore.storeRefreshToken(refreshToken);
+        String retrievedToken = credentialStore.getRefreshToken();
+
+        assertEquals(refreshToken, retrievedToken);
+    }
+
+    @Test
+    void shouldStoreAndRetrieveAuthMode() {
+        String authMode = "oauth2";
+
+        credentialStore.storeAuthMode(authMode);
+        String retrievedMode = credentialStore.getAuthMode();
+
+        assertEquals(authMode, retrievedMode);
+    }
+
+    @Test
+    void shouldReturnDefaultAuthModeWhenNotSet() {
+        String authMode = credentialStore.getAuthMode();
+        assertEquals("none", authMode);
+    }
+
+    @Test
+    void shouldStoreAndRetrieveAuthServerUrl() {
+        String serverUrl = "https://auth.example.com";
+
+        credentialStore.storeAuthServerUrl(serverUrl);
+        String retrievedUrl = credentialStore.getAuthServerUrl();
+
+        assertEquals(serverUrl, retrievedUrl);
+    }
+
+    @Test
+    void shouldReturnTrueWhenCredentialsExist() {
+        assertFalse(credentialStore.hasCredentials());
+
+        credentialStore.storeApiToken("test-token");
+        assertTrue(credentialStore.hasCredentials());
+    }
+
+    @Test
+    void shouldReturnTrueWhenRefreshTokenExists() {
+        assertFalse(credentialStore.hasCredentials());
+
+        credentialStore.storeRefreshToken("test-refresh-token");
+        assertTrue(credentialStore.hasCredentials());
+    }
+
+    @Test
+    void shouldClearAllCredentials() {
+        credentialStore.storeApiToken("test-token");
+        credentialStore.storeRefreshToken("test-refresh");
+        credentialStore.storeAuthMode("oauth2");
+        credentialStore.storeAuthServerUrl("https://auth.example.com");
+
+        assertTrue(credentialStore.hasCredentials());
+
+        credentialStore.clearCredentials();
+
+        assertFalse(credentialStore.hasCredentials());
+        assertNull(credentialStore.getApiToken());
+        assertNull(credentialStore.getRefreshToken());
+        assertEquals("none", credentialStore.getAuthMode());
+        assertNull(credentialStore.getAuthServerUrl());
+    }
+
+    @Test
+    void shouldReturnCorrectCredentialsFileUri() {
+        URI credentialsUri = credentialStore.getCredentialsFile();
+        assertNotNull(credentialsUri);
+        assertTrue(credentialsUri.getPath().endsWith("test-credentials"));
+    }
+
+    @Test
+    void shouldPersistCredentialsAcrossInstances() {
+        String token = "persistent-token";
+        URI credentialsUri = credentialStore.getCredentialsFile();
+
+        credentialStore.storeApiToken(token);
+
+        AuthCredentialStore newStore = new AuthCredentialStore(credentialsUri);
+        assertEquals(token, newStore.getApiToken());
+    }
+}

--- a/cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
@@ -1,0 +1,99 @@
+package ai.wanaku.cli.main.support;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AuthenticationInterceptorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private ClientRequestContext requestContext;
+
+    private MultivaluedMap<String, Object> headers;
+    private AuthCredentialStore credentialStore;
+    private AuthenticationInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        headers = new MultivaluedHashMap<>();
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        Path credentialsFile = tempDir.resolve("test-credentials");
+        URI credentialsUri = credentialsFile.toUri();
+        credentialStore = new AuthCredentialStore(credentialsUri);
+        interceptor = new AuthenticationInterceptor(credentialStore);
+    }
+
+    @Test
+    void shouldAddAuthorizationHeaderWhenTokenExists() throws Exception {
+        String token = "test-api-token";
+        credentialStore.storeApiToken(token);
+        credentialStore.storeAuthMode("token");
+
+        interceptor.filter(requestContext);
+
+        verify(requestContext).getHeaders();
+        assertEquals("Bearer " + token, headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldNotAddHeaderWhenAuthModeIsNone() throws Exception {
+        credentialStore.storeApiToken("test-token");
+        credentialStore.storeAuthMode("none");
+
+        interceptor.filter(requestContext);
+
+        assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldNotAddHeaderWhenNoCredentialsExist() throws Exception {
+        interceptor.filter(requestContext);
+
+        assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldNotAddHeaderWhenTokenIsEmpty() throws Exception {
+        credentialStore.storeApiToken("");
+        credentialStore.storeAuthMode("token");
+
+        interceptor.filter(requestContext);
+
+        assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldNotAddHeaderWhenTokenIsWhitespace() throws Exception {
+        credentialStore.storeApiToken("   ");
+        credentialStore.storeAuthMode("token");
+
+        interceptor.filter(requestContext);
+
+        assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldWorkWithDefaultConstructor() throws Exception {
+        AuthenticationInterceptor defaultInterceptor = new AuthenticationInterceptor();
+
+        defaultInterceptor.filter(requestContext);
+
+        assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+}

--- a/core/core-security/pom.xml
+++ b/core/core-security/pom.xml
@@ -37,6 +37,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/core-security/src/main/java/ai/wanaku/core/security/auth/OidcTokenException.java
+++ b/core/core-security/src/main/java/ai/wanaku/core/security/auth/OidcTokenException.java
@@ -1,0 +1,15 @@
+package ai.wanaku.core.security.auth;
+
+/**
+ * Exception thrown when OIDC token operations fail.
+ */
+public class OidcTokenException extends Exception {
+
+    public OidcTokenException(String message) {
+        super(message);
+    }
+
+    public OidcTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/core-security/src/main/java/ai/wanaku/core/security/auth/OidcTokenService.java
+++ b/core/core-security/src/main/java/ai/wanaku/core/security/auth/OidcTokenService.java
@@ -1,0 +1,152 @@
+package ai.wanaku.core.security.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Service for retrieving OAuth2/OIDC tokens from an authentication server.
+ * Supports password grant type authentication.
+ */
+public class OidcTokenService {
+
+    private static final String TOKEN_ENDPOINT_PATH = "/realms/%s/protocol/openid-connect/token";
+    private static final String GRANT_TYPE_PASSWORD = "password";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OidcTokenService() {
+        this.httpClient = HttpClient.newHttpClient();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public OidcTokenService(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Retrieves an access token using the password grant type.
+     *
+     * @param serverUrl the authentication server URL (e.g., "http://localhost:8543")
+     * @param realm the authentication realm
+     * @param clientId the OAuth2 client ID
+     * @param username the username
+     * @param password the password
+     * @return the token response containing access token and optionally refresh token
+     * @throws OidcTokenException if token retrieval fails
+     */
+    public TokenResponse retrieveToken(
+            String serverUrl, String realm, String clientId, String username, String password)
+            throws OidcTokenException {
+        try {
+            String tokenUrl = buildTokenUrl(serverUrl, realm);
+            String formData = buildPasswordGrantFormData(clientId, username, password);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(tokenUrl))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(formData))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new OidcTokenException("Failed to retrieve token. Status: " + response.statusCode()
+                        + ", Response: " + response.body());
+            }
+
+            return parseTokenResponse(response.body());
+        } catch (OidcTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OidcTokenException("Failed to retrieve token: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Refreshes an access token using a refresh token.
+     *
+     * @param serverUrl the authentication server URL
+     * @param realm the authentication realm
+     * @param clientId the OAuth2 client ID
+     * @param refreshToken the refresh token
+     * @return the token response with new access token
+     * @throws OidcTokenException if token refresh fails
+     */
+    public TokenResponse refreshToken(String serverUrl, String realm, String clientId, String refreshToken)
+            throws OidcTokenException {
+        try {
+            String tokenUrl = buildTokenUrl(serverUrl, realm);
+
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put("client_id", clientId);
+            parameters.put("grant_type", "refresh_token");
+            parameters.put("refresh_token", refreshToken);
+
+            String formData = encodeFormData(parameters);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(tokenUrl))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(formData))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new OidcTokenException(
+                        "Failed to refresh token. Status: " + response.statusCode() + ", Response: " + response.body());
+            }
+
+            return parseTokenResponse(response.body());
+        } catch (OidcTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OidcTokenException("Failed to refresh token: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildTokenUrl(String serverUrl, String realm) {
+        return String.format(serverUrl + TOKEN_ENDPOINT_PATH, realm);
+    }
+
+    private String buildPasswordGrantFormData(String clientId, String username, String password) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("client_id", clientId);
+        parameters.put("username", username);
+        parameters.put("password", password);
+        parameters.put("grant_type", GRANT_TYPE_PASSWORD);
+
+        return encodeFormData(parameters);
+    }
+
+    private String encodeFormData(Map<String, String> parameters) {
+        return parameters.entrySet().stream()
+                .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8) + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+    }
+
+    private TokenResponse parseTokenResponse(String responseBody) throws Exception {
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        String accessToken = jsonNode.get("access_token").asText();
+        String refreshToken =
+                jsonNode.has("refresh_token") ? jsonNode.get("refresh_token").asText() : null;
+        Long expiresIn = jsonNode.has("expires_in") ? jsonNode.get("expires_in").asLong() : null;
+        String tokenType =
+                jsonNode.has("token_type") ? jsonNode.get("token_type").asText() : "Bearer";
+
+        return new TokenResponse(accessToken, refreshToken, expiresIn, tokenType);
+    }
+}

--- a/core/core-security/src/main/java/ai/wanaku/core/security/auth/TokenResponse.java
+++ b/core/core-security/src/main/java/ai/wanaku/core/security/auth/TokenResponse.java
@@ -1,0 +1,54 @@
+package ai.wanaku.core.security.auth;
+
+/**
+ * Represents an OAuth2/OIDC token response containing access and refresh tokens.
+ */
+public class TokenResponse {
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long expiresIn;
+    private final String tokenType;
+
+    public TokenResponse(String accessToken, String refreshToken, Long expiresIn, String tokenType) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiresIn = expiresIn;
+        this.tokenType = tokenType;
+    }
+
+    /**
+     * Gets the access token.
+     *
+     * @return the access token
+     */
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Gets the refresh token.
+     *
+     * @return the refresh token, or null if not provided
+     */
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * Gets the token expiration time in seconds.
+     *
+     * @return expiration time in seconds, or null if not provided
+     */
+    public Long getExpiresIn() {
+        return expiresIn;
+    }
+
+    /**
+     * Gets the token type (e.g., "Bearer").
+     *
+     * @return the token type
+     */
+    public String getTokenType() {
+        return tokenType;
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -193,6 +193,213 @@ executing `wanaku`.
 > It requires access to the internet, in case of using a proxy, please ensure that the proxy is configured for your system.
 > If Wanaku JBang is not working with your current configuration, please look to [Proxy configuration in JBang documentation](https://www.jbang.dev/documentation/jbang/latest/configuration.html#proxy-configuration).
 
+## CLI Authentication
+
+The Wanaku CLI supports authentication to securely interact with the Wanaku MCP Router API. Authentication credentials are stored locally and automatically included in API requests.
+
+### Authentication Modes
+
+The CLI currently supports the following authentication modes:
+
+- **token** (default): Use an API token for authentication via Bearer token
+
+### Authentication Commands
+
+#### Login
+
+Store authentication credentials for use with subsequent CLI commands:
+
+```shell
+wanaku auth login --api-token <your-api-token>
+```
+
+**Options:**
+- `--api-token <token>`: API token for authentication (required)
+- `--auth-server <url>`: Authentication server URL (optional)
+- `--mode <mode>`: Authentication mode - `token` or `oauth2` (default: `token`)
+
+**Example:**
+```shell
+wanaku auth login --api-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+With custom authentication server:
+```shell
+wanaku auth login \
+  --api-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... \
+  --auth-server https://keycloak.example.com \
+  --mode token
+```
+
+#### Status
+
+Check the current authentication status and view stored credentials:
+
+```shell
+wanaku auth status
+```
+
+This command displays:
+- Current authentication mode
+- Masked API token (showing first and last 4 characters)
+- Authentication server URL (if configured)
+- Masked refresh token (if available)
+- Credentials file location
+- Whether credentials are currently stored
+
+**Example output:**
+```
+Authentication Status:
+=====================
+Mode: token
+API Token: eyJh***VCJ9
+Auth Server: https://keycloak.example.com
+Credentials File: /Users/username/.wanaku/credentials
+Has Credentials: true
+```
+
+#### Logout
+
+Clear all stored authentication credentials:
+
+```shell
+wanaku auth logout
+```
+
+This command removes all authentication data from the local credentials file.
+
+#### Token Management
+
+Display the raw authentication token (useful for debugging or using with other tools):
+
+```shell
+wanaku auth token
+```
+
+This outputs the raw API token without masking.
+
+### Using Authentication with Commands
+
+Once authenticated via `wanaku auth login`, all subsequent CLI commands will automatically include the authentication token in their requests.
+
+#### Per-Command Token Override
+
+You can override the stored authentication token for a single command:
+
+```shell
+wanaku tools list --token <temporary-token>
+```
+
+#### Disabling Authentication
+
+To explicitly disable authentication for a command:
+
+```shell
+wanaku tools list --no-auth
+```
+
+### Credential Storage
+
+Authentication credentials are stored in:
+```
+~/.wanaku/credentials
+```
+
+This file is a Java properties file containing:
+- `api.token`: The API bearer token
+- `refresh.token`: OAuth2 refresh token (when applicable)
+- `auth.mode`: The authentication mode (token, oauth2, etc.)
+- `auth.server.url`: The authentication server URL
+
+> [!CAUTION]
+> The credentials file contains sensitive authentication tokens. Ensure proper file permissions are set to prevent unauthorized access.
+> On Unix-like systems, you should restrict access: `chmod 600 ~/.wanaku/credentials`
+
+### Authentication Flow
+
+The CLI authentication process works as follows:
+
+1. **Login**: User provides API token via `wanaku auth login --api-token <token>`
+2. **Storage**: Token is stored in `~/.wanaku/credentials`
+3. **Auto-Injection**: The CLI automatically reads the token and adds it as a Bearer token to the `Authorization` header for all API requests
+4. **Validation**: The Wanaku Router validates the token on each request
+5. **Logout**: User can clear credentials via `wanaku auth logout`
+
+### Troubleshooting Authentication
+
+#### Token Not Working
+
+If you receive authentication errors:
+
+1. Check token validity:
+   ```shell
+   wanaku auth status
+   ```
+
+2. Verify the token hasn't expired
+3. Ensure you're using the correct authentication server URL
+4. Try logging in again with a fresh token
+
+#### Clear and Reset
+
+To completely reset authentication:
+
+```shell
+wanaku auth logout
+wanaku auth login --api-token <new-token>
+```
+
+#### Manual Credential Management
+
+You can manually edit or remove the credentials file if needed:
+
+```shell
+# View credentials
+cat ~/.wanaku/credentials
+
+# Remove credentials manually
+rm ~/.wanaku/credentials
+```
+
+### Security Best Practices
+
+1. **Token Protection**: Never share your API tokens or commit them to version control
+2. **Regular Rotation**: Rotate tokens periodically for enhanced security
+3. **Use Environment Variables**: For CI/CD, consider using `--token` flag with environment variables instead of storing tokens
+4. **File Permissions**: Ensure credentials file has restricted permissions (600)
+5. **Logout When Done**: Use `wanaku auth logout` when finished working on shared systems
+
+### Example Workflows
+
+#### Basic Authentication Workflow
+
+```shell
+# Login with API token
+wanaku auth login --api-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+
+# Verify authentication
+wanaku auth status
+
+# Use authenticated commands
+wanaku tools list
+wanaku resources list
+wanaku data-store list
+
+# Logout when done
+wanaku auth logout
+```
+
+#### CI/CD Usage
+
+For automated scripts, use token override instead of storing credentials:
+
+```shell
+# Use token from environment variable
+wanaku tools list --token $WANAKU_API_TOKEN
+
+# Or disable authentication for public endpoints
+wanaku tools list --no-auth
+```
 
 
 ## Installing and Running the Router

--- a/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
+++ b/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
@@ -77,8 +77,8 @@ quarkus.oidc-proxy.tenant-id=mcp
 quarkus.http.auth.permission.oidcproxy.paths=/.well-known/oauth-protected-resource/*, /.well-known/oauth-authorization-server/*, /q/oidc/*
 quarkus.http.auth.permission.oidcproxy.policy=permit
 
-# Management APIs
-quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*
+# Management APIs and the Data Store APIs
+quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Restricted MCP namespaces


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive authentication support to the Wanaku CLI and core modules, including new auth commands, local credential storage, per-command token overrides, and OAuth2/OIDC token management, along with documentation and tests.

New Features:
- Introduce "wanaku auth" subcommand with login, logout, status, and token management commands
- Implement AuthCredentialStore for secure local storage of API tokens, refresh tokens, auth modes, and server URLs
- Add --token and --no-auth options for per-command authentication overrides
- Integrate OidcTokenService in core-security module to retrieve and refresh OAuth2/OIDC tokens

Enhancements:
- Extend CLI configuration and application.properties for authentication settings
- Update Wanaku router backend permissions to include data-store APIs

Build:
- Add core-security dependency and Jackson Databind for JSON processing

Documentation:
- Document CLI authentication workflows, commands, credential storage, and security best practices in usage guide

Tests:
- Add unit tests for AuthCredentialStore, AuthenticationInterceptor, and auth command classes