### PR TITLE
[#525][UI] Implement Edit/Update Tool Functionality

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Tools/ToolModal.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Tools/ToolModal.tsx
@@ -1,0 +1,123 @@
+import {
+  Modal,
+  Select,
+  SelectItem,
+  TextInput,
+} from "@carbon/react";
+import React, { useEffect, useState } from "react";
+import { Namespace, ToolReference } from "../../models";
+import { listNamespaces } from "../../hooks/api/use-namespaces";
+import { TargetTypeSelect } from "../Targets/TargetTypeSelect";
+import { useCapabilities } from "../../hooks/api/use-capabilities";
+import { formatInputSchema, parseInputSchema } from "./tools-utils.ts";
+
+
+interface ToolModalProps {
+  tool?: ToolReference
+  onSubmit: (tool: ToolReference) => void
+  onRequestClose: () => void
+}
+
+export const ToolModal: React.FC<ToolModalProps> = ({
+  tool,
+  onSubmit,
+  onRequestClose
+}) => {
+  const [toolName, setToolName] = useState(tool?.name || "")
+  const [description, setDescription] = useState(tool?.description || "")
+  const [uri, setUri] = useState(tool?.uri || "")
+  const [toolType, setToolType] = useState(tool?.type || "http")
+  const [inputSchema, setInputSchema] = useState(formatInputSchema(tool?.inputSchema))
+  const [fetchedNamespaceData, setFetchedNamespaceData] = useState<Namespace[]>([])
+  const [selectedNamespace, setSelectedNamespace] = useState(tool?.namespace || "")
+  const { listManagementTools } = useCapabilities()
+
+  useEffect(() => {
+    listNamespaces().then((result) => {
+      setFetchedNamespaceData(result.data.data as Namespace[])
+    })
+  }, [listNamespaces])
+
+  const handleSelectionChange = (event) => {
+    setSelectedNamespace(event.target.value)
+  }
+
+  const handleSubmit = () => {
+    try {
+      const schema = parseInputSchema(inputSchema)
+      onSubmit({
+        id: tool?.id,
+        name: toolName,
+        description,
+        uri,
+        type: toolType,
+        inputSchema: schema,
+        namespace: selectedNamespace,
+      })
+    } catch (error) {
+      console.error("Invalid JSON in input schema:", error)
+    }
+  }
+
+  return (
+    <Modal
+      open={true}
+      modalHeading={tool ? "Edit Tool" : "Add a Tool"}
+      primaryButtonText={tool ? "Save" : "Add"}
+      secondaryButtonText="Cancel"
+      onRequestSubmit={handleSubmit}
+      onRequestClose={onRequestClose}
+    >
+      <TextInput
+        id="tool-name"
+        labelText="Tool Name"
+        placeholder="e.g. meow-facts"
+        value={toolName}
+        onChange={(event) => setToolName(event.target.value)}
+      />
+      <TextInput
+        id="tool-description"
+        labelText="Description"
+        placeholder="e.g. Retrieve random facts about cats"
+        value={description}
+        onChange={(event) => setDescription(event.target.value)}
+      />
+      <TextInput
+        id="tool-uri"
+        labelText="URI"
+        placeholder="e.g. https://meowfacts.herokuapp.com?count={count}"
+        value={uri}
+        onChange={(event) => setUri(event.target.value)}
+      />
+      <TargetTypeSelect
+        value={toolType}
+        onChange={setToolType}
+        apiCall={listManagementTools}
+      />
+      <TextInput
+        id="input-schema"
+        labelText="Input Schema"
+        placeholder='e.g. {"type": "object", "properties": {"count": {"type": "int", "description": "The count of facts to retrieve"}}, "required": ["count"]}'
+        value={inputSchema}
+        onChange={(event) => setInputSchema(event.target.value)}
+      />
+      <Select
+        id="namespace"
+        labelText="Select a Namespace"
+        helperText="Choose a Namespace from the list"
+        value={selectedNamespace}
+        onChange={handleSelectionChange}
+      >
+        <SelectItem text="Choose an option" value="" />
+        {fetchedNamespaceData.map((namespace: Namespace) => (
+          <SelectItem
+            key={namespace.id}
+            id={namespace.id}
+            text={namespace.path || "default"}
+            value={namespace.id}
+          />
+        ))}
+      </Select>
+    </Modal>
+  )
+}

--- a/wanaku-router/ui/admin/src/Pages/Tools/ToolsTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Tools/ToolsTable.tsx
@@ -1,4 +1,4 @@
-import { Add, Upload, TrashCan } from "@carbon/icons-react";
+import { Add, Upload, TrashCan, Edit } from "@carbon/icons-react";
 import {
   Button,
   Column,
@@ -13,31 +13,22 @@ import {
 import { FunctionComponent } from "react";
 import { ToolReference } from "../../models";
 import { getNamespacePathById } from "../../hooks/api/use-namespaces";
+import { formatInputSchema } from "./tools-utils.ts";
 
 interface ToolListProps {
   fetchedData: ToolReference[];
   onDelete: (toolName?: string) => void;
   onImport: () => void;
   onAdd: () => void;
+  onEdit: (tool: ToolReference) => void
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const formatInputSchema = (inputSchema: any) => {
-  return (
-    Object.entries(inputSchema.properties)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map(([key, value]: [string, any]) => {
-        return `${key}: ${value.type} - ${value.description}`;
-      })
-      .join("\n")
-  );
-};
 
 export const ToolsTable: FunctionComponent<ToolListProps> = ({
   fetchedData,
   onDelete,
   onImport,
   onAdd,
+  onEdit
 }) => {
   const headers = [
     "Name",
@@ -77,25 +68,32 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {fetchedData.map((row: ToolReference) => (
-              <TableRow key={row.name}>
-                <TableCell>{row.name}</TableCell>
-                <TableCell>{row.type}</TableCell>
-                <TableCell>{row.description}</TableCell>
+            {fetchedData.map((tool: ToolReference) => (
+              <TableRow key={tool.name}>
+                <TableCell>{tool.name}</TableCell>
+                <TableCell>{tool.type}</TableCell>
+                <TableCell>{tool.description}</TableCell>
                 <TableCell style={{ wordWrap: "break-word" }}>
-                  {row.uri}
+                  {tool.uri}
                 </TableCell>
                 <TableCell style={{ fontSize: "14px" }}>
-                  {formatInputSchema(row.inputSchema)}
+                  {formatInputSchema(tool.inputSchema)}
                 </TableCell>
-                <TableCell>{getNamespacePathById(row.namespace) || "default"}</TableCell>
+                <TableCell>{getNamespacePathById(tool.namespace) || "default"}</TableCell>
                 <TableCell>
+                  <Button
+                    kind="ghost"
+                    renderIcon={Edit}
+                    hasIconOnly
+                    iconDescription="Edit"
+                    onClick={() => onEdit(tool)}
+                  />
                   <Button
                     kind="ghost"
                     renderIcon={TrashCan}
                     iconDescription="Delete"
                     hasIconOnly
-                    onClick={() => onDelete(row.name)}
+                    onClick={() => onDelete(tool.name)}
                   />
                 </TableCell>
               </TableRow>

--- a/wanaku-router/ui/admin/src/Pages/Tools/tools-utils.ts
+++ b/wanaku-router/ui/admin/src/Pages/Tools/tools-utils.ts
@@ -1,0 +1,9 @@
+import { InputSchema } from "../../models";
+
+export function formatInputSchema(inputSchema?: InputSchema): string {
+  return (inputSchema) ? (JSON.stringify(inputSchema, null, 1)) : ""
+}
+
+export function parseInputSchema(inputSchema: string): InputSchema | undefined {
+    return inputSchema === "" ? undefined : JSON.parse(inputSchema)
+}

--- a/wanaku-router/ui/admin/src/hooks/api/use-tools.ts
+++ b/wanaku-router/ui/admin/src/hooks/api/use-tools.ts
@@ -7,7 +7,9 @@ import {
   getApiV1CapabilitiesResponse,
   postApiV1ToolsAddResponse,
   getApiV1ToolsListResponse,
-  putApiV1ToolsRemoveResponse
+  putApiV1ToolsRemoveResponse,
+  postApiV1ToolsUpdateResponse,
+  postApiV1ToolsUpdate
 } from "../../api/wanaku-router-api";
 import {
   PutApiV1ToolsRemoveParams,
@@ -41,6 +43,12 @@ export const useTools = () => {
     []
   );
 
+  const updateTool = useCallback(
+    (tool: ToolReference, options?: RequestInit): Promise<postApiV1ToolsUpdateResponse> => {
+      return postApiV1ToolsUpdate(tool, options)
+    }, []
+  )
+
   /**
    * List tools.
    */
@@ -67,6 +75,7 @@ export const useTools = () => {
   return {
     listManagementTools,
     addTool,
+    updateTool,
     listTools,
     removeTool,
   };


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/525

- I've put the Modal into separate file
- implemented the same way as Edit Resources
- _inputSchema_ didn't work for me. I've created two methods for `InputSchema <-> string` conversion and put it into _tools-utils.ts_. The original method seemed to me like it never worked correctly, but please double check this. I'd hate to break something.

## Summary by Sourcery

Add support for editing existing tools in the admin UI and refactor the tool form into a reusable modal component.

New Features:
- Introduce a reusable ToolModal component used for both creating and editing tools, including namespace selection and input schema editing.
- Add an edit action in the tools table that opens the modal pre-populated with the selected tool's data.
- Wire a new updateTool API hook to submit tool updates to the backend.

Enhancements:
- Replace the inline AddToolModal implementation with the shared ToolModal for cleaner, more maintainable tools page UI.
- Move input schema formatting and parsing into a dedicated tools-utils module and reuse it across the tools table and modal.