### PR TITLE
chore: add performance noop tool for benchmarking

### DIFF
--- a/capabilities/tools/pom.xml
+++ b/capabilities/tools/pom.xml
@@ -12,5 +12,6 @@
     <module>wanaku-tool-service-exec</module>
     <module>wanaku-tool-service-http</module>
     <module>wanaku-tool-service-tavily</module>
+    <module>wanaku-tool-performance-noop</module>
   </modules>
 </project>

--- a/capabilities/tools/wanaku-tool-performance-noop/README.md
+++ b/capabilities/tools/wanaku-tool-performance-noop/README.md
@@ -1,0 +1,3 @@
+# Wanaku Tool - Performance Noop
+
+Mock tool for running performance tests with Wanaku

--- a/capabilities/tools/wanaku-tool-performance-noop/pom.xml
+++ b/capabilities/tools/wanaku-tool-performance-noop/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ai.wanaku</groupId>
+        <artifactId>tools</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wanaku-tool-performance-noop</artifactId>
+    <name>Wanaku :: Services :: Tools :: Performance Noop</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-exchange</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-capabilities-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-capabilities-tool</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-service-discovery</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+
+        <!-- For building containers -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+        </dependency>
+
+        <!-- Tool dependencies go here -->
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${maven-assembly-plugin.version}</version>
+                        <configuration>
+                            <attach>false</attach>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>${distribution.directory}</outputDirectory>
+                            <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-distribution</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/assembly/assembly.xml
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/assembly/assembly.xml
@@ -1,0 +1,37 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>README.md</include>
+                <include>LICENSE</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/quarkus-app</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*.*</include>
+                <include>**/launcher</include>
+                <include>**/service-launcher</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopClient.java
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopClient.java
@@ -1,0 +1,23 @@
+package ai.wanaku.tool.performance.noop;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.capabilities.tool.Client;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+
+@ApplicationScoped
+public class PerformanceNoopClient implements Client {
+    private static final Logger LOG = Logger.getLogger(PerformanceNoopClient.class);
+
+    private static final String SAMPLE_TEXT = "1234567890";
+
+    @Override
+    public Object exchange(ToolInvokeRequest request, ConfigResource configResource) {
+        LOG.debugf(
+                "[%s-%d] Received request for tool invocation",
+                Thread.currentThread().getName(), Thread.currentThread().threadId());
+        return SAMPLE_TEXT;
+    }
+}

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopDelegate.java
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopDelegate.java
@@ -1,0 +1,22 @@
+package ai.wanaku.tool.performance.noop;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.core.capabilities.tool.AbstractToolDelegate;
+
+@ApplicationScoped
+public class PerformanceNoopDelegate extends AbstractToolDelegate {
+
+    @Override
+    protected List<String> coerceResponse(Object response)
+            throws InvalidResponseTypeException, NonConvertableResponseException {
+        if (response == null) {
+            throw new InvalidResponseTypeException("Invalid response type from the consumer: null");
+        }
+
+        return List.of(response.toString());
+    }
+}

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
@@ -1,0 +1,35 @@
+quarkus.http.host-enabled=false
+quarkus.banner.enabled = false
+quarkus.devservices.enabled = false
+quarkus.console.enabled = false
+
+quarkus.grpc.server.host=0.0.0.0
+# If running multiple services on the same host, then you must pick an unique port
+%dev.quarkus.grpc.server.port=9010
+%test.quarkus.grpc.server.port=9010
+
+quarkus.log.level=WARNING
+quarkus.log.category."ai.wanaku".level=INFO
+%dev.quarkus.log.category."ai.wanaku".level=DEBUG
+%test.quarkus.log.category."ai.wanaku".level=INFO
+
+wanaku.service.name=performancenoop
+wanaku.service.base-uri=performancenoop://
+
+# Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.delay-seconds=3
+
+quarkus.oidc-client.enabled=true
+
+# Address of the KeyCloak authentication server - adjust to your KeyCloak instance
+quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
+
+# Client identifier configured in KeyCloak for capability services
+quarkus.oidc-client.client-id=wanaku-service
+
+# Client secret from KeyCloak for service authentication - replace with your actual secret
+#quarkus.oidc-client.credentials.secret=<the secret key>

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/reflection-config.json
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/reflection-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name" : "org.apache.commons.pool2.impl.DefaultEvictionPolicy",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  }
+]

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/launcher
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/launcher
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+localDir="$(dirname $0)"
+installDir="$(dirname "${localDir}")"
+WANAKU_JAVA_OPTS="${WANAKU_JAVA_OPTS:-""}"
+
+java ${WANAKU_JAVA_OPTS} -jar "${installDir}"/quarkus-run.jar "$@"

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/launcher.bat
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/launcher.bat
@@ -1,0 +1,9 @@
+@echo off
+
+set SDM_HOME=%~dp0\..
+
+@REM Set
+if %OS%=="Windows_NT" @setlocal
+if %OS%=="WINNT" @setlocal
+
+@java -jar quarkus-run.jar %*

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/service-launcher
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/scripts/service-launcher
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+RETVAL=0
+WANAKU_COMPONENT="tool-performancenoop"
+WANAKU_JAVA_OPTS="-Dwanaku.component=${WANAKU_COMPONENT}"
+
+localDir="$(dirname $0)"
+installDir="$(dirname "${localDir}")"
+launcher=launcher
+
+RED="\e[0;31m"
+GREEN="\e[0;32m"
+RESET="\e[0m"
+
+function esuccess() {
+    echo -e "${GREEN} OK${RESET}"
+}
+
+function eerror() {
+    echo -e "${RED} failed${RESET} ($@)"
+}
+
+function start() {
+    echo -en "Starting the daemon: "
+    export WANAKU_JAVA_OPTS
+    nohup "${installDir}/${launcher}" ${@} >/dev/null 2>/dev/null &
+    if [[ $? != 0 ]] ; then
+        eerror "failed to daemonize the application"
+        exit 1
+    fi
+
+    sleep 1s
+
+    processCount=0
+    for pid in $(pgrep -U $(id -u) -f ".*wanaku.component=${WANAKU_COMPONENT}.*") ; do
+        if (( processCount == 0 )) ; then
+            esuccess
+        fi
+        echo -e "${WANAKU_COMPONENT} started:${GREEN} ${pid} ${RESET}"
+        ((processCount++))
+    done
+
+    if (( processCount == 0 )) ; then
+        eerror "${WANAKU_COMPONENT} did not start successfully"
+    fi
+}
+
+
+function stop() {
+    for pid in $(pgrep -U $(id -u) -f ".*wanaku.component=${WANAKU_COMPONENT}.*") ; do
+        echo "Killing ${WANAKU_COMPONENT} ${pid}"
+        kill -TERM ${pid}
+    done
+}
+
+function restart() {
+    stop
+    start
+}
+
+function printHelp() {
+    echo "Usage: ${0} [start|stop|restart]"
+}
+
+
+if [[ -z ${1} ]] ; then
+    printHelp
+    exit 2
+fi
+
+
+case "${1}" in
+	start)
+		start "${2}" "${3}"
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		restart
+		;;
+	*)
+		printHelp
+		RETVAL=2
+esac
+
+exit ${RETVAL}

