### PR TITLE
Fix #778: strip trailing slash from token endpoint URLs

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
@@ -95,8 +95,12 @@ public class ServiceAuthenticator {
      * need.
      */
     private static Issuer resolveIssuer(SecurityServiceConfig config) {
-        // The OpenID provider issuer URL
-        Issuer issuer = new Issuer(config.getTokenEndpoint());
+        // The OpenID provider issuer URL (strip trailing slash to avoid malformed paths)
+        String endpoint = config.getTokenEndpoint();
+        if (endpoint != null && endpoint.endsWith("/")) {
+            endpoint = endpoint.substring(0, endpoint.length() - 1);
+        }
+        Issuer issuer = new Issuer(endpoint);
 
         try {
             final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);

--- a/cli/src/main/java/ai/wanaku/cli/main/support/security/TokenEndpoint.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/security/TokenEndpoint.java
@@ -28,7 +28,7 @@ public final class TokenEndpoint {
      * @return The complete token endpoint URL.
      */
     public static String fromBaseUrl(String baseUrl) {
-        return baseUrl + "/protocol/openid-connect/token";
+        return stripTrailingSlash(baseUrl) + "/protocol/openid-connect/token";
     }
 
     /**
@@ -38,6 +38,13 @@ public final class TokenEndpoint {
      * @return The complete token endpoint URL.
      */
     public static String forDiscovery(String baseUrl) {
-        return baseUrl + "/q/oidc/";
+        return stripTrailingSlash(baseUrl) + "/q/oidc/";
+    }
+
+    private static String stripTrailingSlash(String url) {
+        if (url != null && url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
     }
 }


### PR DESCRIPTION
## Summary
- Strip trailing slashes from base URLs in `TokenEndpoint.fromBaseUrl()` and `TokenEndpoint.forDiscovery()` to prevent malformed double-slash paths
- Strip trailing slash from the token endpoint in `ServiceAuthenticator.resolveIssuer()` before constructing the OIDC issuer URL

## Test plan
- [ ] Verify `TokenEndpoint.fromBaseUrl("http://localhost:8543/realms/wanaku/")` produces a URL without double slashes
- [ ] Verify `TokenEndpoint.forDiscovery("http://localhost:8543")` still works correctly without trailing slash
- [ ] Test `wanaku auth login` with a trailing-slash token endpoint URL

## Summary by Sourcery

Normalize token endpoint and issuer URLs to avoid malformed double-slash OIDC paths.

Bug Fixes:
- Strip trailing slashes from base URLs when constructing token endpoint URLs for direct token requests and OIDC discovery.
- Remove trailing slashes from configured token endpoint URLs before deriving the OpenID issuer URL.