### PR TITLE
[#281] Add refresh endpoint for forwarded tools/resources

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/forwards/Forwards.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/forwards/Forwards.java
@@ -26,7 +26,7 @@ import org.jline.terminal.Terminal;
 @Command(
         name = "forwards",
         description = "Manage forwards",
-        subcommands = {ForwardsAdd.class, ForwardsRemove.class, ForwardsList.class})
+        subcommands = {ForwardsAdd.class, ForwardsRemove.class, ForwardsList.class, ForwardsRefresh.class})
 public class Forwards extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws IOException, Exception {

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
@@ -1,0 +1,54 @@
+package ai.wanaku.cli.main.commands.forwards;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
+import static picocli.CommandLine.Command;
+import static picocli.CommandLine.Option;
+
+import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ForwardsService;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.jline.terminal.Terminal;
+
+@Command(name = "refresh", description = "Refresh forward to re-discover tools and resources")
+public class ForwardsRefresh extends BaseCommand {
+    @Option(
+            names = {"--host"},
+            description = "The API host",
+            defaultValue = "http://localhost:8080",
+            arity = "0..1")
+    protected String host;
+
+    @Option(
+            names = {"--name"},
+            description = "The name of the forward to refresh",
+            required = true,
+            arity = "0..1")
+    protected String name;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        ForwardsService forwardsService = initService(ForwardsService.class, host);
+
+        ForwardReference reference = new ForwardReference();
+        reference.setName(name);
+
+        try (Response ignored = forwardsService.refreshForward(reference)) {
+            printer.printSuccessMessage("Successfully refreshed forward reference '" + reference.getName() + "'");
+        } catch (WebApplicationException ex) {
+            Response response = ex.getResponse();
+            if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+                String warningMessage = String.format(
+                        "Forward not found (%s): %s%n",
+                        name, response.getStatusInfo().getReasonPhrase());
+                printer.printWarningMessage(warningMessage);
+                return EXIT_ERROR;
+            }
+            commonResponseErrorHandler(response);
+            return EXIT_ERROR;
+        }
+        return EXIT_OK;
+    }
+}

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ForwardsService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ForwardsService.java
@@ -91,4 +91,15 @@ public interface ForwardsService {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     Response updateForward(ForwardReference reference);
+
+    /**
+     * Refreshes a forward reference to re-discover tools and resources from the remote server.
+     *
+     * @param reference the forward reference to refresh
+     * @return a {@link Response} indicating the result of the refresh operation
+     */
+    @Path("/refresh")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response refreshForward(ForwardReference reference);
 }

--- a/wanaku-router/ui/admin/src/Pages/Forwards/Forwards.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Forwards/Forwards.tsx
@@ -14,9 +14,9 @@ import {
     TableToolbarContent,
     ToastNotification,
 } from "@carbon/react";
-import { Add, TrashCan } from "@carbon/icons-react";
+import { Add, Renew, TrashCan } from "@carbon/icons-react";
 import {useEffect, useState} from "react";
-import {addForward, listForwards, removeForward} from "../../hooks/api/use-forwards";
+import {addForward, listForwards, refreshForward, removeForward} from "../../hooks/api/use-forwards";
 import {ForwardReference} from "../../models";
 import {getNamespacePathById} from "../../hooks/api/use-namespaces";
 import {AddForwardModal} from "./AddForwardModal";
@@ -39,9 +39,10 @@ interface ForwardsTableProps {
     rows: ForwardRow[];
     onAdd: () => void;
     onDelete: (forward: ForwardReference) => void;
+    onRefresh: (forward: ForwardReference) => void;
 }
 
-const ForwardsTable = ({rows: forwardRows, onAdd, onDelete}: ForwardsTableProps) => {
+const ForwardsTable = ({rows: forwardRows, onAdd, onDelete, onRefresh}: ForwardsTableProps) => {
     return (
         <Grid>
             <Column lg={12} md={8} sm={4}>
@@ -76,6 +77,16 @@ const ForwardsTable = ({rows: forwardRows, onAdd, onDelete}: ForwardsTableProps)
                                                 <TableCell key={cell.id}>{cell.value}</TableCell>
                                             ))}
                                             <TableCell>
+                                                <Button
+                                                    kind="ghost"
+                                                    renderIcon={Renew}
+                                                    iconDescription="Refresh"
+                                                    hasIconOnly
+                                                    onClick={() => {
+                                                        const forwardRow = forwardRows.find(r => r.id === row.id);
+                                                        if (forwardRow) onRefresh(forwardRow.original);
+                                                    }}
+                                                />
                                                 <Button
                                                     kind="ghost"
                                                     renderIcon={TrashCan}
@@ -157,6 +168,19 @@ const ForwardsPage = () => {
         }
     };
 
+    const handleRefreshForward = async (forward: ForwardReference) => {
+        try {
+            const response = await refreshForward(forward);
+            if (response.status === 200) {
+                fetchForwards();
+            } else {
+                setErrorMessage("Failed to refresh forward");
+            }
+        } catch (error) {
+            setErrorMessage(error instanceof Error ? error.message : "An error occurred while refreshing forward");
+        }
+    };
+
     return (
         <div>
             <h1 className="title">Forwards</h1>
@@ -179,7 +203,7 @@ const ForwardsPage = () => {
                 />
             )}
             <div id="page-content">
-                <ForwardsTable rows={forwards} onAdd={handleAddClick} onDelete={handleDeleteForward}/>
+                <ForwardsTable rows={forwards} onAdd={handleAddClick} onDelete={handleDeleteForward} onRefresh={handleRefreshForward}/>
             </div>
         </div>
     );

