### PR TITLE
Fix artifacts and failsafe configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ wanaku-router/wanaku-router-backend/application.dev.properties
 *.iml
 *.ipr
 *aws*.log.*
+*.log
 
 ### Eclipse ###
 .apt_generated

--- a/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,16 +22,16 @@
                 <scope>import</scope>
             </dependency>
         </dependencies>
-    </dependencyManagement> 
+    </dependencyManagement>
 
-    <dependencies> 
+    <dependencies>
         <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-qute</artifactId>
             </dependency>
             <dependency>
                 <groupId>io.quarkiverse.mcp</groupId>
-                <artifactId>quarkus-mcp-server-sse</artifactId>
+                <artifactId>quarkus-mcp-server-http</artifactId>
                 <version>${quarkus-mcp-server.version}</version>
             </dependency>
             <dependency>
@@ -57,9 +57,9 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-container-image-jib</artifactId>
-            </dependency>  
+            </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/core/core-mcp/pom.xml
+++ b/core/core-mcp/pom.xml
@@ -19,7 +19,7 @@
 
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
-            <artifactId>quarkus-mcp-server-sse</artifactId> <!-- use 'quarkus-mcp-server-stdio' if you want to use the STDIO transport instead of the SSE transport -->
+            <artifactId>quarkus-mcp-server-http</artifactId> <!-- use 'quarkus-mcp-server-stdio' if you want to use the STDIO transport instead of the SSE transport -->
             <version>${quarkus-mcp-server.version}</version>
         </dependency>
 

--- a/tests/mcp-servers/wanaku-performance-test-mock-mcp/pom.xml
+++ b/tests/mcp-servers/wanaku-performance-test-mock-mcp/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
-            <artifactId>quarkus-mcp-server-sse</artifactId>
+            <artifactId>quarkus-mcp-server-http</artifactId>
             <version>${quarkus-mcp-server.version}</version>
         </dependency>
         <dependency>

--- a/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
+++ b/wanaku-router/ui/admin/src/api/wanaku-router-api.ts
@@ -2493,3 +2493,34 @@ export const getApiV2ToolCallsNotificationsConnectionId = async (
     },
   );
 };
+
+/**
+ * @summary Open Id Configuration
+ */
+export type getTestOidcWellKnownOpenidConfigurationResponse200 = {
+  data: string;
+  status: 200;
+};
+
+export type getTestOidcWellKnownOpenidConfigurationResponseSuccess =
+  getTestOidcWellKnownOpenidConfigurationResponse200 & {
+    headers: Headers;
+  };
+export type getTestOidcWellKnownOpenidConfigurationResponse =
+  getTestOidcWellKnownOpenidConfigurationResponseSuccess;
+
+export const getGetTestOidcWellKnownOpenidConfigurationUrl = () => {
+  return `/test-oidc/.well-known/openid-configuration`;
+};
+
+export const getTestOidcWellKnownOpenidConfiguration = async (
+  options?: RequestInit,
+): Promise<getTestOidcWellKnownOpenidConfigurationResponse> => {
+  return customFetch<getTestOidcWellKnownOpenidConfigurationResponse>(
+    getGetTestOidcWellKnownOpenidConfigurationUrl(),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};

--- a/wanaku-router/wanaku-router-backend/pom.xml
+++ b/wanaku-router/wanaku-router-backend/pom.xml
@@ -112,7 +112,7 @@
 
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
-            <artifactId>quarkus-mcp-server-sse</artifactId>
+            <artifactId>quarkus-mcp-server-http</artifactId>
             <version>${quarkus-mcp-server.version}</version>
         </dependency>
 
@@ -210,22 +210,23 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${maven-failsafe-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*ManualTest.java</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                        <keycloak.docker.image>${keycloak.docker.image}</keycloak.docker.image>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*ManualTest.java</exclude>
-                            </excludes>
-                            <systemPropertyVariables>
-                                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <maven.home>${maven.home}</maven.home>
-                            </systemPropertyVariables>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.json
@@ -2646,6 +2646,24 @@
         "summary" : "Stream Tool Calls By Connection",
         "tags" : [ "Tool Call Resource" ]
       }
+    },
+    "/test-oidc/.well-known/openid-configuration" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Open Id Configuration",
+        "tags" : [ "Test Open Id Configuration Resource" ]
+      }
     }
   },
   "info" : {

--- a/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/wanaku-router/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -1776,6 +1776,18 @@ paths:
       summary: Stream Tool Calls By Connection
       tags:
       - Tool Call Resource
+  /test-oidc/.well-known/openid-configuration:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Open Id Configuration
+      tags:
+      - Test Open Id Configuration Resource
 info:
   title: wanaku-router-backend API
   version: 0.1.0-SNAPSHOT


### PR DESCRIPTION
- replace quarkus-mcp-server-sse for quarkus-mcp-server-http 
  there is a build warning about the former deprecation
- Fix the failsafe configuration in wanaku-router-backend/pom.xml
- There is a couple of modified files by the build: openapi and wanaku-router-api.ts

## Summary by Sourcery

Update MCP server transport dependencies, fix integration test configuration, and expose a new test OIDC configuration endpoint.

New Features:
- Add a test OIDC OpenID configuration REST endpoint and expose it in the generated TypeScript API client.

Enhancements:
- Switch MCP server dependencies from the deprecated SSE artifact to the HTTP variant across core, router backend, archetypes, and test servers.

Build:
- Adjust Maven Failsafe plugin configuration to apply shared integration-test settings globally and include the Keycloak Docker image system property.