### PR TITLE
Fix #815: add e2e integration tests for MCP resource and tool capabilities

### DIFF
--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -157,6 +157,19 @@
             <artifactId>quarkus-test-keycloak-server</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-test</artifactId>
+            <version>${quarkus-mcp-server.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ResourceCapabilityE2ETest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ResourceCapabilityE2ETest.java
@@ -1,0 +1,159 @@
+package ai.wanaku.backend.api.v1.e2e;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import org.jboss.logging.Logger;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import ai.wanaku.backend.support.E2ETestProfile;
+import ai.wanaku.backend.support.MockGrpcCapabilityServer;
+import ai.wanaku.backend.support.TestIndexHelper;
+import ai.wanaku.backend.support.WanakuKeycloakTestResource;
+import ai.wanaku.backend.support.WanakuRouterTest;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * End-to-end test for MCP resource capability dispatch.
+ * Verifies the full chain: McpAssured -> MCP SSE -> router resolver -> gRPC transport -> mock capability.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusTest
+@TestProfile(E2ETestProfile.class)
+@QuarkusTestResource(value = WanakuKeycloakTestResource.class, restrictToAnnotatedClass = true)
+@DisabledIf(value = "isUnsupportedOSOnGithub", disabledReason = "Does not run on macOS or Windows on GitHub")
+public class ResourceCapabilityE2ETest extends WanakuRouterTest {
+    private static final Logger LOG = Logger.getLogger(ResourceCapabilityE2ETest.class);
+
+    private static final String EXPECTED_CONTENT = "test-resource-content-from-mock-capability";
+    private static final String SERVICE_NAME = "test-resource";
+    private static final String RESOURCE_NAME = "sample-resource.test";
+
+    private static MockGrpcCapabilityServer mockServer;
+    private static int mockPort;
+    private static KeycloakTestClient keycloakClient;
+    private static McpAssured.McpSseTestClient mcpClient;
+
+    private String getAccessToken() {
+        return keycloakClient.getRealmClientAccessToken("wanaku", "wanaku-service", "secret");
+    }
+
+    @BeforeAll
+    static void setup() throws IOException {
+        TestIndexHelper.deleteRecursively("target/wanaku/router");
+        keycloakClient = new KeycloakTestClient();
+
+        mockServer = new MockGrpcCapabilityServer(List.of(EXPECTED_CONTENT));
+        mockPort = mockServer.start();
+        LOG.infof("Mock resource capability server started on port %d", mockPort);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (mcpClient != null) {
+            mcpClient.disconnect();
+        }
+        if (mockServer != null) {
+            mockServer.stop();
+        }
+    }
+
+    @Order(1)
+    @Test
+    void testRegisterCapability() {
+        String accessToken = getAccessToken();
+
+        ServiceTarget serviceTarget = new ServiceTarget(
+                null,
+                SERVICE_NAME,
+                "localhost",
+                mockPort,
+                ServiceType.RESOURCE_PROVIDER.asValue(),
+                "mcp",
+                null,
+                null,
+                null);
+
+        given().header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(serviceTarget)
+                .when()
+                .post("/api/v1/management/discovery/register")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("data.id", notNullValue());
+
+        LOG.info("Mock resource capability registered with router");
+    }
+
+    @Order(2)
+    @Test
+    void testExposeResource() {
+        ResourceReference resource = new ResourceReference();
+        resource.setLocation("test-resource://sample-resource.test");
+        resource.setType(SERVICE_NAME);
+        resource.setName(RESOURCE_NAME);
+        resource.setDescription("A test resource for e2e testing");
+        resource.setMimeType("text/plain");
+        resource.setNamespace("public");
+
+        given().header("Content-Type", MediaType.APPLICATION_JSON)
+                .body(resource)
+                .when()
+                .post("/api/v1/resources/expose")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+
+        given().when()
+                .get("/api/v1/resources/list")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("data.size()", is(1), "data[0].name", is(RESOURCE_NAME), "data[0].type", is(SERVICE_NAME));
+
+        LOG.info("Resource exposed successfully");
+    }
+
+    @Order(3)
+    @Test
+    void testReadResourceViaMcp() throws Exception {
+        int port = io.restassured.RestAssured.port;
+        mcpClient = McpAssured.newSseClient()
+                .setBaseUri(new URI("http://localhost:" + port + "/"))
+                .setSsePath("public/mcp/sse")
+                .build();
+        mcpClient.connect();
+
+        mcpClient
+                .when()
+                .resourcesRead("test-resource://sample-resource.test", response -> {
+                    org.junit.jupiter.api.Assertions.assertFalse(
+                            response.contents().isEmpty(), "Resource contents should not be empty");
+                    org.junit.jupiter.api.Assertions.assertEquals(
+                            EXPECTED_CONTENT,
+                            response.contents().get(0).asText().text());
+                })
+                .thenAssertResults();
+
+        LOG.info("Resource read via MCP successfully - content matches expected value");
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ToolCapabilityE2ETest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ToolCapabilityE2ETest.java
@@ -1,0 +1,161 @@
+package ai.wanaku.backend.api.v1.e2e;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jboss.logging.Logger;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import ai.wanaku.backend.support.E2ETestProfile;
+import ai.wanaku.backend.support.MockGrpcCapabilityServer;
+import ai.wanaku.backend.support.TestIndexHelper;
+import ai.wanaku.backend.support.WanakuKeycloakTestResource;
+import ai.wanaku.backend.support.WanakuRouterTest;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
+import ai.wanaku.core.util.support.ToolsHelper;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+/**
+ * End-to-end test for MCP tool capability dispatch.
+ * Verifies the full chain: McpAssured -> MCP SSE -> router resolver -> gRPC transport -> mock capability.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@QuarkusTest
+@TestProfile(E2ETestProfile.class)
+@QuarkusTestResource(value = WanakuKeycloakTestResource.class, restrictToAnnotatedClass = true)
+@DisabledIf(value = "isUnsupportedOSOnGithub", disabledReason = "Does not run on macOS or Windows on GitHub")
+public class ToolCapabilityE2ETest extends WanakuRouterTest {
+    private static final Logger LOG = Logger.getLogger(ToolCapabilityE2ETest.class);
+
+    private static final String EXPECTED_CONTENT = "test-tool-result-from-mock-capability";
+    private static final String SERVICE_NAME = "test-tool";
+    private static final String TOOL_NAME = "test-tool-operation";
+
+    private static MockGrpcCapabilityServer mockServer;
+    private static int mockPort;
+    private static KeycloakTestClient keycloakClient;
+    private static McpAssured.McpSseTestClient mcpClient;
+
+    private String getAccessToken() {
+        return keycloakClient.getRealmClientAccessToken("wanaku", "wanaku-service", "secret");
+    }
+
+    @BeforeAll
+    static void setup() throws IOException {
+        TestIndexHelper.deleteRecursively("target/wanaku/router");
+        keycloakClient = new KeycloakTestClient();
+
+        mockServer = new MockGrpcCapabilityServer(List.of(EXPECTED_CONTENT));
+        mockPort = mockServer.start();
+        LOG.infof("Mock tool capability server started on port %d", mockPort);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (mcpClient != null) {
+            mcpClient.disconnect();
+        }
+        if (mockServer != null) {
+            mockServer.stop();
+        }
+    }
+
+    @Order(1)
+    @Test
+    void testRegisterCapability() {
+        String accessToken = getAccessToken();
+
+        ServiceTarget serviceTarget = new ServiceTarget(
+                null, SERVICE_NAME, "localhost", mockPort, ServiceType.TOOL_INVOKER.asValue(), "mcp", null, null, null);
+
+        given().header("Content-Type", MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(serviceTarget)
+                .when()
+                .post("/api/v1/management/discovery/register")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("data.id", notNullValue());
+
+        LOG.info("Mock tool capability registered with router");
+    }
+
+    @Order(2)
+    @Test
+    void testAddTool() {
+        InputSchema inputSchema = ToolsHelper.createInputSchema(
+                SERVICE_NAME,
+                Collections.singletonMap("input", ToolsHelper.createProperty("string", "An input parameter.")));
+
+        ToolReference toolReference = new ToolReference();
+        toolReference.setName(TOOL_NAME);
+        toolReference.setDescription("A test tool for e2e testing");
+        toolReference.setUri("test-tool://operation");
+        toolReference.setType(SERVICE_NAME);
+        toolReference.setNamespace("public");
+        toolReference.setInputSchema(inputSchema);
+
+        given().header("Content-Type", MediaType.APPLICATION_JSON)
+                .body(toolReference)
+                .when()
+                .post("/api/v1/tools/add")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode());
+
+        given().when()
+                .get("/api/v1/tools/list")
+                .then()
+                .statusCode(Response.Status.OK.getStatusCode())
+                .body("data.size()", is(1), "data[0].name", is(TOOL_NAME), "data[0].type", is(SERVICE_NAME));
+
+        LOG.info("Tool added successfully");
+    }
+
+    @Order(3)
+    @Test
+    void testCallToolViaMcp() throws Exception {
+        int port = io.restassured.RestAssured.port;
+        mcpClient = McpAssured.newSseClient()
+                .setBaseUri(new URI("http://localhost:" + port + "/"))
+                .setSsePath("public/mcp/sse")
+                .build();
+        mcpClient.connect();
+
+        mcpClient
+                .when()
+                .toolsCall(TOOL_NAME, Map.of("input", "test-value"), toolResponse -> {
+                    org.junit.jupiter.api.Assertions.assertFalse(
+                            toolResponse.isError(), "Tool response should not be an error");
+                    org.junit.jupiter.api.Assertions.assertFalse(
+                            toolResponse.content().isEmpty(), "Tool response content should not be empty");
+                    org.junit.jupiter.api.Assertions.assertEquals(
+                            EXPECTED_CONTENT,
+                            toolResponse.content().get(0).asText().text());
+                })
+                .thenAssertResults();
+
+        LOG.info("Tool called via MCP successfully - content matches expected value");
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProfile.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProfile.java
@@ -1,0 +1,17 @@
+package ai.wanaku.backend.support;
+
+import java.util.Set;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Test profile for e2e capability tests.
+ * Enables real resolvers that delegate to gRPC capabilities instead of the NoOp resolvers
+ * used by other tests.
+ */
+public class E2ETestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Set<Class<?>> getEnabledAlternatives() {
+        return Set.of(E2ETestProvider.class);
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProvider.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProvider.java
@@ -1,0 +1,64 @@
+package ai.wanaku.backend.support;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+import ai.wanaku.backend.bridge.InvokerBridge;
+import ai.wanaku.backend.bridge.ResourceAcquirerBridge;
+import ai.wanaku.backend.bridge.WanakuBridgeTransport;
+import ai.wanaku.backend.bridge.transports.grpc.GrpcTransport;
+import ai.wanaku.backend.resolvers.WanakuResourceResolver;
+import ai.wanaku.backend.resolvers.WanakuToolsResolver;
+import ai.wanaku.backend.service.support.FirstAvailable;
+import ai.wanaku.backend.service.support.ServiceResolver;
+import ai.wanaku.core.mcp.common.resolvers.ResourceResolver;
+import ai.wanaku.core.mcp.common.resolvers.ToolsResolver;
+import ai.wanaku.core.mcp.common.resolvers.util.NoopForwardRegistry;
+import ai.wanaku.core.mcp.providers.ForwardRegistry;
+import ai.wanaku.core.mcp.providers.ServiceRegistry;
+
+/**
+ * CDI alternative provider for e2e tests that produces real resolvers backed by gRPC transport.
+ * Activated only when the {@link E2ETestProfile} is active.
+ */
+@Alternative
+@ApplicationScoped
+public class E2ETestProvider {
+    private static final Logger LOG = Logger.getLogger(E2ETestProvider.class);
+
+    @Inject
+    Instance<ServiceRegistry> serviceRegistryInstance;
+
+    private ServiceRegistry serviceRegistry;
+
+    @PostConstruct
+    void init() {
+        serviceRegistry = serviceRegistryInstance.get();
+    }
+
+    @Produces
+    ToolsResolver toolsResolver() {
+        LOG.info("Creating real ToolsResolver for e2e tests");
+        ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+        WanakuBridgeTransport transport = new GrpcTransport();
+        return new WanakuToolsResolver(new InvokerBridge(resolver, transport));
+    }
+
+    @Produces
+    ResourceResolver resourceResolver() {
+        LOG.info("Creating real ResourceResolver for e2e tests");
+        ServiceResolver resolver = new FirstAvailable(serviceRegistry);
+        WanakuBridgeTransport transport = new GrpcTransport();
+        return new WanakuResourceResolver(new ResourceAcquirerBridge(resolver, transport));
+    }
+
+    @Produces
+    ForwardRegistry forwardRegistry() {
+        return new NoopForwardRegistry();
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
@@ -1,0 +1,109 @@
+package ai.wanaku.backend.support;
+
+import java.io.IOException;
+import java.util.List;
+import org.jboss.logging.Logger;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.core.exchange.v1.HealthProbeGrpc;
+import ai.wanaku.core.exchange.v1.HealthProbeReply;
+import ai.wanaku.core.exchange.v1.HealthProbeRequest;
+import ai.wanaku.core.exchange.v1.ProvisionReply;
+import ai.wanaku.core.exchange.v1.ProvisionRequest;
+import ai.wanaku.core.exchange.v1.ProvisionerGrpc;
+import ai.wanaku.core.exchange.v1.ResourceAcquirerGrpc;
+import ai.wanaku.core.exchange.v1.ResourceReply;
+import ai.wanaku.core.exchange.v1.ResourceRequest;
+import ai.wanaku.core.exchange.v1.RuntimeStatus;
+import ai.wanaku.core.exchange.v1.ToolInvokeReply;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+import ai.wanaku.core.exchange.v1.ToolInvokerGrpc;
+
+/**
+ * A standalone gRPC server that mocks both tool and resource capabilities.
+ * Returns pre-configured responses for tool invocations and resource acquisitions.
+ */
+public class MockGrpcCapabilityServer {
+    private static final Logger LOG = Logger.getLogger(MockGrpcCapabilityServer.class);
+
+    private final List<String> responseContent;
+    private Server server;
+
+    public MockGrpcCapabilityServer(List<String> responseContent) {
+        this.responseContent = responseContent;
+    }
+
+    /**
+     * Starts the gRPC server on a random available port.
+     *
+     * @return the port the server is listening on
+     * @throws IOException if the server fails to start
+     */
+    public int start() throws IOException {
+        server = ServerBuilder.forPort(0)
+                .addService(new MockToolInvoker())
+                .addService(new MockResourceAcquirer())
+                .addService(new MockProvisioner())
+                .addService(new MockHealthProbe())
+                .build()
+                .start();
+
+        int port = server.getPort();
+        LOG.infof("Mock gRPC capability server started on port %d", port);
+        return port;
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.shutdownNow();
+            LOG.info("Mock gRPC capability server stopped");
+        }
+    }
+
+    private class MockToolInvoker extends ToolInvokerGrpc.ToolInvokerImplBase {
+        @Override
+        public void invokeTool(ToolInvokeRequest request, StreamObserver<ToolInvokeReply> responseObserver) {
+            LOG.infof("Mock tool invoked with uri=%s", request.getUri());
+            ToolInvokeReply reply =
+                    ToolInvokeReply.newBuilder().addAllContent(responseContent).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
+    }
+
+    private class MockResourceAcquirer extends ResourceAcquirerGrpc.ResourceAcquirerImplBase {
+        @Override
+        public void resourceAcquire(ResourceRequest request, StreamObserver<ResourceReply> responseObserver) {
+            LOG.infof("Mock resource acquired with location=%s, name=%s", request.getLocation(), request.getName());
+            ResourceReply reply =
+                    ResourceReply.newBuilder().addAllContent(responseContent).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
+    }
+
+    private class MockProvisioner extends ProvisionerGrpc.ProvisionerImplBase {
+        @Override
+        public void provision(ProvisionRequest request, StreamObserver<ProvisionReply> responseObserver) {
+            LOG.info("Mock provisioner called");
+            ProvisionReply reply = ProvisionReply.newBuilder()
+                    .setConfigurationUri("file:///tmp/mock-config")
+                    .setSecretUri("file:///tmp/mock-secret")
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
+    }
+
+    private class MockHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
+        @Override
+        public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
+            HealthProbeReply reply = HealthProbeReply.newBuilder()
+                    .setStatus(RuntimeStatus.RUNTIME_STATUS_STARTED)
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds end-to-end integration tests that verify the full MCP capability dispatch chain: McpAssured → MCP SSE → router resolver → gRPC transport → mock capability → response verification
- Creates a `MockGrpcCapabilityServer` that simulates both tool invoker and resource provider gRPC capabilities with pre-configured responses
- Uses `@QuarkusTestProfile` + `@Alternative` CDI beans (`E2ETestProfile`/`E2ETestProvider`) to wire real resolvers backed by `GrpcTransport` only for e2e tests, without affecting existing tests

## Test plan

- [x] `ResourceCapabilityE2ETest`: registers mock gRPC resource capability → exposes resource via REST API → reads resource via MCP SSE → asserts content matches expected value
- [x] `ToolCapabilityE2ETest`: registers mock gRPC tool capability → adds tool via REST API → calls tool via MCP SSE → asserts response matches expected value
- [x] All existing tests continue to pass (they use the default `TestProvider` with NoOp resolvers)
- [x] Full `mvn verify` passes

Closes #815

## Summary by Sourcery

Add end-to-end integration coverage for MCP tool and resource capabilities using a mock gRPC capability server and a dedicated e2e test profile.

Enhancements:
- Provide a mock gRPC capability server for tools, resources, provisioning, and health checks to support integration tests.
- Add an e2e Quarkus test profile and alternative CDI provider that wires real gRPC-based resolvers only for e2e tests.

Build:
- Add test-scoped dependencies for MCP server testing and gRPC Netty transport in the backend module.

Tests:
- Introduce e2e tests that cover registering, exposing, and invoking MCP tool capabilities through the full router and MCP SSE chain.
- Introduce e2e tests that cover registering, exposing, and reading MCP resource capabilities through the full router and MCP SSE chain.