### PR TITLE
Add tools/resource show command

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/resources/Resources.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/resources/Resources.java
@@ -25,7 +25,13 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "resources",
         description = "Manage resources",
-        subcommands = {ResourcesExpose.class, ResourcesRemove.class, ResourcesList.class, ResourcesLabel.class})
+        subcommands = {
+            ResourcesExpose.class,
+            ResourcesRemove.class,
+            ResourcesList.class,
+            ResourcesShow.class,
+            ResourcesLabel.class
+        })
 public class Resources extends BaseCommand {
 
     @Override

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
@@ -1,0 +1,104 @@
+package ai.wanaku.cli.main.commands.resources;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
+import static picocli.CommandLine.Command;
+import static picocli.CommandLine.Option;
+import static picocli.CommandLine.Parameters;
+
+import ai.wanaku.api.types.ResourceReference;
+import ai.wanaku.api.types.WanakuResponse;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ResourcesService;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import org.jline.terminal.Terminal;
+
+/**
+ * Command to show detailed information about a specific resource registered in the Wanaku platform.
+ * <p>
+ * This command retrieves and displays comprehensive details about a resource including
+ * its name, description, type, location, MIME type, namespace, labels, and parameters.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>{@code
+ * wanaku resources show my-resource
+ * wanaku resources show --host http://remote:8080 my-resource
+ * }</pre>
+ */
+@Command(name = "show", description = "Show detailed information about a specific resource")
+public class ResourcesShow extends BaseCommand {
+
+    @Option(
+            names = {"--host"},
+            description = "The API host",
+            defaultValue = "http://localhost:8080",
+            arity = "0..1")
+    protected String host;
+
+    @Parameters(description = "The name of the resource to show", arity = "1")
+    private String resourceName;
+
+    ResourcesService resourcesService;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        resourcesService = initService(ResourcesService.class, host);
+        try {
+            WanakuResponse<ResourceReference> response = resourcesService.getByName(resourceName);
+            ResourceReference resource = response.data();
+
+            if (resource == null) {
+                printer.printWarningMessage("Resource not found: " + resourceName);
+                return EXIT_ERROR;
+            }
+
+            // Create display record with default namespace for display purposes
+            String displayNamespace = resource.getNamespace() != null ? resource.getNamespace() : "default";
+            ResourceDisplay resourceDisplay = new ResourceDisplay(
+                    resource.getName(),
+                    resource.getType(),
+                    resource.getDescription(),
+                    resource.getLocation(),
+                    resource.getMimeType(),
+                    displayNamespace,
+                    resource.getLabels());
+
+            // Print basic resource information
+            printer.printInfoMessage("Resource Details:");
+            printer.printAsMap(
+                    resourceDisplay, "name", "type", "description", "location", "mimeType", "namespace", "labels");
+
+            // Print parameters if available
+            List<ResourceReference.Param> params = resource.getParams();
+            if (params != null && !params.isEmpty()) {
+                printer.printInfoMessage("\nParameters:");
+                printer.printTable(params, "name", "value");
+            }
+
+            return EXIT_OK;
+        } catch (WebApplicationException ex) {
+            Response response = ex.getResponse();
+            commonResponseErrorHandler(response);
+            return EXIT_ERROR;
+        }
+    }
+
+    /**
+     * Helper record to display resource information without mutating the API object.
+     */
+    @RegisterForReflection
+    public record ResourceDisplay(
+            String name,
+            String type,
+            String description,
+            String location,
+            String mimeType,
+            String namespace,
+            Map<String, String> labels) {}
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/tools/Tools.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/tools/Tools.java
@@ -31,6 +31,7 @@ import picocli.CommandLine;
             ToolsAdd.class,
             ToolsRemove.class,
             ToolsList.class,
+            ToolsShow.class,
             ToolsImport.class,
             ToolsGenerate.class,
             ToolsLabel.class

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
@@ -1,0 +1,117 @@
+package ai.wanaku.cli.main.commands.tools;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
+
+import ai.wanaku.api.types.InputSchema;
+import ai.wanaku.api.types.Property;
+import ai.wanaku.api.types.ToolReference;
+import ai.wanaku.api.types.WanakuResponse;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ToolsService;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.jline.terminal.Terminal;
+import picocli.CommandLine;
+
+/**
+ * Command to show detailed information about a specific tool registered in the Wanaku platform.
+ * <p>
+ * This command retrieves and displays comprehensive details about a tool including
+ * its name, description, type, namespace, URI, labels, and input schema properties.
+ * </p>
+ * <p>
+ * Example usage:
+ * </p>
+ * <pre>{@code
+ * wanaku tools show my-tool
+ * wanaku tools show --host http://remote:8080 my-tool
+ * }</pre>
+ */
+@CommandLine.Command(name = "show", description = "Show detailed information about a specific tool")
+public class ToolsShow extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--host"},
+            description = "The API host",
+            defaultValue = "http://localhost:8080",
+            arity = "0..1")
+    protected String host;
+
+    @CommandLine.Parameters(description = "The name of the tool to show", arity = "1")
+    private String toolName;
+
+    ToolsService toolsService;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        toolsService = initService(ToolsService.class, host);
+        try {
+            WanakuResponse<ToolReference> response = toolsService.getByName(toolName);
+            ToolReference tool = response.data();
+
+            if (tool == null) {
+                printer.printWarningMessage("Tool not found: " + toolName);
+                return EXIT_ERROR;
+            }
+
+            // Create display record with default namespace for display purposes
+            String displayNamespace = tool.getNamespace() != null ? tool.getNamespace() : "default";
+            ToolDisplay toolDisplay = new ToolDisplay(
+                    tool.getName(),
+                    displayNamespace,
+                    tool.getType(),
+                    tool.getDescription(),
+                    tool.getUri(),
+                    tool.getLabels());
+
+            // Print basic tool information
+            printer.printInfoMessage("Tool Details:");
+            printer.printAsMap(toolDisplay, "name", "namespace", "type", "description", "uri", "labels");
+
+            // Print input schema properties if available
+            InputSchema inputSchema = tool.getInputSchema();
+            if (inputSchema != null
+                    && inputSchema.getProperties() != null
+                    && !inputSchema.getProperties().isEmpty()) {
+                printer.printInfoMessage("\nInput Schema Properties:");
+                List<PropertyDisplay> properties = new ArrayList<>();
+                List<String> required = inputSchema.getRequired() != null ? inputSchema.getRequired() : List.of();
+
+                for (Map.Entry<String, Property> entry :
+                        inputSchema.getProperties().entrySet()) {
+                    Property prop = entry.getValue();
+                    properties.add(new PropertyDisplay(
+                            entry.getKey(),
+                            prop.getType(),
+                            prop.getDescription(),
+                            required.contains(entry.getKey()) ? "yes" : "no"));
+                }
+                printer.printTable(properties, "name", "type", "description", "required");
+            }
+
+            return EXIT_OK;
+        } catch (WebApplicationException ex) {
+            Response response = ex.getResponse();
+            commonResponseErrorHandler(response);
+            return EXIT_ERROR;
+        }
+    }
+
+    /**
+     * Helper record to display tool information without mutating the API object.
+     */
+    @RegisterForReflection
+    public record ToolDisplay(
+            String name, String namespace, String type, String description, String uri, Map<String, String> labels) {}
+
+    /**
+     * Helper record to display input schema properties in a table format.
+     */
+    @RegisterForReflection
+    public record PropertyDisplay(String name, String type, String description, String required) {}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1107,7 +1107,7 @@ The selected tool's JSON definition will then open in nano for you to make your 
 
 Any available tool is listed by default when you access the UI.
 
