### PR TITLE
ci: fix Javadoc errors preventing release builds

### DIFF
--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -145,7 +145,7 @@ public class ResourcesResource {
     /**
      * Removes a resource capability by name.
      *
-     * @param resource the name of the resource to remove
+     * @param name the name of the resource to remove
      * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the resource doesn't exist
      * @throws WanakuException if removal fails
      */

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -121,7 +121,7 @@ public class ToolsResource {
     /**
      * Removes a tool capability by name.
      *
-     * @param tool the name of the tool to remove
+     * @param name the name of the tool to remove
      * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the tool doesn't exist
      * @throws WanakuException if removal fails
      */

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/package-info.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/package-info.java
@@ -5,7 +5,6 @@
  * and the backend services capable of handling them. Bridges may support various
  * transport mechanisms and protocols for communicating with MCP servers, but for now
  * only grpc is supported/implemented.
- * <p>
  *
  * @see ai.wanaku.backend.bridge.Bridge
  */

--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/LabelsAwareWanakuEntityBean.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/LabelsAwareWanakuEntityBean.java
@@ -35,7 +35,6 @@ public abstract class LabelsAwareWanakuEntityBean<W extends LabelsAwareEntity<St
      *   <li>{@code "category=weather & !action=forecast"} - Remove weather entities that are not forecasts</li>
      *   <li>{@code "(category=weather | category=news) & deprecated=true"} - Remove deprecated weather or news entities</li>
      * </ul>
-     * <p>
      *
      * @param labelExpression the label filter expression to match entities for removal;
      *                        must be a valid label expression following the syntax described above


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/23334881109

### Errors Fixed
- `ResourcesResource.java:148`: `@param resource` referenced non-existent param name; changed to `@param name` to match method signature
- `ToolsResource.java:124`: `@param tool` referenced non-existent param name; changed to `@param name` to match method signature
- `package-info.java:8`: removed empty `<p>` tag causing Javadoc warning
- `LabelsAwareWanakuEntityBean.java:38`: removed empty `<p>` tag causing Javadoc warning

### Deferred Issues
None — all errors were directly fixable.

## Summary by Sourcery

Fix Javadoc issues that were causing CI release builds to fail by aligning parameter tags with method signatures and removing invalid HTML tags in documentation comments.

Bug Fixes:
- Correct Javadoc @param tags in resource and tool APIs to reference the existing method parameters.
- Remove empty HTML paragraph tags from Javadoc comments to eliminate warnings that break release builds.