### PR TITLE
fix: wanaku start local causes 404 errors

### DIFF
--- a/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
+++ b/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
@@ -55,6 +55,73 @@ import type {
 
 import { customFetch } from "../custom-fetch";
 /**
+ * @summary Get Authorization Server Metadata
+ */
+export type getWellKnownOauthAuthorizationServerResponse200 = {
+  data: null;
+  status: 200;
+};
+
+export type getWellKnownOauthAuthorizationServerResponseComposite =
+  getWellKnownOauthAuthorizationServerResponse200;
+
+export type getWellKnownOauthAuthorizationServerResponse =
+  getWellKnownOauthAuthorizationServerResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetWellKnownOauthAuthorizationServerUrl = () => {
+  return `/.well-known/oauth-authorization-server`;
+};
+
+export const getWellKnownOauthAuthorizationServer = async (
+  options?: RequestInit,
+): Promise<getWellKnownOauthAuthorizationServerResponse> => {
+  return customFetch<getWellKnownOauthAuthorizationServerResponse>(
+    getGetWellKnownOauthAuthorizationServerUrl(),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+/**
+ * @summary Get Authorization Server Metadata For Tenant
+ */
+export type getWellKnownOauthAuthorizationServerTenantResponse200 = {
+  data: null;
+  status: 200;
+};
+
+export type getWellKnownOauthAuthorizationServerTenantResponseComposite =
+  getWellKnownOauthAuthorizationServerTenantResponse200;
+
+export type getWellKnownOauthAuthorizationServerTenantResponse =
+  getWellKnownOauthAuthorizationServerTenantResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetWellKnownOauthAuthorizationServerTenantUrl = (
+  tenant: string,
+) => {
+  return `/.well-known/oauth-authorization-server/${tenant}`;
+};
+
+export const getWellKnownOauthAuthorizationServerTenant = async (
+  tenant: string,
+  options?: RequestInit,
+): Promise<getWellKnownOauthAuthorizationServerTenantResponse> => {
+  return customFetch<getWellKnownOauthAuthorizationServerTenantResponse>(
+    getGetWellKnownOauthAuthorizationServerTenantUrl(tenant),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+/**
  * @summary List
  */
 export type getApiV1CapabilitiesResponse200 = {
@@ -2137,6 +2204,38 @@ export const getApiV2ToolCallsNotificationsConnectionId = async (
 ): Promise<getApiV2ToolCallsNotificationsConnectionIdResponse> => {
   return customFetch<getApiV2ToolCallsNotificationsConnectionIdResponse>(
     getGetApiV2ToolCallsNotificationsConnectionIdUrl(connectionId),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+/**
+ * @summary Open Id Configuration
+ */
+export type getTestOidcWellKnownOpenidConfigurationResponse200 = {
+  data: string;
+  status: 200;
+};
+
+export type getTestOidcWellKnownOpenidConfigurationResponseComposite =
+  getTestOidcWellKnownOpenidConfigurationResponse200;
+
+export type getTestOidcWellKnownOpenidConfigurationResponse =
+  getTestOidcWellKnownOpenidConfigurationResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetTestOidcWellKnownOpenidConfigurationUrl = () => {
+  return `/test-oidc/.well-known/openid-configuration`;
+};
+
+export const getTestOidcWellKnownOpenidConfiguration = async (
+  options?: RequestInit,
+): Promise<getTestOidcWellKnownOpenidConfigurationResponse> => {
+  return customFetch<getTestOidcWellKnownOpenidConfigurationResponse>(
+    getGetTestOidcWellKnownOpenidConfigurationUrl(),
     {
       ...options,
       method: "GET",

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
@@ -1,7 +1,10 @@
 package ai.wanaku.backend.api.v1.exceptions;
 
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
@@ -17,10 +20,20 @@ import ai.wanaku.capabilities.sdk.api.exceptions.ToolNotFoundException;
 public abstract class NotFoundExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
     private static final Logger LOG = Logger.getLogger(NotFoundExceptionMapper.class);
 
+    @Context
+    UriInfo uriInfo;
+
+    @Context
+    Request request;
+
     @APIResponse(responseCode = "404")
     @Override
     public Response toResponse(T exception) {
-        LOG.error(exception);
+        if (uriInfo != null && request != null) {
+            LOG.errorf("%s %s -> 404", request.getMethod(), uriInfo.getRequestUri());
+        } else {
+            LOG.error(exception);
+        }
 
         return Response.status(Response.Status.NOT_FOUND).build();
     }

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
@@ -1,0 +1,41 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.http.HttpClient;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/.well-known")
+@Produces(MediaType.APPLICATION_JSON)
+public class OAuthAuthorizationServerWellKnownResource {
+    @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    String oidcProxyRootPath;
+
+    @Context
+    UriInfo uriInfo;
+
+    private final OpenIdConfigurationForwarder forwarder = new OpenIdConfigurationForwarder(HttpClient.newHttpClient());
+
+    @GET
+    @Path("/oauth-authorization-server")
+    public Response getAuthorizationServerMetadata() {
+        return forwardToOpenIdConfiguration();
+    }
+
+    @GET
+    @Path("/oauth-authorization-server/{tenant}")
+    public Response getAuthorizationServerMetadataForTenant(@PathParam("tenant") String tenant) {
+        return forwardToOpenIdConfiguration();
+    }
+
+    private Response forwardToOpenIdConfiguration() {
+        return forwarder.forward(uriInfo != null ? uriInfo.getBaseUri() : null, oidcProxyRootPath);
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OpenIdConfigurationForwarder.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OpenIdConfigurationForwarder.java
@@ -1,0 +1,59 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.jboss.logging.Logger;
+
+public class OpenIdConfigurationForwarder {
+    private static final Logger LOG = Logger.getLogger(OpenIdConfigurationForwarder.class);
+
+    private final HttpClient httpClient;
+
+    public OpenIdConfigurationForwarder(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public Response forward(URI baseUri, String oidcProxyRootPath) {
+        URI target = resolveTarget(baseUri, oidcProxyRootPath);
+        HttpRequest request = HttpRequest.newBuilder(target).GET().build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return Response.ok(response.body(), MediaType.APPLICATION_JSON).build();
+            }
+
+            LOG.warnf("OIDC metadata request to %s returned %d", target, response.statusCode());
+            return Response.status(response.statusCode())
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(response.body())
+                    .build();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.errorf(e, "Failed to fetch OIDC metadata from %s", target);
+            return Response.status(Response.Status.BAD_GATEWAY).build();
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed to fetch OIDC metadata from %s", target);
+            return Response.status(Response.Status.BAD_GATEWAY).build();
+        }
+    }
+
+    private static URI resolveTarget(URI baseUri, String oidcProxyRootPath) {
+        URI safeBase = baseUri != null ? baseUri : URI.create("/");
+        String root = oidcProxyRootPath != null ? oidcProxyRootPath.trim() : "/q/oidc";
+        if (root.startsWith("/")) {
+            root = root.substring(1);
+        }
+        if (!root.endsWith("/")) {
+            root = root + "/";
+        }
+        return safeBase.resolve(root + ".well-known/openid-configuration");
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
@@ -921,6 +921,36 @@
     }
   },
   "paths" : {
+    "/.well-known/oauth-authorization-server" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "summary" : "Get Authorization Server Metadata",
+        "tags" : [ "O Auth Authorization Server Well Known Resource" ]
+      }
+    },
+    "/.well-known/oauth-authorization-server/{tenant}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "tenant",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "summary" : "Get Authorization Server Metadata For Tenant",
+        "tags" : [ "O Auth Authorization Server Well Known Resource" ]
+      }
+    },
     "/api/v1/capabilities" : {
       "get" : {
         "responses" : {
@@ -2495,6 +2525,24 @@
         },
         "summary" : "Stream Tool Calls By Connection",
         "tags" : [ "Tool Call Resource" ]
+      }
+    },
+    "/test-oidc/.well-known/openid-configuration" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Open Id Configuration",
+        "tags" : [ "Test Open Id Configuration Resource" ]
       }
     }
   },

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -618,6 +618,28 @@ components:
       openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
       description: Authentication
 paths:
+  /.well-known/oauth-authorization-server:
+    get:
+      responses:
+        "200":
+          description: OK
+      summary: Get Authorization Server Metadata
+      tags:
+      - O Auth Authorization Server Well Known Resource
+  /.well-known/oauth-authorization-server/{tenant}:
+    get:
+      parameters:
+      - name: tenant
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+      summary: Get Authorization Server Metadata For Tenant
+      tags:
+      - O Auth Authorization Server Well Known Resource
   /api/v1/capabilities:
     get:
       responses:
@@ -1671,6 +1693,18 @@ paths:
       summary: Stream Tool Calls By Connection
       tags:
       - Tool Call Resource
+  /test-oidc/.well-known/openid-configuration:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Open Id Configuration
+      tags:
+      - Test Open Id Configuration Resource
 info:
   title: wanaku-router-backend API
   version: 0.1.0-SNAPSHOT

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceIT.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceIT.java
@@ -1,0 +1,44 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(OAuthAuthorizationServerWellKnownResourceIT.Profile.class)
+class OAuthAuthorizationServerWellKnownResourceIT {
+
+    @Test
+    void forwardsOpenIdConfiguration() {
+        given().when()
+                .get("/.well-known/oauth-authorization-server")
+                .then()
+                .statusCode(200)
+                .body(equalTo("{\"issuer\":\"http://test-issuer\"}"));
+    }
+
+    @Test
+    void forwardsOpenIdConfigurationForTenant() {
+        given().when()
+                .get("/.well-known/oauth-authorization-server/mcp")
+                .then()
+                .statusCode(200)
+                .body(equalTo("{\"issuer\":\"http://test-issuer\"}"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc-proxy.enabled", "false",
+                    "quarkus.oidc.enabled", "false",
+                    "quarkus.oidc-proxy.root-path", "/test-oidc");
+        }
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OpenIdConfigurationForwarderTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OpenIdConfigurationForwarderTest.java
@@ -1,0 +1,94 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class OpenIdConfigurationForwarderTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void forwardsOpenIdConfigurationWhenUpstreamReturns200() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/q/oidc/.well-known/openid-configuration", exchange -> {
+            String body = "{\"issuer\":\"http://example\"}";
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+        server.start();
+
+        URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/");
+        OpenIdConfigurationForwarder forwarder = new OpenIdConfigurationForwarder(HttpClient.newHttpClient());
+
+        Response response = forwarder.forward(baseUri, "/q/oidc");
+
+        assertEquals(200, response.getStatus());
+        assertEquals("{\"issuer\":\"http://example\"}", response.getEntity());
+    }
+
+    @Test
+    void propagatesNonSuccessStatus() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/q/oidc/.well-known/openid-configuration", exchange -> {
+            String body = "{\"error\":\"boom\"}";
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+        });
+        server.start();
+
+        URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/");
+        OpenIdConfigurationForwarder forwarder = new OpenIdConfigurationForwarder(HttpClient.newHttpClient());
+
+        Response response = forwarder.forward(baseUri, "/q/oidc");
+
+        assertEquals(500, response.getStatus());
+        assertEquals("{\"error\":\"boom\"}", response.getEntity());
+    }
+
+    @Test
+    void returnsBadGatewayWhenUpstreamIsUnavailable() throws Exception {
+        int port = reserveUnusedPort();
+        URI baseUri = URI.create("http://127.0.0.1:" + port + "/");
+        OpenIdConfigurationForwarder forwarder = new OpenIdConfigurationForwarder(HttpClient.newHttpClient());
+
+        Response response = forwarder.forward(baseUri, "/q/oidc");
+
+        assertEquals(502, response.getStatus());
+        assertNotNull(response);
+    }
+
+    private static int reserveUnusedPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/TestOpenIdConfigurationResource.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/TestOpenIdConfigurationResource.java
@@ -1,0 +1,19 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@ApplicationScoped
+@Path("/test-oidc/.well-known")
+@Produces(MediaType.APPLICATION_JSON)
+public class TestOpenIdConfigurationResource {
+
+    @GET
+    @Path("/openid-configuration")
+    public String openIdConfiguration() {
+        return "{\"issuer\":\"http://test-issuer\"}";
+    }
+}


### PR DESCRIPTION
Fixes: #781 


I exposed an explicit endpoint in /.well-known/oauth-authorization-server (including a variant with {tenant}) and forwarded it to the OpenID Configuration served by the OIDC proxy (/q/oidc/.well-known/openid-configuration).

Ensuring the backend responds correctly to the OAuth discovery flow and eliminating the 404 error after initial discovery.

## Summary by Sourcery

Expose OAuth 2.0 authorization-server discovery endpoints and forward them to the OIDC proxy’s OpenID configuration to avoid 404s during local startup discovery.

New Features:
- Add REST endpoints for `/.well-known/oauth-authorization-server` and its tenant-specific variant that proxy authorization server metadata from the OIDC proxy.
- Expose a test OpenID configuration endpoint for use in local/test profiles and API clients.

Bug Fixes:
- Ensure OAuth discovery requests are correctly handled instead of returning 404 when running the router locally.

Enhancements:
- Improve 404 logging by including HTTP method and request URI in not-found responses.
- Introduce an OpenID configuration forwarder helper to centralize proxying logic to the OIDC metadata endpoint.

Tests:
- Add unit tests for the OpenID configuration forwarder’s success, error, and upstream-unavailable scenarios.
- Add integration tests verifying that the OAuth authorization-server well-known endpoints correctly forward the OpenID configuration for default and tenant-specific paths.