### PR TITLE
#532 [UI] Add MIME Type Field to Resource Forms

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -25,7 +25,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
   onDelete,
   onAdd,
 }) => {
-  const headers = ["Name", "Location", "Type", "Description", "Namespace", "Actions"];
+  const headers = ["Name", "Location", "Type", "MIME Type", "Description", "Namespace", "Actions"];
 
   return (
     <Grid>
@@ -55,6 +55,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
                 <TableCell>{row.name}</TableCell>
                 <TableCell>{row.location}</TableCell>
                 <TableCell>{row.type}</TableCell>
+                <TableCell>{row.mimeType}</TableCell>
                 <TableCell>{row.description}</TableCell>
                 <TableCell>{getNamespacePathById(row.namespace) || "default"}</TableCell>
                 <TableCell>

--- a/wanaku-router/ui/admin/src/constants/mimeTypes.ts
+++ b/wanaku-router/ui/admin/src/constants/mimeTypes.ts
@@ -1,0 +1,18 @@
+export const commonMimeTypesMapping = new Map([
+  ["json", "application/json"],
+  ["pdf", "application/pdf"],
+  ["xml", "application/xml"],
+  ["zip", "application/zip"],
+  ["mp3", "audio/mpeg"],
+  ["gif", "image/gif"],
+  ["jpg", "image/jpeg"],
+  ["jpeg", "image/jpeg"],
+  ["png", "image/png"],
+  ["svg", "image/svg+xml"],
+  ["csv", "text/csv"],
+  ["html", "text/html"],
+  ["txt", "text/plain"],
+  ["mp4", "video/mp4"]
+])
+
+export const commonMimeTypes = [...new Set([...commonMimeTypesMapping.values()])]


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/532

Please check that _mimeTypes.ts_ is in correct directory.

I've implemented **autoDetectMimeType** as a function. I've noticed it's more common to have lambda closures in the code. Please let me know if I should rewrite it.

## Summary by Sourcery

Add optional MIME type field to resource forms with autocomplete and auto-detection, include MIME type in resource payload, and display it in the resources table.

New Features:
- Introduce MIME type state and ComboBox input in AddResourceModal for selecting or entering content type
- Implement autoDetectMimeType function to infer MIME type from resource location extension
- Include mimeType in the payload when creating a new resource
- Add a MIME Type column to the ResourcesTable to display each resource's content type
- Add commonMimeTypes mapping and list constants for popular MIME types