### PR TITLE
chore: add --no-transfer-progress to all Maven CI builds

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build Wanaku Capabilities SDK Main Project
-        run: mvn -DskipTests clean install
+        run: mvn --no-transfer-progress -DskipTests clean install
         working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create a snapshot build (with container push)
         run: |
-          mvn -Dnative -Pdist \
+          mvn --no-transfer-progress -Dnative -Pdist \
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.additional-tags=${{ github.event.inputs.currentDevelopmentVersion }} \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,7 +53,7 @@ jobs:
         ref: main
         path: wanaku-capabilities-java-sdk
     - name: Build Wanaku Capabilities SDK Main Project
-      run: mvn -DskipTests clean install
+      run: mvn --no-transfer-progress -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
     - name: Set arch
       id: arch
@@ -68,7 +68,7 @@ jobs:
     - name: Build and Publish (x86)
       if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/wanaku'
       run: |
-        mvn -B clean package \
+        mvn -B --no-transfer-progress clean package \
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.tag=${{ github.ref_name }}-${{ steps.arch.outputs.arch }} \
@@ -77,7 +77,7 @@ jobs:
     - name: Build and Publish (arm)
       if: matrix.os == 'ubuntu-24.04-arm' && github.repository == 'wanaku-ai/wanaku'
       run: |
-        mvn -B clean package \
+        mvn -B --no-transfer-progress clean package \
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.tag=${{ github.ref_name }}-${{ steps.arch.outputs.arch }} \

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -55,8 +55,8 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build Wanaku Capabilities SDK Main Project
-      run: mvn -DskipTests clean install
+      run: mvn --no-transfer-progress -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
     - uses: actions/checkout@v6
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B --no-transfer-progress package --file pom.xml

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Create a release build with container push (x86)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          mvn -Pdist -Dnative -DskipTests \
+          mvn --no-transfer-progress -Pdist -Dnative -DskipTests \
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.tag=${{ github.event.inputs.currentDevelopmentVersion }}-${{ steps.arch.outputs.arch }} \
@@ -59,7 +59,7 @@ jobs:
       - name: Create a release build with container push (x86)
         if: matrix.os == 'ubuntu-24.04-arm'
         run: |
-          mvn -Pdist -Dnative -DskipTests \
+          mvn --no-transfer-progress -Pdist -Dnative -DskipTests \
           -Dquarkus.container-image.build=true \
           -Dquarkus.container-image.push=true \
           -Dquarkus.container-image.tag=${{ github.event.inputs.currentDevelopmentVersion }}-${{ steps.arch.outputs.arch }} \
@@ -68,7 +68,7 @@ jobs:
       - name: Create a release build with native executables (macos)
         if: matrix.os != 'ubuntu-latest' || matrix.os != 'ubuntu-24.04-arm'
         run: |
-          mvn -Pdist -Dnative -DskipTests clean package
+          mvn --no-transfer-progress -Pdist -Dnative -DskipTests clean package
       - name: Run JReleaser
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         uses: jreleaser/release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
           export GPG_TTY=$(tty)
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          mvn --batch-mode -Dtag=wanaku-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare
+          mvn --batch-mode --no-transfer-progress -Dtag=wanaku-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare
           sed -i -e "s/${{ github.event.inputs.previousDevelopmentVersion }}/${{ github.event.inputs.currentDevelopmentVersion }}/g" jbang-catalog.json
-          mvn -PcommitFiles scm:checkin
+          mvn --no-transfer-progress -PcommitFiles scm:checkin
           git tag -d wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
           git tag wanaku-${{ github.event.inputs.currentDevelopmentVersion }} HEAD~2
           git push origin wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
-          mvn -Pdist release:perform
+          mvn --no-transfer-progress -Pdist release:perform


### PR DESCRIPTION
## Summary
- Add `--no-transfer-progress` to all Maven invocations across GitHub Actions workflows
- Reduces CI log noise by suppressing dependency download progress bars

## Changed workflows
- `main-build.yml` (3 mvn commands)
- `pr-builds.yml` (2 mvn commands)
- `early-access.yml` (2 mvn commands)
- `release.yml` (3 mvn commands)
- `release-artifacts.yml` (3 mvn commands)

## Summary by Sourcery

CI:
- Update all GitHub Actions workflows to invoke Maven with --no-transfer-progress for builds, packaging, and release-related tasks.