### PR TITLE
chore: add download section to GitHub release page

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -39,6 +39,9 @@ release:
       enabled: true
     skipTag: true
 
+changelog:
+  contentTemplate: src/jreleaser/changelog.tpl
+
 distributions:
   cli:
     artifacts:

--- a/src/jreleaser/changelog.tpl
+++ b/src/jreleaser/changelog.tpl
@@ -1,0 +1,33 @@
+## Downloads
+
+### Wanaku CLI (Command Line Interface)
+
+The CLI is used to manage and interact with the Wanaku MCP Router.
+
+| Platform | File |
+|---|---|
+| **Linux (x86_64)** | [cli-{{projectVersion}}-linux-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}-linux-x86_64.zip) |
+| **macOS (Apple Silicon)** | [cli-{{projectVersion}}-osx-aarch_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}-osx-aarch_64.zip) |
+| **Java (all platforms)** | [cli-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}.zip) |
+
+> **Tip:** You can also install via JBang: `jbang app install wanaku@wanaku-ai/wanaku`
+
+### Wanaku Router
+
+| Component | File |
+|---|---|
+| Router Backend | [wanaku-router-backend-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-router-backend-{{projectVersion}}.zip) |
+
+### Capability Services (Tools)
+
+| Service | File |
+|---|---|
+| HTTP | [wanaku-tool-service-http-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-tool-service-http-{{projectVersion}}.zip) |
+| Exec | [wanaku-tool-service-exec-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-tool-service-exec-{{projectVersion}}.zip) |
+| Tavily | [wanaku-tool-service-tavily-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-tool-service-tavily-{{projectVersion}}.zip) |
+
+---
+
+## Changelog
+
+{{changelogChanges}}


### PR DESCRIPTION
## Summary

- Adds a JReleaser changelog template (`src/jreleaser/changelog.tpl`) that renders a structured **Downloads** section at the top of each GitHub release page
- The template organizes download links by category (CLI, Router, Capability Services) with platform-specific entries and direct download URLs
- The existing changelog content is preserved below the downloads section

This makes it easier for users to find the right binary for their platform instead of scrolling through raw commit logs and the undifferentiated asset list.

## Summary by Sourcery

Add a custom JReleaser changelog template to surface structured download links at the top of GitHub release pages.

Enhancements:
- Configure JReleaser to use a content template for changelog generation.
- Introduce a release changelog template that groups downloadable artifacts by product and platform and preserves the existing changelog content below.