### PR TITLE
Fix #780: add capability availability status via CLI and notifications

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/Capabilities.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/Capabilities.java
@@ -28,6 +28,8 @@ import picocli.CommandLine;
             CapabilitiesList.class,
             CapabilitiesCreate.class,
             CapabilitiesShow.class,
+            CapabilitiesStatus.class,
+            CapabilitiesWatch.class,
             CapabilitiesCleanup.class
         })
 public class Capabilities extends BaseCommand {

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
@@ -1,0 +1,117 @@
+package ai.wanaku.cli.main.commands.capabilities;
+
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.ACTIVE_STATUS;
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.API_TIMEOUT;
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.INACTIVE_STATUS;
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.computeStatusSummary;
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.fetchAndMergeCapabilities;
+import static ai.wanaku.cli.main.support.CapabilitiesHelper.printCapabilities;
+import static picocli.CommandLine.Command;
+import static picocli.CommandLine.Option;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.CapabilitiesHelper;
+import ai.wanaku.cli.main.support.CapabilitiesHelper.PrintableCapability;
+import ai.wanaku.cli.main.support.CapabilitiesHelper.StatusSummary;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.CapabilitiesService;
+import java.util.List;
+import org.jline.terminal.Terminal;
+
+/**
+ * CLI command for checking the availability status of registered capabilities.
+ *
+ * <p>This command provides a focused view of capability availability, showing
+ * a summary of active, inactive, and unknown capabilities along with a filtered
+ * table of capabilities matching the requested status.</p>
+ *
+ * <p>Usage examples:</p>
+ * <pre>
+ * # Show status summary for all capabilities
+ * wanaku capabilities status
+ *
+ * # Show only inactive capabilities
+ * wanaku capabilities status --filter inactive
+ *
+ * # Show only active capabilities from a specific host
+ * wanaku capabilities status --host http://remote:8080 --filter active
+ * </pre>
+ *
+ * @see CapabilitiesList
+ * @see CapabilitiesHelper
+ */
+@Command(name = "status", description = "Show the availability status of registered capabilities")
+public class CapabilitiesStatus extends BaseCommand {
+
+    @Option(
+            names = {"--host"},
+            description = "The API host URL (default: http://localhost:8080)",
+            defaultValue = "http://localhost:8080")
+    private String host;
+
+    @Option(
+            names = {"--filter"},
+            description = "Filter by status: active, inactive, or unknown (default: show all)")
+    private String filter;
+
+    private CapabilitiesService capabilitiesService;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        capabilitiesService = initService(CapabilitiesService.class, host);
+
+        List<PrintableCapability> capabilities =
+                fetchAndMergeCapabilities(capabilitiesService).await().atMost(API_TIMEOUT);
+
+        if (capabilities.isEmpty()) {
+            printer.printInfoMessage("No capabilities registered.");
+            return EXIT_OK;
+        }
+
+        StatusSummary summary = computeStatusSummary(capabilities);
+
+        // Print summary
+        printer.printInfoMessage("Capability Status Summary:");
+        printer.printSuccessMessage(String.format("  Active:   %d", summary.active()));
+        if (summary.inactive() > 0) {
+            printer.printErrorMessage(String.format("  Inactive: %d", summary.inactive()));
+        } else {
+            printer.printInfoMessage(String.format("  Inactive: %d", summary.inactive()));
+        }
+        printer.printWarningMessage(String.format("  Unknown:  %d", summary.unknown()));
+        printer.printInfoMessage(String.format("  Total:    %d", summary.total()));
+        System.out.println();
+
+        // Apply filter if requested
+        List<PrintableCapability> filtered = applyFilter(capabilities);
+        if (filtered.isEmpty()) {
+            printer.printWarningMessage("No capabilities match the filter: " + filter);
+            return EXIT_OK;
+        }
+
+        printCapabilities(filtered, printer);
+        return EXIT_OK;
+    }
+
+    private List<PrintableCapability> applyFilter(List<PrintableCapability> capabilities) {
+        if (filter == null || filter.isBlank()) {
+            return capabilities;
+        }
+
+        return switch (filter.toLowerCase()) {
+            case "active" ->
+                capabilities.stream()
+                        .filter(c -> ACTIVE_STATUS.equals(c.status()))
+                        .toList();
+            case "inactive" ->
+                capabilities.stream()
+                        .filter(c -> INACTIVE_STATUS.equals(c.status()))
+                        .toList();
+            case "unknown" ->
+                capabilities.stream()
+                        .filter(c -> !ACTIVE_STATUS.equals(c.status()) && !INACTIVE_STATUS.equals(c.status()))
+                        .toList();
+            default -> capabilities;
+        };
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesWatch.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesWatch.java
@@ -1,0 +1,149 @@
+package ai.wanaku.cli.main.commands.capabilities;
+
+import static picocli.CommandLine.Command;
+import static picocli.CommandLine.Option;
+
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.jline.terminal.Terminal;
+
+/**
+ * CLI command for watching real-time capability events via Server-Sent Events (SSE).
+ *
+ * <p>This command connects to the capabilities notifications endpoint and displays
+ * events as they occur, including capability registrations, deregistrations, updates,
+ * and health pings. The command runs continuously until interrupted with Ctrl+C.</p>
+ *
+ * <p>Usage examples:</p>
+ * <pre>
+ * # Watch capability events from localhost
+ * wanaku capabilities watch
+ *
+ * # Watch events from a remote host
+ * wanaku capabilities watch --host http://remote:8080
+ * </pre>
+ *
+ * @see CapabilitiesStatus
+ * @see CapabilitiesList
+ */
+@Command(name = "watch", description = "Watch real-time capability registration and status events")
+public class CapabilitiesWatch extends BaseCommand {
+
+    private static final String NOTIFICATIONS_PATH = "/api/v1/capabilities/notifications";
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    @Option(
+            names = {"--host"},
+            description = "The API host URL (default: http://localhost:8080)",
+            defaultValue = "http://localhost:8080")
+    private String host;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        String url = host + NOTIFICATIONS_PATH;
+        printer.printInfoMessage("Connecting to " + url + " ...");
+        printer.printInfoMessage("Press Ctrl+C to stop watching.\n");
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Accept", "text/event-stream")
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            if (response.statusCode() != 200) {
+                printer.printErrorMessage("Failed to connect: HTTP " + response.statusCode());
+                return EXIT_ERROR;
+            }
+
+            printer.printSuccessMessage("Connected. Watching for capability events...\n");
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body()))) {
+                String eventType = null;
+                String eventId = null;
+                StringBuilder dataBuilder = new StringBuilder();
+
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("event:")) {
+                        eventType = line.substring("event:".length()).trim();
+                    } else if (line.startsWith("id:")) {
+                        eventId = line.substring("id:".length()).trim();
+                    } else if (line.startsWith("data:")) {
+                        if (!dataBuilder.isEmpty()) {
+                            dataBuilder.append("\n");
+                        }
+                        dataBuilder.append(line.substring("data:".length()).trim());
+                    } else if (line.isEmpty()) {
+                        // Empty line marks end of event
+                        if (eventType != null || !dataBuilder.isEmpty()) {
+                            printEvent(printer, eventType, eventId, dataBuilder.toString());
+                            eventType = null;
+                            eventId = null;
+                            dataBuilder.setLength(0);
+                        }
+                    }
+                }
+            }
+        } catch (java.net.ConnectException e) {
+            printer.printErrorMessage("Unable to connect to " + url + ". Is the server running?");
+            return EXIT_ERROR;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        printer.printInfoMessage("\nDisconnected.");
+        return EXIT_OK;
+    }
+
+    private void printEvent(WanakuPrinter printer, String eventType, String eventId, String data) {
+        String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMAT);
+        String type = eventType != null ? eventType : "unknown";
+
+        switch (type.toUpperCase()) {
+            case "REGISTER" ->
+                printer.printSuccessMessage(
+                        String.format("[%s] REGISTER  id=%s  %s", timestamp, truncate(eventId), formatData(data)));
+            case "DEREGISTER" ->
+                printer.printErrorMessage(
+                        String.format("[%s] DEREGISTER  id=%s  %s", timestamp, truncate(eventId), formatData(data)));
+            case "UPDATE" ->
+                printer.printWarningMessage(
+                        String.format("[%s] UPDATE  id=%s  %s", timestamp, truncate(eventId), formatData(data)));
+            case "PING" -> printer.printInfoMessage(String.format("[%s] PING  id=%s", timestamp, truncate(eventId)));
+            default ->
+                printer.printInfoMessage(
+                        String.format("[%s] %s  id=%s  %s", timestamp, type, truncate(eventId), formatData(data)));
+        }
+    }
+
+    private static String truncate(String value) {
+        if (value == null) {
+            return "-";
+        }
+        if (value.length() <= 16) {
+            return value;
+        }
+        return value.substring(0, 13) + "...";
+    }
+
+    private static String formatData(String data) {
+        if (data == null || data.isBlank()) {
+            return "";
+        }
+        // Show a compact single-line summary of the JSON data
+        return data.replace("\n", " ");
+    }
+}

