### PR TITLE
chore: fix broken Javadoc reference in DefaultHealthProbeDelegate

### DIFF
--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
@@ -8,7 +8,7 @@ import ai.wanaku.core.exchange.v1.RuntimeStatus;
 /**
  * Default health probe delegate implementation.
  * <p>
- * Returns {@link RuntimeStatus#STARTED} when the capability is responding.
+ * Returns {@link RuntimeStatus#RUNTIME_STATUS_STARTED} when the capability is responding.
  * If a capability can respond to the probe, it is considered started.
  */
 @ApplicationScoped


### PR DESCRIPTION
## Summary
- Fix broken `{@link RuntimeStatus#STARTED}` Javadoc reference in `DefaultHealthProbeDelegate` to use the correct enum constant `RuntimeStatus#RUNTIME_STATUS_STARTED`

## Test plan
- [x] `mvn verify` passes with no javadoc errors for `core-capabilities-base`

## Summary by Sourcery

Documentation:
- Fix the Javadoc in DefaultHealthProbeDelegate to reference RuntimeStatus#RUNTIME_STATUS_STARTED instead of the invalid RuntimeStatus#STARTED.