### PR TITLE
chore: add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# Default owners for the entire repository
+* @wanaku-ai/maintainers
+
+# API
+/api/ @wanaku-ai/maintainers
+
+# Core
+/core/ @wanaku-ai/maintainers
+
+# CLI
+/cli/ @wanaku-ai/maintainers
+
+# Capabilities
+/capabilities/ @wanaku-ai/maintainers
+
+# UI
+/ui/ @wanaku-ai/maintainers-ui
+
+# Router
+/wanaku-router/ @wanaku-ai/maintainers
+/wanaku-router/ui/ @wanaku-ai/maintainers-ui
+
+# Operator
+/wanaku-operator/ @wanaku-ai/maintainers
+
+# Documentation
+/docs/ @wanaku-ai/maintainers
+
+# Deployment
+/deploy/ @wanaku-ai/maintainers
+
+# Archetypes and JBang
+/archetypes/ @wanaku-ai/maintainers
+/jbang/ @wanaku-ai/maintainers
+
+# CI/CD
+/.github/ @wanaku-ai/maintainers


### PR DESCRIPTION
## Summary
- Adds a `.github/CODEOWNERS` file to enforce code review ownership
- Sets `@wanaku-ai/maintainers` as the default owner for the entire repository
- Assigns `@wanaku-ai/maintainers-ui` to `ui/` and `wanaku-router/ui/` directories
- All other major modules (api, core, cli, capabilities, router, operator, docs, deploy, archetypes, jbang, .github) are owned by `@wanaku-ai/maintainers`

## Notes
- The teams `@wanaku-ai/maintainers` and `@wanaku-ai/maintainers-ui` must exist in the GitHub organization for CODEOWNERS to take effect
- CODEOWNERS rules are evaluated bottom-up; the last matching pattern takes precedence

## Summary by Sourcery

Chores:
- Introduce a .github/CODEOWNERS file assigning default ownership to the maintainers team and specialized ownership for UI directories.