### PR TITLE
[#531][UI] Add Configuration and Secrets URI Fields to Resource Forms

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Resources/AddResourceModal.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/AddResourceModal.tsx
@@ -35,6 +35,8 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
   const [fetchedData, setFetchedData] = useState<Namespace[]>([]);
   const [selectedNamespace, setSelectedNamespace] = useState('');
   const [params, setParams] = useState<Param[]>([]);
+  const [configurationURI, setConfigurationURI] = useState("")
+  const [secretsURI, setSecretsURI] = useState("")
   const { listManagementResources } = useCapabilities();
   
   useEffect(() => {
@@ -55,7 +57,9 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
       type: resourceType,
       mimeType,
       namespace: selectedNamespace,
-      params: nonEmptyParameters()
+      params: nonEmptyParameters(),
+      configurationURI,
+      secretsURI
     });
   };
 
@@ -99,6 +103,7 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
         <TabList>
           <Tab>Overview</Tab>
           <Tab>Parameters</Tab>
+          <Tab>External</Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -171,6 +176,22 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
                 onSetName={(i, name) => params[i].name = name}
                 onSetValue={(i, value) => params[i].value = value}
                 onDelete={removeParameter}
+            />
+          </TabPanel>
+          <TabPanel>
+            <TextInput
+              id="resource-configuration-uri"
+              labelText="Configuration URI"
+              placeholder="e.g. file:///config/resource-config.json"
+              value={configurationURI}
+              onChange={(event) => setConfigurationURI(event.target.value)}
+            />
+            <TextInput
+              id="resource-secrets-uri"
+              labelText="Secrets URI"
+              placeholder="e.g. vault://secrets/db-credentials"
+              value={secretsURI}
+              onChange={(event) => setSecretsURI(event.target.value)}
             />
           </TabPanel>
         </TabPanels>

--- a/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -52,8 +52,14 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
     }))
   }
 
+  function resourceHasParameters(resource: ResourceReference): boolean {
+    return !!resource.params?.length
+  }
+
   function resourceHasDetails(resource: ResourceReference) {
-    return resource.params && resource.params.length > 0
+    return resourceHasParameters(resource)
+            || resource.configurationURI
+            || resource.secretsURI
   }
 
   function tableCells(resource) {
@@ -75,6 +81,31 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
           />
         </TableCell>
       </React.Fragment>
+    )
+  }
+
+  function resourceDetails(resource: ResourceReference, rowProps) {
+    return (
+      <TableExpandedRow colSpan={headers.length + 3} {...rowProps}>
+        {resourceHasParameters(resource) && (
+          <div>
+            <strong>Parameters:</strong>
+            {resource.params?.map((parameter: Param) => {
+              return (<div>{parameter.name + ": " + parameter.value}</div>)
+            })}
+          </div>
+        )}
+        {resource.configurationURI && (
+          <div>
+            <strong>Configuration URI:</strong> {resource.configurationURI}
+          </div>
+        )}
+        {resource.secretsURI && (
+          <div>
+            <strong>Secrets URI:</strong> {resource.secretsURI}
+          </div>
+        )}
+      </TableExpandedRow>
     )
   }
 
@@ -116,18 +147,11 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
                         <TableExpandRow expandIconDescription="Show details" {...getRowProps({row})}>
                           {tableCells(resource)}
                         </TableExpandRow>
-                        {row.isExpanded && (
-                          <TableExpandedRow colSpan={headers.length + 3} {...getExpandedRowProps({row})}>
-                            Parameters:
-                            {resource.params?.map((parameter: Param) => {
-                              return (<div>{parameter.name + ": " + parameter.value}</div>)
-                            })}
-                          </TableExpandedRow>
-                        )}
+                        {row.isExpanded && resourceDetails(resource, getExpandedRowProps({row}))}
                       </React.Fragment>
                     )
                   } else if (resource) {
-                    // resource without detials, no expansion available
+                    // resource without details, no expansion available
                     return (
                       <TableRow {...getRowProps({row})}>
                         <TableCell />


### PR DESCRIPTION
Isuue: https://github.com/wanaku-ai/wanaku/issues/531

I've added the two new field on a separate tab. 
I've put values for these two fields into resource details (ExpandedRow) in order to avoid adding more columns to the table.

Any comment are welcome!

## Summary by Sourcery

Add support for configuring external URIs on resources and displaying them in the resources table details view.

New Features:
- Add configuration and secrets URI fields to the Add Resource modal under a new External tab.
- Include configuration and secrets URIs in the resource creation payload so they are persisted with the resource.
- Show configuration and secrets URIs in the expanded details row of the resources table alongside existing parameters.

Enhancements:
- Refine resource detail detection to consider presence of configuration or secrets URIs in addition to parameters.