### PR TITLE
Add Java 21 requirement to installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ South America.
 
 ### Wanaku CLI Installation
 
+> **Note:** Java 21 or later is required to run Wanaku.
+
 ```shell
-# Install via JBang
+# Install via JBang (requires Java 21+)
 jbang app install wanaku@wanaku-ai/wanaku
 
 # Or download the latest binary from releases

--- a/cli/README.md
+++ b/cli/README.md
@@ -25,6 +25,8 @@ The Wanaku CLI provides a user-friendly interface for:
 
 ## Installation
 
+> **Note:** Java 21 or later is required to run Wanaku CLI.
+
 ### Via JBang (Recommended)
 
 ```shell

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,9 +157,19 @@ Finally, for security, you must regenerate the client secret for the `wanaku-ser
 
 To run Wanaku, you need to first download and install the router and the command line client.
 
+## Prerequisites
+
+> **Important:** Java 21 or later is required to run Wanaku. Ensure you have Java 21+ installed before proceeding with the installation.
+
+You can verify your Java version by running:
+
+```shell
+java -version
+```
+
 ## Installing the Command Line Interface (CLI)
 
-Although the router comes with a UI, the CLI is the primary method used to manage the router. 
+Although the router comes with a UI, the CLI is the primary method used to manage the router.
 As such, it's recommended to have it installed.
 
 #### Installing the CLI by downloading binary
@@ -170,6 +180,8 @@ The most recommended method for installing the Wanaku CLI is to download the lat
 #### Installing the CLI via JBang
 
 To simplify using the Wanaku Command Line Interface (CLI), you can install it via [JBang](https://www.jbang.dev/).
+
+> **Note:** JBang requires Java 21 or later for running Wanaku CLI.
 
 First, ensure JBang is installed on your system. You can find detailed [download and installation](https://www.jbang.dev/download/) instructions on the official JBang website.
 


### PR DESCRIPTION
## Summary

- Add Java 21 requirement note to README quick start section
- Add Java 21 requirement note to CLI README installation section
- Add Prerequisites section in usage guide with Java 21 requirement
- Add Java 21 note specifically for JBang installation

## Test plan

- [ ] Review documentation renders correctly on GitHub
- [ ] Verify notes are visible and clear to users

## Summary by Sourcery

Document Java 21+ as a prerequisite across user-facing installation and usage docs for Wanaku and its CLI.

Documentation:
- Add Java 21+ prerequisite and verification instructions to the main usage guide.
- Clarify in the root README that Wanaku installation via JBang requires Java 21+.
- Note the Java 21+ requirement in the CLI README installation section, including for JBang-based setup.