### PR TITLE
Fix #837: fix invalid package declaration and missing imports in archetype templates

### DIFF
--- a/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/src/main/java/__name__Tool.java
+++ b/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/src/main/java/__name__Tool.java
@@ -1,8 +1,9 @@
-package $
+package ${package};
 
 import ai.wanaku.core.forward.discovery.client.ForwardRegistrationManager;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceDelegate.java
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceDelegate.java
@@ -1,10 +1,14 @@
-package $
+package ${package};
 
 import java.util.List;
 import java.util.Map;
 
 import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
+import ai.wanaku.core.capabilities.provider.AbstractResourceDelegate;
+import ai.wanaku.core.exchange.v1.ResourceRequest;
 import ai.wanaku.core.runtime.camel.CamelQueryParameterBuilder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Delegate.java
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Delegate.java
@@ -1,8 +1,10 @@
-package $
+package ${package};
 
 import java.util.List;
 
 import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.core.capabilities.tool.AbstractToolDelegate;
 import jakarta.enterprise.context.ApplicationScoped;
 
 


### PR DESCRIPTION
## Summary
- Fixed `package $` → `package ${package};` in all three archetype templates (Velocity syntax)
- Added missing imports for `AbstractResourceDelegate`, `AbstractToolDelegate`, `NonConvertableResponseException`, `ConfigResource`, `ResourceRequest`, and `ApplicationScoped`

## Affected templates
- `wanaku-provider-archetype/__name__ResourceDelegate.java`
- `wanaku-tool-service-archetype/__name__Delegate.java`
- `wanaku-mcp-servers-archetype/__name__Tool.java`

Closes #837

## Summary by Sourcery

Correct archetype Java templates to use the proper package declaration and required imports.

Bug Fixes:
- Fix invalid package placeholder syntax in all affected archetype templates.
- Add missing Java imports to generated archetype classes so they compile out of the box.