### PR TITLE
feat: Admin commands should pick the admin username and password from env

### DIFF
--- a/cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
+++ b/cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
@@ -13,11 +13,23 @@ import ai.wanaku.cli.main.support.keycloak.KeycloakAdminClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
 
 public abstract class BaseAdminCommand extends BaseCommand {
 
+    @FunctionalInterface
+    protected interface EnvironmentProvider {
+        String get(String name);
+    }
+
     private static final String DEFAULT_KEYCLOAK_URL = "http://localhost:8543";
     private static final String DEFAULT_REALM = "wanaku";
+    private static final String ENV_ADMIN_USERNAME = "WANAKU_ADMIN_USERNAME";
+    private static final String ENV_ADMIN_PASSWORD = "WANAKU_ADMIN_PASSWORD";
+
+    @Spec
+    protected CommandSpec spec;
 
     @CommandLine.Option(
             names = {"--keycloak-url"},
@@ -33,26 +45,30 @@ public abstract class BaseAdminCommand extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--admin-username"},
-            description = "Admin username for Keycloak",
-            required = true)
+            description = "Admin username for Keycloak (or set " + ENV_ADMIN_USERNAME + ")")
     protected String adminUsername;
 
     @CommandLine.Option(
             names = {"--admin-password"},
-            description = "Admin password for Keycloak",
-            required = true,
+            description = "Admin password for Keycloak (or set " + ENV_ADMIN_PASSWORD + ")",
             interactive = true,
             arity = "0..1")
     protected String adminPassword;
 
     private final KeycloakAdminClient adminClientOverride;
+    private final EnvironmentProvider environmentProvider;
 
     protected BaseAdminCommand() {
-        this(null);
+        this(null, System::getenv);
     }
 
     protected BaseAdminCommand(KeycloakAdminClient adminClientOverride) {
+        this(adminClientOverride, System::getenv);
+    }
+
+    protected BaseAdminCommand(KeycloakAdminClient adminClientOverride, EnvironmentProvider environmentProvider) {
         this.adminClientOverride = adminClientOverride;
+        this.environmentProvider = environmentProvider == null ? System::getenv : environmentProvider;
     }
 
     protected KeycloakAdminClient createAdminClient() {
@@ -66,11 +82,13 @@ public abstract class BaseAdminCommand extends BaseCommand {
 
     private String obtainAdminToken() {
         String tokenUrl = keycloakUrl + "/realms/master/protocol/openid-connect/token";
+        String resolvedUsername = resolveAdminUsername();
+        String resolvedPassword = resolveAdminPassword();
 
         String formBody = "grant_type=password"
                 + "&client_id=admin-cli"
-                + "&username=" + URLEncoder.encode(adminUsername, StandardCharsets.UTF_8)
-                + "&password=" + URLEncoder.encode(adminPassword, StandardCharsets.UTF_8);
+                + "&username=" + URLEncoder.encode(resolvedUsername, StandardCharsets.UTF_8)
+                + "&password=" + URLEncoder.encode(resolvedPassword, StandardCharsets.UTF_8);
 
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(tokenUrl))
@@ -100,5 +118,32 @@ public abstract class BaseAdminCommand extends BaseCommand {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted while obtaining admin token", e);
         }
+    }
+
+    protected String resolveAdminUsername() {
+        if (adminUsername != null && !adminUsername.isBlank()) {
+            return adminUsername;
+        }
+        String envValue = environmentProvider.get(ENV_ADMIN_USERNAME);
+        if (envValue != null && !envValue.isBlank()) {
+            return envValue;
+        }
+        throw missingParameter("Admin username not provided. Use --admin-username or set " + ENV_ADMIN_USERNAME + ".");
+    }
+
+    protected String resolveAdminPassword() {
+        if (adminPassword != null && !adminPassword.isBlank()) {
+            return adminPassword;
+        }
+        String envValue = environmentProvider.get(ENV_ADMIN_PASSWORD);
+        if (envValue != null && !envValue.isBlank()) {
+            return envValue;
+        }
+        throw missingParameter("Admin password not provided. Use --admin-password or set " + ENV_ADMIN_PASSWORD + ".");
+    }
+
+    private CommandLine.ParameterException missingParameter(String message) {
+        CommandLine commandLine = spec == null ? new CommandLine(this) : spec.commandLine();
+        return new CommandLine.ParameterException(commandLine, message);
     }
 }

