### PR TITLE
Add prompt to UI header menu.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1406,9 +1406,7 @@ This displays all prompts with their names, descriptions, and namespaces.
 
 ### Editing Prompts
 
-You can edit an existing prompt using either the CLI or the UI.
-
-#### Using CLI
+You can edit an existing prompt using the CLI.
 
 The `wanaku prompts edit` command allows you to modify an existing prompt. Only the fields you specify will be updated:
 
@@ -1438,10 +1436,6 @@ wanaku prompts edit \
   --message "user:text:Review the following code for security issues: {{code}}" \
   --message "assistant:text:I'll perform a security audit."
 ```
-
-#### Using UI
-
-Navigate to the Prompts page in the Web UI, select the prompt you want to edit, make your changes, and save.
 
 ### Removing Prompts
 

--- a/wanaku-router/ui/admin/src/components/Header.tsx
+++ b/wanaku-router/ui/admin/src/components/Header.tsx
@@ -54,6 +54,9 @@ function HeaderComponent({ onClickSideNavExpand, isSideNavExpanded }:HeaderCompo
                 <HeaderMenuItem as={Link} to={Links.Resources}>
                     Resources
                 </HeaderMenuItem>
+                <HeaderMenuItem as={Link} to={Links.Prompts}>
+                    Prompts
+                </HeaderMenuItem>
                 <HeaderMenuItem as={Link} to={Links.LLMChat}>
                     LLMChat
                 </HeaderMenuItem>


### PR DESCRIPTION
## Summary by Sourcery

Add Prompts link to the admin UI header and align documentation with CLI-based prompt editing and target listing commands

New Features:
- Add "Prompts" link to the admin UI header menu

Enhancements:
- Remove outdated UI-based prompt editing instructions and update CLI tab-completion output to include the 'targets' command

Documentation:
- Add "Listing Targets" section with examples and notes on 'wanaku targets tools|resources list'
- Update service registration examples to use 'wanaku targets ... list' commands