### PR TITLE
[#608] Change default imagePullPolicy from Always to IfNotPresent

### DIFF
--- a/wanaku-operator/samples/router.yaml
+++ b/wanaku-operator/samples/router.yaml
@@ -22,10 +22,15 @@ spec:
 #        value: value2
 # You can also set a custom image for the router
 #    image: quay.io/wanaku/wanaku-router-backend:latest # Optional
+# You can also configure the image pull policy (default: IfNotPresent)
+# Valid values: Always, IfNotPresent, Never
+#    imagePullPolicy: IfNotPresent
   capabilities:
 # For the capabilities, you need to provide the name, image to use and any environment variables required:
+# You can also optionally specify the imagePullPolicy (default: IfNotPresent)
     - name: wanaku-http
       image: quay.io/wanaku/wanaku-tool-service-http:latest
+#      imagePullPolicy: IfNotPresent  # Optional: Always, IfNotPresent, or Never
     - name: finance-system
       image: quay.io/wanaku/camel-integration-capability:latest
     - name: employee-system

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "wanaku-service"
         - name: CLIENT_SECRET
           value: ""
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 10

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
               value: ""
           image: ""
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: wanaku-capability
           ports:
             - containerPort: 9000


### PR DESCRIPTION
## Summary
- Change default imagePullPolicy for capability deployments from `Always` to `IfNotPresent`
- Add documentation in samples/router.yaml showing how to configure imagePullPolicy

## Changes
- `wanaku-capability-deployment.yaml`: Always → IfNotPresent
- `camel-integration-capability-deployment.yaml`: Always → IfNotPresent
- `samples/router.yaml`: Added comments documenting imagePullPolicy configuration

## Benefits
- Reduces unnecessary image pulls, improving deployment speed
- Reduces bandwidth usage and registry load
- More suitable for production environments
- Aligns with standard Kubernetes defaults

The imagePullPolicy can still be overridden per deployment by setting it in the Wanaku CR spec. Valid values are: `Always`, `IfNotPresent`, `Never`.

Fixes #608

## Summary by Sourcery

Update default image pull policy for Wanaku capability deployments to be more production-friendly and document how to configure it.

Enhancements:
- Change capability deployment manifests to use IfNotPresent as the default imagePullPolicy instead of Always to reduce unnecessary image pulls.
- Document configurable imagePullPolicy options in the router sample manifest for both the router and capabilities.