### PR TITLE
chore: document wanaku_meta_ prefix for metadata headers

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2618,11 +2618,56 @@ the body of the data exchange, rather than as a parameter.
 
 For instance, in an HTTP call, `wanaku_body` specifies that the property should be part of the HTTP body, not the HTTP URI.
 
-The handling of such parameters may vary depending on the service being used. 
+The handling of such parameters may vary depending on the service being used.
 
-Currently special arguments: 
+### Passing Metadata as Headers
 
-* `wanaku_body` 
+The `wanaku_meta_` prefix is a special argument prefix that allows AI services to inject headers into tool invocations
+without requiring changes to the tool's configuration or route definition.
+
+Arguments with this prefix are:
+1. Extracted from the regular arguments (they are not passed to the tool as arguments)
+2. Stripped of the `wanaku_meta_` prefix
+3. Forwarded as headers in the gRPC tool invocation request
+
+For example, an argument named `wanaku_meta_contextId` with value `ctx-123` becomes a header with key `contextId` and
+value `ctx-123`.
+
+This is useful for passing context information (such as user IDs, session IDs, or correlation IDs) from the AI service
+through to the downstream capability service.
+
+#### Example: LangChain4j AI Service
+
+```java
+@RegisterAiService
+public interface MyService {
+    @McpToolBox("toolbox")
+    String callTool(
+        @Header("wanaku_meta_contextId") String contextId,
+        @Header("wanaku_meta_userId") String userId,
+        @UserMessage String message
+    );
+}
+```
+
+In the tool implementation, these become accessible as headers in the `ToolInvokeRequest`:
+
+```java
+Map<String, String> headers = request.getHeadersMap();
+String contextId = headers.get("contextId");  // prefix stripped
+String userId = headers.get("userId");
+```
+
+> [!NOTE]
+> If a metadata header has the same name as a tool-defined header (from the tool's schema), the tool-defined header
+> takes precedence.
+
+### Reserved Argument Names
+
+Currently special arguments:
+
+* `wanaku_body` - Indicates the argument should be included in the request body
+* `wanaku_meta_` - Prefix for arguments that are converted to headers (e.g., `wanaku_meta_contextId`)
 
 ## Extending Wanaku: Adding Your Own Capabilities
 


### PR DESCRIPTION
## Summary

- Adds documentation for the `wanaku_meta_` prefix in the usage guide, explaining how AI services can inject headers into tool invocations
- Includes a LangChain4j example showing usage with `@Header` annotations
- Documents header precedence behavior (tool-defined headers win on conflict)
- Renames the "Currently special arguments" list to "Reserved Argument Names" and includes both `wanaku_body` and `wanaku_meta_`

## Test plan

- [ ] Verify the documentation renders correctly in the docs site

## Summary by Sourcery

Document support for the `wanaku_meta_` argument prefix for passing metadata as headers and clarify reserved argument names in the usage guide.

Documentation:
- Explain how `wanaku_meta_` prefixed arguments are converted into headers for tool invocations, including precedence rules versus tool-defined headers.
- Add a LangChain4j example demonstrating usage of `wanaku_meta_` with `@Header` annotations.
- Rename and expand the special-arguments section into "Reserved Argument Names", documenting both `wanaku_body` and `wanaku_meta_`.