--- a/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
+++ b/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
@@ -671,6 +671,53 @@ export const postApiV1ForwardsUpdate = async (
 };
 
 /**
+ * @summary Refresh Forward
+ */
+export type postApiV1ForwardsRefreshResponse200 = {
+  data: null;
+  status: 200;
+};
+
+export type postApiV1ForwardsRefreshResponse400 = {
+  data: null;
+  status: 400;
+};
+
+export type postApiV1ForwardsRefreshResponse500 = {
+  data: WanakuResponse;
+  status: 500;
+};
+
+export type postApiV1ForwardsRefreshResponseComposite =
+  | postApiV1ForwardsRefreshResponse200
+  | postApiV1ForwardsRefreshResponse400
+  | postApiV1ForwardsRefreshResponse500;
+
+export type postApiV1ForwardsRefreshResponse =
+  postApiV1ForwardsRefreshResponseComposite & {
+    headers: Headers;
+  };
+
+export const getPostApiV1ForwardsRefreshUrl = () => {
+  return `/api/v1/forwards/refresh`;
+};
+
+export const postApiV1ForwardsRefresh = async (
+  forwardReference: ForwardReference,
+  options?: RequestInit,
+): Promise<postApiV1ForwardsRefreshResponse> => {
+  return customFetch<postApiV1ForwardsRefreshResponse>(
+    getPostApiV1ForwardsRefreshUrl(),
+    {
+      ...options,
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(forwardReference),
+    },
+  );
+};
+
+/**
  * @summary Deregister
  */
 export type postApiV1ManagementDiscoveryDeregisterResponse200 = {

--- a/wanaku-router/ui/admin/src/hooks/api/use-forwards.ts
+++ b/wanaku-router/ui/admin/src/hooks/api/use-forwards.ts
@@ -1,4 +1,4 @@
-import { getApiV1ForwardsList, postApiV1ForwardsAdd, postApiV1ForwardsAddResponse, putApiV1ForwardsRemove, putApiV1ForwardsRemoveResponse } from "../../api/wanaku-router-api";
+import { getApiV1ForwardsList, postApiV1ForwardsAdd, postApiV1ForwardsAddResponse, postApiV1ForwardsRefresh, postApiV1ForwardsRefreshResponse, putApiV1ForwardsRemove, putApiV1ForwardsRemoveResponse } from "../../api/wanaku-router-api";
 import { ForwardReference } from "../../models";
 
 // Simple in-memory cache for Client Components
@@ -48,4 +48,12 @@ export const removeForward = async (
 ): Promise<putApiV1ForwardsRemoveResponse> => {
   clearForwardsCache();
   return putApiV1ForwardsRemove(forwardReference, options);
+};
+
+export const refreshForward = async (
+  forwardReference: ForwardReference,
+  options?: RequestInit
+): Promise<postApiV1ForwardsRefreshResponse> => {
+  clearForwardsCache();
+  return postApiV1ForwardsRefresh(forwardReference, options);
 };

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -246,6 +246,21 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         forwardReferenceRepository.update(resource.getName(), resource);
     }
 
+    public void refresh(ForwardReference forwardReferenceHint) {
+        List<ForwardReference> references = forwardReferenceRepository.findByName(forwardReferenceHint.getName());
+        if (references.isEmpty()) {
+            throw new WanakuException("Forward reference not found: " + forwardReferenceHint.getName());
+        }
+
+        ForwardReference forwardReference = references.getFirst();
+
+        // Remove existing tools/resources and unlink resolver
+        removeLinkedEntries(forwardReference);
+
+        // Re-register with fresh data from remote server
+        registerForward(forwardReference);
+    }
+
     @Override
     protected WanakuRepository<ForwardReference, String> getRepository() {
         return forwardReferenceRepository;

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -58,4 +58,12 @@ public class ForwardsResource {
         forwardsBean.update(resource);
         return Response.ok().build();
     }
+
+    @Path("/refresh")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response refresh(ForwardReference reference) throws WanakuException {
+        forwardsBean.refresh(reference);
+        return Response.ok().build();
+    }
 }

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -779,6 +779,28 @@ paths:
       summary: Update
       tags:
       - Forwards Resource
+  /api/v1/forwards/refresh:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForwardReference"
+        required: true
+      responses:
+        "200":
+          description: OK
+        "500":
+          description: Wanaku error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WanakuResponse"
+        "400":
+          description: Bad Request
+      summary: Refresh Forward
+      tags:
+      - Forwards Resource
   /api/v1/management/discovery/deregister:
     post:
       requestBody:


### PR DESCRIPTION
## Summary
- Add `/api/v1/forwards/refresh` endpoint to re-discover tools/resources from remote MCP servers
- Add `wanaku forwards refresh --name <name>` CLI command
- Add refresh button (circular arrow icon) next to each forward in the UI table

## Test plan
- [ ] Start wanaku-router with a forward MCP configured
- [ ] Note the tools/resources listed
- [ ] Add new tool/resource to the remote MCP server
- [ ] Click refresh button on the forward (or use CLI command)
- [ ] Verify new tools/resources appear without removing/re-adding the forward

Closes #281

## Summary by Sourcery

Add support for refreshing forwards to re-discover tools and resources from remote MCP servers via API, CLI, and UI.

New Features:
- Expose a POST /api/v1/forwards/refresh endpoint and service method to refresh a forward reference against the remote server.
- Introduce a CLI command `wanaku forwards refresh --name <name>` to trigger a forward refresh from the command line.
- Add a refresh action in the forwards admin UI table to invoke the refresh endpoint and reload the forwards list.

Enhancements:
- Extend backend forward management logic to clear existing linked tools/resources and re-register the forward based on the latest remote data.