### PR TITLE
chore: exclude OIDC endpoints from OpenAPI spec

### DIFF
--- a/apps/ui/admin/src/api/wanaku-router-api.ts
+++ b/apps/ui/admin/src/api/wanaku-router-api.ts
@@ -57,71 +57,6 @@ import type {
 
 import { customFetch } from "../custom-fetch";
 /**
- * @summary Get Authorization Server Metadata
- */
-export type getWellKnownOauthAuthorizationServerResponse200 = {
-  data: void;
-  status: 200;
-};
-
-export type getWellKnownOauthAuthorizationServerResponseSuccess =
-  getWellKnownOauthAuthorizationServerResponse200 & {
-    headers: Headers;
-  };
-export type getWellKnownOauthAuthorizationServerResponse =
-  getWellKnownOauthAuthorizationServerResponseSuccess;
-
-export const getGetWellKnownOauthAuthorizationServerUrl = () => {
-  return `/.well-known/oauth-authorization-server`;
-};
-
-export const getWellKnownOauthAuthorizationServer = async (
-  options?: RequestInit,
-): Promise<getWellKnownOauthAuthorizationServerResponse> => {
-  return customFetch<getWellKnownOauthAuthorizationServerResponse>(
-    getGetWellKnownOauthAuthorizationServerUrl(),
-    {
-      ...options,
-      method: "GET",
-    },
-  );
-};
-
-/**
- * @summary Get Authorization Server Metadata For Tenant
- */
-export type getWellKnownOauthAuthorizationServerTenantResponse200 = {
-  data: void;
-  status: 200;
-};
-
-export type getWellKnownOauthAuthorizationServerTenantResponseSuccess =
-  getWellKnownOauthAuthorizationServerTenantResponse200 & {
-    headers: Headers;
-  };
-export type getWellKnownOauthAuthorizationServerTenantResponse =
-  getWellKnownOauthAuthorizationServerTenantResponseSuccess;
-
-export const getGetWellKnownOauthAuthorizationServerTenantUrl = (
-  tenant: string,
-) => {
-  return `/.well-known/oauth-authorization-server/${tenant}`;
-};
-
-export const getWellKnownOauthAuthorizationServerTenant = async (
-  tenant: string,
-  options?: RequestInit,
-): Promise<getWellKnownOauthAuthorizationServerTenantResponse> => {
-  return customFetch<getWellKnownOauthAuthorizationServerTenantResponse>(
-    getGetWellKnownOauthAuthorizationServerTenantUrl(tenant),
-    {
-      ...options,
-      method: "GET",
-    },
-  );
-};
-
-/**
  * @summary List
  */
 export type getApiV1CapabilitiesResponse200 = {
@@ -2487,37 +2422,6 @@ export const getApiV2ToolCallsNotificationsConnectionId = async (
 ): Promise<getApiV2ToolCallsNotificationsConnectionIdResponse> => {
   return customFetch<getApiV2ToolCallsNotificationsConnectionIdResponse>(
     getGetApiV2ToolCallsNotificationsConnectionIdUrl(connectionId),
-    {
-      ...options,
-      method: "GET",
-    },
-  );
-};
-
-/**
- * @summary Open Id Configuration
- */
-export type getTestOidcWellKnownOpenidConfigurationResponse200 = {
-  data: string;
-  status: 200;
-};
-
-export type getTestOidcWellKnownOpenidConfigurationResponseSuccess =
-  getTestOidcWellKnownOpenidConfigurationResponse200 & {
-    headers: Headers;
-  };
-export type getTestOidcWellKnownOpenidConfigurationResponse =
-  getTestOidcWellKnownOpenidConfigurationResponseSuccess;
-
-export const getGetTestOidcWellKnownOpenidConfigurationUrl = () => {
-  return `/test-oidc/.well-known/openid-configuration`;
-};
-
-export const getTestOidcWellKnownOpenidConfiguration = async (
-  options?: RequestInit,
-): Promise<getTestOidcWellKnownOpenidConfigurationResponse> => {
-  return customFetch<getTestOidcWellKnownOpenidConfigurationResponse>(
-    getGetTestOidcWellKnownOpenidConfigurationUrl(),
     {
       ...options,
       method: "GET",

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -150,6 +150,7 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 %test.quarkus.log.category."org.apache.http".level=INFO
 
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
+mp.openapi.scan.exclude.packages=ai.wanaku.backend.api.v1.oidc
 
 # Quinoa configuration
 quarkus.quinoa=true

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -914,36 +914,6 @@
     }
   },
   "paths" : {
-    "/.well-known/oauth-authorization-server" : {
-      "get" : {
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          }
-        },
-        "summary" : "Get Authorization Server Metadata",
-        "tags" : [ "O Auth Authorization Server Well Known Resource" ]
-      }
-    },
-    "/.well-known/oauth-authorization-server/{tenant}" : {
-      "get" : {
-        "parameters" : [ {
-          "name" : "tenant",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          }
-        },
-        "summary" : "Get Authorization Server Metadata For Tenant",
-        "tags" : [ "O Auth Authorization Server Well Known Resource" ]
-      }
-    },
     "/api/v1/capabilities" : {
       "get" : {
         "responses" : {
@@ -2638,24 +2608,6 @@
         },
         "summary" : "Stream Tool Calls By Connection",
         "tags" : [ "Tool Call Resource" ]
-      }
-    },
-    "/test-oidc/.well-known/openid-configuration" : {
-      "get" : {
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          }
-        },
-        "summary" : "Open Id Configuration",
-        "tags" : [ "Test Open Id Configuration Resource" ]
       }
     }
   },

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -613,28 +613,6 @@ components:
         data:
           $ref: "#/components/schemas/ToolReference"
 paths:
