### PR TITLE
test(unit): Enhance core utilities test coverage for #563

### DIFF
--- a/core/core-util/src/test/java/ai/wanaku/core/uri/URIHelperTest.java
+++ b/core/core-util/src/test/java/ai/wanaku/core/uri/URIHelperTest.java
@@ -1,11 +1,16 @@
 package ai.wanaku.core.uri;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class URIHelperTest {
 
@@ -47,5 +52,92 @@ class URIHelperTest {
         params.put("key2", "value2");
         String uri = URIHelper.addQueryParameters("ftp://test?foo=bar&dead=false", params);
         assertEquals("ftp://test?foo=bar&dead=false&key1=value1&key2=value2", uri);
+    }
+
+    @Test
+    void testSpecialCharactersInParameterValues() {
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("key1", "a&b");
+        params.put("key2", "x=y");
+        params.put("key3", "path/to?resource#anchor");
+        params.put("key4", "value%20test");
+        String uri = URIHelper.buildUri("http://example.com", params);
+        assertEquals("http://example.com?key1=a&b&key2=x=y&key3=path/to?resource#anchor&key4=value%20test", uri);
+    }
+
+    @Test
+    void testSpacesInParameterValues() {
+        String uri = URIHelper.buildUri("http://example.com", Map.of("name", "John Doe"));
+        assertEquals("http://example.com?name=John Doe", uri);
+    }
+
+    @Test
+    void testUnicodeCharactersInParameters() {
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("emoji", "😀🎉");
+        params.put("chinese", "你好");
+        params.put("arabic", "مرحبا");
+        String uri = URIHelper.buildUri("http://example.com", params);
+        assertEquals("http://example.com?arabic=مرحبا&chinese=你好&emoji=😀🎉", uri);
+    }
+
+    @Test
+    void testNullParameterValue() {
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("key1", "value1");
+        params.put("key2", null);
+        String uri = URIHelper.buildUri("http://example.com", params);
+        assertEquals("http://example.com?key1=value1&key2=null", uri);
+    }
+
+    @Test
+    void testEmptyStringParameterValue() {
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("key1", "value1");
+        params.put("key2", "");
+        String uri = URIHelper.buildUri("http://example.com", params);
+        assertEquals("http://example.com?key1=value1&key2=", uri);
+    }
+
+    @Test
+    void testLargeNumberOfParameters() {
+        Map<String, String> params = generateLargeMap(50);
+        String uri = URIHelper.buildUri("http://example.com", params);
+        for (int i = 0; i < 50; i++) {
+            assertEquals(true, uri.contains("p" + i + "=v" + i));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemeProvider")
+    void testBuildUriWithDifferentSchemes(String baseUri, Map<String, String> params) {
+        String uri = URIHelper.buildUri(baseUri, params);
+        assertEquals(baseUri, uri);
+    }
+
+    @Test
+    void testAddQueryParametersToUriWithFragment() {
+        SortedMap<String, String> params = new TreeMap<>();
+        params.put("key1", "value1");
+        params.put("key2", "value2");
+        String uri = URIHelper.addQueryParameters("http://example.com/path#section", params);
+        assertEquals("http://example.com/path#section?key1=value1&key2=value2", uri);
+    }
+
+    private static Stream<Arguments> schemeProvider() {
+        return Stream.of(
+                arguments("http://example.com", Map.of()),
+                arguments("https://example.com", Map.of()),
+                arguments("ftp://example.com", Map.of()),
+                arguments("file:///path/to/file", Map.of()),
+                arguments("custom://resource", Map.of()));
+    }
+
+    private static Map<String, String> generateLargeMap(int size) {
+        SortedMap<String, String> map = new TreeMap<>();
+        for (int i = 0; i < size; i++) {
+            map.put("p" + i, "v" + i);
+        }
+        return map;
     }
 }

--- a/core/core-util/src/test/java/ai/wanaku/core/uri/URIParserTest.java
+++ b/core/core-util/src/test/java/ai/wanaku/core/uri/URIParserTest.java
@@ -59,7 +59,29 @@ class URIParserTest {
                 arguments(
                         "http://my-host/data?id=456",
                         "http://my-host/data{parameter.query('id')}",
-                        makeArg(Map.of("id", "456", "name", "My Name With Spaces"))));
+                        makeArg(Map.of("id", "456", "name", "My Name With Spaces"))),
+                // Edge case: Empty template
+                arguments("", "", emptyArg()),
+                // Edge case: No substitution
+                arguments("http://example.com", "http://example.com", emptyArg()),
+                // Edge case: Empty string value
+                arguments("http://host/", "http://host/{id}", makeArg(Map.of("id", ""))),
+                // Edge case: Multiple substitutions
+                arguments(
+                        "http://host:8080/path?id=123",
+                        "http://{host}:{port}/{path}?id={id}",
+                        makeArg(Map.of("host", "host", "port", "8080", "path", "path", "id", "123"))),
+                // Edge case: Special chars (encoded)
+                arguments(
+                        "http://my-host/?query=a%26b%3Dc",
+                        "http://my-host/{parameter.query('query')}", makeArg(Map.of("query", "a&b=c"))),
+                // Edge case: valueOrElse with multiple params
+                arguments(
+                        "http://my-host/123/user/data",
+                        "http://my-host/{parameter.valueOrElse('id', 'default')}/user/data",
+                        makeArg(Map.of("id", "123"))),
+                // Edge case: Missing param with parameter.value
+                arguments("http://host//data", "http://host/{parameter.value('{missing}')}/data", emptyArg()));
     }
 
     static Map<String, Object> makeArg(Map<String, Object> map) {


### PR DESCRIPTION
## Summary
- Added 8 new edge case tests to URIHelperTest for special chars, spaces, unicode, null values, empty strings, large param sets, different schemes, and fragment handling
- Added 7 new edge cases to URIParserTest for empty templates, no substitution, empty string values, multiple substitutions, special char encoding, valueOrElse, and missing params
- All 43 tests passing in core-util module

## Test plan
- [x] Run `mvn clean test -pl core/core-util` - all tests pass
- [x] Verify 15 new tests added (8 URIHelper + 7 URIParser)
- [x] Confirm no regressions in existing tests

## Summary by Sourcery

Increase URI utility edge-case test coverage in the core-util module.

Tests:
- Add URIHelper tests covering special characters, spaces, Unicode, null and empty values, large parameter sets, multiple schemes, and fragment handling.
- Extend URIParser parameterized tests with additional edge-case templates, including empty templates, no substitutions, empty values, multiple substitutions, encoding, valueOrElse, and missing parameters.