### PR TITLE
Clean up Maven POM files

### DIFF
--- a/capabilities/tools/wanaku-tool-service-exec/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-exec/pom.xml
@@ -73,17 +73,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/capabilities/tools/wanaku-tool-service-http/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-http/pom.xml
@@ -63,17 +63,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/capabilities/tools/wanaku-tool-service-tavily/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-tavily/pom.xml
@@ -107,17 +107,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -22,24 +22,24 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models</artifactId>
-                <version>${swagger-core-version}</version>
+                <version>${swagger-core.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core</artifactId>
-                <version>${swagger-core-version}</version>
+                <version>${swagger-core.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>${jline-version}</version>
+                <version>${jline.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline-console-ui</artifactId>
-                <version>${jline-version}</version>
+                <version>${jline.version}</version>
             </dependency>
 
             <dependency>
@@ -51,19 +51,19 @@
             <dependency>
                 <groupId>org.skyscreamer</groupId>
                 <artifactId>jsonassert</artifactId>
-                <version>${jsonassert-version}</version>
+                <version>${jsonassert.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.googlecode.juniversalchardet</groupId>
                 <artifactId>juniversalchardet</artifactId>
-                <version>${juniversalchardet-version}</version>
+                <version>${juniversalchardet.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
-                <version>${jansi-version}</version>
+                <version>${jansi.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -173,26 +173,9 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/core/core-exchange/pom.xml
+++ b/core/core-exchange/pom.xml
@@ -62,21 +62,11 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <sourcepath>${project.basedir}/src/main/java:${project.build.directory}/generated-sources/grpc</sourcepath>
                 </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,7 +27,7 @@
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
-        <maven-enforcer-plugin-version>3.6.2</maven-enforcer-plugin-version>
+        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <executable-suffix />
         <distribution.directory>${project.build.directory}/distributions</distribution.directory>
@@ -55,14 +55,14 @@
         <quarkus-quinoa.version>2.7.1</quarkus-quinoa.version>
         <testcontainers.version>2.0.3</testcontainers.version>
         <commons-pool2.version>2.13.1</commons-pool2.version>
-        <jsonassert-version>1.5.3</jsonassert-version>
-        <swagger-core-version>2.2.42</swagger-core-version>
-        <jline-version>3.30.6</jline-version>
+        <jsonassert.version>1.5.3</jsonassert.version>
+        <swagger-core.version>2.2.42</swagger-core.version>
+        <jline.version>3.30.6</jline.version>
         <swagger-parser.version>2.1.36</swagger-parser.version>
         <quarkus-infinispan-embedded.version>1.2.1</quarkus-infinispan-embedded.version>
-        <assertj-version>3.27.7</assertj-version>
-        <juniversalchardet-version>1.0.3</juniversalchardet-version>
-        <jansi-version>2.4.2</jansi-version>
+        <assertj.version>3.27.7</assertj.version>
+        <juniversalchardet.version>1.0.3</juniversalchardet.version>
+        <jansi.version>2.4.2</jansi.version>
         <jna.version>5.18.1</jna.version>
         <commons-logging.version>1.3.5</commons-logging.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -73,7 +73,7 @@
         <commonmark.version>0.27.1</commonmark.version>
         <oauth2-oidc-sdk.version>11.33</oauth2-oidc-sdk.version>
         <operator-framework.version>5.2.2</operator-framework.version>
-        <palantir-format-version.version>2.71.0</palantir-format-version.version>
+        <palantir-format.version>2.71.0</palantir-format.version>
 
         <assembly.descriptor>src/main/assembly/assembly.xml</assembly.descriptor>
         <dist.final.name>${project.artifactId}-${project.version}</dist.final.name>
@@ -178,13 +178,37 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>${quarkus.platform.group-id}</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>build</goal>
+                                <goal>generate-code</goal>
+                                <goal>generate-code-tests</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>${spotless-maven-plugin.version}</version>
                     <configuration>
                         <java>
                             <palantirJavaFormat>
-                                <version>${palantir-format-version.version}</version>
+                                <version>${palantir-format.version}</version>
                             </palantirJavaFormat>
                             <removeUnusedImports />
                             <formatAnnotations />

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
         <maven-scm-plugin.version>2.2.1</maven-scm-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
     </properties>
 
@@ -125,6 +126,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj-version}</version>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -86,26 +86,9 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/wanaku-operator/pom.xml
+++ b/wanaku-operator/pom.xml
@@ -89,26 +89,9 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -177,26 +177,9 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Standardize 8 property names from hyphen-separated to dot notation (e.g. `jsonassert-version` → `jsonassert.version`)
- Add missing `<version>` to `maven-source-plugin` and `maven-javadoc-plugin` declarations
- Consolidate `quarkus-maven-plugin` and `maven-compiler-plugin` config into `pluginManagement` in parent POM, simplifying 8 module POMs

## Test plan
- [x] `mvn verify` passes (excluding pre-existing JMH test failure in `wanaku-router-backend`)