--- a/cli/src/main/java/ai/wanaku/cli/main/support/CapabilitiesHelper.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/CapabilitiesHelper.java
@@ -364,6 +364,42 @@ public final class CapabilitiesHelper {
     }
 
     /**
+     * Computes a summary of capabilities grouped by status.
+     *
+     * @param capabilities the list of capabilities to summarize
+     * @return a {@link StatusSummary} with counts per status and the grouped capabilities
+     * @throws NullPointerException if capabilities is null
+     */
+    public static StatusSummary computeStatusSummary(List<PrintableCapability> capabilities) {
+        Objects.requireNonNull(capabilities, "Capabilities list cannot be null");
+
+        int active = 0;
+        int inactive = 0;
+        int unknown = 0;
+
+        for (PrintableCapability cap : capabilities) {
+            switch (cap.status()) {
+                case ACTIVE_STATUS -> active++;
+                case INACTIVE_STATUS -> inactive++;
+                default -> unknown++;
+            }
+        }
+
+        return new StatusSummary(capabilities.size(), active, inactive, unknown);
+    }
+
+    /**
+     * Record representing a summary of capability statuses.
+     *
+     * @param total total number of capabilities
+     * @param active number of active capabilities
+     * @param inactive number of inactive capabilities
+     * @param unknown number of capabilities with unknown status
+     */
+    @RegisterForReflection
+    public record StatusSummary(int total, int active, int inactive, int unknown) {}
+
+    /**
      * Prints a single capability in map format.
      *
      * @param capability the capability to print

--- a/cli/src/test/java/ai/wanaku/cli/main/support/CapabilitiesHelperTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/support/CapabilitiesHelperTest.java
@@ -1,0 +1,108 @@
+package ai.wanaku.cli.main.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.wanaku.cli.main.support.CapabilitiesHelper.PrintableCapability;
+import ai.wanaku.cli.main.support.CapabilitiesHelper.StatusSummary;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CapabilitiesHelperTest {
+
+    @Test
+    void testComputeStatusSummaryAllActive() {
+        List<PrintableCapability> capabilities = List.of(
+                cap("http", "tool-invoker", "active"),
+                cap("sqs", "tool-invoker", "active"),
+                cap("file", "resource-provider", "active"));
+
+        StatusSummary summary = CapabilitiesHelper.computeStatusSummary(capabilities);
+
+        assertEquals(3, summary.total());
+        assertEquals(3, summary.active());
+        assertEquals(0, summary.inactive());
+        assertEquals(0, summary.unknown());
+    }
+
+    @Test
+    void testComputeStatusSummaryMixed() {
+        List<PrintableCapability> capabilities = List.of(
+                cap("http", "tool-invoker", "active"),
+                cap("sqs", "tool-invoker", "inactive"),
+                cap("file", "resource-provider", "-"));
+
+        StatusSummary summary = CapabilitiesHelper.computeStatusSummary(capabilities);
+
+        assertEquals(3, summary.total());
+        assertEquals(1, summary.active());
+        assertEquals(1, summary.inactive());
+        assertEquals(1, summary.unknown());
+    }
+
+    @Test
+    void testComputeStatusSummaryEmpty() {
+        StatusSummary summary = CapabilitiesHelper.computeStatusSummary(List.of());
+
+        assertEquals(0, summary.total());
+        assertEquals(0, summary.active());
+        assertEquals(0, summary.inactive());
+        assertEquals(0, summary.unknown());
+    }
+
+    @Test
+    void testComputeStatusSummaryAllInactive() {
+        List<PrintableCapability> capabilities =
+                List.of(cap("http", "tool-invoker", "inactive"), cap("sqs", "tool-invoker", "inactive"));
+
+        StatusSummary summary = CapabilitiesHelper.computeStatusSummary(capabilities);
+
+        assertEquals(2, summary.total());
+        assertEquals(0, summary.active());
+        assertEquals(2, summary.inactive());
+        assertEquals(0, summary.unknown());
+    }
+
+    @Test
+    void testComputeStatusSummaryAllUnknown() {
+        List<PrintableCapability> capabilities =
+                List.of(cap("http", "tool-invoker", "-"), cap("sqs", "tool-invoker", ""));
+
+        StatusSummary summary = CapabilitiesHelper.computeStatusSummary(capabilities);
+
+        assertEquals(2, summary.total());
+        assertEquals(0, summary.active());
+        assertEquals(0, summary.inactive());
+        assertEquals(2, summary.unknown());
+    }
+
+    @Test
+    void testDetermineServiceStatusActive() {
+        assertEquals("active", CapabilitiesHelper.determineServiceStatus(activeRecord()));
+    }
+
+    @Test
+    void testDetermineServiceStatusInactive() {
+        assertEquals("inactive", CapabilitiesHelper.determineServiceStatus(inactiveRecord()));
+    }
+
+    @Test
+    void testDetermineServiceStatusNull() {
+        assertEquals("-", CapabilitiesHelper.determineServiceStatus(null));
+    }
+
+    private static PrintableCapability cap(String service, String serviceType, String status) {
+        return new PrintableCapability(service, serviceType, "localhost", 9000, status, "", List.of());
+    }
+
+    private static ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord activeRecord() {
+        var record = new ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord();
+        record.setActive(true);
+        return record;
+    }
+
+    private static ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord inactiveRecord() {
+        var record = new ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord();
+        record.setActive(false);
+        return record;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `wanaku capabilities status` command that shows a focused availability summary (active/inactive/unknown counts) with optional `--filter` flag to show only capabilities matching a given status
- Adds `wanaku capabilities watch` command that connects to the SSE `/api/v1/capabilities/notifications` endpoint and streams real-time events (register, deregister, update, ping) until Ctrl+C
- Adds `computeStatusSummary()` helper method in `CapabilitiesHelper` with unit tests

## Test plan

- [x] All existing tests pass (`mvn verify`)
- [x] Unit tests for `computeStatusSummary()` covering all-active, all-inactive, all-unknown, mixed, and empty cases
- [ ] Manual: `wanaku capabilities status` displays summary and table
- [ ] Manual: `wanaku capabilities status --filter active` filters correctly
- [ ] Manual: `wanaku capabilities watch` streams SSE events in real-time

## Summary by Sourcery

Add CLI support for viewing capability availability status and watching real-time capability events.

New Features:
- Introduce `wanaku capabilities status` command to show a summary of capability availability with optional status filtering and a detailed table view.
- Introduce `wanaku capabilities watch` command to stream real-time capability registration and status events from the server via SSE.

Enhancements:
- Add a `computeStatusSummary` helper and `StatusSummary` record to aggregate capability status counts for reuse across commands.

Tests:
- Add unit tests for `computeStatusSummary` and `determineServiceStatus` covering mixed, empty, and edge-case scenarios.