### PR TITLE
Add Shell Completion Support for Wanaku CLI

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/CliMain.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/CliMain.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.main;
 
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.commands.capabilities.Capabilities;
+import ai.wanaku.cli.main.commands.completion.Completion;
 import ai.wanaku.cli.main.commands.forwards.Forwards;
 import ai.wanaku.cli.main.commands.man.Man;
 import ai.wanaku.cli.main.commands.namespaces.Namespaces;
@@ -30,7 +31,8 @@ import picocli.CommandLine;
             Tools.class,
             ToolSet.class,
             Namespaces.class,
-            Man.class
+            Man.class,
+            Completion.class
         })
 public class CliMain implements Callable<Integer>, QuarkusApplication {
     @Inject

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/completion/Completion.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/completion/Completion.java
@@ -1,0 +1,28 @@
+package ai.wanaku.cli.main.commands.completion;
+
+import static picocli.CommandLine.usage;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+/**
+ * Parent command for managing shell completion scripts.
+ * <p>
+ * This command provides access to shell completion generation operations for
+ * bash and zsh shells supported by picocli.
+ * </p>
+ */
+@CommandLine.Command(
+        name = "completion",
+        description = "Generate shell completion scripts",
+        subcommands = {CompletionGenerate.class})
+public class Completion extends BaseCommand {
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        usage(this, System.out);
+        return EXIT_ERROR;
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/completion/CompletionGenerate.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/completion/CompletionGenerate.java
@@ -1,0 +1,129 @@
+package ai.wanaku.cli.main.commands.completion;
+
+import ai.wanaku.cli.main.CliMain;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.jline.terminal.Terminal;
+import picocli.AutoComplete;
+import picocli.CommandLine;
+
+/**
+ * Command to generate shell completion scripts for bash and zsh.
+ * <p>
+ * Supports generating completion scripts for:
+ * </p>
+ * <ul>
+ *   <li>bash - Bash shell completion</li>
+ *   <li>zsh - Zsh shell completion (uses bash completion via bashcompinit)</li>
+ * </ul>
+ * <p>
+ * The generated completion script includes all subcommands, options, and their descriptions,
+ * enabling tab-completion for the entire Wanaku CLI.
+ * </p>
+ *
+ * <h2>Usage Examples</h2>
+ * <pre>
+ * # Generate bash completion script to stdout
+ * wanaku completion generate
+ *
+ * # Generate and save bash completion script
+ * wanaku completion generate --output /etc/bash_completion.d/wanaku_completion
+ *
+ * # Generate zsh completion script (same format works for both)
+ * wanaku completion generate --output ~/.zsh/completions/_wanaku
+ * </pre>
+ *
+ * <h2>Installation</h2>
+ * <p>
+ * After generating the completion script, you need to source it in your shell:
+ * </p>
+ * <pre>
+ * # For bash (add to ~/.bashrc)
+ * source /etc/bash_completion.d/wanaku_completion
+ *
+ * # For zsh (add to ~/.zshrc)
+ * autoload -U +X bashcompinit && bashcompinit
+ * source ~/.zsh/completions/_wanaku
+ * </pre>
+ */
+@CommandLine.Command(name = "generate", description = "Generate shell completion script for bash and zsh")
+public class CompletionGenerate extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"-o", "--output"},
+            description = "Output file path (default: stdout)")
+    private File outputFile;
+
+    @CommandLine.Option(
+            names = {"-n", "--name"},
+            description = "Command name for completion (default: wanaku)")
+    private String commandName = "wanaku";
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        try {
+            // Create a CommandLine instance for the main CLI command
+            CommandLine commandLine = new CommandLine(CliMain.class);
+
+            // Generate the completion script
+            String completionScript = AutoComplete.bash(commandName, commandLine);
+
+            // Output the script
+            if (outputFile != null) {
+                // Generate to file
+                File parentDir = outputFile.getParentFile();
+                if (parentDir != null && !parentDir.exists()) {
+                    if (!parentDir.mkdirs()) {
+                        printer.println("Error: Failed to create directory: " + parentDir);
+                        return EXIT_ERROR;
+                    }
+                }
+
+                try (BufferedWriter writer = Files.newBufferedWriter(outputFile.toPath(), StandardCharsets.UTF_8)) {
+                    writer.write(completionScript);
+                }
+                printer.println("Completion script generated: " + outputFile.getAbsolutePath());
+                printInstallationInstructions(printer, outputFile.getAbsolutePath());
+            } else {
+                // Generate to stdout
+                System.out.println(completionScript);
+            }
+
+            return EXIT_OK;
+        } catch (IOException e) {
+            printer.println("Error generating completion script: " + e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    /**
+     * Prints installation instructions for the generated completion script.
+     *
+     * @param printer the printer to output instructions to
+     * @param outputPath the path where the completion script was saved
+     */
+    private void printInstallationInstructions(WanakuPrinter printer, String outputPath) {
+        printer.println("");
+        printer.println("Installation instructions:");
+        printer.println("");
+        printer.println("For Bash:");
+        printer.println("  Add the following line to your ~/.bashrc:");
+        printer.println("    source " + outputPath);
+        printer.println("");
+        printer.println("  Then reload your shell:");
+        printer.println("    source ~/.bashrc");
+        printer.println("");
+        printer.println("For Zsh:");
+        printer.println("  Add the following lines to your ~/.zshrc:");
+        printer.println("    autoload -U +X bashcompinit && bashcompinit");
+        printer.println("    source " + outputPath);
+        printer.println("");
+        printer.println("  Then reload your shell:");
+        printer.println("    source ~/.zshrc");
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1647,6 +1647,180 @@ wanaku namespaces list --label-filter 'env=production & tier=backend'
 
 See the [Label Expressions Guide](LABEL_EXPRESSIONS.md) for detailed information on the label expression syntax and advanced filtering options.
 
+## Shell Completion
+
+Wanaku provides shell completion support for bash and zsh, enabling tab-completion for all commands, subcommands, and their options. This significantly improves the command-line experience by reducing typing and helping discover available commands and options.
+
+### Generating Completion Scripts
+
+To generate a completion script, use the `wanaku completion generate` command:
+
+```shell
+# Generate completion script and output to stdout
+wanaku completion generate
+
+# Save completion script to a file
+wanaku completion generate --output ~/.wanaku_completion
+```
+
+The generated script includes completion support for:
+- All parent commands (namespaces, tools, resources, forwards, capabilities, etc.)
+- All subcommands (namespaces label add, tools list, etc.)
+- All command options (--help, --verbose, command-specific options)
+- Automatic detection of bash vs zsh shell
+
+### Quick Setup for Current Session Only
+
+If you want to enable completion for just your current terminal session without making permanent changes:
+
+```shell
+# One-liner for bash or zsh (works on both Linux and macOS)
+source <(wanaku completion generate)
+
+# Alternative using eval (also works on both bash and zsh)
+eval "$(wanaku completion generate)"
+```
+
+This generates and immediately sources the completion script in your current shell. Completion will be active until you close the terminal, without creating any files or modifying your shell configuration files.
+
+This is useful for:
+- Testing completion before permanent installation
+- Temporary/one-time use
+- Environments where you don't want to modify shell configuration
+
+### Installing Completion on Linux
+
+#### For Bash
+
+1. Generate the completion script to a standard location:
+```shell
+wanaku completion generate --output /etc/bash_completion.d/wanaku_completion
+```
+
+2. Add the following line to your `~/.bashrc`:
+```shell
+source /etc/bash_completion.d/wanaku_completion
+```
+
+3. Reload your shell:
+```shell
+source ~/.bashrc
+```
+
+Alternatively, for user-specific installation:
+```shell
+wanaku completion generate --output ~/.wanaku_completion
+echo "source ~/.wanaku_completion" >> ~/.bashrc
+source ~/.bashrc
+```
+
+#### For Zsh
+
+1. Generate the completion script:
+```shell
+mkdir -p ~/.zsh/completions
+wanaku completion generate --output ~/.zsh/completions/_wanaku
+```
+
+2. Add the following lines to your `~/.zshrc`:
+```shell
+autoload -U +X bashcompinit && bashcompinit
+source ~/.zsh/completions/_wanaku
+```
+
+3. Reload your shell:
+```shell
+source ~/.zshrc
+```
+
+### Installing Completion on macOS
+
+#### For Zsh (Default on macOS Catalina and later)
+
+1. Generate the completion script:
+```shell
+mkdir -p ~/.zsh/completions
+wanaku completion generate --output ~/.zsh/completions/_wanaku
+```
+
+2. Add the following lines to your `~/.zshrc`:
+```shell
+autoload -U +X bashcompinit && bashcompinit
+source ~/.zsh/completions/_wanaku
+```
+
+3. Reload your shell:
+```shell
+source ~/.zshrc
+```
+
+#### For Bash (If using bash on macOS)
+
+1. Generate the completion script:
+```shell
+wanaku completion generate --output /usr/local/etc/bash_completion.d/wanaku
+```
+
+2. Add the following line to your `~/.bash_profile`:
+```shell
+source /usr/local/etc/bash_completion.d/wanaku
+```
+
+3. Reload your shell:
+```shell
+source ~/.bash_profile
+```
+
+### Using Shell Completion
+
+Once installed, you can use tab-completion with the Wanaku CLI:
+
+```shell
+# Tab-complete commands
+wanaku <TAB>
+# Shows: capabilities, completion, forwards, man, namespaces, resources, start, targets, tools, toolset
+
+# Tab-complete subcommands
+wanaku namespaces <TAB>
+# Shows: label, list
+
+# Tab-complete options
+wanaku tools add --<TAB>
+# Shows: --description, --help, --name, --namespace, --property, --required, --type, --uri, --verbose
+
+# Tab-complete after partial input
+wanaku name<TAB>
+# Completes to: wanaku namespaces
+```
+
+### Troubleshooting
+
+If completion doesn't work after installation:
+
+1. **Verify the script was sourced:** Check that your shell configuration file (`.bashrc`, `.zshrc`, or `.bash_profile`) contains the source command and was reloaded.
+
+2. **Check shell detection:** The completion script automatically detects whether you're using bash or zsh. Verify you're using a supported shell:
+   ```shell
+   echo $BASH_VERSION  # For bash
+   echo $ZSH_VERSION   # For zsh
+   ```
+
+3. **Manually source the script:** Try sourcing the completion script directly:
+   ```shell
+   source ~/.wanaku_completion
+   ```
+
+4. **Regenerate the script:** If you've updated Wanaku and new commands aren't appearing, regenerate the completion script:
+   ```shell
+   wanaku completion generate --output ~/.wanaku_completion
+   source ~/.wanaku_completion
+   ```
+
+### Limitations
+
+- **PowerShell:** Shell completion is not currently supported for PowerShell on Windows. Users on Windows should use WSL (Windows Subsystem for Linux) with bash or zsh for completion support.
+- **Fish shell:** Fish shell is not supported by picocli 4.7.7. Only bash and zsh are supported.
+
 ## Understanding URIs
 
 Universal Resource Identifiers (URI) are central to Wanaku.


### PR DESCRIPTION
resolve #645

## Summary by Sourcery

Introduce shell completion support to the Wanaku CLI by adding a new 'completion generate' command for bash and zsh scripts and updating documentation with comprehensive usage, installation, and troubleshooting instructions.

New Features:
- Implement 'wanaku completion generate' command to produce bash and zsh shell completion scripts
- Allow users to specify output file and command name for generated completion scripts

Documentation:
- Add detailed Shell Completion section to usage guide covering script generation, setup, installation on Linux and macOS, troubleshooting, and limitations