### PR TITLE
chore: add link to main documentation website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ For complete installation and configuration instructions, see the [Usage Guide](
 
 ## Documentation
 
-- **[Wanaku Documentation](https://wanaku.ai/docs/)** - Main documentation website
+For most users, the **[Wanaku Documentation](https://wanaku.ai/docs/)** website is the recommended starting point. It covers installation, configuration, and usage for stable releases.
+
+The documentation below is intended for developers working on the project and may reference unreleased features or in-progress changes:
+
 - **[Usage Guide](docs/usage.md)** - Installation, deployment, and CLI usage
 - **[Architecture](docs/architecture.md)** - System architecture and components
 - **[Building](docs/building.md)** - Build and package the project


### PR DESCRIPTION
Add a link to the main Wanaku documentation website (https://wanaku.ai/docs/) in the README's Documentation section.

## Summary by Sourcery

Documentation:
- Link the README documentation section to the main Wanaku documentation website.