### PR TITLE
Fix #832: add JMH performance tests for InvokerToolExecutor and ResourceAcquirerBridge

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,6 +74,7 @@
         <oauth2-oidc-sdk.version>11.33</oauth2-oidc-sdk.version>
         <operator-framework.version>5.2.2</operator-framework.version>
         <palantir-format-version.version>2.71.0</palantir-format-version.version>
+        <jmh.version>1.37</jmh.version>
 
         <assembly.descriptor>src/main/assembly/assembly.xml</assembly.descriptor>
         <dist.final.name>${project.artifactId}-${project.version}</dist.final.name>
@@ -145,6 +146,16 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmh.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -170,6 +170,17 @@
             <artifactId>grpc-netty-shaded</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerToolExecutorBenchmarkManualTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerToolExecutorBenchmarkManualTest.java
@@ -1,0 +1,97 @@
+package ai.wanaku.backend.bridge;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.ToolManager;
+import ai.wanaku.backend.service.support.ServiceResolver;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.v1.ToolInvokeReply;
+
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+public class InvokerToolExecutorBenchmarkManualTest {
+
+    private InvokerToolExecutor executor;
+    private ToolManager.ToolArguments toolArguments;
+    private ToolReference toolReference;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        ServiceTarget serviceTarget = ServiceTarget.newEmptyTarget("test-service", "localhost", 8080, "http");
+
+        ServiceResolver serviceResolver = mock(ServiceResolver.class);
+        when(serviceResolver.resolve(any(), any())).thenReturn(serviceTarget);
+
+        ToolInvokeReply reply =
+                ToolInvokeReply.newBuilder().addContent("benchmark result").build();
+
+        WanakuBridgeTransport transport = mock(WanakuBridgeTransport.class);
+        when(transport.invokeTool(any(), any())).thenReturn(reply);
+
+        executor = new InvokerToolExecutor(serviceResolver, transport);
+
+        McpConnection connection = mock(McpConnection.class);
+        when(connection.id()).thenReturn("bench-conn-1");
+
+        toolArguments = mock(ToolManager.ToolArguments.class);
+        when(toolArguments.connection()).thenReturn(connection);
+        Map<String, Object> args = new HashMap<>();
+        args.put("param1", "value1");
+        when(toolArguments.args()).thenReturn(args);
+
+        Map<String, Property> properties = new HashMap<>();
+        Property p = new Property();
+        p.setType("string");
+        p.setDescription("A test parameter");
+        properties.put("param1", p);
+
+        InputSchema schema = new InputSchema();
+        schema.setType("object");
+        schema.setProperties(properties);
+
+        toolReference = new ToolReference();
+        toolReference.setName("bench-tool");
+        toolReference.setType("http");
+        toolReference.setUri("https://example.com/api/test");
+        toolReference.setInputSchema(schema);
+    }
+
+    @Benchmark
+    public void executeToolBenchmark(Blackhole blackhole) {
+        blackhole.consume(executor.execute(toolArguments, toolReference));
+    }
+
+    @Test
+    void runBenchmark() throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(InvokerToolExecutorBenchmarkManualTest.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/ResourceAcquirerBridgeBenchmarkManualTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/ResourceAcquirerBridgeBenchmarkManualTest.java
@@ -1,0 +1,82 @@
+package ai.wanaku.backend.bridge;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.ResourceManager;
+import ai.wanaku.backend.service.support.ServiceResolver;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.v1.ResourceReply;
+
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+public class ResourceAcquirerBridgeBenchmarkManualTest {
+
+    private ResourceAcquirerBridge bridge;
+    private ResourceManager.ResourceArguments arguments;
+    private ResourceReference resourceReference;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        ServiceTarget serviceTarget = ServiceTarget.newEmptyTarget("test-service", "localhost", 9090, "file");
+
+        ServiceResolver serviceResolver = mock(ServiceResolver.class);
+        when(serviceResolver.resolve(any(), any())).thenReturn(serviceTarget);
+
+        ResourceReply reply = ResourceReply.newBuilder()
+                .addContent("benchmark resource content")
+                .build();
+
+        WanakuBridgeTransport transport = mock(WanakuBridgeTransport.class);
+        when(transport.acquireResource(any(), any())).thenReturn(reply);
+
+        bridge = new ResourceAcquirerBridge(serviceResolver, transport);
+
+        McpConnection connection = mock(McpConnection.class);
+        when(connection.id()).thenReturn("bench-conn-1");
+
+        arguments = mock(ResourceManager.ResourceArguments.class);
+        when(arguments.connection()).thenReturn(connection);
+        when(arguments.requestUri()).thenReturn(new RequestUri("file:///tmp/test.txt"));
+
+        resourceReference = new ResourceReference();
+        resourceReference.setLocation("/tmp/test.txt");
+        resourceReference.setType("file");
+        resourceReference.setName("test-resource");
+        resourceReference.setMimeType("text/plain");
+    }
+
+    @Benchmark
+    public Object evalResourceBenchmark() {
+        return bridge.eval(arguments, resourceReference);
+    }
+
+    @Test
+    void runBenchmark() throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(ResourceAcquirerBridgeBenchmarkManualTest.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add JMH-based performance benchmarks for InvokerToolExecutor and ResourceAcquirerBridge and wire JMH dependencies into the build.

New Features:
- Introduce JMH throughput benchmark test for InvokerToolExecutor execution flow.
- Introduce JMH throughput benchmark test for ResourceAcquirerBridge resource evaluation flow.

Build:
- Add configurable JMH version property and JMH core/annotation processor dependencies to the parent POM and backend module for test-time benchmarking.