### PR TITLE
Add macOS native build to early-access workflow

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -8,11 +8,16 @@ on:
         required: true
 
 jobs:
-  pre-release-build-linux:
-    name: Build Pre-release Artifacts (Linux)
-    runs-on: ubuntu-latest
+  pre-release-build:
+    name: Build Pre-release Artifacts (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: true
+
     steps:
       - name: Checkout Wanaku Capabilities SDK Main Project
         uses: actions/checkout@v6
@@ -44,6 +49,7 @@ jobs:
           cache: maven
 
       - name: Login to Container Registry
+        if: matrix.os == 'ubuntu-latest'
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -51,6 +57,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Create a snapshot build (with container push)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           mvn --no-transfer-progress -Dnative -Pdist \
           -Dquarkus.container-image.build=true \
@@ -58,8 +65,28 @@ jobs:
           -Dquarkus.container-image.additional-tags=${{ github.event.inputs.currentDevelopmentVersion }} \
           clean package
 
+      - name: Create a snapshot build with native executables (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          mvn --no-transfer-progress -Dnative -Pdist -DskipTests clean package
+
       - name: Run JReleaser (Linux)
+        if: matrix.os == 'ubuntu-latest'
         uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
+          JRELEASER_PROJECT_SNAPSHOT_LABEL: early-access
+          JRELEASER_SELECT_CURRENT_PLATFORM: true
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Run JReleaser (macOS)
+        if: matrix.os == 'macos-latest'
+        uses: jreleaser/release-action@v2
+        with:
+          arguments: 'full-release --exclude-distribution=cli'
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -75,7 +102,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jreleaser-release-linux
+          name: jreleaser-release-${{ matrix.os }}
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties


### PR DESCRIPTION
## Summary
- Converts the single Linux early-access job to a matrix strategy (`ubuntu-latest`, `macos-latest`)
- Gates container registry login and container image push to Linux only
- Adds a macOS-specific native build step (no containers, skips tests)
- Splits JReleaser into Linux and macOS steps, with macOS excluding the platform-less `cli` distribution
- Uses per-OS artifact upload names to avoid conflicts

## Test plan
- [ ] Trigger the early-access workflow and verify both Linux and macOS jobs run successfully
- [ ] Verify macOS native binaries are included in the early-access release artifacts
- [ ] Verify Linux container images are still pushed correctly

## Summary by Sourcery

Add macOS to the early-access build workflow alongside Linux using a matrix job, producing native macOS artifacts while keeping container image publishing on Linux.

New Features:
- Introduce a matrix-based early-access job that runs on both ubuntu-latest and macos-latest.
- Add a macOS native snapshot build step that produces binaries without using containers.

Enhancements:
- Restrict container registry login and image pushes to the Linux job only in the matrix workflow.
- Split JReleaser execution into separate Linux and macOS steps, excluding the CLI distribution on macOS.
- Use OS-specific artifact names for JReleaser outputs to avoid naming conflicts across matrix jobs.