### PR TITLE
Added additional details about the internals of the router

### DIFF
--- a/docs/internals-persistence.md
+++ b/docs/internals-persistence.md
@@ -1,0 +1,543 @@
+# Wanaku Persistence Architecture
+
+This document describes the Wanaku persistence layer architecture, designed as a reference for implementing similar persistence systems.
+
+## Overview
+
+The persistence layer follows a layered architecture:
+
+```
+┌─────────────────────────────────────┐
+│         Service Layer               │
+├─────────────────────────────────────┤
+│       Repository Interfaces         │  ← API module
+├─────────────────────────────────────┤
+│    Abstract Implementations         │  ← Infinispan module
+├─────────────────────────────────────┤
+│     Concrete Repositories           │
+├─────────────────────────────────────┤
+│    Infinispan Embedded Cache        │
+├─────────────────────────────────────┤
+│      SingleFileStore (Disk)         │
+└─────────────────────────────────────┘
+```
+
+**Key characteristics:**
+- Repository pattern with generics
+- Infinispan embedded cache with file-based persistence
+- Protocol Buffers (proto3) for serialization
+- CDI for dependency injection
+- Thread-safe operations with ReentrantLock
+
+## Entity Hierarchy
+
+### Base Interface: WanakuEntity
+
+All persisted entities implement `WanakuEntity<K>`:
+
+```java
+public interface WanakuEntity<K> {
+    K getId();
+    void setId(K id);
+}
+```
+
+### Labels Support: LabelsAwareEntity
+
+Entities requiring metadata labels extend `LabelsAwareEntity<T>`:
+
+```java
+public abstract class LabelsAwareEntity<T> implements WanakuEntity<T> {
+    private Map<String, String> labels;
+
+    public Map<String, String> getLabels();
+    public void setLabels(Map<String, String> labels);
+    public void addLabel(String key, String value);
+    public void addLabels(Map<String, String> labelsMap);
+    public String getLabelValue(String labelKey);
+    public boolean hasLabel(String labelKey);
+    public boolean hasLabel(String labelKey, String labelValue);
+    public boolean removeLabel(String labelKey);
+}
+```
+
+### Concrete Entity Example
+
+```java
+public class DataStore extends LabelsAwareEntity<String> {
+    private String id;
+    private String name;
+    private String data;  // Base64-encoded content
+
+    // getters/setters
+}
+```
+
+## Repository Interfaces
+
+### Base Repository: WanakuRepository
+
+```java
+public interface WanakuRepository<A extends WanakuEntity, C> {
+    A persist(A entity);
+    List<A> listAll();
+    boolean deleteById(C id);
+    A findById(C id);
+    boolean update(C id, A entity);
+    boolean remove(Predicate<A> matching);
+    int size();
+    int removeByField(String fieldName, Object fieldValue);
+    int removeByFields(Map<String, Object> fields);
+    int removeAll();
+    boolean exists(C key);
+}
+```
+
+**Key operations:**
+- `persist()` - Generates ID if null, stores entity
+- `removeByField()/removeByFields()` - Bulk deletion using Ickle queries
+- `update()` - Lock-protected entity modification
+
+### Label-Aware Repository: LabelAwareInfinispanRepository
+
+```java
+public interface LabelAwareInfinispanRepository<A extends LabelsAwareEntity<K>, K>
+    extends WanakuRepository<A, K> {
+
+    List<A> findAllFilterByLabelExpression(String labelExpression);
+    int removeIf(String labelExpression) throws LabelExpressionParseException;
+}
+```
+
+**Label expression examples:**
+- `category=weather` - Exact match
+- `category=weather & !action=forecast` - AND with negation
+- `(category=weather | category=news) & environment=production` - Complex boolean
+
+### Domain-Specific Interfaces
+
+```java
+public interface DataStoreRepository
+    extends LabelAwareInfinispanRepository<DataStore, String> {
+    List<DataStore> findByName(String name);
+}
+```
+
+## Abstract Implementations
+
+### AbstractInfinispanRepository
+
+Base implementation providing thread-safe CRUD operations:
+
+```java
+public abstract class AbstractInfinispanRepository<A extends WanakuEntity<K>, K>
+    implements WanakuRepository<A, K> {
+
+    protected final EmbeddedCacheManager cacheManager;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    protected abstract Class<A> entityType();
+    protected abstract String entityName();
+    protected abstract K newId();
+
+    @Override
+    public A persist(A entity) {
+        lock.lock();
+        try {
+            if (entity.getId() == null) {
+                entity.setId(newId());
+            }
+            getCache().put(entity.getId(), entity);
+            return entity;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean update(K id, A entity) {
+        lock.lock();
+        try {
+            if (!getCache().containsKey(id)) {
+                return false;
+            }
+            entity.setId(id);
+            getCache().put(id, entity);
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public int removeByField(String fieldName, Object fieldValue) {
+        // Uses Ickle query: DELETE FROM EntityClass WHERE field = :value
+    }
+
+    protected Cache<K, A> getCache() {
+        return cacheManager.getCache(entityName());
+    }
+}
+```
+
+### AbstractLabelAwareInfinispanRepository
+
+Extends base with label filtering:
+
+```java
+public abstract class AbstractLabelAwareInfinispanRepository<A extends LabelsAwareEntity<K>, K>
+    extends AbstractInfinispanRepository<A, K>
+    implements LabelAwareInfinispanRepository<A, K> {
+
+    @Override
+    public List<A> findAllFilterByLabelExpression(String labelExpression) {
+        Predicate<A> predicate = LabelExpressionParser.parse(labelExpression);
+        return listAll().stream()
+            .filter(predicate)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public int removeIf(String labelExpression) {
+        Predicate<A> predicate = LabelExpressionParser.parse(labelExpression);
+        List<A> toRemove = listAll().stream()
+            .filter(predicate)
+            .collect(Collectors.toList());
+        toRemove.forEach(e -> deleteById(e.getId()));
+        return toRemove.size();
+    }
+}
+```
+
+## Concrete Repository Implementation
+
+```java
+public class InfinispanDataStoreRepository
+    extends AbstractLabelAwareInfinispanRepository<DataStore, String>
+    implements DataStoreRepository {
+
+    public InfinispanDataStoreRepository(EmbeddedCacheManager cacheManager,
+                                          Configuration configuration) {
+        super(cacheManager, configuration);
+    }
+
+    @Override
+    protected String entityName() {
+        return "datastore";
+    }
+
+    @Override
+    protected Class<DataStore> entityType() {
+        return DataStore.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<DataStore> findByName(String name) {
+        QueryFactory queryFactory = Search.getQueryFactory(getCache());
+        Query<DataStore> query = queryFactory.create(
+            "from ai.wanaku.capabilities.sdk.api.types.DataStore d where d.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+}
+```
+
+## Serialization Layer
+
+### Proto Schema Definition
+
+Create `.proto` files in `src/main/resources/proto/`:
+
+```protobuf
+// data_store.proto
+syntax = "proto3";
+package ai.wanaku.capabilities.sdk.api.types;
+
+message DataStore {
+  string id = 1;
+  string name = 2;
+  string data = 3;
+  map<string, string> labels = 4;
+}
+```
+
+**Field type mappings:**
+- Strings → `string`
+- Labels → `map<string, string>`
+- Nested objects → `message`
+- Lists → `repeated`
+
+### Marshaller Implementation
+
+Implement `MessageMarshaller<T>` for each entity:
+
+```java
+public class DataStoreMarshaller implements MessageMarshaller<DataStore> {
+
+    @Override
+    public String getTypeName() {
+        return DataStore.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends DataStore> getJavaClass() {
+        return DataStore.class;
+    }
+
+    @Override
+    public DataStore readFrom(ProtoStreamReader reader) throws IOException {
+        DataStore dataStore = new DataStore();
+        dataStore.setId(reader.readString("id"));
+        dataStore.setName(reader.readString("name"));
+        dataStore.setData(reader.readString("data"));
+        dataStore.setLabels(reader.readMap("labels",
+            new HashMap<>(), String.class, String.class));
+        return dataStore;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, DataStore dataStore)
+            throws IOException {
+        writer.writeString("id", dataStore.getId());
+        writer.writeString("name", dataStore.getName());
+        writer.writeString("data", dataStore.getData());
+        writer.writeMap("labels", dataStore.getLabels(),
+            String.class, String.class);
+    }
+}
+```
+
+### Schema Initializer
+
+Register schemas and marshallers:
+
+```java
+public class DataStoreSchema
+    extends AbstractWanakuSerializationContextInitializer {
+
+    @Override
+    public String getProtoFileName() {
+        return "data_store.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new DataStoreMarshaller());
+    }
+}
+```
+
+**Base class loads proto file from classpath:**
+
+```java
+public abstract class AbstractWanakuSerializationContextInitializer
+    implements SerializationContextInitializer {
+
+    public abstract String getProtoFileName();
+
+    public String getProtoFile() {
+        return ResourceUtils.getResourceAsString(
+            getClass(), "/proto/" + getProtoFileName());
+    }
+
+    public void registerSchema(SerializationContext serCtx) {
+        serCtx.registerProtoFiles(
+            FileDescriptorSource.fromString(getProtoFileName(), getProtoFile()));
+    }
+
+    public abstract void registerMarshallers(SerializationContext serCtx);
+}
+```
+
+## CDI Configuration
+
+### Infinispan Configuration Provider
+
+```java
+public class InfinispanConfigurationProvider {
+
+    @ConfigProperty(name = "wanaku.persistence.infinispan.base-folder",
+                   defaultValue = "${user.home}/.wanaku/router/")
+    String baseFolder;
+
+    @Produces
+    Configuration newConfiguration() {
+        String location = baseFolder.replace(
+            "${user.home}", System.getProperty("user.home"));
+        Files.createDirectories(Paths.get(location));
+
+        return new ConfigurationBuilder()
+            .clustering()
+            .cacheMode(CacheMode.LOCAL)
+            .persistence()
+            .passivation(false)
+            .addStore(SingleFileStoreConfigurationBuilder.class)
+            .location(location)
+            .build();
+    }
+}
+```
+
+**Configuration options:**
+- `CacheMode.LOCAL` - Single-node caching
+- `SingleFileStore` - File-based persistence
+- `passivation(false)` - All entries persisted to disk
+- Configurable storage location via property
+
+### Repository Producer
+
+```java
+public class InfinispanPersistenceConfiguration {
+
+    @Inject
+    EmbeddedCacheManager cacheManager;
+
+    @Inject
+    Configuration configuration;
+
+    @Produces
+    DataStoreRepository dataStoreRepository() {
+        return new InfinispanDataStoreRepository(cacheManager, configuration);
+    }
+
+    @Produces
+    ToolReferenceRepository toolReferenceRepository() {
+        return new InfinispanToolReferenceRepository(cacheManager, configuration);
+    }
+
+    // Additional producers for each repository type
+}
+```
+
+## Usage Patterns
+
+### Injecting Repositories
+
+```java
+@ApplicationScoped
+public class DataStoreService {
+
+    @Inject
+    DataStoreRepository repository;
+
+    public DataStore create(String name, String data) {
+        DataStore store = new DataStore();
+        store.setName(name);
+        store.setData(Base64.getEncoder().encodeToString(data.getBytes()));
+        store.addLabel("type", "config");
+        return repository.persist(store);
+    }
+
+    public List<DataStore> findByLabel(String expression) {
+        return repository.findAllFilterByLabelExpression(expression);
+    }
+}
+```
+
+### Label-Based Queries
+
+```java
+// Find all with specific label
+List<ToolReference> tools = toolRepo.findAllFilterByLabelExpression("category=weather");
+
+// Complex expression with AND/OR/NOT
+List<ResourceReference> resources = resourceRepo.findAllFilterByLabelExpression(
+    "(type=file | type=database) & !environment=test");
+
+// Remove by label expression
+int removed = toolRepo.removeIf("deprecated=true & !protected=true");
+```
+
+### Bulk Operations
+
+```java
+// Remove by single field
+int count = repository.removeByField("namespace", "old-namespace");
+
+// Remove by multiple fields (AND condition)
+Map<String, Object> fields = Map.of(
+    "namespace", "test",
+    "type", "temporary"
+);
+int count = repository.removeByFields(fields);
+```
+
+## Directory Structure
+
+```
+core/core-persistence/
+├── core-persistence-api/
+│   └── src/main/java/ai/wanaku/core/persistence/api/
+│       ├── WanakuRepository.java
+│       ├── LabelAwareInfinispanRepository.java
+│       └── {Domain}Repository.java
+│
+└── core-persistence-infinispan/
+    └── src/main/
+        ├── java/ai/wanaku/core/persistence/infinispan/
+        │   ├── AbstractInfinispanRepository.java
+        │   ├── AbstractLabelAwareInfinispanRepository.java
+        │   ├── Infinispan{Domain}Repository.java
+        │   ├── InfinispanPersistenceConfiguration.java
+        │   ├── providers/
+        │   │   └── InfinispanConfigurationProvider.java
+        │   └── protostream/
+        │       ├── schema/
+        │       │   ├── AbstractWanakuSerializationContextInitializer.java
+        │       │   └── {Domain}Schema.java
+        │       └── marshaller/
+        │           └── {Domain}Marshaller.java
+        └── resources/proto/
+            └── {domain}.proto
+```
+
+## Implementation Checklist
+
+When adding a new entity type:
+
+1. **Entity Class**
+   - [ ] Implement `WanakuEntity<K>` or extend `LabelsAwareEntity<T>`
+   - [ ] Define fields with getters/setters
+
+2. **Repository Interface**
+   - [ ] Extend `WanakuRepository` or `LabelAwareInfinispanRepository`
+   - [ ] Add domain-specific query methods
+
+3. **Repository Implementation**
+   - [ ] Extend appropriate abstract class
+   - [ ] Implement `entityName()`, `entityType()`, `newId()`
+   - [ ] Implement domain-specific query methods
+
+4. **Proto Schema**
+   - [ ] Create `.proto` file in `resources/proto/`
+   - [ ] Define message with field numbers
+
+5. **Marshaller**
+   - [ ] Implement `MessageMarshaller<T>`
+   - [ ] Handle all fields in `readFrom()` and `writeTo()`
+
+6. **Schema Initializer**
+   - [ ] Extend `AbstractWanakuSerializationContextInitializer`
+   - [ ] Return proto filename
+   - [ ] Register marshaller
+
+7. **CDI Producer**
+   - [ ] Add `@Produces` method in configuration class
+
+## Key Design Decisions
+
+1. **Embedded Cache**: Uses Infinispan embedded mode for simplicity and zero external dependencies. Data persists to local file system.
+
+2. **Local Cache Mode**: Single-node operation. For distributed scenarios, change to `CacheMode.DIST_SYNC` or `REPL_SYNC`.
+
+3. **ReentrantLock**: Ensures thread-safe ID generation and updates. Lock is held only during cache operations.
+
+4. **Ickle Queries**: Infinispan's query language for bulk operations. More efficient than iterating and removing individually.
+
+5. **Label Expressions**: In-memory filtering with parsed predicates. Suitable for moderate data sizes; consider indexed queries for large datasets.
+
+6. **Proto3 Serialization**: Efficient binary format with forward/backward compatibility. Field numbers must not change once deployed.

