### PR TITLE
Fix #793: move changelog under release.github in jreleaser.yml

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -38,9 +38,8 @@ release:
     update:
       enabled: true
     skipTag: true
-
-changelog:
-  contentTemplate: src/jreleaser/changelog.tpl
+    changelog:
+      contentTemplate: src/jreleaser/changelog.tpl
 
 distributions:
   cli:


### PR DESCRIPTION
## Summary

- Moves the `changelog` block from a top-level field to `release.github.changelog` in `jreleaser.yml`
- This fixes the parse error introduced in fac5eb49 — `changelog` is not a recognized top-level field in the JReleaserModel bundled with `release-action@v2`

Fixes #793