--- a/cli/src/test/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommandTest.java
+++ b/cli/src/test/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommandTest.java
@@ -1,0 +1,102 @@
+package ai.wanaku.cli.main.commands.admin;
+
+import java.util.Map;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import picocli.CommandLine;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BaseAdminCommandTest {
+
+    private static class TestAdminCommand extends BaseAdminCommand {
+        private TestAdminCommand(Map<String, String> env) {
+            super(null, env::get);
+        }
+
+        @Override
+        public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+            return EXIT_OK;
+        }
+
+        private String resolveUsernameForTest() {
+            return resolveAdminUsername();
+        }
+
+        private String resolvePasswordForTest() {
+            return resolveAdminPassword();
+        }
+    }
+
+    @Test
+    void resolvesCredentialsFromEnvironmentWhenOptionsMissing() {
+        TestAdminCommand command = new TestAdminCommand(Map.of(
+                "WANAKU_ADMIN_USERNAME", "env-admin",
+                "WANAKU_ADMIN_PASSWORD", "env-pass"));
+
+        assertEquals("env-admin", command.resolveUsernameForTest());
+        assertEquals("env-pass", command.resolvePasswordForTest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "\t", "\n", "  \t  "})
+    void treatsBlankOrWhitespaceUsernameEnvAsMissing(String usernameEnvValue) {
+        TestAdminCommand command = new TestAdminCommand(
+                Map.of("WANAKU_ADMIN_USERNAME", usernameEnvValue, "WANAKU_ADMIN_PASSWORD", "env-pass"));
+
+        CommandLine.ParameterException ex =
+                assertThrows(CommandLine.ParameterException.class, command::resolveUsernameForTest);
+        assertEquals(
+                "Admin username not provided. Use --admin-username or set WANAKU_ADMIN_USERNAME.", ex.getMessage());
+        assertEquals("env-pass", command.resolvePasswordForTest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "\t", "\n", "  \t  "})
+    void treatsBlankOrWhitespacePasswordEnvAsMissing(String passwordEnvValue) {
+        TestAdminCommand command = new TestAdminCommand(
+                Map.of("WANAKU_ADMIN_USERNAME", "env-admin", "WANAKU_ADMIN_PASSWORD", passwordEnvValue));
+
+        assertEquals("env-admin", command.resolveUsernameForTest());
+        CommandLine.ParameterException ex =
+                assertThrows(CommandLine.ParameterException.class, command::resolvePasswordForTest);
+        assertEquals(
+                "Admin password not provided. Use --admin-password or set WANAKU_ADMIN_PASSWORD.", ex.getMessage());
+    }
+
+    @Test
+    void optionsOverrideEnvironment() {
+        TestAdminCommand command = new TestAdminCommand(Map.of(
+                "WANAKU_ADMIN_USERNAME", "env-admin",
+                "WANAKU_ADMIN_PASSWORD", "env-pass"));
+        command.adminUsername = "cli-admin";
+        command.adminPassword = "cli-pass";
+
+        assertEquals("cli-admin", command.resolveUsernameForTest());
+        assertEquals("cli-pass", command.resolvePasswordForTest());
+    }
+
+    @Test
+    void throwsWhenUsernameMissingEverywhere() {
+        TestAdminCommand command = new TestAdminCommand(Map.of());
+
+        CommandLine.ParameterException ex =
+                assertThrows(CommandLine.ParameterException.class, command::resolveUsernameForTest);
+        assertEquals(
+                "Admin username not provided. Use --admin-username or set WANAKU_ADMIN_USERNAME.", ex.getMessage());
+    }
+
+    @Test
+    void throwsWhenPasswordMissingEverywhere() {
+        TestAdminCommand command = new TestAdminCommand(Map.of());
+
+        CommandLine.ParameterException ex =
+                assertThrows(CommandLine.ParameterException.class, command::resolvePasswordForTest);
+        assertEquals(
+                "Admin password not provided. Use --admin-password or set WANAKU_ADMIN_PASSWORD.", ex.getMessage());
+    }
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -263,7 +263,9 @@ podman run -d \
 If it is the first time you are using it, you will need to configure Wanaku's realm. You can use the CLI:
 
 ```shell
-wanaku admin realm create --admin-username admin --admin-password admin
+export WANAKU_ADMIN_USERNAME=admin
+export WANAKU_ADMIN_PASSWORD=admin
+wanaku admin realm create
 ```
 
 Or alternatively, use the shell script:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,10 +127,12 @@ oc apply -f deploy/auth
 
 ### Importing the Wanaku Realm Configuration (via Wanaku CLI)
 
-The simplest way to import the realm configuration is using the Wanaku CLI:
+The simplest way to import the realm configuration is using the Wanaku CLI. You can set admin credentials once via environment variables:
 
 ```shell
-wanaku admin realm create --admin-username admin --admin-password admin
+export WANAKU_ADMIN_USERNAME=admin
+export WANAKU_ADMIN_PASSWORD=admin
+wanaku admin realm create
 ```
 
 This imports the default realm configuration from `deploy/auth/wanaku-config.json`. You can specify a custom configuration file with `--config /path/to/realm.json` and a custom Keycloak URL with `--keycloak-url`.
@@ -948,10 +950,18 @@ All admin commands share the following options:
 
 | Option | Description | Default |
 |---|---|---|
-| `--admin-username` | Admin username for Keycloak (required) | |
-| `--admin-password` | Admin password for Keycloak (required, interactive) | |
+| `--admin-username` | Admin username for Keycloak (required unless `WANAKU_ADMIN_USERNAME` is set) | |
+| `--admin-password` | Admin password for Keycloak (required unless `WANAKU_ADMIN_PASSWORD` is set, interactive) | |
 | `--keycloak-url` | Keycloak server URL | `http://localhost:8543` |
 | `--realm` | Keycloak realm to manage | `wanaku` |
+
+If you prefer not to pass admin credentials on every command, set them once in your environment:
+
+```shell
+export WANAKU_ADMIN_USERNAME=admin
+export WANAKU_ADMIN_PASSWORD=admin
+wanaku admin users list
+```
 
 ### User Management
 


### PR DESCRIPTION
Closes: #882

## Summary by Sourcery

Allow admin CLI commands to read Keycloak admin credentials from environment variables as well as CLI options, and document the new usage pattern.

New Features:
- Support resolving admin username and password from WANAKU_ADMIN_USERNAME and WANAKU_ADMIN_PASSWORD environment variables when not provided as CLI options.

Enhancements:
- Relax required flags for admin username and password by resolving them via helper methods that prioritize CLI options over environment variables.

Documentation:
- Update usage and contributing docs to show configuring admin credentials via environment variables instead of always passing CLI flags, and clarify option requirements.

Tests:
- Add unit tests for BaseAdminCommand to verify environment-based credential resolution, CLI override behavior, and error handling when credentials are missing.