### PR TITLE
Fix early-access workflow by splitting into sequential Linux and macOS jobs

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -8,15 +8,11 @@ on:
         required: true
 
 jobs:
-  pre-release-build:
-    name: Build Pre-release Artifacts (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+  pre-release-build-linux:
+    name: Build Pre-release Artifacts (Linux)
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-      fail-fast: true
 
     steps:
       - name: Checkout Wanaku Capabilities SDK Main Project
@@ -49,7 +45,6 @@ jobs:
           cache: maven
 
       - name: Login to Container Registry
-        if: matrix.os == 'ubuntu-latest'
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -57,7 +52,6 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Create a snapshot build (with container push)
-        if: matrix.os == 'ubuntu-latest'
         run: |
           mvn --no-transfer-progress -Dnative -Pdist \
           -Dquarkus.container-image.build=true \
@@ -65,13 +59,7 @@ jobs:
           -Dquarkus.container-image.additional-tags=${{ github.event.inputs.currentDevelopmentVersion }} \
           clean package
 
-      - name: Create a snapshot build with native executables (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          mvn --no-transfer-progress -Dnative -Pdist -DskipTests clean package
-
-      - name: Run JReleaser (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Run JReleaser
         uses: jreleaser/release-action@v2
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,8 +70,59 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Run JReleaser (macOS)
-        if: matrix.os == 'macos-latest'
+      # Persist logs
+
+      - name: JReleaser release output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release-ubuntu-latest
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties
+
+  pre-release-build-macos:
+    name: Build Pre-release Artifacts (macOS)
+    needs: pre-release-build-linux
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Wanaku Capabilities SDK Main Project
+        uses: actions/checkout@v6
+        with:
+          repository: wanaku-ai/wanaku-capabilities-java-sdk
+          persist-credentials: false
+          ref: main
+          path: wanaku-capabilities-java-sdk
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build Wanaku Capabilities SDK Main Project
+        run: mvn --no-transfer-progress -DskipTests clean install
+        working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: graalvm/setup-graalvm@v1.3.4
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          cache: maven
+
+      - name: Create a snapshot build with native executables
+        run: |
+          mvn --no-transfer-progress -Dnative -Pdist -DskipTests clean package
+
+      - name: Run JReleaser
         uses: jreleaser/release-action@v2
         with:
           arguments: 'full-release --exclude-distribution=cli'
@@ -102,7 +141,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jreleaser-release-${{ matrix.os }}
+          name: jreleaser-release-macos-latest
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties


### PR DESCRIPTION
## Problem

The matrix strategy introduced in ffa9e3ab ran Linux and macOS JReleaser jobs in parallel, causing a race condition on the GitHub release. Both jobs competed to create/update the same `early-access` release simultaneously, resulting in only macOS artifacts surviving while all Linux artifacts were lost:

**Expected** (from v0.0.9): `cli` (JVM), `cli-native` (linux + osx), `router`, `service-http`, `service-tavily`, `service-exec`
**Actual**: only `cli-native` (osx)

## Fix

Split the single matrix job into two separate jobs with a dependency:

1. **`pre-release-build-linux`** — runs first, builds + pushes containers, runs JReleaser to create the release with all Linux artifacts
2. **`pre-release-build-macos`** — runs after Linux completes (`needs: pre-release-build-linux`), builds macOS native executables, runs JReleaser with `--exclude-distribution=cli` to add macOS artifacts to the existing release

This ensures Linux creates the release (with checksums, JVM CLI, all Linux-platform distributions) before macOS updates it with the native macOS binary.

## Summary by Sourcery

Split the early-access pre-release workflow into separate sequential Linux and macOS jobs to avoid race conditions when publishing the GitHub early-access release.

CI:
- Run Linux pre-release build and JReleaser as a dedicated job before macOS to establish the GitHub release with all Linux artifacts.
- Run macOS native build in a dependent job that updates the existing release and excludes the JVM CLI distribution when invoking JReleaser.
- Upload JReleaser logs separately for Linux and macOS jobs to aid debugging of the early-access workflow.