### PR TITLE
chore: remove unused imports from DiscoveryResourceTest

### DIFF
--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResourceTest.java
@@ -4,7 +4,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
-import java.time.Instant;
 import org.jboss.logging.Logger;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -12,7 +11,6 @@ import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import ai.wanaku.backend.support.TestIndexHelper;
 import ai.wanaku.backend.support.WanakuKeycloakTestResource;
 import ai.wanaku.backend.support.WanakuRouterTest;
-import ai.wanaku.capabilities.sdk.api.types.discovery.ServiceState;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 


### PR DESCRIPTION
Remove unused imports (`Instant` and `ServiceState`) from `DiscoveryResourceTest` left over after outdated discovery tests were removed.

## Summary by Sourcery

Chores:
- Remove unused imports from the DiscoveryResourceTest unit test class.