### PR TITLE
Update testcontainers to 2.0.3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
         <langchain4j.version>1.8.0</langchain4j.version>
         <langchain4j-mcp.version>1.8.0-beta15</langchain4j-mcp.version>
         <quarkus-quinoa.version>2.7.1</quarkus-quinoa.version>
-        <test-containers.version>1.21.4</test-containers.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
         <commons-pool2.version>2.12.1</commons-pool2.version>
         <jsonassert-version>1.5.3</jsonassert-version>
         <swagger-core-version>2.2.42</swagger-core-version>
@@ -129,6 +129,24 @@
                 <groupId>io.swagger.parser.v3</groupId>
                 <artifactId>swagger-parser</artifactId>
                 <version>${swagger-parser.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-localstack</artifactId>
+                <version>${testcontainers.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -34,12 +34,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>localstack</artifactId>
+            <artifactId>testcontainers-localstack</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
+            <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -138,8 +138,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${test-containers.version}</version>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Testcontainers dependencies and align module usage with the new artifact coordinates while cleaning up logging configuration.

Build:
- Bump Testcontainers version in the parent POM and import the Testcontainers BOM to centralize version management for core and LocalStack modules.

Tests:
- Update module POMs to use the new Testcontainers 2.x artifact names (JUnit Jupiter, Kafka, LocalStack) and rely on the shared BOM-managed version.

Chores:
- Comment out verbose Quarkus category-specific logging to reduce default log noise in the backend service.