### PR TITLE
Remove deprecated state update APIs

### DIFF
--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -106,24 +106,21 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
 
             List<String> response = coerceResponse(obj);
 
-            registrationManager.lastAsSuccessful();
             return ResourceReply.newBuilder().addAllContent(response).build();
         } catch (InvalidResponseTypeException e) {
             String stateMsg = "Invalid response type from the consumer: " + e.getMessage();
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
+
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         } catch (NonConvertableResponseException e) {
             String stateMsg = "Non-convertable response from the consumer " + e.getMessage();
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         } catch (Exception e) {
             String stateMsg = findRootCause(e);
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         }

--- a/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
+++ b/core/core-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
@@ -93,24 +93,20 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
             ToolInvokeReply.Builder builder = ToolInvokeReply.newBuilder();
             builder.addAllContent(response);
 
-            registrationManager.lastAsSuccessful();
             return builder.build();
         } catch (InvalidResponseTypeException e) {
             String stateMsg = "Invalid response type from the consumer: " + e.getMessage();
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         } catch (NonConvertableResponseException e) {
             String stateMsg = "Non-convertable response from the consumer " + e.getMessage();
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         } catch (Exception e) {
             String stateMsg = findRootCause(e);
             LOG.error(stateMsg, e);
-            registrationManager.lastAsFail(stateMsg);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
         }

--- a/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
+++ b/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
@@ -31,7 +31,6 @@ import type {
   PutApiV1ToolsRemoveParams,
   ResourcePayload,
   ResourceReference,
-  ServiceState,
   ServiceTarget,
   ToolPayload,
   ToolReference,
@@ -890,6 +889,7 @@ export const postApiV1ManagementDiscoveryDeregister = async (
 };
 
 /**
+ * @deprecated
  * @summary Ping
  */
 export type postApiV1ManagementDiscoveryPingResponse200 = {
@@ -961,48 +961,6 @@ export const postApiV1ManagementDiscoveryRegister = async (
       method: "POST",
       headers: { "Content-Type": "application/json", ...options?.headers },
       body: JSON.stringify(serviceTarget),
-    },
-  );
-};
-
-/**
- * @summary Update State
- */
-export type postApiV1ManagementDiscoveryUpdateIdResponse200 = {
-  data: null;
-  status: 200;
-};
-
-export type postApiV1ManagementDiscoveryUpdateIdResponse400 = {
-  data: null;
-  status: 400;
-};
-
-export type postApiV1ManagementDiscoveryUpdateIdResponseComposite =
-  | postApiV1ManagementDiscoveryUpdateIdResponse200
-  | postApiV1ManagementDiscoveryUpdateIdResponse400;
-
-export type postApiV1ManagementDiscoveryUpdateIdResponse =
-  postApiV1ManagementDiscoveryUpdateIdResponseComposite & {
-    headers: Headers;
-  };
-
-export const getPostApiV1ManagementDiscoveryUpdateIdUrl = (id: string) => {
-  return `/api/v1/management/discovery/update/${id}`;
-};
-
-export const postApiV1ManagementDiscoveryUpdateId = async (
-  id: string,
-  serviceState: ServiceState,
-  options?: RequestInit,
-): Promise<postApiV1ManagementDiscoveryUpdateIdResponse> => {
-  return customFetch<postApiV1ManagementDiscoveryUpdateIdResponse>(
-    getPostApiV1ManagementDiscoveryUpdateIdUrl(id),
-    {
-      ...options,
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...options?.headers },
-      body: JSON.stringify(serviceState),
     },
   );
 };

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResource.java
@@ -5,8 +5,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -19,7 +17,6 @@ import io.vertx.core.eventbus.EventBus;
 import ai.wanaku.backend.common.ServiceTargetEvent;
 import ai.wanaku.backend.health.PeriodicHealthCheckService;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
-import ai.wanaku.capabilities.sdk.api.types.discovery.ServiceState;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 
 @ApplicationScoped
@@ -58,19 +55,10 @@ public class DiscoveryResource {
         return Response.ok().build();
     }
 
-    @Path("/update/{id}")
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response updateState(@PathParam("id") String id, ServiceState serviceState) {
-        discoveryBean.updateState(id, serviceState);
-        emitEvent(ServiceTargetEvent.update(id, serviceState));
-        return Response.ok().build();
-    }
-
     @Path("/ping")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @Deprecated
     public Response ping(String id) {
         LOG.tracef("Service %s is pinging", id);
         discoveryBean.ping(id);

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
@@ -1471,6 +1471,7 @@
     },
     "/api/v1/management/discovery/ping" : {
       "post" : {
+        "deprecated" : true,
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -1518,38 +1519,6 @@
           }
         },
         "summary" : "Register",
-        "tags" : [ "Discovery Resource" ]
-      }
-    },
-    "/api/v1/management/discovery/update/{id}" : {
-      "post" : {
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/ServiceState"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          },
-          "400" : {
-            "description" : "Bad Request"
-          }
-        },
-        "summary" : "Update State",
         "tags" : [ "Discovery Resource" ]
       }
     },

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -983,6 +983,7 @@ paths:
       - Discovery Resource
   /api/v1/management/discovery/ping:
     post:
+      deprecated: true
       requestBody:
         content:
           application/json:
@@ -1013,28 +1014,6 @@ paths:
         "400":
           description: Bad Request
       summary: Register
-      tags:
-      - Discovery Resource
-  /api/v1/management/discovery/update/{id}:
-    post:
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ServiceState"
-        required: true
-      responses:
-        "200":
-          description: OK
-        "400":
-          description: Bad Request
-      summary: Update State
       tags:
       - Discovery Resource
   /api/v1/management/info/version:


### PR DESCRIPTION
This fixes issue #847

## Summary by Sourcery

Remove capability ping and state update support from the discovery registration flow and router APIs.

Bug Fixes:
- Stop invoking deprecated registration state update callbacks on resource and tool delegates.

Enhancements:
- Simplify registration manager logic by removing ping handling and last state tracking.
- Deprecate the discovery ping endpoint in the router backend and admin UI API types.