### PR TITLE
chore: upgrade actions/checkout to v6 and actions/setup-java to v5

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -15,14 +15,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout Wanaku Capabilities SDK Main Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wanaku-ai/wanaku-capabilities-java-sdk
           persist-credentials: false
           ref: main
           path: wanaku-capabilities-java-sdk
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -31,7 +31,7 @@ jobs:
         run: mvn -DskipTests clean install
         working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -38,15 +38,15 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Checkout Wanaku Capabilities SDK Main Project
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
@@ -89,7 +89,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/wanaku'
         uses: docker/login-action@v3

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'wanaku-ai/wanaku'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install CLI tools from Mirror
       uses: redhat-actions/openshift-tools-installer@v1
       with:

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -42,14 +42,14 @@ jobs:
 
     steps:
     - name: Checkout Wanaku Capabilities SDK Main Project
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
         ref: main
         path: wanaku-capabilities-java-sdk
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -57,6 +57,6 @@ jobs:
     - name: Build Wanaku Capabilities SDK Main Project
       run: mvn -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
@@ -107,7 +107,7 @@ jobs:
     needs: release-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/wanaku'
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'zulu'


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v4 to v6 across all GitHub Actions workflows
- Upgrade `actions/setup-java` from v4 to v5 across all GitHub Actions workflows

## Affected workflows

- `main-build.yml`
- `main-deploy.yml`
- `pr-builds.yml`
- `release.yml`
- `release-artifacts.yml`
- `early-access.yml`

## Summary by Sourcery

Upgrade GitHub Actions workflows to use the latest versions of core checkout and Java setup actions.

Build:
- Update all workflows to use actions/checkout v6 instead of v4.
- Update all workflows to use actions/setup-java v5 instead of v4 where Java is configured.