### PR TITLE
test: Add negative test cases to CapabilitiesResourceIT

### DIFF
--- a/tests/integration/src/test/java/ai/wanaku/mcp/CapabilitiesResourceIT.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/CapabilitiesResourceIT.java
@@ -27,14 +27,17 @@ import static io.restassured.RestAssured.given;
 
 /**
  * Negative (error-path) integration tests for the Capabilities REST API.
- *
  * These tests verify that the API correctly rejects invalid, malformed, or
  * unauthorized requests and returns appropriate HTTP error status codes.
- *
  * Reference: Issue #909
  * Related PR: #907
  */
 public class CapabilitiesResourceIT extends WanakuIntegrationBase {
+
+    private static final String REGISTER_ENDPOINT = "/q/capabilities/register";
+    private static final String DEREGISTER_ENDPOINT = "/q/capabilities/deregister";
+    private static final String LIST_ENDPOINT = "/q/capabilities/list";
+    private static final String DEFAULT_SERVICE = "tool-invoker";
 
     @Override
     public List<WanakuContainerDownstreamService> activeWanakuDownstreamServices() {
@@ -42,9 +45,14 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     }
 
     private static String validCapabilityJson() {
-        return "{\"host\": \"localhost\", \"port\": 8080, \"service\": \"tool-invoker\"}";
+        return "{\"host\": \"localhost\", \"port\": 8080, \"service\": \"" + DEFAULT_SERVICE + "\"}";
     }
 
+    /**
+     * Checks if Keycloak auth is enabled in the current test profile.
+     * WanakuIntegrationBase does not expose an equivalent method.
+     * Uses the auth system property consistent with PR #914.
+     */
     private static boolean isAuthEnabled() {
         return System.getProperty("auth.enabled", "false").equals("true");
     }
@@ -59,7 +67,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.TEXT)
                 .body("malformed-body-not-json")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -70,7 +78,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.JSON)
                 .body("{}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -83,9 +91,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityMissingHost() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"port\": 8080, \"service\": \"tool-invoker\"}")
+                .body("{\"port\": 8080, \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -94,9 +102,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityMissingPort() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"host\": \"localhost\", \"service\": \"tool-invoker\"}")
+                .body("{\"host\": \"localhost\", \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -107,7 +115,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.JSON)
                 .body("{\"host\": \"localhost\", \"port\": 8080}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -120,9 +128,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityPortTooHigh() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"host\": \"localhost\", \"port\": 99999, \"service\": \"tool-invoker\"}")
+                .body("{\"host\": \"localhost\", \"port\": 99999, \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -131,9 +139,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityNegativePort() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"host\": \"localhost\", \"port\": -1, \"service\": \"tool-invoker\"}")
+                .body("{\"host\": \"localhost\", \"port\": -1, \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -142,9 +150,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityEmptyHost() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"host\": \"\", \"port\": 8080, \"service\": \"tool-invoker\"}")
+                .body("{\"host\": \"\", \"port\": 8080, \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -153,9 +161,9 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testRegisterCapabilityNullHost() {
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"host\": null, \"port\": 8080, \"service\": \"tool-invoker\"}")
+                .body("{\"host\": null, \"port\": 8080, \"service\": \"" + DEFAULT_SERVICE + "\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -170,7 +178,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.JSON)
                 .body("{\"host\": \"localhost\", \"port\": 8080, \"service\": \"INVALID_SERVICE_XYZ\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -181,7 +189,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.JSON)
                 .body("{\"host\": \"localhost\", \"port\": 8080, \"service\": \"\"}")
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(400);
     }
@@ -194,7 +202,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testDeregisterNonExistentCapability() {
         given()
                 .when()
-                .delete("/q/capabilities/deregister/non-existent-host-xyz/99999")
+                .delete(DEREGISTER_ENDPOINT + "/non-existent-host-xyz/99999")
                 .then()
                 .statusCode(404);
     }
@@ -203,7 +211,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
     void testListCapabilitiesForUnknownService() {
         given()
                 .when()
-                .get("/q/capabilities/list/UNKNOWN_SERVICE_XYZ")
+                .get(LIST_ENDPOINT + "/UNKNOWN_SERVICE_XYZ")
                 .then()
                 .statusCode(404);
     }
@@ -220,7 +228,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 .contentType(ContentType.JSON)
                 .body(validCapabilityJson())
                 .when()
-                .post("/q/capabilities/register")
+                .post(REGISTER_ENDPOINT)
                 .then()
                 .statusCode(401);
     }
@@ -231,7 +239,7 @@ public class CapabilitiesResourceIT extends WanakuIntegrationBase {
                 "Skipping — auth is not enabled in this test profile");
         given()
                 .when()
-                .delete("/q/capabilities/deregister/localhost/8080")
+                .delete(DEREGISTER_ENDPOINT + "/localhost/8080")
                 .then()
                 .statusCode(401);
     }


### PR DESCRIPTION
## Summary

Closes #909

Adds negative (error-path) integration tests to `CapabilitiesResourceIT`
as requested in issue #909. The existing tests from PR #907 only covered happy
path scenarios. This PR improves test coverage by validating that the API
correctly rejects invalid, malformed, and unauthorized requests.

## Test Cases Added

### 1. Malformed / Invalid Payload
- `testRegisterCapabilityMalformedJson` — non-JSON body should return 400
- `testRegisterCapabilityEmptyBody` — empty `{}` body should return 400

### 2. Missing Required Fields
- `testRegisterCapabilityMissingHost` — missing host field should return 400
- `testRegisterCapabilityMissingPort` — missing port field should return 400
- `testRegisterCapabilityMissingService` — missing service field should return 400

### 3. Invalid Values / Edge Cases
- `testRegisterCapabilityPortTooHigh` — port 99999 (above valid range) should return 400
- `testRegisterCapabilityNegativePort` — port -1 should return 400
- `testRegisterCapabilityEmptyHost` — empty string host should return 400
- `testRegisterCapabilityNullHost` — null host should return 400

### 4. Invalid Service Type
- `testRegisterCapabilityInvalidServiceType` — unknown service name should return 400
- `testRegisterCapabilityEmptyServiceType` — empty service string should return 400

### 5. Non-Existent Capability Operations
- `testDeregisterNonExistentCapability` — removing unknown capability should return 404
- `testListCapabilitiesForUnknownService` — listing unknown service should return 404

### 6. Unauthorized Access
- `testRegisterCapabilityUnauthorized` — register without auth header should return 401
- `testDeregisterCapabilityUnauthorized` — deregister without auth header should return 401

## Notes

- Tests extend `WanakuIntegrationBase` and return an empty list from
  `activeWanakuDownstreamServices()` since no downstream services are needed
- Unauthorized tests are guarded with `Assumptions.assumeTrue` so they are
  automatically skipped when Keycloak auth is not enabled in the test profile
- Some scenarios (e.g. port range validation) may require server-side
  validation to be added before these tests fully pass
- Follows the same structure and patterns established in PR #914 for
  `TargetsManagementResourceIT`

## Summary by Sourcery

Add integration coverage for Capabilities API error scenarios and unauthorized access handling.

Tests:
- Add negative integration tests for registering capabilities with malformed, incomplete, or invalid payloads.
- Add tests for capability operations on non-existent resources returning appropriate 4xx codes.
- Add authorization-dependent tests verifying that unauthenticated capability register/deregister requests are rejected.