### PR TITLE
issue 846: Add --output plain flag for stdout output without JLine

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,7 @@ The Wanaku CLI provides a user-friendly interface for:
 - **Project Scaffolding**: Generate new tool and provider projects from templates
 - **Authentication**: OAuth 2.0/OIDC authentication with the router
 - **Label Filtering**: Advanced filtering using label expressions
+- **Plain Output Mode**: `--plain` flag for clean, parsable output without ANSI colors (useful for scripting and piping)
 
 ## Installation
 

--- a/cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
@@ -45,6 +45,11 @@ public abstract class BaseCommand implements Callable<Integer> {
             description = "Disable authentication for this command")
     protected boolean noAuth = false;
 
+    @CommandLine.Option(
+            names = {"--plain"},
+            description = "Route output through stdout so it can be captured by a parent process")
+    boolean plain = false;
+
     /**
      * Initializes and configures the REST client for communicating with the Wanaku service.
      *
@@ -102,9 +107,12 @@ public abstract class BaseCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        WanakuPrinter.setPlainMode(plain);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
             WanakuPrinter printer = new WanakuPrinter(null, terminal);
             return doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
         }
     }
 

--- a/cli/src/main/java/ai/wanaku/cli/main/support/WanakuExceptionHandler.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/WanakuExceptionHandler.java
@@ -41,6 +41,7 @@ public class WanakuExceptionHandler implements IExecutionExceptionHandler {
     @Override
     public int handleExecutionException(Exception ex, CommandLine commandLine, ParseResult parseResult)
             throws Exception {
+        WanakuPrinter.setPlainMode(isPlainOutput(parseResult));
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
             WanakuPrinter printer = new WanakuPrinter(null, terminal);
 
@@ -79,6 +80,8 @@ public class WanakuExceptionHandler implements IExecutionExceptionHandler {
 
             terminal.flush();
             return BaseCommand.EXIT_ERROR;
+        } finally {
+            WanakuPrinter.setPlainMode(false);
         }
     }
 
@@ -132,17 +135,45 @@ public class WanakuExceptionHandler implements IExecutionExceptionHandler {
 
     /**
      * Checks if verbose mode is enabled from the parse result.
+     * Traverses the subcommand chain because the flag may be defined on a subcommand.
      *
      * @param parseResult the command line parse result
      * @return true if --verbose flag is present, false otherwise
      */
     private boolean isVerbose(ParseResult parseResult) {
+        return hasOptionAnywhere(parseResult, "--verbose");
+    }
+
+    /**
+     * Checks if plain output mode is enabled from the parse result.
+     * Traverses the subcommand chain because the flag is defined on {@link BaseCommand}.
+     *
+     * @param parseResult the command line parse result
+     * @return true if --plain flag is present, false otherwise
+     */
+    private boolean isPlainOutput(ParseResult parseResult) {
+        return hasOptionAnywhere(parseResult, "--plain");
+    }
+
+    /**
+     * Searches for a matched option anywhere in the parse result chain (current command
+     * and all resolved subcommands).
+     *
+     * @param parseResult the top-level parse result
+     * @param option the option name to look for (e.g. "--plain")
+     * @return true if the option was matched at any level, false otherwise
+     */
+    private boolean hasOptionAnywhere(ParseResult parseResult, String option) {
         try {
-            if (parseResult.hasMatchedOption("--verbose")) {
-                return true;
+            ParseResult current = parseResult;
+            while (current != null) {
+                if (current.hasMatchedOption(option)) {
+                    return true;
+                }
+                current = current.hasSubcommand() ? current.subcommand() : null;
             }
         } catch (Exception e) {
-            // Ignore and return false if unable to check verbose flag
+            // Ignore and return false if unable to check the flag
         }
         return false;
     }

--- a/cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -62,6 +62,23 @@ import static org.jline.console.Printer.TableRows.EVEN;
  */
 public class WanakuPrinter extends DefaultPrinter {
 
+    /**
+     * When {@code true}, the terminal is created with {@code system(false)} so that output
+     * goes through {@code System.out} instead of {@code /dev/tty}.  This keeps ANSI
+     * colors/formatting intact but allows a parent process to capture the output.
+     */
+    private static volatile boolean plainMode = false;
+
+    /**
+     * Enables or disables plain output mode.
+     *
+     * @param plain {@code true} to route output through stdout (capturable),
+     *              {@code false} (default) to use the system terminal directly
+     */
+    public static void setPlainMode(boolean plain) {
+        plainMode = plain;
+    }
+
     // Styling constants for different message types
     /** Style for error messages - bold red text. */
     private static final AttributedStyle ERROR_STYLE = AttributedStyle.BOLD.foreground(AttributedStyle.RED);
@@ -120,45 +137,54 @@ public class WanakuPrinter extends DefaultPrinter {
     }
 
     /**
-     * Creates a new terminal instance with resilient fallback handling.
+     * Creates a new terminal instance, respecting the current {@link #setPlainMode(boolean) plainMode} setting.
      *
-     * <p>This factory method attempts to create a terminal in the following order:</p>
+     * <p>When {@code plainMode} is {@code false} (default), JLine opens {@code /dev/tty}
+     * directly for the best interactive experience. When {@code true}, JLine uses
+     * {@code System.in} and {@code System.out} instead with color and Jansi disabled,
+     * producing clean output without ANSI escape sequences that is easy to parse by a
+     * parent process.</p>
+     *
+     * <p>In interactive mode, terminal creation is attempted in the following order:</p>
      * <ol>
-     *   <li>System terminal with Jansi and color support (best experience)</li>
-     *   <li>System terminal without Jansi if native libraries fail</li>
-     *   <li>Dumb terminal if system terminal is unavailable (fallback)</li>
+     *   <li>Terminal with Jansi and color support (best experience)</li>
+     *   <li>Terminal without Jansi if native libraries fail</li>
+     *   <li>Dumb terminal if all else fails (fallback, no colors)</li>
      * </ol>
-     *
-     * <p>This approach ensures the CLI works in various environments including:
-     * standard terminals, CI/CD pipelines, Docker containers, and IDEs.</p>
      *
      * @return a new terminal instance, guaranteed to be non-null
      * @throws IOException if terminal creation fails catastrophically
+     * @see #setPlainMode(boolean)
      */
     public static Terminal terminalInstance() throws IOException {
-        TerminalBuilder builder = TerminalBuilder.builder();
+        if (plainMode) {
+            // Plain mode: route I/O through System.in/System.out with no ANSI escapes
+            // Disable all native providers (JNI, JNA, Jansi) to avoid loading issues
+            return newBuilder().jansi(false).jni(false).jna(false).color(false).build();
+        }
 
         try {
-            // First attempt: full-featured system terminal with Jansi
-            return builder.system(true)
-                    .jansi(true)
-                    .color(true)
-                    .jna(false) // Disable JNA to avoid native library issues
-                    .build();
+            // First attempt: Jansi-backed terminal with color support
+            return newBuilder().jansi(true).color(true).jna(false).build();
         } catch (Exception e) {
-            // Second attempt: system terminal without Jansi
+            // Second attempt: without Jansi (native library may be unavailable)
             try {
-                return TerminalBuilder.builder()
-                        .system(true)
-                        .jansi(false)
-                        .jna(false)
-                        .build();
+                return newBuilder().jansi(false).jna(false).build();
             } catch (Exception ex) {
-                // Final fallback: dumb terminal (always works but no colors)
-                // This won't print warnings and will silently work
+                // Final fallback: dumb terminal (no colors, but always works)
                 return TerminalBuilder.builder().dumb(true).build();
             }
         }
+    }
+
+    private static TerminalBuilder newBuilder() {
+        TerminalBuilder builder = TerminalBuilder.builder().system(!plainMode);
+        if (plainMode) {
+            // When not using the system terminal, JLine needs explicit streams
+            // otherwise masterInput/masterOutput are null and any I/O throws NPE
+            builder.streams(System.in, System.out);
+        }
+        return builder;
     }
 
     /**
@@ -373,7 +399,7 @@ public class WanakuPrinter extends DefaultPrinter {
         }
 
         AttributedString rendered = MarkdownRenderer.render(markdown);
-        terminal.writer().println(rendered.toAnsi());
+        terminal.writer().println(rendered.toAnsi(terminal));
         terminal.flush();
     }
 
@@ -414,7 +440,7 @@ public class WanakuPrinter extends DefaultPrinter {
 
         // Render Markdown to styled text
         AttributedString rendered = MarkdownRenderer.render(markdown);
-        String styledContent = rendered.toAnsi();
+        String styledContent = rendered.toAnsi(terminal);
 
         // Count lines in the rendered content
         long lineCount = styledContent.lines().count();
@@ -507,10 +533,13 @@ public class WanakuPrinter extends DefaultPrinter {
      * @param style the styling to apply to the message
      */
     private void printStyledMessage(String message, AttributedStyle style) {
-        AttributedString styledMessage =
-                new AttributedStringBuilder().style(style).append(message).toAttributedString();
-
-        terminal.writer().println(styledMessage.toAnsi());
+        if (plainMode) {
+            terminal.writer().println(message);
+        } else {
+            AttributedString styledMessage =
+                    new AttributedStringBuilder().style(style).append(message).toAttributedString();
+            terminal.writer().println(styledMessage.toAnsi(terminal));
+        }
         terminal.flush();
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2401,7 +2401,7 @@ wanaku completion generate --output ~/.wanaku_completion
 The generated script includes completion support for:
 - All parent commands (namespaces, tools, resources, forwards, capabilities, etc.)
 - All subcommands (namespaces label add, tools list, etc.)
-- All command options (--help, --verbose, command-specific options)
+- All command options (--help, --verbose, --plain, command-specific options)
 - Automatic detection of bash vs zsh shell
 
 ### Quick Setup for Current Session Only
@@ -2521,7 +2521,7 @@ wanaku namespaces <TAB>
 
 # Tab-complete options
 wanaku tools add --<TAB>
-# Shows: --description, --help, --name, --namespace, --property, --required, --type, --uri, --verbose
+# Shows: --description, --help, --name, --namespace, --plain, --property, --required, --type, --uri, --verbose
 
 # Tab-complete after partial input
 wanaku name<TAB>
@@ -3262,6 +3262,11 @@ quarkus.log.category."ai.wanaku".level=DEBUG
 **CLI:**
 ```shell
 wanaku --verbose tools list
+```
+
+To produce clean, parsable output without ANSI colors or escape sequences (useful for scripting and piping):
+```shell
+wanaku tools list --plain
 ```
 
 #### Access logs


### PR DESCRIPTION
fix #846

## Summary by Sourcery

Add a configurable plain output mode that routes CLI terminal output through stdout for easier capture by parent processes, and ensure ANSI rendering respects the active terminal.

New Features:
- Introduce a global plain output mode flag in the CLI printer to switch between interactive terminal and stdout-based output.
- Add a --plain command-line option on the base CLI command to enable capturable plain output across commands.

Bug Fixes:
- Ensure exception handling respects the --plain flag by detecting it across subcommand chains and configuring the printer accordingly.

Enhancements:
- Adjust terminal creation to support both interactive and plain modes while maintaining robust fallbacks for non-interactive environments.
- Update markdown and styled message rendering to use the active terminal for ANSI conversion and to omit styling when plain mode is enabled.