### PR TITLE
Fix #813: disable console logging for router backend tests

### DIFF
--- a/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
+++ b/wanaku-router/wanaku-router-backend/src/main/resources/application.properties
@@ -112,6 +112,7 @@ quarkus.log.category."io.quarkus.oidc.proxy".level=DEBUG
 
 %dev.quarkus.log.category."org.apache.http".level=INFO
 
+%test.quarkus.log.console.enable=false
 %test.quarkus.log.file.enable=true
 %test.quarkus.log.file.path=target/wanaku.log
 %test.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n


### PR DESCRIPTION
## Summary
- Disable console logging for the router backend test profile so test log messages go to `target/wanaku.log` instead of stdout
- File logging was already enabled but console logging was left on by default, causing noise in build output

## Test plan
- [x] `mvn verify` passes
- [x] Verified no log lines appear on stdout during test execution

## Summary by Sourcery

Build:
- Configure the test profile to disable console logging while keeping file logging to target/wanaku.log enabled.