### PR TITLE
[#764][CLI] Add automatic token refresh to prevent premature logout

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -82,6 +82,8 @@ public class AuthLogin extends BaseCommand {
 
                 credentialStore.storeApiToken(serviceAuthenticator.currentValidAccessToken());
                 credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
+                credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
+                credentialStore.storeClientId(DEFAULT_CLIENT_ID);
 
                 credentialStore.storeAuthMode("token");
                 credentialStore.storeAuthServerUrl(serverUrl);

--- a/cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -19,6 +19,8 @@ public class AuthCredentialStore {
     private static final String REFRESH_TOKEN_KEY = "refresh.token";
     private static final String AUTH_MODE_KEY = "auth.mode";
     private static final String AUTH_SERVER_URL_KEY = "auth.server.url";
+    private static final String TOKEN_EXPIRY_KEY = "token.expiry";
+    private static final String CLIENT_ID_KEY = "client.id";
 
     private final URI credentialsUri;
 
@@ -111,6 +113,43 @@ public class AuthCredentialStore {
      */
     public String getAuthServerUrl() {
         return get(AUTH_SERVER_URL_KEY);
+    }
+
+    /**
+     * Stores the token expiry time as epoch seconds.
+     *
+     * @param expiryEpochSeconds the expiry time in epoch seconds
+     */
+    public void storeTokenExpiry(long expiryEpochSeconds) {
+        storeCredential(TOKEN_EXPIRY_KEY, String.valueOf(expiryEpochSeconds));
+    }
+
+    /**
+     * Retrieves the token expiry time as epoch seconds.
+     *
+     * @return the expiry time in epoch seconds, or 0 if not found
+     */
+    public long getTokenExpiry() {
+        String expiry = get(TOKEN_EXPIRY_KEY);
+        return expiry != null ? Long.parseLong(expiry) : 0;
+    }
+
+    /**
+     * Stores the OAuth2 client ID.
+     *
+     * @param clientId the client ID
+     */
+    public void storeClientId(String clientId) {
+        storeCredential(CLIENT_ID_KEY, clientId);
+    }
+
+    /**
+     * Retrieves the OAuth2 client ID.
+     *
+     * @return the client ID, or null if not found
+     */
+    public String getClientId() {
+        return get(CLIENT_ID_KEY);
     }
 
     /**

--- a/cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -1,24 +1,45 @@
 package ai.wanaku.cli.main.support;
 
+import ai.wanaku.cli.main.support.security.TokenRefresher;
+import ai.wanaku.cli.main.support.security.TokenRefresher.RefreshResult;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.HttpHeaders;
 import java.io.IOException;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A JAX-RS client request filter that automatically adds authentication headers
- * to outgoing requests based on stored credentials.
+ * to outgoing requests based on stored credentials. Automatically refreshes
+ * expired tokens using the stored refresh token.
  */
 public class AuthenticationInterceptor implements ClientRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(AuthenticationInterceptor.class);
+
+    /**
+     * Buffer time in seconds before token expiry to trigger refresh.
+     * Tokens will be refreshed when they are within this many seconds of expiring.
+     */
+    private static final long REFRESH_BUFFER_SECONDS = 30;
 
     private final AuthCredentialStore credentialStore;
+    private final TokenRefresher tokenRefresher;
 
     public AuthenticationInterceptor() {
         this.credentialStore = new AuthCredentialStore();
+        this.tokenRefresher = new TokenRefresher();
     }
 
     public AuthenticationInterceptor(AuthCredentialStore credentialStore) {
         this.credentialStore = credentialStore;
+        this.tokenRefresher = new TokenRefresher();
+    }
+
+    public AuthenticationInterceptor(AuthCredentialStore credentialStore, TokenRefresher tokenRefresher) {
+        this.credentialStore = credentialStore;
+        this.tokenRefresher = tokenRefresher;
     }
 
     @Override
@@ -29,9 +50,93 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             return;
         }
 
-        String apiToken = credentialStore.getApiToken();
+        String apiToken = getValidAccessToken();
         if (apiToken != null && !apiToken.trim().isEmpty()) {
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + apiToken);
+        }
+    }
+
+    /**
+     * Gets a valid access token, refreshing it if necessary.
+     *
+     * @return a valid access token, or null if unavailable
+     */
+    private String getValidAccessToken() {
+        String apiToken = credentialStore.getApiToken();
+        if (apiToken == null || apiToken.trim().isEmpty()) {
+            return null;
+        }
+
+        // Check if token is expired or about to expire
+        if (isTokenExpiredOrExpiring()) {
+            LOG.debug("Token is expired or about to expire, attempting refresh");
+            if (tryRefreshToken()) {
+                apiToken = credentialStore.getApiToken();
+            } else {
+                LOG.warn("Token refresh failed, using existing token");
+            }
+        }
+
+        return apiToken;
+    }
+
+    /**
+     * Checks if the stored token is expired or about to expire.
+     *
+     * @return true if the token needs to be refreshed
+     */
+    private boolean isTokenExpiredOrExpiring() {
+        long expiryEpochSeconds = credentialStore.getTokenExpiry();
+        if (expiryEpochSeconds == 0) {
+            // No expiry stored - might be a token from before this feature
+            // For backwards compatibility, we don't refresh
+            return false;
+        }
+
+        long currentEpochSeconds = Instant.now().getEpochSecond();
+        long secondsUntilExpiry = expiryEpochSeconds - currentEpochSeconds;
+
+        return secondsUntilExpiry <= REFRESH_BUFFER_SECONDS;
+    }
+
+    /**
+     * Attempts to refresh the access token using the stored refresh token.
+     *
+     * @return true if refresh was successful, false otherwise
+     */
+    private boolean tryRefreshToken() {
+        String refreshToken = credentialStore.getRefreshToken();
+        String authServerUrl = credentialStore.getAuthServerUrl();
+        String clientId = credentialStore.getClientId();
+
+        if (refreshToken == null || refreshToken.trim().isEmpty()) {
+            LOG.warn("No refresh token available for token refresh");
+            return false;
+        }
+
+        if (authServerUrl == null || authServerUrl.trim().isEmpty()) {
+            LOG.warn("No auth server URL available for token refresh");
+            return false;
+        }
+
+        if (clientId == null || clientId.trim().isEmpty()) {
+            // Fall back to default client ID for backwards compatibility
+            clientId = "admin-cli";
+        }
+
+        try {
+            RefreshResult result = tokenRefresher.refresh(refreshToken, authServerUrl, clientId);
+
+            // Store the new tokens
+            credentialStore.storeApiToken(result.getAccessToken());
+            credentialStore.storeRefreshToken(result.getRefreshToken());
+            credentialStore.storeTokenExpiry(result.getExpiryEpochSeconds());
+
+            LOG.info("Successfully refreshed access token");
+            return true;
+        } catch (TokenRefresher.TokenRefreshException e) {
+            LOG.error("Failed to refresh token: {}", e.getMessage());
+            return false;
         }
     }
 }

