### PR TITLE
[#527][UI] Add Parameters Array Support to Resource Forms

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Resources/AddResourceModal.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/AddResourceModal.tsx
@@ -2,14 +2,21 @@ import {
   Modal,
   TextInput,
   Select,
-  SelectItem, ComboBox,
+  SelectItem,
+  ComboBox,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs
 } from "@carbon/react";
 import React, { useEffect, useState } from "react";
-import { Namespace, ResourceReference } from "../../models";
+import { Namespace, Param, ResourceReference } from "../../models";
 import { commonMimeTypes, commonMimeTypesMapping } from "../../constants/mimeTypes.ts";
 import { listNamespaces } from "../../hooks/api/use-namespaces";
 import { useCapabilities } from "../../hooks/api/use-capabilities";
 import { TargetTypeSelect } from "../Targets/TargetTypeSelect";
+import { ParametersTable } from "./ParametersTable.tsx";
 
 interface AddResourceModalProps {
   onRequestClose: () => void;
@@ -27,6 +34,7 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
   const [mimeType, setMimeType] = useState("");
   const [fetchedData, setFetchedData] = useState<Namespace[]>([]);
   const [selectedNamespace, setSelectedNamespace] = useState('');
+  const [params, setParams] = useState<Param[]>([]);
   const { listManagementResources } = useCapabilities();
   
   useEffect(() => {
@@ -47,6 +55,7 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
       type: resourceType,
       mimeType,
       namespace: selectedNamespace,
+      params: nonEmptyParameters()
     });
   };
 
@@ -61,6 +70,22 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
     }
   }
 
+  function newParameter() {
+    const temp = [...params]
+    temp.push({name: '', value: ''})
+    setParams(temp)
+  }
+
+  function removeParameter(i: number) {
+    const temp = [...params]
+    temp.splice(i, 1)
+    setParams(temp)
+  }
+
+  function nonEmptyParameters() {
+    return params.filter(parameter => parameter.name !== '')
+  }
+
   return (
     <Modal
       open={true}
@@ -70,67 +95,86 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
       onRequestClose={onRequestClose}
       onRequestSubmit={handleSubmit}
     >
-      <TextInput
-        id="resource-name"
-        labelText="Resource Name"
-        placeholder="e.g. example-resource"
-        value={resourceName}
-        onChange={(e) => setResourceName(e.target.value)}
-      />
-      <TextInput
-        id="resource-description"
-        labelText="Description"
-        placeholder="e.g. Description of the resource"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-      />
-      <TextInput
-        id="resource-location"
-        labelText="Location"
-        placeholder="e.g. /path/to/resource"
-        value={location}
-        onChange={(e) => {
-          const location = e.target.value
-          setLocation(location)
-          autoDetectMimeType(location)
-        }}
-      />
-      <TargetTypeSelect
-        value={resourceType}
-        onChange={setResourceType}
-        apiCall={listManagementResources}
-      />
-      <ComboBox
-          id="resource-mime-type"
-          titleText="MIME Type"
-          placeholder="Select or enter MIME type"
-          items={commonMimeTypes}
-          selectedItem={mimeType}
-          onChange={(e) => {
-            let value = e.selectedItem
-            if (value === undefined || value === null) {
-              value = ""
-            }
-            setMimeType(value)
-          }}
-          helperText="Content type of the resource (optional)"
-      />
-      <Select
-        id="namespace"
-        labelText="Select a Namespace"
-        helperText="Choose a Namespace from the list"
-        value={selectedNamespace}
-        onChange={handleSelectionChange}
-      >
-        <SelectItem text="Choose an option" value="" />
-        {fetchedData.map((namespace) => (
-          <SelectItem
-            id={namespace.id}
-            text={namespace.path || "default"}
-            value={namespace.id}
-          />
-        ))}
-      </Select>
+      <Tabs>
+        <TabList>
+          <Tab>Overview</Tab>
+          <Tab>Parameters</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <TextInput
+              id="resource-name"
+              labelText="Resource Name"
+              placeholder="e.g. example-resource"
+              value={resourceName}
+              onChange={(e) => setResourceName(e.target.value)}
+            />
+            <TextInput
+              id="resource-description"
+              labelText="Description"
+              placeholder="e.g. Description of the resource"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+            <TextInput
+              id="resource-location"
+              labelText="Location"
+              placeholder="e.g. /path/to/resource"
+              value={location}
+              onChange={(e) => {
+                const location = e.target.value
+                setLocation(location)
+                autoDetectMimeType(location)
+              }}
+            />
+            <TargetTypeSelect
+              value={resourceType}
+              onChange={setResourceType}
+              apiCall={listManagementResources}
+            />
+            <ComboBox
+                id="resource-mime-type"
+                titleText="MIME Type"
+                placeholder="Select or enter MIME type"
+                items={commonMimeTypes}
+                selectedItem={mimeType}
+                onChange={(e) => {
+                  let value = e.selectedItem
+                  if (value === undefined || value === null) {
+                    value = ""
+                  }
+                  setMimeType(value)
+                }}
+                helperText="Content type of the resource (optional)"
+            />
+            <Select
+              id="namespace"
+              labelText="Select a Namespace"
+              helperText="Choose a Namespace from the list"
+              value={selectedNamespace}
+              onChange={handleSelectionChange}
+            >
+              <SelectItem text="Choose an option" value="" />
+              {fetchedData.map((namespace) => (
+                <SelectItem
+                  id={namespace.id}
+                  text={namespace.path || "default"}
+                  value={namespace.id}
+                />
+              ))}
+            </Select>
+          </TabPanel>
+          <TabPanel>
+            <ParametersTable
+                parameters={params}
+                onAdd={newParameter}
+                onSetName={(i, name) => params[i].name = name}
+                onSetValue={(i, value) => params[i].value = value}
+                onDelete={removeParameter}
+            />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Modal>
   );
 };

