### PR TITLE
chore: add JaCoCo 0.8.14 support via coverage profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -65,6 +65,7 @@
         <jansi-version>2.4.2</jansi-version>
         <jna.version>5.18.1</jna.version>
         <commons-logging.version>1.3.5</commons-logging.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
         <quarkus-operator-sdk.version>7.4.0</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.2.7</quarkus-helm.version>
@@ -157,6 +158,26 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <phase>test</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>${spotless-maven-plugin.version}</version>
@@ -199,5 +220,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Add JaCoCo Maven plugin (0.8.14) to the parent POM behind a `coverage` Maven profile.

- Adds `jacoco-maven-plugin.version` property set to `0.8.14`
- Configures `prepare-agent` and `report` goals in `pluginManagement`
- Activates via `-Pcoverage` profile to avoid interfering with default builds

Usage: `mvn verify -Pcoverage` to generate per-module coverage reports under `target/site/jacoco/`.