### PR TITLE
[#526][UI] Implement Edit/Update Resource Functionality

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Resources/ResourceModal.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/ResourceModal.tsx
@@ -18,25 +18,27 @@ import { useCapabilities } from "../../hooks/api/use-capabilities";
 import { TargetTypeSelect } from "../Targets/TargetTypeSelect";
 import { ParametersTable } from "./ParametersTable.tsx";
 
-interface AddResourceModalProps {
+interface ResourceModalProps {
+  resource?: ResourceReference
   onRequestClose: () => void;
-  onSubmit: (newResource: ResourceReference) => void;
+  onSubmit: (resource: ResourceReference) => void;
 }
 
-export const AddResourceModal: React.FC<AddResourceModalProps> = ({
+export const ResourceModal: React.FC<ResourceModalProps> = ({
+  resource,
   onRequestClose,
   onSubmit,
 }) => {
-  const [resourceName, setResourceName] = useState("");
-  const [description, setDescription] = useState("");
-  const [location, setLocation] = useState("");
-  const [resourceType, setResourceType] = useState("file");
-  const [mimeType, setMimeType] = useState("");
+  const [resourceName, setResourceName] = useState(resource?.name || "");
+  const [description, setDescription] = useState(resource?.description || "");
+  const [location, setLocation] = useState(resource?.location || "");
+  const [resourceType, setResourceType] = useState(resource?.type || "file");
+  const [mimeType, setMimeType] = useState(resource?.mimeType || "");
   const [fetchedData, setFetchedData] = useState<Namespace[]>([]);
-  const [selectedNamespace, setSelectedNamespace] = useState('');
-  const [params, setParams] = useState<Param[]>([]);
-  const [configurationURI, setConfigurationURI] = useState("")
-  const [secretsURI, setSecretsURI] = useState("")
+  const [selectedNamespace, setSelectedNamespace] = useState(resource?.namespace || "");
+  const [params, setParams] = useState<Param[]>(resource?.params || []);
+  const [configurationURI, setConfigurationURI] = useState(resource?.configurationURI || "")
+  const [secretsURI, setSecretsURI] = useState(resource?.secretsURI || "")
   const { listManagementResources } = useCapabilities();
   
   useEffect(() => {
@@ -51,6 +53,7 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
 
   const handleSubmit = () => {
     onSubmit({
+      id: resource?.id,
       name: resourceName,
       description,
       location,
@@ -93,8 +96,8 @@ export const AddResourceModal: React.FC<AddResourceModalProps> = ({
   return (
     <Modal
       open={true}
-      modalHeading="Add a Resource"
-      primaryButtonText="Add"
+      modalHeading={resource ? "Edit resource" : "Add a Resource"}
+      primaryButtonText={resource ? "Save" : "Add"}
       secondaryButtonText="Cancel"
       onRequestClose={onRequestClose}
       onRequestSubmit={handleSubmit}

--- a/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -14,21 +14,23 @@ import {
   TableToolbar,
   TableToolbarContent,
 } from "@carbon/react";
-import { Add, TrashCan} from "@carbon/icons-react";
+import { Add, TrashCan, Edit } from "@carbon/icons-react";
 import React from "react";
-import { Param, ResourceReference} from "../../models";
+import { Param, ResourceReference } from "../../models";
 import { getNamespacePathById } from "../../hooks/api/use-namespaces";
 
 interface ResourcesTableProps {
   resources: ResourceReference[];
   onDelete: (resourceName?: string) => void;
   onAdd: () => void;
+  onEdit: (resource: ResourceReference) => void
 }
 
 export const ResourcesTable: React.FC<ResourcesTableProps> = ({
   resources,
   onDelete,
   onAdd,
+  onEdit
 }) => {
   const headers = [
     {key: "name", header: "Name"},
@@ -42,7 +44,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
 
   function resourcesToRows() {
     return resources.map((resource: ResourceReference, index: number) => ({
-      id: resource.name || `resource-${index}`,
+      id: resource.id || `resource-${index}`,
       name: resource.name,
       location: resource.location,
       type: resource.type,
@@ -73,11 +75,18 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
         <TableCell>{getNamespacePathById(resource.namespace) || "default"}</TableCell>
         <TableCell>
           <Button
-              kind="ghost"
-              renderIcon={TrashCan}
-              hasIconOnly
-              iconDescription="Delete"
-              onClick={() => onDelete(resource.name)}
+            kind="ghost"
+            renderIcon={Edit}
+            hasIconOnly
+            iconDescription="Edit"
+            onClick={() => onEdit(resource)}
+          />
+          <Button
+            kind="ghost"
+            renderIcon={TrashCan}
+            hasIconOnly
+            iconDescription="Delete"
+            onClick={() => onDelete(resource.name)}
           />
         </TableCell>
       </React.Fragment>
@@ -139,7 +148,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
               </TableHead>
               <TableBody>
                 {rows.map((row) => {
-                  const resource = resources.find((item) => item.name === row.id)
+                  const resource = resources.find((item) => item.id === row.id)
                   if (resource && resourceHasDetails(resource)) {
                     // resource with details, expansion available
                     return (

--- a/wanaku-router/ui/admin/src/Pages/Resources/index.ts
+++ b/wanaku-router/ui/admin/src/Pages/Resources/index.ts
@@ -1,4 +1,4 @@
 export * from './router-exports';
 export * from './ResourcesPage';
 export * from './ResourcesTable';
-export * from './AddResourceModal';
+export * from './ResourceModal.tsx';

--- a/wanaku-router/ui/admin/src/hooks/api/use-resources.ts
+++ b/wanaku-router/ui/admin/src/hooks/api/use-resources.ts
@@ -7,7 +7,9 @@ import {
   postApiV1ResourcesExposeResponse,
   getApiV1ResourcesListResponse,
   putApiV1ResourcesRemoveResponse,
-  getApiV1CapabilitiesResponse
+  getApiV1CapabilitiesResponse,
+  postApiV1DataStoreUpdateResponse,
+  postApiV1ResourcesUpdate
 } from "../../api/wanaku-router-api";
 import {
   PutApiV1ResourcesRemoveParams,
@@ -42,6 +44,16 @@ export const useResources = () => {
     []
   );
 
+  const updateResource = useCallback(
+    (
+      resource: ResourceReference,
+      options?: RequestInit
+    ): Promise<postApiV1DataStoreUpdateResponse> => {
+      return postApiV1ResourcesUpdate(resource, options)
+    },
+    []
+  )
+
   /**
    * List resources.
    */
@@ -71,6 +83,7 @@ export const useResources = () => {
     listManagementResources,
     exposeResource,
     listResources,
+    updateResource,
     removeResource,
   };
 };


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/526

I've added optional _resource_ (_ResourceReference_) to the modal dialogue. If present, the fields are filled with resource data. Some text values are changed based on whether editing or adding a resource.

## Summary by Sourcery

Add support for editing existing resources in the admin UI alongside the existing create and delete flows.

New Features:
- Introduce an edit resource flow in the admin UI, allowing users to modify existing resources from the resources table.

Enhancements:
- Replace the dedicated add-only modal with a unified resource modal that handles both creating and editing resources, including prefilled form fields and context-aware labels.
- Extend the resources hook with an updateResource API wrapper and wire it through to the resources page and table actions.
- Use stable resource IDs instead of names as table row identifiers and for expansion handling in the resources table.