### PR TITLE
Improve error messages when tool already exist

### DIFF
--- a/api/src/main/java/ai/wanaku/api/exceptions/EntityAlreadyExistsException.java
+++ b/api/src/main/java/ai/wanaku/api/exceptions/EntityAlreadyExistsException.java
@@ -1,0 +1,71 @@
+package ai.wanaku.api.exceptions;
+
+/**
+ * This exception is thrown when an attempt is made to create an entity that already exists.
+ *
+ * This custom exception extends {@link WanakuException} and provides a
+ * clear indication of when a requested entity cannot be created because it already exists.
+ * It is mapped to HTTP status code 409 (Conflict) by the router.
+ */
+public class EntityAlreadyExistsException extends WanakuException {
+
+    /**
+     * Default constructor for the exception, providing no additional information.
+     */
+    public EntityAlreadyExistsException() {
+        super();
+    }
+
+    /**
+     * Constructor that allows specifying a custom error message for the exception.
+     *
+     * @param message The detailed message describing which entity already exists.
+     */
+    public EntityAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor that provides both a custom error message and an underlying cause for the exception.
+     *
+     * @param message   The detailed message describing which entity already exists.
+     * @param cause     The root cause of the exception, providing additional context.
+     */
+    public EntityAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor that specifies an underlying cause for the exception without a custom error message.
+     *
+     * @param cause The root cause of the exception, providing additional context.
+     */
+    public EntityAlreadyExistsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor that allows specifying both a custom error message and an underlying cause for the exception,
+     * along with options to enable suppression or writable stack trace.
+     *
+     * @param message         The detailed message describing which entity already exists.
+     * @param cause           The root cause of the exception, providing additional context.
+     * @param enableSuppression Whether to allow suppressing this exception during exception propagation.
+     * @param writableStackTrace Whether to include a stack trace with this exception.
+     */
+    public EntityAlreadyExistsException(
+            String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    /**
+     * Factory method that creates a new instance of the exception for a given entity name,
+     * providing a pre-formatted error message indicating that the entity already exists.
+     *
+     * @param entityName The name or identifier of the entity that already exists.
+     * @return A new instance of the {@link EntityAlreadyExistsException} class with a custom error message.
+     */
+    public static EntityAlreadyExistsException forName(String entityName) {
+        return new EntityAlreadyExistsException(String.format("Entity %s already exists", entityName));
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/EntityAlreadyExistsExceptionMapper.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/EntityAlreadyExistsExceptionMapper.java
@@ -1,0 +1,32 @@
+package ai.wanaku.backend.api.v1.exceptions;
+
+import ai.wanaku.api.exceptions.EntityAlreadyExistsException;
+import ai.wanaku.api.types.WanakuResponse;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.logging.Logger;
+
+/**
+ * Exception mapper that converts {@link EntityAlreadyExistsException} to HTTP 409 (Conflict) responses.
+ */
+@Provider
+public class EntityAlreadyExistsExceptionMapper implements ExceptionMapper<EntityAlreadyExistsException> {
+    private static final Logger LOG = Logger.getLogger(EntityAlreadyExistsExceptionMapper.class);
+
+    @APIResponse(
+            responseCode = "409",
+            description = "Entity already exists",
+            content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
+    @Override
+    public Response toResponse(EntityAlreadyExistsException e) {
+        LOG.error(e);
+
+        return Response.status(Response.Status.CONFLICT)
+                .entity(new WanakuResponse<Void>(e.getMessage()))
+                .build();
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -2,6 +2,7 @@ package ai.wanaku.backend.api.v1.forwards;
 
 import static io.micrometer.common.util.StringUtils.*;
 
+import ai.wanaku.api.exceptions.EntityAlreadyExistsException;
 import ai.wanaku.api.exceptions.WanakuException;
 import ai.wanaku.api.types.ForwardReference;
 import ai.wanaku.api.types.LabelsAwareEntity;
@@ -222,6 +223,8 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         for (ForwardReference forwardReference : forwardReferenceRepository.listAll()) {
             try {
                 registerForward(forwardReference);
+            } catch (EntityAlreadyExistsException e) {
+                LOG.errorf("Tried to register a tool named %s during startup, but it already exists", forwardReference.getAddress());
             } catch (Exception e) {
                 LOG.errorf("Error registering forwards from %s during startup", forwardReference.getAddress());
             }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
@@ -1,5 +1,6 @@
 package ai.wanaku.backend.api.v1.resources;
 
+import ai.wanaku.api.exceptions.EntityAlreadyExistsException;
 import ai.wanaku.api.types.Namespace;
 import ai.wanaku.api.types.ResourceReference;
 import ai.wanaku.api.types.io.ResourcePayload;
@@ -70,7 +71,11 @@ public class ResourcesBean extends AbstractBean<ResourceReference> {
         namespacesBean.preload();
 
         for (ResourceReference resourceReference : list()) {
-            doExposeResource(resourceReference);
+            try {
+                doExposeResource(resourceReference);
+            } catch (EntityAlreadyExistsException e) {
+                LOG.errorf("Error registering a resource named %s during startup, but it already exists", resourceReference.getName());
+            }
         }
     }
 

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -1,5 +1,6 @@
 package ai.wanaku.backend.api.v1.tools;
 
+import ai.wanaku.api.exceptions.EntityAlreadyExistsException;
 import ai.wanaku.api.exceptions.ToolNotFoundException;
 import ai.wanaku.api.exceptions.WanakuException;
 import ai.wanaku.api.types.Namespace;
@@ -63,8 +64,6 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
     }
 
     private void registerTool(ToolReference toolReference) throws ToolNotFoundException {
-        //        Namespace ns = namespacesBean.
-
         if (!StringHelper.isEmpty(toolReference.getNamespace())) {
 
             final Namespace namespace = namespacesBean.alocateNamespace(toolReference.getNamespace());
@@ -94,7 +93,11 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
         namespacesBean.preload();
 
         for (ToolReference toolReference : list()) {
-            registerTool(toolReference);
+            try {
+                registerTool(toolReference);
+            } catch (EntityAlreadyExistsException e) {
+                LOG.errorf("Error registering a tool named %s during startup, but it already exists", toolReference.getName());
+            }
         }
     }
 


### PR DESCRIPTION
This solves issue #655

## Summary by Sourcery

Improve duplicate entity handling by introducing a custom conflict exception and preventing startup failures

New Features:
- Add EntityAlreadyExistsException with a factory method to report duplicate entities
- Introduce JAX-RS ExceptionMapper to map EntityAlreadyExistsException to HTTP 409 Conflict

Enhancements:
- Throw EntityAlreadyExistsException when registering an existing tool, resource, or forward
- Catch EntityAlreadyExistsException during application startup and log duplicate registration errors instead of failing