### PR TITLE
Fix #875: Skip health check for deregistered capabilities

### DIFF
--- a/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/wanaku-router/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -16,6 +16,7 @@ import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
 import ai.wanaku.backend.common.ServiceTargetEvent;
+import ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord;
 import ai.wanaku.capabilities.sdk.api.types.discovery.HealthStatus;
 import ai.wanaku.capabilities.sdk.api.types.discovery.ServiceState;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
@@ -83,6 +84,15 @@ public class PeriodicHealthCheckService {
     public void checkInstanceHealth(ServiceTarget target) {
         String id = target.getId();
         if (id == null) {
+            return;
+        }
+
+        // Skip capabilities that were explicitly deregistered.
+        // Capabilities that crashed without deregistering remain ACTIVE
+        // and will still be probed and marked as DOWN.
+        ActivityRecord record = serviceRegistry.getStates(id);
+        if (record != null && !record.isActive()) {
+            LOG.debugf("Skipping health check for deregistered capability %s (%s)", target.getServiceName(), id);
             return;
         }
 

--- a/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
+++ b/wanaku-router/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
@@ -1,0 +1,151 @@
+package ai.wanaku.backend.health;
+
+import ai.wanaku.backend.common.ServiceTargetEvent;
+import ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord;
+import ai.wanaku.capabilities.sdk.api.types.discovery.HealthStatus;
+import ai.wanaku.capabilities.sdk.api.types.discovery.ServiceState;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.mcp.providers.ServiceRegistry;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link PeriodicHealthCheckService}.
+ */
+class PeriodicHealthCheckServiceTest {
+
+    private static final String SERVICE_ID = "test-service-id";
+    private static final String SERVICE_NAME = "test-service";
+
+    private PeriodicHealthCheckService healthCheckService;
+    private ServiceRegistry serviceRegistry;
+    private HealthProbeClient probeClient;
+    private ManagedExecutor managedExecutor;
+    private MutinyEmitter<ServiceTargetEvent> eventEmitter;
+
+    @BeforeEach
+    void setUp() {
+        healthCheckService = new PeriodicHealthCheckService();
+        serviceRegistry = mock(ServiceRegistry.class);
+        probeClient = mock(HealthProbeClient.class);
+        managedExecutor = mock(ManagedExecutor.class);
+        eventEmitter = mock(MutinyEmitter.class);
+
+        // Inject mocks using reflection
+        injectField(healthCheckService, "serviceRegistry", serviceRegistry);
+        injectField(healthCheckService, "probeClient", probeClient);
+        injectField(healthCheckService, "managedExecutor", managedExecutor);
+        injectField(healthCheckService, "serviceTargetEventEmitter", eventEmitter);
+
+        when(managedExecutor.submit(any(Runnable.class))).thenAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        when(eventEmitter.hasRequests()).thenReturn(false);
+    }
+
+    @Test
+    void checkInstanceHealth_skipsDeregisteredCapability() {
+        // Given: a service target that was already captured in the sweep
+        ServiceTarget target = new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
+
+        // And: the capability was deregistered (marked as inactive)
+        ActivityRecord inactiveRecord = createInactiveRecord();
+        when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(inactiveRecord);
+
+        // When: checkInstanceHealth is called
+        healthCheckService.checkInstanceHealth(target);
+
+        // Then: the probe should NOT be called
+        verify(probeClient, never()).probe(any());
+        verify(serviceRegistry, never()).updateHealthStatus(any(), any());
+    }
+
+    @Test
+    void checkInstanceHealth_probesActiveCapability() {
+        // Given: a service target that is still active
+        ServiceTarget target = new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
+
+        // And: the capability is active
+        ActivityRecord activeRecord = createActiveRecord();
+        when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(activeRecord);
+        when(probeClient.probe(target)).thenReturn(HealthStatus.HEALTHY);
+
+        // When: checkInstanceHealth is called
+        healthCheckService.checkInstanceHealth(target);
+
+        // Then: the probe should be called
+        verify(probeClient).probe(target);
+        verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.HEALTHY);
+    }
+
+    @Test
+    void checkInstanceHealth_probesWhenNoActivityRecord() {
+        // Given: a service target with no activity record (newly registered)
+        ServiceTarget target = new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
+
+        // And: no activity record exists yet
+        when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(null);
+        when(probeClient.probe(target)).thenReturn(HealthStatus.HEALTHY);
+
+        // When: checkInstanceHealth is called
+        healthCheckService.checkInstanceHealth(target);
+
+        // Then: the probe should still be called (no record = not explicitly deregistered)
+        verify(probeClient).probe(target);
+        verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.HEALTHY);
+    }
+
+    @Test
+    void checkInstanceHealth_probesCrashedCapability() {
+        // Given: a service target that crashed without deregistering
+        ServiceTarget target = new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
+
+        // And: the capability is still marked as ACTIVE (because it crashed without deregistering)
+        ActivityRecord crashedRecord = createActiveRecord();
+        when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(crashedRecord);
+        when(probeClient.probe(target)).thenThrow(new RuntimeException("Connection refused"));
+
+        // When: checkInstanceHealth is called
+        healthCheckService.checkInstanceHealth(target);
+
+        // Then: the probe should be called and mark as DOWN
+        verify(probeClient).probe(target);
+        verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.DOWN);
+    }
+
+    private ActivityRecord createActiveRecord() {
+        ActivityRecord record = new ActivityRecord();
+        record.setActive(true);
+        record.setStates(new java.util.ArrayList<>());
+        return record;
+    }
+
+    private ActivityRecord createInactiveRecord() {
+        ActivityRecord record = new ActivityRecord();
+        record.setActive(false);
+        record.setHealthStatus(HealthStatus.DOWN);
+        record.setStates(new java.util.ArrayList<>());
+        record.getStates().add(ServiceState.newInactive());
+        return record;
+    }
+
+    private void injectField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inject field " + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #875 - PeriodicHealthCheckService was probing deregistered capabilities, causing 'Service unavailable' errors in the logs.

## Problem

When a capability is deregistered via the API, the registry marks its ActivityRecord as INACTIVE and DOWN. However, PeriodicHealthCheckService.sweep() loads the capability list once via serviceRegistry.getEntries(), then submits async health checks for each entry. If a capability is deregistered between the getEntries() snapshot and the actual probeClient.probe() call, the probe hits a dead process.

## Solution

- Add check in checkInstanceHealth() to skip probing capabilities that were explicitly deregistered
- Capabilities marked as INACTIVE in ActivityRecord are skipped to avoid 'Service unavailable' errors  
- Capabilities that crashed without deregistering remain ACTIVE and will still be probed and marked as DOWN

## Testing

Added regression test PeriodicHealthCheckServiceTest with 4 test cases:
- Verifies deregistered capabilities are skipped
- Verifies active capabilities are probed
- Verifies newly registered capabilities are probed
- Verifies crashed capabilities are still probed and marked as DOWN

## Summary by Sourcery

Skip health checks for deregistered capabilities to avoid probing inactive services and log noise.

Bug Fixes:
- Prevent periodic health checks from probing capabilities that have been explicitly deregistered and marked inactive in the registry.

Tests:
- Add PeriodicHealthCheckServiceTest to cover deregistered, active, newly registered, and crashed capability health-check behaviors.