### PR TITLE
fix javadoc generation

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/completion/CompletionGenerate.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/completion/CompletionGenerate.java
@@ -47,7 +47,7 @@ import picocli.CommandLine;
  * source /etc/bash_completion.d/wanaku_completion
  *
  * # For zsh (add to ~/.zshrc)
- * autoload -U +X bashcompinit && bashcompinit
+ * autoload -U +X bashcompinit &amp;&amp; bashcompinit
  * source ~/.zsh/completions/_wanaku
  * </pre>
  */

--- a/core/core-exchange/pom.xml
+++ b/core/core-exchange/pom.xml
@@ -61,6 +61,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <sourcepath>${project.basedir}/src/main/java:${project.build.directory}/generated-sources/grpc</sourcepath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary by Sourcery

Fix Javadoc generation by configuring the Maven Javadoc plugin to include generated sources and correcting snippet escaping in Javadoc comments

Build:
- Configure maven-javadoc-plugin to include src/main/java and generated-sources/grpc in its sourcepath

Documentation:
- Escape ampersands in the CLI completion command Javadoc example to render correctly