### PR TITLE
Deprecates the old integration base

### DIFF
--- a/tests/integration/src/test/java/ai/wanaku/mcp/WanakuIntegrationBase.java
+++ b/tests/integration/src/test/java/ai/wanaku/mcp/WanakuIntegrationBase.java
@@ -25,7 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
  * This class sets up the necessary Testcontainers environment, including a shared network,
  * a central router, and required downstream services. It also provides utility methods
  * for interacting with the system, such as executing CLI commands.
+ *
+ * NOTE: this is deprecated, as the integration tests are moving to the Wanaku tests project.
  */
+@Deprecated(forRemoval = true)
 public abstract class WanakuIntegrationBase {
     private static final Logger LOG = LoggerFactory.getLogger(WanakuIntegrationBase.class);
 


### PR DESCRIPTION
Heavier and more elaborate integration tests are now part of the Wanaku Tests project

## Summary by Sourcery

Enhancements:
- Mark the WanakuIntegrationBase test support class as deprecated for future removal and document the migration to the Wanaku Tests project.