--- a/wanaku-router/ui/admin/src/Pages/Resources/ParametersTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/ParametersTable.tsx
@@ -1,0 +1,124 @@
+import { FunctionComponent } from "react";
+import {
+  Button,
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TextInput
+} from "@carbon/react";
+import { Add, TrashCan } from "@carbon/icons-react";
+import { Param } from "../../models";
+
+interface ParametersTableProps {
+  parameters: Param[]
+  onAdd: () => void
+  onSetName: (index: number, name: string) => void
+  onSetValue: (index: number, value: string) => void
+  onDelete: (index: number) => void
+}
+
+export const ParametersTable: FunctionComponent<ParametersTableProps> = ({
+  parameters,
+  onDelete,
+  onAdd,
+  onSetName,
+  onSetValue,
+}) => {
+
+  const headers = [
+    {key: "name", header: "Name"},
+    {key: "value", header: "Value"},
+    {key: "actions", header: "Actions"}
+  ]
+
+  function parametersAsRows() {
+    return parameters.map((parameter: Param, index: number) => ({
+        id: parameter.name || `parameter-${index}`,
+        name: parameter.name,
+        value: parameter.value ,
+    }))
+  }
+
+  return (
+    <DataTable headers={headers} rows={parametersAsRows()}>
+      {({
+        headers,
+        rows,
+        getTableProps,
+        getHeaderProps,
+        getRowProps,
+        getToolbarProps,
+      }) => (
+        <TableContainer>
+          <TableToolbar {...getToolbarProps()}>
+            <TableToolbarContent>
+              <Button renderIcon={Add} onClick={onAdd}>New Parameter</Button>
+            </TableToolbarContent>
+          </TableToolbar>
+          <Table {...getTableProps()}>
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableHeader {...getHeaderProps({header})}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row, i) => {
+                const parameter = parameters[i]
+                const alreadyFilled = parameter && parameter.name
+                return (
+                  <TableRow {...getRowProps({row})}>
+                    <TableCell>
+                      {alreadyFilled ? (
+                        // if the name is already filled, just display it
+                        parameter.name
+                      ) : (
+                        <TextInput
+                            id={"parameter-" + i + "-name"}
+                            labelText="Parameter name"
+                            placeholder="Parameter name"
+                            onChange={(event) => onSetName(i, event.target.value)}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {alreadyFilled ? (
+                        // if the value is already filled, just display it
+                        parameter.value
+                      ) : (
+                        <TextInput
+                            id={"parameter-" + i + "-value"}
+                            labelText="Parameter value"
+                            placeholder="Parameter value"
+                            onChange={(event) => onSetValue(i, event.target.value)}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Button kind="ghost"
+                              renderIcon={TrashCan}
+                              iconDescription="Delete"
+                              hasIconOnly
+                              onClick={() => onDelete(i)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+  )
+}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/527

- I've made tabs panel in AddResourceModal in order to separate parameters table from the rest of the dialog to avoid visual clutter
- I've changed the ResourcesTable into DataGrid. The motivation was to support expandable rows with resource details. Resources without any parameters are still displayed as they were up to now. Resources with parameters have exansion butto available that provides details
- The new ParametersTable is a little awkward. I'm sure it will sort in time when we have more UI features like that.

Any comment are welcome!

## Summary by Sourcery

Add support for defining and viewing per-resource parameters in the admin UI.

New Features:
- Allow users to define name/value parameters for a resource in a dedicated Parameters tab within the Add Resource modal.
- Display resource parameters in an expandable details section in the resources table when they are present.

Enhancements:
- Refactor the resources listing to use Carbon DataTable with toolbar actions and expandable rows for detailed information.
- Introduce a reusable ParametersTable component to manage and display resource parameters in a structured table layout.