### PR TITLE
Fix #815: add unit tests for AbstractToolDelegate and AbstractResourceDelegate

### DIFF
--- a/core/core-capabilities-base/pom.xml
+++ b/core/core-capabilities-base/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegateTest.java
+++ b/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegateTest.java
@@ -1,0 +1,181 @@
+package ai.wanaku.core.capabilities.provider;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.exchange.v1.ResourceReply;
+import ai.wanaku.core.exchange.v1.ResourceRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractResourceDelegateTest {
+
+    @Mock
+    private ResourceConsumer consumer;
+
+    @Mock
+    private RegistrationManager registrationManager;
+
+    private String configuredUri;
+    private List<String> configuredResponse;
+    private RuntimeException coerceException;
+
+    private AbstractResourceDelegate delegate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        configuredUri = "test://resource";
+        configuredResponse = null;
+        coerceException = null;
+
+        delegate = new AbstractResourceDelegate() {
+            @Override
+            protected String getEndpointUri(ResourceRequest request, ConfigResource configResource) {
+                return configuredUri;
+            }
+
+            @Override
+            protected List<String> coerceResponse(Object response)
+                    throws InvalidResponseTypeException, NonConvertableResponseException, ResourceNotFoundException {
+                if (coerceException instanceof InvalidResponseTypeException) {
+                    throw (InvalidResponseTypeException) coerceException;
+                }
+                if (coerceException instanceof NonConvertableResponseException) {
+                    throw (NonConvertableResponseException) coerceException;
+                }
+                if (coerceException instanceof ResourceNotFoundException) {
+                    throw (ResourceNotFoundException) coerceException;
+                }
+                return configuredResponse;
+            }
+        };
+
+        setField(delegate, "consumer", consumer);
+        setField(delegate, "registrationManager", registrationManager);
+    }
+
+    @Test
+    void acquireHappyPath() throws Exception {
+        configuredResponse = List.of("resource content");
+        when(consumer.consume(any(String.class), any(ResourceRequest.class))).thenReturn("raw");
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        ResourceReply reply = delegate.acquire(request);
+
+        assertNotNull(reply);
+        assertEquals(1, reply.getContentCount());
+        assertEquals("resource content", reply.getContent(0));
+        verify(registrationManager).lastAsSuccessful();
+    }
+
+    @Test
+    void acquireVerifiesUriForwarding() throws Exception {
+        configuredUri = "custom://my-endpoint";
+        configuredResponse = List.of("data");
+        when(consumer.consume(any(String.class), any(ResourceRequest.class))).thenReturn("raw");
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        delegate.acquire(request);
+
+        verify(consumer).consume(eq("custom://my-endpoint"), any(ResourceRequest.class));
+    }
+
+    @Test
+    void acquireMultipleContentItems() throws Exception {
+        configuredResponse = List.of("item1", "item2", "item3");
+        when(consumer.consume(any(String.class), any(ResourceRequest.class))).thenReturn("raw");
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        ResourceReply reply = delegate.acquire(request);
+
+        assertEquals(3, reply.getContentCount());
+        assertEquals("item1", reply.getContent(0));
+        assertEquals("item2", reply.getContent(1));
+        assertEquals("item3", reply.getContent(2));
+        verify(registrationManager).lastAsSuccessful();
+    }
+
+    @Test
+    void acquireInvalidResponseType() throws Exception {
+        coerceException = new InvalidResponseTypeException("bad type");
+        when(consumer.consume(any(String.class), any(ResourceRequest.class))).thenReturn("raw");
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.acquire(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    @Test
+    void acquireNonConvertableResponse() throws Exception {
+        coerceException = new NonConvertableResponseException("cannot convert");
+        when(consumer.consume(any(String.class), any(ResourceRequest.class))).thenReturn("raw");
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.acquire(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    @Test
+    void acquireConsumerThrowsException() throws Exception {
+        when(consumer.consume(any(String.class), any(ResourceRequest.class)))
+                .thenThrow(new RuntimeException("connection failed"));
+
+        ResourceRequest request =
+                ResourceRequest.newBuilder().setLocation("test-location").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.acquire(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegateTest.java
+++ b/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegateTest.java
@@ -1,0 +1,159 @@
+package ai.wanaku.core.capabilities.tool;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.exchange.v1.ToolInvokeReply;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractToolDelegateTest {
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private RegistrationManager registrationManager;
+
+    private List<String> configuredResponse;
+    private RuntimeException coerceException;
+
+    private AbstractToolDelegate delegate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        configuredResponse = null;
+        coerceException = null;
+
+        delegate = new AbstractToolDelegate() {
+            @Override
+            protected List<String> coerceResponse(Object response)
+                    throws InvalidResponseTypeException, NonConvertableResponseException {
+                if (coerceException instanceof InvalidResponseTypeException) {
+                    throw (InvalidResponseTypeException) coerceException;
+                }
+                if (coerceException instanceof NonConvertableResponseException) {
+                    throw (NonConvertableResponseException) coerceException;
+                }
+                return configuredResponse;
+            }
+        };
+
+        setField(delegate, "client", client);
+        setField(delegate, "registrationManager", registrationManager);
+    }
+
+    @Test
+    void invokeHappyPath() throws Exception {
+        configuredResponse = List.of("result data");
+        when(client.exchange(any(ToolInvokeRequest.class), any(ConfigResource.class)))
+                .thenReturn("raw");
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        ToolInvokeReply reply = delegate.invoke(request);
+
+        assertNotNull(reply);
+        assertEquals(1, reply.getContentCount());
+        assertEquals("result data", reply.getContent(0));
+        verify(registrationManager).lastAsSuccessful();
+    }
+
+    @Test
+    void invokeMultipleContentItems() throws Exception {
+        configuredResponse = List.of("item1", "item2", "item3");
+        when(client.exchange(any(ToolInvokeRequest.class), any(ConfigResource.class)))
+                .thenReturn("raw");
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        ToolInvokeReply reply = delegate.invoke(request);
+
+        assertEquals(3, reply.getContentCount());
+        assertEquals("item1", reply.getContent(0));
+        assertEquals("item2", reply.getContent(1));
+        assertEquals("item3", reply.getContent(2));
+        verify(registrationManager).lastAsSuccessful();
+    }
+
+    @Test
+    void invokeInvalidResponseType() throws Exception {
+        coerceException = new InvalidResponseTypeException("bad type");
+        when(client.exchange(any(ToolInvokeRequest.class), any(ConfigResource.class)))
+                .thenReturn("raw");
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.invoke(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    @Test
+    void invokeNonConvertableResponse() throws Exception {
+        coerceException = new NonConvertableResponseException("cannot convert");
+        when(client.exchange(any(ToolInvokeRequest.class), any(ConfigResource.class)))
+                .thenReturn("raw");
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.invoke(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    @Test
+    void invokeClientThrowsException() throws Exception {
+        when(client.exchange(any(ToolInvokeRequest.class), any(ConfigResource.class)))
+                .thenThrow(new RuntimeException("connection failed"));
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () -> delegate.invoke(request));
+
+        assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+        verify(registrationManager).lastAsFail(any(String.class));
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `AbstractToolDelegate` and `AbstractResourceDelegate` in `core-capabilities-base`
- Tests cover happy path, multiple content items, error handling (`InvalidResponseTypeException`, `NonConvertableResponseException`), and client/consumer exceptions
- Add `mockito-core` test dependency to `core-capabilities-base`

## Test plan
- [x] All 11 new tests pass (5 tool delegate + 6 resource delegate)
- [x] Full `mvn verify` passes

## Summary by Sourcery

Add unit tests for the core capability delegates to validate successful responses and error handling.

Build:
- Add mockito-core as a test-scoped dependency to core-capabilities-base for mocking collaborators in new tests.

Tests:
- Add unit tests for AbstractResourceDelegate covering URI forwarding, multiple content responses, and failure scenarios for invalid/convertible responses and consumer errors.
- Add unit tests for AbstractToolDelegate covering multiple content responses and failure scenarios for invalid/convertible responses and client errors.