### PR TITLE
[#771][Operator] Add ingress configuration to Helm chart CRD

### DIFF
--- a/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakus.wanaku.ai-v1.yml
+++ b/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakus.wanaku.ai-v1.yml
@@ -31,6 +31,13 @@ spec:
                 - "Always"
                 - "IfNotPresent"
                 - "Never"
+              ingress:
+                description: "Ingress configuration for Kubernetes clusters (not needed for OpenShift)"
+                properties:
+                  host:
+                    type: "string"
+                    description: "Hostname for Kubernetes Ingress (required on non-OpenShift clusters)"
+                type: "object"
               capabilities:
                 items:
                   properties:

--- a/wanaku-operator/samples/router.yaml
+++ b/wanaku-operator/samples/router.yaml
@@ -17,6 +17,11 @@ spec:
 # Default: IfNotPresent
 # Can be overridden per-component using router.imagePullPolicy or capability.imagePullPolicy
 #  imagePullPolicy: IfNotPresent
+# Ingress configuration for Kubernetes clusters (not needed for OpenShift)
+# OpenShift clusters auto-generate the host via Routes, but Kubernetes requires explicit configuration
+# Uncomment and set the host when deploying on vanilla Kubernetes:
+#  ingress:
+#    host: wanaku.example.com
 # Router settings are optional
   router:
     env:


### PR DESCRIPTION
## Summary

Fixes #771

Adds the `ingress` property to the Wanaku CRD schema and sample CR to allow users to specify the ingress host when deploying on vanilla Kubernetes clusters.

This is a follow-up to PR #769, which added Kubernetes Ingress support to the operator code but did not update the CRD schema.

## Changes

### CRD (`wanakus.wanaku.ai-v1.yml`)
Added the `ingress` property with:
- `host` field (string) - Hostname for Kubernetes Ingress
- Description explaining this is only needed for non-OpenShift clusters

### Sample CR (`samples/router.yaml`)
Added commented example showing how to configure ingress for Kubernetes:
```yaml
ingress:
  host: wanaku.example.com
```

## Usage

For **OpenShift** clusters: No changes needed - Routes are auto-generated

For **Kubernetes** clusters: Specify the ingress host:
```yaml
apiVersion: wanaku.ai/v1alpha1
kind: Wanaku
metadata:
  name: my-wanaku
spec:
  ingress:
    host: wanaku.example.com
  # ... other spec fields
```

## Test plan

- [x] CRD YAML is valid
- [x] Build passes
- [ ] Manual test on Kubernetes cluster with ingress.host specified

## Summary by Sourcery

Add ingress configuration support to the Wanaku Helm chart CRD and update the sample custom resource to document how to set the ingress host on vanilla Kubernetes clusters.

New Features:
- Expose an ingress configuration object with a host field in the Wanaku CRD schema for Kubernetes deployments.

Documentation:
- Document ingress host configuration in the sample router custom resource for Kubernetes versus OpenShift clusters.