--- a/docs/internals-service-registration.md
+++ b/docs/internals-service-registration.md
@@ -1,0 +1,596 @@
+# Service Registration Architecture
+
+This document describes the capability registration workflow for the Wanaku service discovery system. It is intended as a reference for implementing similar service discovery patterns.
+
+## Architecture Overview
+
+The service registration system uses a layered design:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    REST API Layer                       │
+│              (DiscoveryResource.java)                   │
+├─────────────────────────────────────────────────────────┤
+│                    Bean Layer                           │
+│               (DiscoveryBean.java)                      │
+├─────────────────────────────────────────────────────────┤
+│                  Registry Interface                     │
+│             (ServiceRegistry.java)                      │
+├─────────────────────────────────────────────────────────┤
+│               Persistence Layer                         │
+│         (InfinispanServiceRegistry.java)                │
+│    ┌─────────────────────┬─────────────────────────┐    │
+│    │CapabilitiesRepository│ ServiceRecordRepository│    │
+│    └─────────────────────┴─────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+Key characteristics:
+- Service targets represent downstream capability endpoints
+- Reactive messaging distributes events to subscribers
+- gRPC transport for service-to-service communication
+- Dual-repository pattern separates service metadata from activity history
+
+---
+
+## Core Data Types
+
+### ServiceTarget
+
+Service endpoint descriptor stored in the registry.
+
+**Package:** `ai.wanaku.capabilities.sdk.api.types.providers`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String` | Unique identifier (assigned by registry) |
+| `serviceName` | `String` | Logical name of the service |
+| `host` | `String` | Host address |
+| `port` | `int` | Port number |
+| `serviceType` | `String` | Type category (see ServiceType) |
+| `serviceSubType` | `String` | Engine type: jvm, interpreted, camel |
+| `languageName` | `String` | Language: java, python, yaml, xml |
+| `languageType` | `String` | compiled, interpreted |
+| `languageSubType` | `String` | jvm, cpython, etc. |
+
+**Key Methods:**
+```java
+String toAddress()                    // Returns "host:port"
+static ServiceTarget newEmptyTarget(String serviceName, String host,
+    int port, String serviceType, String serviceSubType)
+```
+
+### ServiceType
+
+Enumeration of service categories.
+
+**Package:** `ai.wanaku.capabilities.sdk.api.types.providers`
+
+| Value | String | Int |
+|-------|--------|-----|
+| `RESOURCE_PROVIDER` | "resource-provider" | 1 |
+| `TOOL_INVOKER` | "tool-invoker" | 2 |
+| `MULTI_CAPABILITY` | "multi-capability" | 3 |
+| `CODE_EXECUTION_ENGINE` | "code-execution-engine" | 4 |
+
+### ServiceState
+
+Point-in-time health snapshot.
+
+**Package:** `ai.wanaku.capabilities.sdk.api.types.discovery`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | `Instant` | When state was recorded |
+| `healthy` | `boolean` | Health status |
+| `reason` | `String` | Message (used when unhealthy) |
+
+**Factory Methods:**
+```java
+static ServiceState newHealthy()                    // Healthy with "HEALTHY" message
+static ServiceState newUnhealthy(String reason)     // Unhealthy with reason
+static ServiceState newMissingInAction()            // "MISSING_IN_ACTION"
+static ServiceState newInactive()                   // "AUTO_DEREGISTRATION"
+```
+
+### ActivityRecord
+
+Service lifecycle tracking with state history.
+
+**Package:** `ai.wanaku.capabilities.sdk.api.types.discovery`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String` | Service identifier |
+| `lastSeen` | `Instant` | Last activity timestamp |
+| `active` | `boolean` | Current active status |
+| `states` | `List<ServiceState>` | State history (circular buffer) |
+
+---
+
+## Discovery API Endpoints
+
+**Base Path:** `/api/v1/management/discovery`
+
+### POST /register
+
+Register a service with the router. Returns the service target with assigned ID.
+
+**Request:** `ServiceTarget` (JSON)
+**Response:** `WanakuResponse<ServiceTarget>`
+
+```java
+RestResponse<WanakuResponse<ServiceTarget>> register(ServiceTarget serviceTarget);
+```
+
+### POST /deregister
+
+Remove a service from the registry.
+
+**Request:** `ServiceTarget` (JSON)
+**Response:** 200 OK
+
+```java
+Response deregister(ServiceTarget serviceTarget);
+```
+
+### POST /update/{id}
+
+Update service state (report health status).
+
+**Path Parameter:** `id` - Service identifier
+**Request:** `ServiceState` (JSON)
+**Response:** 200 OK
+
+```java
+Response updateState(@PathParam("id") String id, ServiceState serviceState);
+```
+
+### POST /ping
+
+Send heartbeat to indicate service is still active.
+
+**Request:** Service ID as plain text
+**Response:** 200 OK
+
+```java
+Response ping(String id);
+```
+
+---
+
+## Registry Layer
+
+### ServiceRegistry Interface
+
+**Package:** `ai.wanaku.core.mcp.providers`
+
+Defines the contract for service registration and discovery operations.
+
+```java
+public interface ServiceRegistry {
+    // Registration
+    ServiceTarget register(ServiceTarget serviceTarget);
+    void deregister(ServiceTarget serviceTarget);
+    void update(ServiceTarget serviceTarget);
+
+    // Query
+    List<ServiceTarget> getServiceByName(String serviceName, String serviceType);
+    List<ServiceTarget> getCodeExecutionService(String serviceType,
+        String serviceSubType, String serviceName);
+    List<ServiceTarget> getEntries();
+    List<ServiceTarget> getEntries(String serviceType);
+
+    // State Management
+    ActivityRecord getStates(String id);
+    void updateLastState(String id, ServiceState state);
+    void ping(String id);
+}
+```
+
+### InfinispanServiceRegistry
+
+**Package:** `ai.wanaku.core.persistence.infinispan.discovery`
+
+Implementation using dual-repository pattern:
+- `InfinispanCapabilitiesRepository` - stores `ServiceTarget` entities
+- `InfinispanServiceRecordRepository` - stores `ActivityRecord` entities
+
+**Key Behaviors:**
+
+1. **Registration:** Delegates to capabilities repository, generates UUID for ID
+2. **Multi-Capability Matching:** Queries include services with type "multi-capability"
+3. **Circular Buffer:** States list capped at configurable max (default 10), removes oldest 50% when exceeded
+
+```java
+// Configuration
+@ConfigProperty(name = "wanaku.persistence.infinispan.max-state-count",
+    defaultValue = "10")
+int maxStateCount;
+```
+
+### Repository Queries
+
+**Capabilities Repository:**
+
+```java
+// Find by name and type (includes multi-capability)
+findByService(serviceName, serviceType)
+// WHERE serviceName = :serviceName
+//   AND (serviceType = :serviceType OR serviceType = 'multi-capability')
+
+// List by type (includes multi-capability)
+listCapable(serviceType)
+// WHERE serviceType = :serviceType OR serviceType = 'multi-capability'
+
+// Find code execution engine (exact match)
+findCodeExecutionService(serviceType, serviceSubType, languageName)
+// WHERE serviceType = :serviceType
+//   AND serviceSubType = :serviceSubType
+//   AND languageName = :languageName
+```
+
+---
+
+## Registration Workflow (Service Side)
+
+### RegistrationManager Interface
+
+**Package:** `ai.wanaku.capabilities.sdk.api.discovery`
+
+Defines the contract for managing service lifecycle registration.
+
+```java
+public interface RegistrationManager {
+    void register();
+    void deregister();
+    void ping();
+    void lastAsFail(String reason);
+    void lastAsSuccessful();
+    void addCallBack(DiscoveryCallback callback);
+}
+```
+
+### DefaultRegistrationManager
+
+**Package:** `ai.wanaku.core.capabilities.discovery`
+
+Quarkus CDI implementation with retry logic and persistent identity.
+
+**Key Features:**
+- Restores service ID from persistent storage on startup
+- Uses `ReentrantLock` for thread-safe registration
+- Retry logic with configurable wait time
+- Callback pattern for lifecycle notifications
+
+**Registration Flow:**
+
+```
+┌──────────────────┐
+│ register() called│
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐     Yes    ┌─────────────┐
+│ Already registered?├─────────►│ Call ping() │
+└────────┬─────────┘            └─────────────┘
+         │ No
+         ▼
+┌──────────────────┐
+│ Acquire lock     │
+│ (1s timeout)     │
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│ tryRegistering() │◄─────────┐
+└────────┬─────────┘          │
+         │                    │ Retry
+         ▼                    │
+┌──────────────────┐   Fail   │
+│ Call REST API    ├──────────┘
+└────────┬─────────┘
+         │ Success
+         ▼
+┌──────────────────┐
+│ Save ID to disk  │
+│ Set registered   │
+│ Invoke callbacks │
+└──────────────────┘
+```
+
+### DiscoveryCallback Interface
+
+**Package:** `ai.wanaku.capabilities.sdk.api.discovery`
+
+Callback interface for receiving registration lifecycle events.
+
+```java
+public interface DiscoveryCallback {
+    void onPing(RegistrationManager manager, ServiceTarget target, int status);
+    void onRegistration(RegistrationManager manager, ServiceTarget target);
+    void onDeregistration(RegistrationManager manager, ServiceTarget target, int status);
+}
+```
+
+**Usage:**
+```java
+registrationManager.addCallBack(new DiscoveryCallback() {
+    @Override
+    public void onRegistration(RegistrationManager manager, ServiceTarget target) {
+        LOG.info("Registered with ID: " + target.getId());
+    }
+
+    @Override
+    public void onPing(RegistrationManager manager, ServiceTarget target, int status) {
+        if (status != 200) {
+            LOG.warn("Ping failed with status: " + status);
+        }
+    }
+
+    @Override
+    public void onDeregistration(RegistrationManager manager, ServiceTarget target, int status) {
+        LOG.info("Deregistered");
+    }
+});
+```
+
+---
+
+## Service Resolution (Router Side)
+
+### ServiceResolver Interface
+
+**Package:** `ai.wanaku.backend.service.support`
+
+Defines contract for resolving services from the registry.
+
+```java
+public interface ServiceResolver {
+    ServiceTarget resolve(String serviceName, String serviceType);
+    ServiceTarget resolveCodeExecution(String serviceType, String serviceSubType,
+        String languageName);
+}
+```
+
+### FirstAvailable Strategy
+
+**Package:** `ai.wanaku.backend.service.support`
+
+Simple strategy that returns the first matching service from the registry.
+
+```java
+public class FirstAvailable implements ServiceResolver {
+    private final ServiceRegistry serviceRegistry;
+
+    public FirstAvailable(ServiceRegistry serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    public ServiceTarget resolve(String serviceName, String serviceType) {
+        List<ServiceTarget> services = serviceRegistry.getServiceByName(
+            serviceName, serviceType);
+        if (services != null && !services.isEmpty()) {
+            return services.getFirst();
+        }
+        return null;
+    }
+
+    @Override
+    public ServiceTarget resolveCodeExecution(String serviceType,
+            String serviceSubType, String languageName) {
+        List<ServiceTarget> services = serviceRegistry.getCodeExecutionService(
+            serviceType, serviceSubType, languageName);
+        if (services != null && !services.isEmpty()) {
+            return services.getFirst();
+        }
+        return null;
+    }
+}
+```
+
+### Provider Pattern
+
+Resolvers are exposed via CDI producers:
+
+```java
+@ApplicationScoped
+public class ToolsProvider {
+    @Inject
+    Instance<ServiceRegistry> serviceRegistryInstance;
+
+    @Produces
+    @DefaultBean
+    ToolsResolver getResolver() {
+        ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+        WanakuBridgeTransport transport = new GrpcTransport();
+        return new WanakuToolsResolver(
+            new InvokerBridge(resolver, transport, toolCallEventEmitter));
+    }
+}
+```
+
+---
+
+## Event System
+
+### ServiceTargetEvent
+
+**Package:** `ai.wanaku.backend.common`
+
+Event object emitted when service registration state changes.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `eventType` | `EventType` | Type of event |
+| `id` | `String` | Service identifier |
+| `serviceTarget` | `ServiceTarget` | Full service descriptor (register/deregister) |
+| `serviceState` | `ServiceState` | Health state (update events) |
+
+**Factory Methods:**
+```java
+static ServiceTargetEvent register(ServiceTarget serviceTarget)
+static ServiceTargetEvent deregister(ServiceTarget serviceTarget)
+static ServiceTargetEvent update(String id, ServiceState serviceState)
+static ServiceTargetEvent ping(String id)
+```
+
+### EventType Enum
+
+```java
+public enum EventType {
+    REGISTER("register"),
+    DEREGISTER("deregister"),
+    UPDATE("update"),
+    PING("ping");
+}
+```
+
+### Reactive Messaging
+
+Events are published to the `service-target-event` channel:
+
+```java
+@Inject
+@Channel("service-target-event")
+@OnOverflow(OnOverflow.Strategy.DROP)
+MutinyEmitter<ServiceTargetEvent> serviceTargetEventEmitter;
+
+private void emitEvent(ServiceTargetEvent event) {
+    if (serviceTargetEventEmitter.hasRequests()) {
+        serviceTargetEventEmitter.send(event);
+    }
+}
+```
+
+### SSE Notifications
+
+Events are exposed via Server-Sent Events at `/api/v1/capabilities/notifications`:
+
+```java
+@Path("/notifications")
+@Produces(MediaType.SERVER_SENT_EVENTS)
+@GET
+@RestStreamElementType(MediaType.APPLICATION_JSON)
+public Multi<OutboundSseEvent> targetsEventStream(@Context Sse sse) {
+    return serviceTargetEvents.map(event -> sse.newEventBuilder()
+            .name(event.getEventType().name())
+            .id(event.getId())
+            .data(event)
+            .build());
+}
+```
+
+---
+
+## Code Examples
+
+### Creating a ServiceTarget
+
+```java
+ServiceTarget target = new ServiceTarget();
+target.setServiceName("my-tool-provider");
+target.setHost("localhost");
+target.setPort(8080);
+target.setServiceType(ServiceType.TOOL_INVOKER.asValue());
+
+// Or using factory method
+ServiceTarget target = ServiceTarget.newEmptyTarget(
+    "my-tool-provider",
+    "localhost",
+    8080,
+    ServiceType.TOOL_INVOKER.asValue(),
+    null  // serviceSubType
+);
+```
+
+### Registration Lifecycle
+
+```java
+// Create the discovery service client (Quarkus REST Client)
+DiscoveryService discoveryService = RestClientBuilder.newBuilder()
+    .baseUri(URI.create("http://router:8080"))
+    .build(DiscoveryService.class);
+
+// Register
+RestResponse<WanakuResponse<ServiceTarget>> response =
+    discoveryService.register(target);
+String assignedId = response.getEntity().getData().getId();
+
+// Periodic heartbeat
+scheduledExecutor.scheduleAtFixedRate(() -> {
+    discoveryService.ping(assignedId);
+}, 30, 30, TimeUnit.SECONDS);
+
+// Report state changes
+discoveryService.updateState(assignedId, ServiceState.newHealthy());
+discoveryService.updateState(assignedId,
+    ServiceState.newUnhealthy("Database connection lost"));
+
+// Deregister on shutdown
+discoveryService.deregister(target);
+```
+
+### Service Resolution
+
+```java
+@Inject
+ServiceRegistry serviceRegistry;
+
+// Resolve a tool invoker
+ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+ServiceTarget toolService = resolver.resolve(
+    "my-tool",
+    ServiceType.TOOL_INVOKER.asValue()
+);
+
+if (toolService != null) {
+    String address = toolService.toAddress();  // "host:port"
+    // Connect to service...
+}
+
+// Resolve code execution engine
+ServiceTarget engine = resolver.resolveCodeExecution(
+    ServiceType.CODE_EXECUTION_ENGINE.asValue(),
+    "camel",      // engine type
+    "yaml"        // language
+);
+```
+
+### Event Handling
+
+```java
+// Subscribe to service events
+@Inject
+@Channel("service-target-event")
+Multi<ServiceTargetEvent> events;
+
+void subscribeToEvents() {
+    events.subscribe().with(event -> {
+        switch (event.getEventType()) {
+            case REGISTER -> handleRegistration(event.getServiceTarget());
+            case DEREGISTER -> handleDeregistration(event.getServiceTarget());
+            case UPDATE -> handleStateUpdate(event.getId(), event.getServiceState());
+            case PING -> handlePing(event.getId());
+        }
+    });
+}
+```
+
+---
+
+## File Locations
+
+| Component | Path |
+|-----------|------|
+| Discovery REST API | `wanaku-router/wanaku-router-backend/.../discovery/DiscoveryResource.java` |
+| Discovery Bean | `wanaku-router/wanaku-router-backend/.../discovery/DiscoveryBean.java` |
+| ServiceRegistry Interface | `core/core-mcp/.../providers/ServiceRegistry.java` |
+| Infinispan Implementation | `core/core-persistence/core-persistence-infinispan/.../discovery/` |
+| ServiceTarget Model | `capabilities-api/.../types/providers/ServiceTarget.java` |
+| State Models | `capabilities-api/.../types/discovery/` |
+| Registration Manager | `core/core-capabilities-base/.../discovery/DefaultRegistrationManager.java` |
+| Service Resolver | `wanaku-router/wanaku-router-backend/.../support/ServiceResolver.java` |
+| Event Types | `wanaku-router/wanaku-router-backend/.../common/EventType.java` |
+| SSE Endpoint | `wanaku-router/wanaku-router-backend/.../capabilities/CapabilitiesResource.java` |

--- a/docs/wanaku-router-internals.md
+++ b/docs/wanaku-router-internals.md
@@ -328,6 +328,8 @@ Different capability types use strategy pattern to:
 
 ## Related Documentation
 
+- **[Persistence](internals-persistence.md)** - Persistence information
+- **[Persistence](internals-service-registration.md)** - Service registration information
 - **[Architecture Overview](architecture.md)** - High-level system architecture and components
 - **[Configuration Guide](configurations.md)** - Router and service configuration reference
 - **[Contributing Guide](../CONTRIBUTING.md)** - How to extend Wanaku with new capabilities


### PR DESCRIPTION
## Summary by Sourcery

Document the internal architecture and workflows for Wanaku's service registration and persistence layers.

Documentation:
- Add detailed service registration architecture documentation covering data types, APIs, registry implementation, workflows, resolution strategies, and eventing.
- Add detailed persistence layer documentation covering entity hierarchy, repository patterns, serialization with ProtoBuf, CDI configuration, and usage patterns.
- Link the new persistence and service registration internals documents from the router internals documentation.