--- a/images.txt
+++ b/images.txt
@@ -1,6 +1,7 @@
 quay.io/wanaku/wanaku-tool-service-exec:latest
 quay.io/wanaku/wanaku-tool-service-tavily:latest
 quay.io/wanaku/wanaku-tool-service-http:latest
+quay.io/wanaku/wanaku-tool-performance-noop:latest
 quay.io/wanaku/wanaku-provider-performance-static-file:latest
 quay.io/wanaku/wanaku-router-backend:latest
 quay.io/wanaku/wanaku-operator:latest

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -65,6 +65,11 @@ distributions:
     artifacts:
       - path: capabilities/tools/wanaku-tool-service-exec/target/distributions/wanaku-tool-service-exec-{{projectVersion}}.zip
         platform: linux-x86_64
+  tool-performance-noop:
+    artifacts:
+      - path: capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-{{projectVersion}}.zip
+        platform: linux-x86_64
+    type: JAVA_BINARY
   provider-performance-static-file:
     artifacts:
       - path: capabilities/providers/wanaku-provider-performance-static-file/target/distributions/wanaku-provider-performance-static-file-{{projectVersion}}.zip


### PR DESCRIPTION
Adds a new mock tool service (`wanaku-tool-performance-noop`) for performance testing, mirroring the approach used by the performance static file resource provider.

The tool returns a static string response for every invocation, eliminating any I/O or computation overhead, which makes it suitable for benchmarking the tool invocation pipeline itself.

**Changes:**
- New `wanaku-tool-performance-noop` module with `PerformanceNoopDelegate` and `PerformanceNoopClient`
- Updated `capabilities/tools/pom.xml` to include the new module
- Updated `images.txt` with the container image entry
- Updated `jreleaser.yml` with the distribution entry

## Summary by Sourcery

Introduce a dedicated no-op tool service for benchmarking the tool invocation pipeline and wire it into the existing build and distribution configuration.

New Features:
- Add the wanaku-tool-performance-noop module providing a mock tool that always returns a static response for performance testing.

Enhancements:
- Register the performance noop tool module in the tools aggregator POM so it is built with other tool services.
- Configure packaging and distribution for the performance noop tool, including assembly setup, scripts, and runtime properties for the Quarkus-based service.
- Update release and image metadata to include the performance noop tool distribution artifact.

Build:
- Add a new jreleaser distribution entry for the performance noop tool binary.