### PR TITLE
Support configurable pull policies in operator

### DIFF
--- a/wanaku-operator/samples/router.yaml
+++ b/wanaku-operator/samples/router.yaml
@@ -22,10 +22,15 @@ spec:
 #        value: value2
 # You can also set a custom image for the router
 #    image: quay.io/wanaku/wanaku-router-backend:latest # Optional
+# You can also configure the image pull policy (default: IfNotPresent)
+# Valid values: Always, IfNotPresent, Never
+#    imagePullPolicy: IfNotPresent
   capabilities:
 # For the capabilities, you need to provide the name, image to use and any environment variables required:
+# You can also optionally specify the imagePullPolicy (default: IfNotPresent)
     - name: wanaku-http
       image: quay.io/wanaku/wanaku-tool-service-http:latest
+#      imagePullPolicy: IfNotPresent  # Optional: Always, IfNotPresent, or Never
     - name: finance-system
       image: quay.io/wanaku/camel-integration-capability:latest
     - name: employee-system

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "wanaku-service"
         - name: CLIENT_SECRET
           value: ""
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 10

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
               value: ""
           image: ""
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: wanaku-capability
           ports:
             - containerPort: 9000


### PR DESCRIPTION
## Summary
Changes the default `imagePullPolicy` for capability deployments from `Always` to `IfNotPresent`, making it more efficient and production-ready while still allowing users to override it via the Wanaku CR.

## Changes
1. **Updated deployment templates:**
   - `wanaku-capability-deployment.yaml`: Changed default from `Always` to `IfNotPresent`
   - `camel-integration-capability-deployment.yaml`: Changed default from `Always` to `IfNotPresent`

2. **Enhanced documentation:**
   - Added comments in `samples/router.yaml` showing how to configure `imagePullPolicy`
   - Documented valid values: `Always`, `IfNotPresent`, `Never`
   - Noted default behavior for both router and capabilities

## Configuration Example
Users can now configure image pull policy in their Wanaku CR:

```yaml
spec:
  router:
    image: quay.io/wanaku/wanaku-router-backend:latest
    imagePullPolicy: IfNotPresent  # Optional, defaults to IfNotPresent

  capabilities:
    - name: wanaku-http
      image: quay.io/wanaku/wanaku-tool-service-http:latest
      imagePullPolicy: Always  # Override default if needed
```

## Benefits
- ✅ **Faster deployments** - Avoids unnecessary image pulls
- ✅ **Reduced bandwidth** - Less registry traffic
- ✅ **Production-ready** - Aligns with Kubernetes best practices
- ✅ **Fully configurable** - Users can still set `Always` or `Never` if needed

## Backwards Compatibility
The operator code already supported the `imagePullPolicy` field in the spec. This change only updates the default values in the YAML templates. Users who explicitly set `imagePullPolicy` in their CRs will not be affected.

## Testing
- ✅ Build successful
- ✅ Operator compiles without errors
- ✅ YAML templates validated

Fixes #608

## Summary by Sourcery

Set IfNotPresent as the default image pull policy for capability deployments and document how to configure imagePullPolicy in the sample Wanaku router configuration.

Enhancements:
- Change default imagePullPolicy for wanaku and camel integration capability deployments from Always to IfNotPresent to improve deployment efficiency.

Documentation:
- Document configurable imagePullPolicy options and defaults for router and capabilities in the sample router.yaml.