### PR TITLE
Align the features of tool performance tester

### DIFF
--- a/capabilities/tools/wanaku-tool-performance-noop/pom.xml
+++ b/capabilities/tools/wanaku-tool-performance-noop/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-services-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopClient.java
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopClient.java
@@ -1,6 +1,7 @@
 package ai.wanaku.tool.performance.noop;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
@@ -13,8 +14,21 @@ public class PerformanceNoopClient implements Client {
 
     private static final String SAMPLE_TEXT = "1234567890";
 
+    @Inject
+    WanakuPerformanceServiceConfig config;
+
     @Override
     public Object exchange(ToolInvokeRequest request, ConfigResource configResource) {
+        int delay = config.delay();
+
+        if (delay > 0) {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
         LOG.debugf(
                 "[%s-%d] Received request for tool invocation",
                 Thread.currentThread().getName(), Thread.currentThread().threadId());

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopDelegate.java
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/PerformanceNoopDelegate.java
@@ -1,14 +1,85 @@
 package ai.wanaku.tool.performance.noop;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
 
+import java.net.URI;
 import java.util.List;
+import org.jboss.logging.Logger;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
 import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.capabilities.tool.AbstractToolDelegate;
+import ai.wanaku.core.services.api.ToolsService;
 
 @ApplicationScoped
 public class PerformanceNoopDelegate extends AbstractToolDelegate {
+    private static final Logger LOG = Logger.getLogger(PerformanceNoopDelegate.class);
+
+    @Inject
+    WanakuServiceConfig config;
+
+    @Override
+    protected void initializeRegistrationManager(RegistrationManager registrationManager) {
+        super.initializeRegistrationManager(registrationManager);
+
+        registrationManager.addCallBack(new DiscoveryCallback() {
+
+            final ToolsService toolsService = QuarkusRestClientBuilder.newBuilder()
+                    .baseUri(URI.create(config.registration().uri()))
+                    .build(ToolsService.class);
+
+            final ToolReference toolReference = new ToolReference();
+
+            @Override
+            public void onPing(RegistrationManager registrationManager, ServiceTarget serviceTarget, int i) {}
+
+            @Override
+            public void onRegistration(RegistrationManager registrationManager, ServiceTarget serviceTarget) {
+                toolReference.setName("test-tool");
+                toolReference.setType(config.name());
+                toolReference.setId(config.name());
+                toolReference.setDescription("Static tool for performance tests");
+                toolReference.setUri(config.name() + "://static-tool");
+                toolReference.setNamespace("public");
+
+                InputSchema inputSchema = new InputSchema();
+                inputSchema.setType("object");
+
+                Property property = new Property();
+                property.setType("string");
+                property.setDescription("sample parameter");
+
+                inputSchema.getProperties().put("name", property);
+
+                toolReference.setInputSchema(inputSchema);
+                inputSchema.setRequired(List.of());
+
+                try {
+                    toolsService.add(toolReference);
+                } catch (WebApplicationException e) {
+                    LOG.warn(e);
+                }
+            }
+
+            @Override
+            public void onDeregistration(RegistrationManager registrationManager, ServiceTarget serviceTarget, int i) {
+                try {
+                    toolsService.remove(toolReference.getName());
+                } catch (WebApplicationException e) {
+                    LOG.warn(e);
+                }
+            }
+        });
+    }
 
     @Override
     protected List<String> coerceResponse(Object response)

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/WanakuPerformanceServiceConfig.java
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/java/ai/wanaku/tool/performance/noop/WanakuPerformanceServiceConfig.java
@@ -1,0 +1,11 @@
+package ai.wanaku.tool.performance.noop;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "wanaku.service.performance")
+public interface WanakuPerformanceServiceConfig {
+
+    @WithDefault("10")
+    int delay();
+}

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
@@ -15,6 +15,7 @@ quarkus.log.category."ai.wanaku".level=INFO
 
 wanaku.service.name=performancenoop
 wanaku.service.base-uri=performancenoop://
+wanaku.service.performance.delay=100
 
 # Registration settings
 #wanaku.service.registration.uri=http://localhost:8080


### PR DESCRIPTION
- Add delay support
- Auto-add tools on registration

## Summary by Sourcery

Align the performance noop tool with the capabilities platform by adding configurable delay behavior and automatic tool registration lifecycle handling.

New Features:
- Introduce configurable delay for performance noop tool executions via service configuration.
- Automatically register and deregister a static test tool with the tools service on service registration lifecycle events.

Enhancements:
- Integrate performance noop delegate with the registration manager using discovery callbacks to manage a dedicated test tool.
- Add configuration mapping for performance-related settings, including default delay, for the performance noop service.

Build:
- Add core-services-api dependency to the performance noop tool module.