### PR TITLE
Use StringHelper for blank checks

### DIFF
--- a/core/core-util/src/main/java/ai/wanaku/core/util/StringHelper.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/StringHelper.java
@@ -39,4 +39,17 @@ public final class StringHelper {
     public static boolean isNotEmpty(String str) {
         return !isEmpty(str);
     }
+
+    /**
+     * Checks if a string is null, empty, or contains only whitespace.
+     * <p>
+     * A string is considered blank if it is {@code null} or {@link String#isBlank()}
+     * returns {@code true}.
+     *
+     * @param str the string to check
+     * @return {@code true} if the string is null, empty, or whitespace-only, {@code false} otherwise
+     */
+    public static boolean isBlank(String str) {
+        return str == null || str.isBlank();
+    }
 }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -35,8 +35,6 @@ import ai.wanaku.core.persistence.api.ForwardReferenceRepository;
 import ai.wanaku.core.persistence.api.WanakuRepository;
 import ai.wanaku.core.util.StringHelper;
 
-import static io.micrometer.common.util.StringUtils.isBlank;
-
 @ApplicationScoped
 public class ForwardsBean extends AbstractBean<ForwardReference> {
     private static final Logger LOG = Logger.getLogger(ForwardsBean.class);
@@ -205,7 +203,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
     }
 
     public List<ToolReference> listAllAsTools(String labelFilter) {
-        if (isBlank(labelFilter)) {
+        if (StringHelper.isBlank(labelFilter)) {
             return listAllAsTools();
         }
 

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
-import io.micrometer.common.util.StringUtils;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkus.runtime.StartupEvent;
 import ai.wanaku.backend.api.v1.namespaces.NamespacesBean;
@@ -118,7 +117,7 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
     }
 
     public List<ToolReference> list(String labelFilter) {
-        if (StringUtils.isBlank(labelFilter)) {
+        if (StringHelper.isBlank(labelFilter)) {
             return toolReferenceRepository.listAll();
         }
         return toolReferenceRepository.findAllFilterByLabelExpression(labelFilter);


### PR DESCRIPTION
## Summary by Sourcery

Use the shared StringHelper utility for blank-string checks across router backend beans.

Enhancements:
- Add a StringHelper.isBlank helper to centralize null/whitespace string checks.
- Refactor ForwardsBean and ToolsBean to use StringHelper.isBlank instead of external StringUtils implementations.