-  /.well-known/oauth-authorization-server:
-    get:
-      responses:
-        "200":
-          description: OK
-      summary: Get Authorization Server Metadata
-      tags:
-      - O Auth Authorization Server Well Known Resource
-  /.well-known/oauth-authorization-server/{tenant}:
-    get:
-      parameters:
-      - name: tenant
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          description: OK
-      summary: Get Authorization Server Metadata For Tenant
-      tags:
-      - O Auth Authorization Server Well Known Resource
   /api/v1/capabilities:
     get:
       responses:
@@ -1771,18 +1749,6 @@ paths:
       summary: Stream Tool Calls By Connection
       tags:
       - Tool Call Resource
-  /test-oidc/.well-known/openid-configuration:
-    get:
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-      summary: Open Id Configuration
-      tags:
-      - Test Open Id Configuration Resource
 info:
   title: wanaku-router-backend API
   version: 0.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Excludes the `ai.wanaku.backend.api.v1.oidc` package from OpenAPI scanning via `mp.openapi.scan.exclude.packages`
- Removes the `/.well-known/oauth-authorization-server`, `/.well-known/oauth-authorization-server/{tenant}`, and `/test-oidc/.well-known/openid-configuration` endpoints from the generated OpenAPI spec
- These security-related endpoints were inadvertently added to the spec by commit cd92a50f

## Test plan

- [x] Build passes (`mvn verify`)
- [x] Verified `openapi.json` and `openapi.yaml` no longer contain the OIDC endpoints
- [x] TypeScript API client regenerated without the OIDC endpoints

## Summary by Sourcery

Exclude OIDC-related endpoints from the public API surface and generated OpenAPI artifacts.

Enhancements:
- Remove OIDC well-known endpoints from the backend OpenAPI specification and generated OpenAPI JSON/YAML artifacts.
- Update the backend configuration to exclude the OIDC API package from OpenAPI scanning.

Build:
- Regenerate the TypeScript API client to drop OIDC-related endpoint definitions.