### PR TITLE
Fix #803: prevent duplicate data store names

### DIFF
--- a/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/DataStoreRepository.java
+++ b/core/core-persistence/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/DataStoreRepository.java
@@ -13,8 +13,6 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 public interface DataStoreRepository extends LabelAwareInfinispanRepository<DataStore, String> {
     /**
      * Find all data stores with the given name.
-     * <p>
-     * Multiple data stores may share the same name but will have unique IDs.
      *
      * @param name the name to search for
      * @return list of matching data stores, or an empty list if none found

--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/AbstractInfinispanRepository.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/AbstractInfinispanRepository.java
@@ -18,7 +18,7 @@ import ai.wanaku.core.persistence.api.WanakuRepository;
 public abstract class AbstractInfinispanRepository<A extends WanakuEntity<K>, K> implements WanakuRepository<A, K> {
 
     protected final EmbeddedCacheManager cacheManager;
-    private final ReentrantLock lock = new ReentrantLock();
+    protected final ReentrantLock lock = new ReentrantLock();
 
     private static final String DEFAULT_DELETE_TEMPLATE = "DELETE FROM %s r WHERE %s";
 

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/datastores/DataStoresResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/datastores/DataStoresResourceTest.java
@@ -223,7 +223,7 @@ public class DataStoresResourceTest extends WanakuRouterTest {
                 .then()
                 .statusCode(200);
 
-        // Add second entry with same name
+        // Add second entry with same name — should be rejected as duplicate
         DataStore dataStore2 = new DataStore();
         dataStore2.setName("duplicate-test");
         dataStore2.setData("Second entry");
@@ -234,16 +234,17 @@ public class DataStoresResourceTest extends WanakuRouterTest {
                 .header("Authorization", "Bearer " + accessToken)
                 .post("/api/v1/data-store/add")
                 .then()
-                .statusCode(200);
+                .statusCode(409);
 
-        // Get by name should return both
+        // Get by name should return only the first entry
         given().queryParam("name", "duplicate-test")
                 .when()
                 .header("Authorization", "Bearer " + accessToken)
                 .get("/api/v1/data-store/get")
                 .then()
                 .statusCode(200)
-                .body("data.size()", equalTo(2));
+                .body("data.size()", equalTo(1))
+                .body("data[0].data", equalTo("First entry"));
     }
 
     @Order(10)


### PR DESCRIPTION
## Summary
- Add duplicate name check in `DataStoresBean.add()` before persisting, throwing `EntityAlreadyExistsException` (HTTP 409) when a data store with the same name already exists
- Update `DataStoreRepository` Javadoc to remove outdated comment about allowing duplicate names
- Update REST test to expect HTTP 409 on duplicate name insertion

## Test plan
- [x] `mvn verify` passes (all modules BUILD SUCCESS)
- [x] `testAddMultipleWithSameName` now verifies second add returns 409 and only 1 entry exists

## Summary by Sourcery

Enforce uniqueness of data store names and update tests and documentation accordingly.

Bug Fixes:
- Prevent creation of multiple data stores with the same name by rejecting duplicate name inserts with an EntityAlreadyExistsException (HTTP 409).

Documentation:
- Update DataStoreRepository Javadoc to remove the statement that duplicate names are allowed.

Tests:
- Adjust REST API tests to expect HTTP 409 on duplicate data store name insertion and verify only one entry exists for a given name.