### PR TITLE
Add namespace support to tools import command

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
@@ -25,6 +25,12 @@ public class ToolsImport extends BaseCommand {
             arity = "0..1")
     protected String host;
 
+    @CommandLine.Option(
+            names = {"-N", "--namespace"},
+            description = "Default namespace for tools that don't have one set",
+            arity = "0..1")
+    private String namespace;
+
     @CommandLine.Parameters(
             description = "location to the toolset, can be a local path or an URL",
             arity = "1..1",
@@ -37,6 +43,17 @@ public class ToolsImport extends BaseCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         try {
             List<ToolReference> toolReferences = ToolsetIndexHelper.loadToolsIndex(location);
+
+            // Apply default namespace to tools that don't have one
+            if (namespace != null && !namespace.isEmpty()) {
+                for (ToolReference toolReference : toolReferences) {
+                    if (toolReference.getNamespace() == null
+                            || toolReference.getNamespace().isEmpty()) {
+                        toolReference.setNamespace(namespace);
+                    }
+                }
+            }
+
             importToolset(toolReferences, host);
         } catch (Exception e) {
             printer.printErrorMessage(String.format("Failed to load tools index: %s", e.getMessage()));


### PR DESCRIPTION
## Summary
Adds `--namespace` / `-N` option to the `wanaku tools import` command, allowing users to specify a default namespace for tools that don't already have one defined.

## Changes
- Added optional `--namespace` / `-N` CLI parameter to `ToolsImport` command
- Implemented logic to apply the default namespace only to tools without an existing namespace
- Tools with pre-existing namespaces in the toolset definition are preserved

## Usage
```bash
# Import toolset with default namespace
wanaku tools import --namespace my-namespace /path/to/toolset.json

# Short form
wanaku tools import -N production https://example.com/toolset.json
```

## Testing
- All 139 CLI tests pass
- Build completes successfully with no errors

Fixes #600

## Summary by Sourcery

Add support for specifying a default namespace when importing a toolset via the CLI.

New Features:
- Introduce an optional -N/--namespace flag to the tools import command to set a default namespace for imported tools lacking one.

Enhancements:
- Ensure existing namespaces in imported tools are preserved when applying a default namespace during import.