### PR TITLE
[#529][UI] Implement Delete Forward Functionality

### DIFF
--- a/wanaku-router/ui/admin/src/hooks/api/use-forwards.ts
+++ b/wanaku-router/ui/admin/src/hooks/api/use-forwards.ts
@@ -1,4 +1,4 @@
-import { getApiV1ForwardsList, postApiV1ForwardsAdd, postApiV1ForwardsAddResponse } from "../../api/wanaku-router-api";
+import { getApiV1ForwardsList, postApiV1ForwardsAdd, postApiV1ForwardsAddResponse, putApiV1ForwardsRemove, putApiV1ForwardsRemoveResponse } from "../../api/wanaku-router-api";
 import { ForwardReference } from "../../models";
 
 // Simple in-memory cache for Client Components
@@ -40,4 +40,12 @@ export const addForward = async (
 ): Promise<postApiV1ForwardsAddResponse> => {
   clearForwardsCache();
   return postApiV1ForwardsAdd(forwardReference, options);
+};
+
+export const removeForward = async (
+  forwardReference: ForwardReference,
+  options?: RequestInit
+): Promise<putApiV1ForwardsRemoveResponse> => {
+  clearForwardsCache();
+  return putApiV1ForwardsRemove(forwardReference, options);
 };


### PR DESCRIPTION
## Summary
- Add delete button (trash can icon) to each row in the Forwards table
- Implement `removeForward` function in the use-forwards hook
- Add `handleDeleteForward` handler with error handling and cache invalidation
- Follows existing patterns from Tools and Resources pages

## Test plan
- [ ] Navigate to the Forwards page
- [ ] Verify delete button appears in each row
- [ ] Click delete on a forward and verify it is removed from the list
- [ ] Verify error toast appears if deletion fails
- [ ] Verify the forwards list refreshes after successful deletion

Closes #529

## Summary by Sourcery

Add UI and API support for deleting forwards from the Forwards page.

New Features:
- Allow users to delete individual forwards directly from the Forwards table via a new actions column.

Enhancements:
- Introduce a removeForward API helper in the forwards hook and wire it into the Forwards page with cache invalidation and error handling.