### PR TITLE
Convert Wanaku data store to the soft index one

### DIFF
--- a/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/providers/InfinispanConfigurationProvider.java
+++ b/core/core-persistence/core-persistence-infinispan/src/main/java/ai/wanaku/core/persistence/infinispan/providers/InfinispanConfigurationProvider.java
@@ -9,29 +9,50 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.StorageType;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 
 public class InfinispanConfigurationProvider {
     @ConfigProperty(name = "wanaku.persistence.infinispan.base-folder", defaultValue = "${user.home}/.wanaku/router/")
     String baseFolder;
 
+    @ConfigProperty(name = "wanaku.persistence.infinispan.max-entries", defaultValue = "10000")
+    int maxEntries;
+
+    @ConfigProperty(name = "wanaku.persistence.infinispan.file-store", defaultValue = "true")
+    boolean fileStore;
+
     @Produces
     Configuration newConfiguration() {
-        String location = baseFolder.replace("${user.home}", System.getProperty("user.home"));
-        try {
-            Files.createDirectories(Paths.get(location));
-        } catch (IOException e) {
-            throw new WanakuException(e);
+        ConfigurationBuilder builder = new ConfigurationBuilder();
+        builder.clustering()
+                .cacheMode(CacheMode.LOCAL)
+                .memory()
+                .storage(StorageType.HEAP)
+                .maxCount(maxEntries);
+
+        if (fileStore) {
+            String location = resolveBaseFolder();
+            try {
+                Files.createDirectories(Paths.get(location));
+            } catch (IOException e) {
+                throw new WanakuException(e);
+            }
+
+            builder.persistence()
+                    .passivation(false)
+                    .addSoftIndexFileStore()
+                    .dataLocation(location)
+                    .indexLocation(location)
+                    .shared(false)
+                    .preload(true)
+                    .purgeOnStartup(false);
         }
 
-        return new ConfigurationBuilder()
-                .clustering()
-                .cacheMode(CacheMode.LOCAL)
-                .persistence()
-                .passivation(false)
-                .addStore(SingleFileStoreConfigurationBuilder.class)
-                .location(location)
-                .build();
+        return builder.build();
+    }
+
+    private String resolveBaseFolder() {
+        return baseFolder.replace("${user.home}", System.getProperty("user.home"));
     }
 }

--- a/core/core-persistence/core-persistence-infinispan/src/test/resources/application.properties
+++ b/core/core-persistence/core-persistence-infinispan/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 wanaku.persistence.infinispan.base-folder=target/wanaku/router
+wanaku.persistence.infinispan.file-store=false

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ResourceCapabilityE2ETest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ResourceCapabilityE2ETest.java
@@ -60,7 +60,7 @@ public class ResourceCapabilityE2ETest extends WanakuRouterTest {
 
     @BeforeAll
     static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+        TestIndexHelper.clearAllCaches();
         keycloakClient = new KeycloakTestClient();
 
         mockServer = new MockGrpcCapabilityServer(List.of(EXPECTED_CONTENT));

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ToolCapabilityE2ETest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/e2e/ToolCapabilityE2ETest.java
@@ -64,7 +64,7 @@ public class ToolCapabilityE2ETest extends WanakuRouterTest {
 
     @BeforeAll
     static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+        TestIndexHelper.clearAllCaches();
         keycloakClient = new KeycloakTestClient();
 
         mockServer = new MockGrpcCapabilityServer(List.of(EXPECTED_CONTENT));

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResourceTest.java
@@ -3,7 +3,6 @@ package ai.wanaku.backend.api.v1.management.discovery;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import org.jboss.logging.Logger;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -42,8 +41,8 @@ public class DiscoveryResourceTest extends WanakuRouterTest {
     }
 
     @BeforeAll
-    static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+    static void setup() {
+        TestIndexHelper.clearAllCaches();
 
         keycloakClient = new KeycloakTestClient();
     }

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/statistics/StatisticsResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/statistics/StatisticsResourceTest.java
@@ -2,7 +2,6 @@ package ai.wanaku.backend.api.v1.management.statistics;
 
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
@@ -30,8 +29,8 @@ public class StatisticsResourceTest extends WanakuRouterTest {
     }
 
     @BeforeAll
-    static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+    static void setup() {
+        TestIndexHelper.clearAllCaches();
         keycloakClient = new KeycloakTestClient();
     }
 

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/prompts/PromptsResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/prompts/PromptsResourceTest.java
@@ -3,7 +3,6 @@ package ai.wanaku.backend.api.v1.prompts;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.util.List;
 import org.jboss.logging.Logger;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -35,8 +34,8 @@ public class PromptsResourceTest extends WanakuRouterTest {
     private static String createdName;
 
     @BeforeAll
-    static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+    static void setup() {
+        TestIndexHelper.clearAllCaches();
     }
 
     @Order(1)

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/resources/ResourcesResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/resources/ResourcesResourceTest.java
@@ -3,7 +3,6 @@ package ai.wanaku.backend.api.v1.resources;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import org.jboss.logging.Logger;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -33,8 +32,8 @@ public class ResourcesResourceTest extends WanakuRouterTest {
     private static String createdName;
 
     @BeforeAll
-    static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+    static void setup() {
+        TestIndexHelper.clearAllCaches();
     }
 
     @Order(1)

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/tools/ToolsResourceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/tools/ToolsResourceTest.java
@@ -3,7 +3,6 @@ package ai.wanaku.backend.api.v1.tools;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.util.Collections;
 import org.jboss.logging.Logger;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -35,8 +34,8 @@ public class ToolsResourceTest extends WanakuRouterTest {
     private static String createdName;
 
     @BeforeAll
-    static void setup() throws IOException {
-        TestIndexHelper.deleteRecursively("target/wanaku/router");
+    static void setup() {
+        TestIndexHelper.clearAllCaches();
     }
 
     @Order(1)

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/TestIndexHelper.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/TestIndexHelper.java
@@ -1,27 +1,45 @@
 package ai.wanaku.backend.support;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Comparator;
+import org.infinispan.Cache;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.logging.Logger;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import ai.wanaku.backend.api.v1.namespaces.NamespacesBean;
 
 public class TestIndexHelper {
     private static final Logger LOG = Logger.getLogger(TestIndexHelper.class);
 
-    public static void deleteRecursively(String baseDir) throws IOException {
-        Path dir = Paths.get(baseDir);
-        if (!dir.toFile().exists()) {
-            return;
-        }
-
-        Files.walk(dir).sorted(Comparator.reverseOrder()).forEach(path -> {
-            try {
-                Files.delete(path);
-            } catch (IOException e) {
-                LOG.errorf("Failed to delete file: %s", path, e);
+    /**
+     * Clears all Infinispan caches via CDI and re-preloads namespaces.
+     * If CDI is not yet available (e.g., before Quarkus starts), this is
+     * a no-op since purgeOnStartup will handle the cleanup.
+     */
+    public static void clearAllCaches() {
+        try {
+            ArcContainer container = Arc.container();
+            if (container == null) {
+                return;
             }
-        });
+            InstanceHandle<EmbeddedCacheManager> handle = container.instance(EmbeddedCacheManager.class);
+            if (handle.isAvailable()) {
+                EmbeddedCacheManager cacheManager = handle.get();
+                for (String name : cacheManager.getCacheNames()) {
+                    Cache<?, ?> cache = cacheManager.getCache(name);
+                    if (cache != null) {
+                        cache.clear();
+                    }
+                }
+            }
+
+            // Re-preload namespaces since clearing caches removes them
+            InstanceHandle<NamespacesBean> nsHandle = container.instance(NamespacesBean.class);
+            if (nsHandle.isAvailable()) {
+                nsHandle.get().preload();
+            }
+        } catch (Exception e) {
+            LOG.warnf("Could not clear caches: %s", e.getMessage());
+        }
     }
 }

--- a/wanaku-router/wanaku-router-backend/src/test/resources/application.properties
+++ b/wanaku-router/wanaku-router-backend/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 wanaku.persistence.infinispan.base-folder=target/wanaku/router
+wanaku.persistence.infinispan.file-store=false


### PR DESCRIPTION
The previous format was deprecated

This fixes #860

## Summary by Sourcery

Switch Infinispan persistence to use a heap-based, soft-index file store with configurable entry limits instead of the deprecated single file store.

New Features:
- Introduce a configurable maximum number of Infinispan cache entries via a new configuration property.

Enhancements:
- Replace the deprecated single file store with a soft index file store for Infinispan persistence.
- Refine base folder resolution into a dedicated helper method for reuse and clarity.