--- a/cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
@@ -207,6 +207,15 @@ public class ServiceAuthenticator {
     }
 
     /**
+     * Returns the expiry time of the current access token as epoch seconds.
+     *
+     * @return The token expiry time in epoch seconds.
+     */
+    public long getTokenExpiryEpochSeconds() {
+        return creationTime.getEpochSecond() + accessToken.getLifetime();
+    }
+
+    /**
      * Formats the access token as an Authorization header value.
      *
      * @return The formatted Bearer token header value.

--- a/cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
@@ -1,0 +1,158 @@
+package ai.wanaku.cli.main.support.security;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.GeneralException;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Instant;
+import net.minidev.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles OAuth2 token refresh using stored refresh tokens.
+ * This class is designed to be used by the AuthenticationInterceptor
+ * to automatically refresh expired access tokens.
+ */
+public class TokenRefresher {
+    private static final Logger LOG = LoggerFactory.getLogger(TokenRefresher.class);
+
+    /**
+     * Result of a token refresh operation.
+     */
+    public static class RefreshResult {
+        private final String accessToken;
+        private final String refreshToken;
+        private final long expiryEpochSeconds;
+
+        public RefreshResult(String accessToken, String refreshToken, long expiryEpochSeconds) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+            this.expiryEpochSeconds = expiryEpochSeconds;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+
+        public long getExpiryEpochSeconds() {
+            return expiryEpochSeconds;
+        }
+    }
+
+    /**
+     * Refreshes an access token using a refresh token.
+     *
+     * @param refreshTokenValue the refresh token value
+     * @param authServerUrl the authentication server URL (e.g., http://localhost:8080)
+     * @param clientId the OAuth2 client ID
+     * @return the refresh result containing new tokens and expiry
+     * @throws TokenRefreshException if the refresh fails
+     */
+    public RefreshResult refresh(String refreshTokenValue, String authServerUrl, String clientId) {
+        try {
+            URI tokenEndpoint = resolveTokenEndpointUri(authServerUrl);
+            RefreshToken refreshToken = new RefreshToken(refreshTokenValue);
+            AuthorizationGrant refreshTokenGrant = new RefreshTokenGrant(refreshToken);
+            ClientID clientID = new ClientID(clientId);
+
+            TokenRequest request = new TokenRequest(tokenEndpoint, clientID, refreshTokenGrant, null);
+
+            LOG.debug("Sending token refresh request to {}", tokenEndpoint);
+            TokenResponse response = TokenResponse.parse(request.toHTTPRequest().send());
+
+            if (!response.indicatesSuccess()) {
+                TokenErrorResponse errorResponse = response.toErrorResponse();
+                String errorDescription = errorResponse.getErrorObject().getDescription();
+                LOG.error("Token refresh failed: {}", errorDescription);
+                throw new TokenRefreshException("Token refresh failed: " + errorDescription);
+            }
+
+            AccessTokenResponse successResponse = response.toSuccessResponse();
+            AccessToken newAccessToken = successResponse.getTokens().getAccessToken();
+            RefreshToken newRefreshToken = successResponse.getTokens().getRefreshToken();
+
+            long expiryEpochSeconds = Instant.now().getEpochSecond() + newAccessToken.getLifetime();
+            LOG.info("Token refreshed successfully, new token expires in {} seconds", newAccessToken.getLifetime());
+
+            return new RefreshResult(
+                    newAccessToken.getValue(),
+                    newRefreshToken != null ? newRefreshToken.getValue() : refreshTokenValue,
+                    expiryEpochSeconds);
+        } catch (IOException e) {
+            throw new TokenRefreshException("I/O error during token refresh: " + e.getMessage(), e);
+        } catch (ParseException e) {
+            throw new TokenRefreshException("Failed to parse token response: " + e.getMessage(), e);
+        }
+    }
+
+    private static Issuer resolveIssuer(String authServerUrl) {
+        String discoveryUrl = authServerUrl + "/q/oidc/";
+        Issuer issuer = new Issuer(discoveryUrl);
+
+        try {
+            final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);
+
+            HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, openIdConfigUrl);
+            HTTPResponse httpResponse = httpRequest.send();
+
+            if (httpResponse.getStatusCode() != 200) {
+                throw new TokenRefreshException("Unable to download OpenID Provider metadata from " + openIdConfigUrl
+                        + ": Status code " + httpResponse.getStatusCode());
+            }
+
+            JSONObject jsonObject = httpResponse.getBodyAsJSONObject();
+            OIDCProviderMetadata op = OIDCProviderMetadata.parse(jsonObject);
+
+            return op.getIssuer();
+        } catch (GeneralException e) {
+            throw new TokenRefreshException("Unable to resolve token endpoint URI: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new TokenRefreshException("I/O error while resolving token endpoint URI: " + e.getMessage(), e);
+        }
+    }
+
+    private static URI resolveTokenEndpointUri(String authServerUrl) {
+        Issuer issuer = new Issuer(resolveIssuer(authServerUrl));
+
+        try {
+            final OIDCProviderMetadata resolvedOp = OIDCProviderMetadata.resolve(issuer);
+            return resolvedOp.getTokenEndpointURI();
+        } catch (GeneralException e) {
+            throw new TokenRefreshException("Unable to resolve token endpoint URI: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new TokenRefreshException("I/O error while resolving token endpoint URI: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Exception thrown when token refresh fails.
+     */
+    public static class TokenRefreshException extends RuntimeException {
+        public TokenRefreshException(String message) {
+            super(message);
+        }
+
+        public TokenRefreshException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
@@ -122,4 +122,35 @@ class AuthCredentialStoreTest {
         AuthCredentialStore newStore = new AuthCredentialStore(credentialsUri);
         assertEquals(token, newStore.getApiToken());
     }
+
+    @Test
+    void shouldStoreAndRetrieveTokenExpiry() {
+        long expiryTime = 1704067200L;
+
+        credentialStore.storeTokenExpiry(expiryTime);
+        long retrievedExpiry = credentialStore.getTokenExpiry();
+
+        assertEquals(expiryTime, retrievedExpiry);
+    }
+
+    @Test
+    void shouldReturnZeroWhenTokenExpiryNotSet() {
+        long expiryTime = credentialStore.getTokenExpiry();
+        assertEquals(0, expiryTime);
+    }
+
+    @Test
+    void shouldStoreAndRetrieveClientId() {
+        String clientId = "test-client-id";
+
+        credentialStore.storeClientId(clientId);
+        String retrievedClientId = credentialStore.getClientId();
+
+        assertEquals(clientId, retrievedClientId);
+    }
+
+    @Test
+    void shouldReturnNullWhenClientIdNotSet() {
+        assertNull(credentialStore.getClientId());
+    }
 }

--- a/cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
@@ -3,12 +3,15 @@ package ai.wanaku.cli.main.support;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import ai.wanaku.cli.main.support.security.TokenRefresher;
+import ai.wanaku.cli.main.support.security.TokenRefresher.RefreshResult;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,5 +89,120 @@ class AuthenticationInterceptorTest {
         interceptor.filter(requestContext);
 
         assertNull(headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldRefreshTokenWhenExpired() throws Exception {
+        String oldToken = "old-token";
+        String newToken = "new-token";
+        String refreshToken = "refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expired 60 seconds ago
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId);
+        assertEquals("Bearer " + newToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
+        assertEquals(newToken, credentialStore.getApiToken());
+        assertEquals(newExpiry, credentialStore.getTokenExpiry());
+    }
+
+    @Test
+    void shouldNotRefreshTokenWhenNotExpired() throws Exception {
+        String token = "valid-token";
+        credentialStore.storeApiToken(token);
+        credentialStore.storeAuthMode("token");
+        // Token expires in 5 minutes
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 300);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        verify(mockRefresher, never()).refresh(any(), any(), any());
+        assertEquals("Bearer " + token, headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldUseExistingTokenWhenRefreshFails() throws Exception {
+        String oldToken = "old-token";
+        String refreshToken = "refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expired
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+                .thenThrow(new TokenRefresher.TokenRefreshException("Refresh failed"));
+
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        // Should still use old token as fallback
+        assertEquals("Bearer " + oldToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldNotRefreshWhenNoExpiryStored() throws Exception {
+        String token = "legacy-token";
+        credentialStore.storeApiToken(token);
+        credentialStore.storeAuthMode("token");
+        // No expiry stored (legacy token)
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        verify(mockRefresher, never()).refresh(any(), any(), any());
+        assertEquals("Bearer " + token, headers.getFirst(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void shouldRefreshTokenWhenAboutToExpire() throws Exception {
+        String oldToken = "old-token";
+        String newToken = "new-token";
+        String refreshToken = "refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expires in 20 seconds (within 30 second buffer)
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 20);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId);
+        assertEquals("Bearer " + newToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #764

- Add automatic token refresh to the CLI authentication flow
- Tokens are now refreshed before they expire, preventing premature logout
- Store token expiry time and client ID during login for use in subsequent commands

## Changes

- **TokenRefresher**: New class to handle OAuth2 token refresh using the stored refresh token
- **AuthenticationInterceptor**: Now checks token expiry before each request and refreshes if needed (within 30 seconds of expiry)
- **AuthCredentialStore**: Added methods to store/retrieve token expiry and client ID
- **AuthLogin**: Now stores token expiry and client ID during login
- **ServiceAuthenticator**: Added method to get token expiry epoch seconds

## Test plan

- [x] Existing CLI authentication tests pass
- [x] New tests for token refresh functionality
- [x] Test expired token is refreshed
- [x] Test token about to expire is refreshed (30 second buffer)
- [x] Test fallback to existing token when refresh fails
- [x] Test backwards compatibility with tokens that don't have expiry stored