-When using the CLI, the `wanaku tools list` command allows you to view all available tools on your Wanaku MCP Router instance. 
+When using the CLI, the `wanaku tools list` command allows you to view all available tools on your Wanaku MCP Router instance.
 
 Running this command will display a comprehensive list of tools, including their names and descriptions.
 
@@ -1121,6 +1121,47 @@ For example, you should receive an output similar to this.
 Name               Type               URI
 meow-facts      => http            => https://meowfacts.herokuapp.com?count={parameter.valueOrElse('count', 1)}
 dog-facts       => http            => https://dogapi.dog/api/v2/facts?limit={parameter.valueOrElse('count', 1)}
+```
+
+### Showing Tool Details
+
+The `wanaku tools show` command displays detailed information about a specific tool registered in the Wanaku MCP Router.
+
+```shell
+wanaku tools show <tool-name>
+```
+
+This command retrieves comprehensive details including the tool's name, namespace, type, description, URI, labels, and input schema properties.
+
+**Example:**
+
+```shell
+wanaku tools show meow-facts
+```
+
+**Sample Output:**
+
+```
+Tool Details:
+name        meow-facts
+namespace   default
+type        http
+description Retrieve random facts about cats
+uri         https://meowfacts.herokuapp.com?count={parameter.valueOrElse('count', 1)}
+labels      category=animals
+
+Input Schema Properties:
+name   type   description                    required
+count  int    The count of facts to retrieve yes
+```
+
+**Options:**
+- `--host <url>`: The API host URL (default: `http://localhost:8080`)
+
+**Example with remote host:**
+
+```shell
+wanaku tools show --host http://api.example.com:8080 meow-facts
 ```
 
 ### Removing Tools
@@ -1424,6 +1465,49 @@ Executing this command will display a list of available resources, including the
 
 ```shell
 wanaku resources list
+```
+
+### Showing Resource Details
+
+The `wanaku resources show` command displays detailed information about a specific resource registered in the Wanaku MCP Router.
+
+```shell
+wanaku resources show <resource-name>
+```
+
+This command retrieves comprehensive details including the resource's name, type, description, location, MIME type, namespace, labels, and parameters.
+
+**Example:**
+
+```shell
+wanaku resources show q4-report
+```
+
+**Sample Output:**
+
+```
+Resource Details:
+name        q4-report
+type        file
+description Q4 Financial Report
+location    /home/user/documents/report.pdf
+mimeType    application/pdf
+namespace   default
+labels      category=finance, year=2024
+
+Parameters:
+name   value
+key1   value1
+key2   value2
+```
+
+**Options:**
+- `--host <url>`: The API host URL (default: `http://localhost:8080`)
+
+**Example with remote host:**
+
+```shell
+wanaku resources show --host http://api.example.com:8080 q4-report
 ```
 
 ## Managing MCP Prompts


### PR DESCRIPTION
This fixes issue #666

## Summary by Sourcery

Add CLI commands to show detailed information for individual tools and resources.

New Features:
- Introduce `wanaku tools show` for displaying detailed information about a specific tool, including metadata and input schema properties.
- Introduce `wanaku resources show` for displaying detailed information about a specific resource, including metadata and parameters.

Enhancements:
- Register the new `show` subcommands under the existing `tools` and `resources` command groups in the CLI.