### PR TITLE
[#736][UI] Fix tools not showing on LLM Chat page

### DIFF
--- a/wanaku-router/ui/admin/src/custom-fetch.ts
+++ b/wanaku-router/ui/admin/src/custom-fetch.ts
@@ -37,6 +37,7 @@ const getBody = <T>(c: Response | Request): Promise<T> => {
     const requestInit: RequestInit = {
       ...options,
       headers: requestHeaders,
+      credentials: 'include',
     };
 
     const request = new Request(requestUrl, requestInit);


### PR DESCRIPTION
## Summary
- Add `credentials: 'include'` to `customFetch` for authenticated REST API requests
- Add credentials to MCP SSE client connection:
  - `withCredentials: true` for EventSource (SSE connection)
  - `credentials: 'include'` for POST requests
- Use REST API (`/api/v1/tools/list`) for listing tools instead of MCP client
- Add error state display for debugging fetch failures
- Add message when no tools are available

## Root Cause
After authentication was introduced, the MCP SSE client and REST API calls were not including credentials (cookies), resulting in 401 errors.

## Test plan
- [ ] Navigate to the LLM Chat page
- [ ] Go to the Tools Selection tab
- [ ] Verify tools are displayed and selectable
- [ ] Select some tools and verify they appear in the Chat tab
- [ ] Test chat functionality with selected tools

Fixes #736