### PR TITLE
[#530][UI] Add Configuration and Secrets URI Fields to Tool Forms

### DIFF
--- a/wanaku-router/ui/admin/src/Pages/Tools/ToolModal.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Tools/ToolModal.tsx
@@ -2,7 +2,12 @@ import {
   Modal,
   Select,
   SelectItem,
-  TextInput,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  TextInput
 } from "@carbon/react";
 import React, { useEffect, useState } from "react";
 import { Namespace, ToolReference } from "../../models";
@@ -30,6 +35,8 @@ export const ToolModal: React.FC<ToolModalProps> = ({
   const [inputSchema, setInputSchema] = useState(formatInputSchema(tool?.inputSchema))
   const [fetchedNamespaceData, setFetchedNamespaceData] = useState<Namespace[]>([])
   const [selectedNamespace, setSelectedNamespace] = useState(tool?.namespace || "")
+  const [configurationURI, setConfigurationURI] = useState(tool?.configurationURI || "")
+  const [secretsURI, setSecretsURI] = useState(tool?.secretsURI || "")
   const { listManagementTools } = useCapabilities()
 
   useEffect(() => {
@@ -53,6 +60,8 @@ export const ToolModal: React.FC<ToolModalProps> = ({
         type: toolType,
         inputSchema: schema,
         namespace: selectedNamespace,
+        configurationURI,
+        secretsURI
       })
     } catch (error) {
       console.error("Invalid JSON in input schema:", error)
@@ -68,56 +77,82 @@ export const ToolModal: React.FC<ToolModalProps> = ({
       onRequestSubmit={handleSubmit}
       onRequestClose={onRequestClose}
     >
-      <TextInput
-        id="tool-name"
-        labelText="Tool Name"
-        placeholder="e.g. meow-facts"
-        value={toolName}
-        onChange={(event) => setToolName(event.target.value)}
-      />
-      <TextInput
-        id="tool-description"
-        labelText="Description"
-        placeholder="e.g. Retrieve random facts about cats"
-        value={description}
-        onChange={(event) => setDescription(event.target.value)}
-      />
-      <TextInput
-        id="tool-uri"
-        labelText="URI"
-        placeholder="e.g. https://meowfacts.herokuapp.com?count={count}"
-        value={uri}
-        onChange={(event) => setUri(event.target.value)}
-      />
-      <TargetTypeSelect
-        value={toolType}
-        onChange={setToolType}
-        apiCall={listManagementTools}
-      />
-      <TextInput
-        id="input-schema"
-        labelText="Input Schema"
-        placeholder='e.g. {"type": "object", "properties": {"count": {"type": "int", "description": "The count of facts to retrieve"}}, "required": ["count"]}'
-        value={inputSchema}
-        onChange={(event) => setInputSchema(event.target.value)}
-      />
-      <Select
-        id="namespace"
-        labelText="Select a Namespace"
-        helperText="Choose a Namespace from the list"
-        value={selectedNamespace}
-        onChange={handleSelectionChange}
-      >
-        <SelectItem text="Choose an option" value="" />
-        {fetchedNamespaceData.map((namespace: Namespace) => (
-          <SelectItem
-            key={namespace.id}
-            id={namespace.id}
-            text={namespace.path || "default"}
-            value={namespace.id}
-          />
-        ))}
-      </Select>
+      <Tabs>
+        <TabList>
+          <Tab>Overview</Tab>
+          <Tab>External</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <TextInput
+              id="tool-name"
+              labelText="Tool Name"
+              placeholder="e.g. meow-facts"
+              value={toolName}
+              onChange={(event) => setToolName(event.target.value)}
+            />
+            <TextInput
+              id="tool-description"
+              labelText="Description"
+              placeholder="e.g. Retrieve random facts about cats"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+            />
+            <TextInput
+              id="tool-uri"
+              labelText="URI"
+              placeholder="e.g. https://meowfacts.herokuapp.com?count={count}"
+              value={uri}
+              onChange={(event) => setUri(event.target.value)}
+            />
+            <TargetTypeSelect
+              value={toolType}
+              onChange={setToolType}
+              apiCall={listManagementTools}
+            />
+            <TextInput
+              id="input-schema"
+              labelText="Input Schema"
+              placeholder='e.g. {"type": "object", "properties": {"count": {"type": "int", "description": "The count of facts to retrieve"}}, "required": ["count"]}'
+              value={inputSchema}
+              onChange={(event) => setInputSchema(event.target.value)}
+            />
+            <Select
+              id="namespace"
+              labelText="Select a Namespace"
+              helperText="Choose a Namespace from the list"
+              value={selectedNamespace}
+              onChange={handleSelectionChange}
+            >
+              <SelectItem text="Choose an option" value="" />
+              {fetchedNamespaceData.map((namespace: Namespace) => (
+                <SelectItem
+                  key={namespace.id}
+                  id={namespace.id}
+                  text={namespace.path || "default"}
+                  value={namespace.id}
+                />
+              ))}
+            </Select>
+          </TabPanel>
+          <TabPanel>
+            <TextInput
+              id="configuration-uri"
+              labelText="Configuration URI"
+              placeholder="e.g., file:///config/tool-config.json"
+              value={configurationURI}
+              onChange={(event) => setConfigurationURI(event.target.value)}
+            />
+            <TextInput
+              id="secrets-uri"
+              labelText="Secrets URI"
+              placeholder="e.g., vault://secrets/api-keys/tool-name"
+              value={secretsURI}
+              onChange={(event) => setSecretsURI(event.target.value)}
+            />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Modal>
   )
 }

--- a/wanaku-router/ui/admin/src/Pages/Tools/ToolsTable.tsx
+++ b/wanaku-router/ui/admin/src/Pages/Tools/ToolsTable.tsx
@@ -1,19 +1,24 @@
 import { Add, Upload, TrashCan, Edit } from "@carbon/icons-react";
 import {
   Button,
-  Column,
-  Grid,
+  DataTable,
   Table,
   TableBody,
   TableCell,
+  TableContainer,
+  TableExpandRow,
+  TableExpandedRow,
   TableHead,
   TableHeader,
   TableRow,
+  TableToolbar,
+  TableToolbarContent
 } from "@carbon/react";
-import { FunctionComponent } from "react";
+import React, { FunctionComponent } from "react";
 import { ToolReference } from "../../models";
 import { getNamespacePathById } from "../../hooks/api/use-namespaces";
 import { formatInputSchema } from "./tools-utils.ts";
+import { TableExpandHeader } from "@carbon/react";
 
 interface ToolListProps {
   fetchedData: ToolReference[];
@@ -31,76 +36,141 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
   onEdit
 }) => {
   const headers = [
-    "Name",
-    "Type",
-    "Description",
-    "URI",
-    "Input Schema",
-    "Namespace",
-    "Actions",
-  ];
+    {key: "name", header: "Name"},
+    {key: "type", header: "Type"},
+    {key: "description", header: "Description"},
+    {key: "uri", header: "URI"},
+    {key: "input-schema", header: "Input Schema"},
+    {key: "namespace", header: "Namespace"},
+    {key: "actions", header: "Actions"}
+  ]
+
+  function toolsToRows() {
+    return fetchedData.map((tool: ToolReference, index: number) => ({
+      id: tool.id || `tool-${index}`,
+      ...tool
+    }))
+  }
+
+  function toolHasDetails(tool: ToolReference) {
+    return tool.configurationURI || tool.secretsURI
+  }
+
+  function tableCells(tool: ToolReference) {
+    return (
+      <React.Fragment>
+        <TableCell>{tool.name}</TableCell>
+        <TableCell>{tool.type}</TableCell>
+        <TableCell>{tool.description}</TableCell>
+        <TableCell style={{ wordWrap: "break-word" }}>
+          {tool.uri}
+        </TableCell>
+        <TableCell style={{ fontSize: "14px" }}>
+          {formatInputSchema(tool.inputSchema)}
+        </TableCell>
+        <TableCell>{getNamespacePathById(tool.namespace) || "default"}</TableCell>
+        <TableCell>
+          <Button
+            kind="ghost"
+            renderIcon={Edit}
+            hasIconOnly
+            iconDescription="Edit"
+            onClick={() => onEdit(tool)}
+          />
+          <Button
+            kind="ghost"
+            renderIcon={TrashCan}
+            iconDescription="Delete"
+            hasIconOnly
+            onClick={() => onDelete(tool.name)}
+          />
+        </TableCell>
+      </React.Fragment>
+    )
+  }
+
+  function toolDetails(tool: ToolReference, rowProps) {
+    return (
+        <TableExpandedRow colSpan={headers.length + 3} {...rowProps}>
+          {tool.configurationURI && (
+            <div>
+              <strong>Configuration URI:</strong> {tool.configurationURI}
+            </div>
+          )}
+          {tool.secretsURI && (
+            <div>
+              <strong>Secrets URI:</strong> {tool.secretsURI}
+            </div>
+          )}
+        </TableExpandedRow>
+    )
+  }
 
   return (
-    <Grid>
-      <Column lg={12} md={8} sm={4}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "flex-end",
-            alignItems: "center",
-          }}
-        >
-          <Button kind="secondary" renderIcon={Upload} onClick={onImport}>
-            Import Toolset
-          </Button>
-          <Button renderIcon={Add} onClick={onAdd}>
-            Add Tool
-          </Button>
-        </div>
-        <Table aria-label="Tools table">
-          <TableHead>
-            <TableRow>
-              {headers.map((header) => (
-                <TableHeader id={header} key={header}>
-                  {header}
-                </TableHeader>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {fetchedData.map((tool: ToolReference) => (
-              <TableRow key={tool.name}>
-                <TableCell>{tool.name}</TableCell>
-                <TableCell>{tool.type}</TableCell>
-                <TableCell>{tool.description}</TableCell>
-                <TableCell style={{ wordWrap: "break-word" }}>
-                  {tool.uri}
-                </TableCell>
-                <TableCell style={{ fontSize: "14px" }}>
-                  {formatInputSchema(tool.inputSchema)}
-                </TableCell>
-                <TableCell>{getNamespacePathById(tool.namespace) || "default"}</TableCell>
-                <TableCell>
-                  <Button
-                    kind="ghost"
-                    renderIcon={Edit}
-                    hasIconOnly
-                    iconDescription="Edit"
-                    onClick={() => onEdit(tool)}
-                  />
-                  <Button
-                    kind="ghost"
-                    renderIcon={TrashCan}
-                    iconDescription="Delete"
-                    hasIconOnly
-                    onClick={() => onDelete(tool.name)}
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </Column>
-    </Grid>
-  );
-};
+    <DataTable headers={headers} rows={toolsToRows()}>
+      {({
+        headers,
+        rows,
+        getTableProps,
+        getHeaderProps,
+        getRowProps,
+        getExpandedRowProps,
+        getToolbarProps
+        }) => (
+          <TableContainer>
+            <TableToolbar {...getToolbarProps()}>
+              <TableToolbarContent>
+                <Button
+                  renderIcon={Upload}
+                  kind="secondary"
+                  onClick={onImport}>
+                    Import Toolset
+                </Button>
+                <Button
+                  renderIcon={Add}
+                  onClick={onAdd}>
+                    Add Tool
+                </Button>
+              </TableToolbarContent>
+            </TableToolbar>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  <TableExpandHeader/>
+                  {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({header})}>
+                        {header.header}
+                      </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => {
+                  const tool = fetchedData.find((item) => item.id === row.id)
+                  if (tool && toolHasDetails(tool)) {
+                    // tool with details, expansion available
+                    return (
+                        <React.Fragment key={tool.id}>
+                          <TableExpandRow expandIconDescription="Show details" {...getRowProps({row})}>
+                            {tableCells(tool)}
+                          </TableExpandRow>
+                          {row.isExpanded && toolDetails(tool, getExpandedRowProps({row}))}
+                        </React.Fragment>
+                    )
+                  } else if (tool) {
+                    // tool without details, no expansion available
+                    return (
+                      <TableRow {...getRowProps({row})}>
+                        <TableCell />
+                        {tableCells(tool)}
+                      </TableRow>
+                    )
+                  }
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+      )}
+    </DataTable>
+  )
+}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/530

## Summary by Sourcery

Add support in the admin UI for configuring external configuration and secrets URIs on tools and surface them in the tools table with an expandable details view.

New Features:
- Allow tools to store and submit configurationURI and secretsURI values from the tool creation/edit modal.
- Display each tool’s configuration and secrets URIs in an expandable details section in the tools list.

Enhancements:
- Refactor the tools listing page to use Carbon DataTable with toolbar actions and expandable rows instead of a simple static table.
- Organize tool settings in the modal into Overview and External tabs for clearer separation of core and external configuration fields.