### PR TITLE
[#608] Add global imagePullPolicy with priority resolution

### DIFF
--- a/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakus.wanaku.ai-v1.yml
+++ b/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakus.wanaku.ai-v1.yml
@@ -24,6 +24,13 @@ spec:
                   authServer:
                     type: "string"
                 type: "object"
+              imagePullPolicy:
+                type: "string"
+                description: "Global default image pull policy for all deployments"
+                enum:
+                - "Always"
+                - "IfNotPresent"
+                - "Never"
               capabilities:
                 items:
                   properties:
@@ -40,6 +47,11 @@ spec:
                       type: "string"
                     imagePullPolicy:
                       type: "string"
+                      description: "Override image pull policy for this capability (overrides global)"
+                      enum:
+                      - "Always"
+                      - "IfNotPresent"
+                      - "Never"
                     name:
                       type: "string"
                     type:
@@ -61,6 +73,11 @@ spec:
                     type: "string"
                   imagePullPolicy:
                     type: "string"
+                    description: "Override image pull policy for router (overrides global)"
+                    enum:
+                    - "Always"
+                    - "IfNotPresent"
+                    - "Never"
                 type: "object"
               secrets:
                 properties:

--- a/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
+++ b/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_NAMESPACES
               value: {{ .Values.app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_NAMESPACES | quote }}
           image: {{ .Values.app.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.app.imagePullPolicy }}
           livenessProbe:
             failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
             httpGet:

--- a/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
+++ b/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
@@ -3,6 +3,7 @@ app:
   envs:
     QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_NAMESPACES: JOSDK_WATCH_CURRENT
   image: quay.io/wanaku/wanaku-operator:latest
+  imagePullPolicy: IfNotPresent
   livenessProbe:
     failureThreshold: 3
     httpGet:

--- a/wanaku-operator/samples/router.yaml
+++ b/wanaku-operator/samples/router.yaml
@@ -12,6 +12,11 @@ spec:
   secrets:
 # This is the OIDC credentials secret for the services
     oidcCredentialsSecret: ""
+# Global image pull policy for all deployments (router and capabilities)
+# Valid values: Always, IfNotPresent, Never
+# Default: IfNotPresent
+# Can be overridden per-component using router.imagePullPolicy or capability.imagePullPolicy
+#  imagePullPolicy: IfNotPresent
 # Router settings are optional
   router:
     env:
@@ -22,10 +27,14 @@ spec:
 #        value: value2
 # You can also set a custom image for the router
 #    image: quay.io/wanaku/wanaku-router-backend:latest # Optional
+# Override pull policy for router only (takes precedence over global setting)
+#    imagePullPolicy: Always
   capabilities:
 # For the capabilities, you need to provide the name, image to use and any environment variables required:
+# You can also optionally set imagePullPolicy per capability (overrides global setting)
     - name: wanaku-http
       image: quay.io/wanaku/wanaku-tool-service-http:latest
+#      imagePullPolicy: Always  # Optional: Always, IfNotPresent, Never
     - name: finance-system
       image: quay.io/wanaku/camel-integration-capability:latest
     - name: employee-system

--- a/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuSpec.java
+++ b/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuSpec.java
@@ -7,6 +7,15 @@ public class WanakuSpec {
     private SecretsSpec secrets;
     private RouterSpec router;
     private List<CapabilitiesSpec> capabilities;
+    private String imagePullPolicy;
+
+    public String getImagePullPolicy() {
+        return imagePullPolicy;
+    }
+
+    public void setImagePullPolicy(String imagePullPolicy) {
+        this.imagePullPolicy = imagePullPolicy;
+    }
 
     public AuthSpec getAuth() {
         return auth;

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: "wanaku-service"
         - name: CLIENT_SECRET
           value: ""
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 10

--- a/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
               value: ""
           image: ""
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: wanaku-capability
           ports:
             - containerPort: 9000


### PR DESCRIPTION
## Summary
Implements configurable image pull policies for all operator-managed deployments with a priority resolution chain.

## Changes

### WanakuSpec.java
- Add global `imagePullPolicy` field at spec level

### OperatorUtil.java
- Add `resolveImagePullPolicy()` helper method with priority:
  1. Component-specific policy (router.imagePullPolicy or capability.imagePullPolicy)
  2. Global policy (spec.imagePullPolicy)
  3. Default (IfNotPresent)
- Add validation for allowed values: Always, IfNotPresent, Never
- Update `setupBackendContainer()` to use resolution chain
- Update `setupCapabilityContainer()` to accept Wanaku resource and use resolution chain

### CRD Schema (wanakus.wanaku.ai-v1.yml)
- Add global `imagePullPolicy` field with enum validation
- Add enum validation and descriptions to router and capability imagePullPolicy fields

### Helm Chart
- Add `imagePullPolicy` to values.yaml (default: IfNotPresent)
- Update deployment.yaml template to use configurable value

### YAML Templates
- Change default from `Always` to `IfNotPresent` in:
  - wanaku-capability-deployment.yaml
  - camel-integration-capability-deployment.yaml

### Documentation (samples/router.yaml)
- Add examples for global imagePullPolicy
- Add examples for router-specific and capability-specific overrides

## Usage Examples

**Global default for all:**
```yaml
spec:
  imagePullPolicy: IfNotPresent  # Applied to all deployments
```

**Mixed policies:**
```yaml
spec:
  imagePullPolicy: IfNotPresent  # Default
  router:
    imagePullPolicy: Always      # Override for router only
  capabilities:
    - name: wanaku-http
      image: quay.io/wanaku/wanaku-tool-service-http:latest
      # Inherits IfNotPresent from global
    - name: dev-capability
      image: my-registry/dev-capability:latest
      imagePullPolicy: Always    # Override for this capability
```

## Test Plan
- [ ] Verify global imagePullPolicy applies to all deployments
- [ ] Verify component-specific override takes precedence over global
- [ ] Verify invalid values fall back to default with warning
- [ ] Verify backward compatibility (no imagePullPolicy = uses IfNotPresent default)
- [ ] Verify Helm chart templating works correctly

Fixes #608

## Summary by Sourcery

Introduce a configurable global imagePullPolicy for Wanaku-managed deployments with precedence rules and schema support.

New Features:
- Add a global imagePullPolicy field to WanakuSpec that applies to all operator-managed deployments with component-level overrides.
- Allow configuring the operator deployment imagePullPolicy via Helm chart values.

Enhancements:
- Implement centralized image pull policy resolution with validation and a priority chain of component-specific, global, then default policies.
- Update router and capability deployment templates to default to IfNotPresent instead of Always for image pull policy.
- Extend the CRD schema and sample manifests with documented imagePullPolicy options and override behavior.

Build:
- Make the operator Helm deployment template consume a configurable imagePullPolicy value from values.yaml.

Documentation:
- Document global and per-component imagePullPolicy usage and override examples in the sample router manifest.