### PR TITLE
Fix #804: Disable capability-side ping by default

### DIFF
--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/config/WanakuServiceConfig.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/config/WanakuServiceConfig.java
@@ -124,6 +124,16 @@ public interface WanakuServiceConfig extends WanakuConfig {
 
         @WithDefault("auto")
         String announceAddress();
+
+        /**
+         * Returns whether capability-side ping is enabled.
+         * When disabled, the capability will not send periodic ping requests to the router
+         * after initial registration.
+         *
+         * @return {@code true} if ping is enabled, {@code false} otherwise. Defaults to {@code false}.
+         */
+        @WithDefault("false")
+        boolean pingEnabled();
     }
 
     /**

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/discovery/DefaultRegistrationManager.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/discovery/DefaultRegistrationManager.java
@@ -52,6 +52,7 @@ public class DefaultRegistrationManager implements RegistrationManager {
     private ServiceTarget target;
     private int retries;
     private final int waitSeconds;
+    private final boolean pingEnabled;
     private final InstanceDataManager instanceDataManager;
     private volatile boolean registered;
     private final ReentrantLock lock = new ReentrantLock();
@@ -77,6 +78,9 @@ public class DefaultRegistrationManager implements RegistrationManager {
 
         // the number of seconds to wait between retry attempts
         this.waitSeconds = config.registration().retryWaitSeconds();
+
+        // whether capability-side ping is enabled
+        this.pingEnabled = config.registration().pingEnabled();
 
         // the directory path for persisting service identity data
         String dataDir = ServicesHelper.getCanonicalServiceHome(config);
@@ -169,7 +173,9 @@ public class DefaultRegistrationManager implements RegistrationManager {
     @Override
     public void register() {
         if (isRegistered()) {
-            ping();
+            if (pingEnabled) {
+                ping();
+            }
         } else {
             LOG.debugf(
                     "Registering %s service %s with address %s",

--- a/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/TestServiceConfig.java
+++ b/core/core-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/TestServiceConfig.java
@@ -78,6 +78,11 @@ class TestServiceConfig implements WanakuServiceConfig {
             public String announceAddress() {
                 return "auto";
             }
+
+            @Override
+            public boolean pingEnabled() {
+                return false;
+            }
         };
     }
 }


### PR DESCRIPTION
## Summary
- Add `pingEnabled()` with `@WithDefault("false")` to `WanakuServiceConfig.Registration`
- Guard ping call in `DefaultRegistrationManager.register()` behind the flag
- Update `TestServiceConfig` to implement the new method

## Test plan
- [ ] Verify build passes (`mvn verify`)
- [ ] Confirm capability no longer pings by default after registration
- [ ] Confirm ping can be enabled by setting `wanaku.service.registration.ping-enabled=true`

Fixes #804

## Summary by Sourcery

Disable capability-side ping by default and make it configurable via service registration settings.

Bug Fixes:
- Prevent capabilities from sending periodic ping requests to the router by default after registration.

Enhancements:
- Introduce a configuration flag on service registration to enable or disable capability-side pinging.
- Update registration management to respect the new ping configuration when deciding whether to send pings.
- Adjust test service configuration to implement the new registration ping setting.