### PR TITLE
feat: adding support for sampling

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -73,7 +73,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
 
     private boolean removeLinkedEntries(ForwardReference forwardReference) {
         final NameNamespacePair nameNamespacePair =
-                new NameNamespacePair(forwardReference.getName(), forwardReference.getNamespace());
+            new NameNamespacePair(forwardReference.getName(), forwardReference.getNamespace());
 
         String address = forwardRegistry.getClientAddress(nameNamespacePair);
         if (address == null) {
@@ -84,6 +84,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             removeRemoteTools(nameNamespacePair, forwardClient);
             removeRemoteResources(forwardClient);
         } finally {
+            mcpBridge.removeConnection(address);
             forwardRegistry.unlink(nameNamespacePair);
         }
 
@@ -174,9 +175,9 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
                 new NameNamespacePair(forwardReference.getName(), forwardReference.getNamespace());
 
         String address = forwardReference.getAddress();
-
         final List<RemoteToolReference> locallyRegisteredTools = new ArrayList<>();
-        try (var forwardClient = ForwardClient.newClient(address)) {
+        try (ForwardClient forwardClient = ForwardClient.newClient(
+                address, mcpBridge.createSamplingHandler(address), mcpBridge.createElicitationHandler(address))) {
             List<ResourceReference> resourceReferences = mcpBridge.listResources(forwardClient);
             for (ResourceReference reference : resourceReferences) {
                 LOG.debugf("Exposing remote resource %s", reference.getName());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
@@ -2,6 +2,8 @@ package ai.wanaku.backend.bridge;
 
 import io.quarkus.logging.Log;
 import ai.wanaku.core.mcp.client.ClientUtil;
+import ai.wanaku.core.mcp.client.McpElicitationHandler;
+import ai.wanaku.core.mcp.client.McpSamplingHandler;
 import dev.langchain4j.mcp.client.McpClient;
 
 /**
@@ -33,7 +35,36 @@ public record ForwardClient(String address, McpClient client) implements AutoClo
      * @throws IllegalArgumentException if the address is invalid or unsupported
      */
     public static ForwardClient newClient(String address) {
-        return new ForwardClient(address, ClientUtil.createClient(address));
+        return newClient(address, null);
+    }
+
+    /**
+     * Creates a new ForwardClient with a fresh MCP client connection and sampling
+     * support.
+     *
+     * @param address         the remote MCP server address to connect to
+     * @param samplingHandler the sampling handler to support server-initiated
+     *                        sampling/createMessage
+     * @return a new ForwardClient instance with an initialized client
+     * @throws IllegalArgumentException if the address is invalid or unsupported
+     */
+    public static ForwardClient newClient(String address, McpSamplingHandler samplingHandler) {
+        return newClient(address, samplingHandler, null);
+    }
+
+    /**
+     * Creates a new ForwardClient with a fresh MCP client connection, with optional
+     * sampling and elicitation support.
+     *
+     * @param address            the remote MCP server address to connect to
+     * @param samplingHandler    optional handler for server-initiated sampling/createMessage
+     * @param elicitationHandler optional handler for server-initiated elicitation/create
+     * @return a new ForwardClient instance with an initialized client
+     * @throws IllegalArgumentException if the address is invalid or unsupported
+     */
+    public static ForwardClient newClient(
+            String address, McpSamplingHandler samplingHandler, McpElicitationHandler elicitationHandler) {
+        return new ForwardClient(address, ClientUtil.createClient(address, samplingHandler, elicitationHandler));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/McpBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/McpBridge.java
@@ -10,6 +10,8 @@ import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.types.CallableReference;
 import ai.wanaku.capabilities.sdk.api.types.RemoteToolReference;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.core.mcp.client.McpElicitationHandler;
+import ai.wanaku.core.mcp.client.McpSamplingHandler;
 
 /**
  * Bridge interface for interacting with remote MCP servers via the langchain4j MCP client.
@@ -28,4 +30,33 @@ public interface McpBridge {
 
     Uni<ResourceResponse> read(
             ForwardClient forwardClient, ResourceManager.ResourceArguments arguments, ResourceReference mcpResource);
+
+    default McpSamplingHandler createSamplingHandler(String address) {
+        return null;
+    }
+
+    /**
+     * Creates an {@link McpElicitationHandler} bound to the given remote server address.
+     * <p>
+     * Implementations override this to delegate {@code elicitation/create} requests from
+     * remote MCP servers to the local client-side {@code Elicitation} infrastructure.
+     *
+     * @param address the remote MCP server address
+     * @return the handler, or {@code null} if elicitation is not supported
+     */
+    default McpElicitationHandler createElicitationHandler(String address) {
+        return null;
+    }
+
+    /**
+     * Removes all state associated with a forward connection address.
+     *
+     * <p>Implementations should clear any cached sampling/elicitation entries
+     * or other per-connection state to avoid unbounded growth when connections
+     * are closed or become stale.</p>
+     *
+     * @param address the remote MCP server address to clean up
+     */
+    default void removeConnection(String address) {
+    }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
@@ -1,22 +1,40 @@
 package ai.wanaku.backend.bridge.mcp;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
-import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest;
 import io.quarkiverse.mcp.server.ResourceManager;
 import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingRequest;
+import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.TextResourceContents;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.json.JsonObject;
+import org.jboss.logging.Logger;
+
 import ai.wanaku.backend.bridge.ForwardClient;
 import ai.wanaku.backend.bridge.McpBridge;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
@@ -26,6 +44,8 @@ import ai.wanaku.capabilities.sdk.api.types.InputSchema;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.RemoteToolReference;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.core.mcp.client.McpElicitationHandler;
+import ai.wanaku.core.mcp.client.McpSamplingHandler;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.McpReadResourceResult;
@@ -45,6 +65,18 @@ public class DefaultMcpBridge implements McpBridge {
     private static final Logger LOG = Logger.getLogger(DefaultMcpBridge.class);
 
     private final Map<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+    private final Map<String, Sampling> activeSamplings = new ConcurrentHashMap<>();
+    private final Map<String, Elicitation> activeElicitations = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Sampling sampling;
+    Elicitation elicitation;
+
+    @Inject
+    Instance<Sampling> samplingInstance;
+
+    @Inject
+    Instance<Elicitation> elicitationInstance;
 
     // ---- Tools ----
 
@@ -74,9 +106,10 @@ public class DefaultMcpBridge implements McpBridge {
 
     private ToolResponse doExecuteTool(
             ForwardClient forwardClient, ToolManager.ToolArguments toolArguments, CallableReference toolReference) {
-        LOG.infof(
-                "Calling tool on behalf of connection %s",
-                toolArguments.connection().id());
+        LOG.infof("Calling tool on behalf of connection %s", toolArguments.connection().id());
+
+        activeSamplings.put(forwardClient.address(), toolArguments.sampling());
+        activeElicitations.put(forwardClient.address(), toolArguments.elicitation());
 
         ReentrantLock lock = locks.computeIfAbsent(forwardClient.address(), k -> new ReentrantLock());
         try {
@@ -93,11 +126,7 @@ public class DefaultMcpBridge implements McpBridge {
 
             return ToolResponse.success(result.resultText());
         } catch (Exception e) {
-            LOG.errorf(
-                    e,
-                    "Unable to remote tool: %s (connection: %s)",
-                    e.getMessage(),
-                    toolArguments.connection().id());
+            LOG.errorf(e, "Unable to remote tool: %s (connection: %s)", e.getMessage(), toolArguments.connection().id());
             return ToolResponse.error(e.getMessage());
         } finally {
             lock.unlock();
@@ -110,7 +139,6 @@ public class DefaultMcpBridge implements McpBridge {
     public List<ResourceReference> listResources(ForwardClient forwardClient) throws ServiceUnavailableException {
         try {
             List<McpResource> resourceRefs = forwardClient.client().listResources();
-
             return resourceRefs.stream().map(DefaultMcpBridge::remoteToLocal).collect(Collectors.toList());
         } catch (Exception e) {
             throw ServiceUnavailableException.forName(forwardClient.address());
@@ -120,6 +148,8 @@ public class DefaultMcpBridge implements McpBridge {
     @Override
     public Uni<ResourceResponse> read(
             ForwardClient forwardClient, ResourceManager.ResourceArguments arguments, ResourceReference mcpResource) {
+        activeSamplings.put(forwardClient.address(), arguments.sampling());
+        activeElicitations.put(forwardClient.address(), arguments.elicitation());
         return Uni.createFrom()
                 .item(() -> doRead(forwardClient, mcpResource))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor());
@@ -139,15 +169,305 @@ public class DefaultMcpBridge implements McpBridge {
         }
     }
 
-    // ---- Private helpers ----
+    // ---- Sampling / Elicitation handlers ----
+
+    @Override
+    public McpSamplingHandler createSamplingHandler(String address) {
+        return params -> handleSampling(address, params);
+    }
+
+    @Override
+    public McpElicitationHandler createElicitationHandler(String address) {
+        return params -> handleElicitation(address, params);
+    }
+
+    // ---- Sampling ----
+
+    private CompletableFuture<JsonNode> handleSampling(String address, JsonNode params) {
+        Sampling s = resolveSampling(address);
+        if (s == null || !s.isSupported()) {
+            return CompletableFuture.failedFuture(
+                    new RuntimeException("Sampling not supported or no active connection"));
+        }
+
+        IllegalArgumentException validationError = validateSamplingContent(params);
+        if (validationError != null) {
+            return CompletableFuture.failedFuture(validationError);
+        }
+
+        try {
+            SamplingRequest.Builder builder = buildSamplingRequest(s, params);
+            return builder.build().send().subscribeAsCompletionStage().thenApply(this::toSamplingResult);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private Sampling resolveSampling(String address) {
+        Sampling s = activeSamplings.get(address);
+        if (s != null) {
+            return s;
+        }
+        return defaultSampling();
+    }
+
+    private IllegalArgumentException validateSamplingContent(JsonNode params) {
+        if (params == null || !params.has("messages")) {
+            return null;
+        }
+
+        for (JsonNode messageNode : params.get("messages")) {
+            if (messageNode == null || messageNode.isNull()) {
+                continue;
+            }
+            JsonNode contentNode = messageNode.get("content");
+            if (contentNode == null || contentNode.isNull()) {
+                continue;
+            }
+
+            IllegalArgumentException error = validateContentNode(contentNode);
+            if (error != null) {
+                return error;
+            }
+        }
+
+        return null;
+    }
+
+    private IllegalArgumentException validateContentNode(JsonNode contentNode) {
+        if (contentNode.isArray()) {
+            return validateArrayContent(contentNode);
+        }
+        return validateObjectContent(contentNode);
+    }
+
+    private IllegalArgumentException validateArrayContent(JsonNode contentNode) {
+        if (contentNode.size() != 1) {
+            String error = "Sampling currently supports only a single text content part per message; "
+                    + "received " + contentNode.size() + " parts: " + contentNode;
+            LOG.warn(error);
+            return new IllegalArgumentException(error);
+        }
+        JsonNode part = contentNode.get(0);
+        String type = part.path("type").asText(null);
+        if (!"text".equals(type)) {
+            String error = "Sampling currently supports only text content parts; "
+                    + "received non-text content: " + part;
+            LOG.warn(error);
+            return new IllegalArgumentException(error);
+        }
+        return null;
+    }
+
+    private IllegalArgumentException validateObjectContent(JsonNode contentNode) {
+        String type = contentNode.path("type").asText(null);
+        if (type != null && !"text".equals(type)) {
+            String error = "Sampling currently supports only text content; "
+                    + "received non-text content: " + contentNode;
+            LOG.warn(error);
+            return new IllegalArgumentException(error);
+        }
+        return null;
+    }
+
+    private SamplingRequest.Builder buildSamplingRequest(Sampling s, JsonNode params) {
+        SamplingRequest.Builder builder = s.requestBuilder();
+
+        if (params.has("maxTokens")) {
+            builder.setMaxTokens(params.get("maxTokens").asLong());
+        }
+        if (params.has("systemPrompt")) {
+            builder.setSystemPrompt(params.get("systemPrompt").asText());
+        }
+        if (params.has("temperature")) {
+            builder.setTemperature(new BigDecimal(params.get("temperature").asText()));
+        }
+
+        if (params.has("messages") && params.get("messages").isArray()) {
+            for (JsonNode msgNode : params.get("messages")) {
+                addSamplingMessage(builder, msgNode);
+            }
+        }
+
+        return builder;
+    }
+
+    private void addSamplingMessage(SamplingRequest.Builder builder, JsonNode msgNode) {
+        String role = msgNode.has("role") ? msgNode.get("role").asText() : "user";
+        JsonNode contentNode = msgNode.get("content");
+        if (contentNode == null) {
+            return;
+        }
+        if (contentNode.isObject() && "text".equals(contentNode.path("type").asText("text"))) {
+            Content textContent = new TextContent(contentNode.path("text").asText(""));
+            if ("assistant".equals(role)) {
+                builder.addMessage(SamplingMessage.withAssistantRole(textContent));
+            } else {
+                builder.addMessage(SamplingMessage.withUserRole(textContent));
+            }
+        }
+    }
+
+    private ObjectNode toSamplingResult(io.quarkiverse.mcp.server.SamplingResponse resp) {
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("model", resp.model());
+        if (resp.role() != null) {
+            result.put("role", resp.role().toString().toLowerCase());
+        }
+        if (resp.stopReason() != null) {
+            result.put("stopReason", resp.stopReason());
+        }
+        if (resp.content() != null && "text".equals(resp.content().getType())) {
+            ObjectNode contentObj = result.putObject("content");
+            contentObj.put("type", "text");
+            contentObj.put("text", resp.content().asText().text());
+        }
+        return result;
+    }
+
+    private Sampling defaultSampling() {
+        if (sampling != null) {
+            return sampling;
+        }
+        if (samplingInstance != null && samplingInstance.isResolvable()) {
+            return samplingInstance.get();
+        }
+        return null;
+    }
+
+    // ---- Elicitation ----
+
+    private CompletableFuture<JsonNode> handleElicitation(String address, JsonNode params) {
+        Elicitation e = resolveElicitation(address);
+        if (e == null || !e.isSupported()) {
+            return CompletableFuture.failedFuture(
+                    new RuntimeException("Elicitation not supported or no active connection"));
+        }
+
+        String mode = params.path("mode").asText("form");
+        if ("url".equals(mode)) {
+            return CompletableFuture.failedFuture(
+                    new RuntimeException("URL mode elicitation is not supported yet"));
+        }
+
+        try {
+            ElicitationRequest.Builder builder = buildElicitationRequest(e, params);
+            return builder.build().send().subscribeAsCompletionStage().thenApply(this::toElicitationResult);
+        } catch (Exception ex) {
+            return CompletableFuture.failedFuture(ex);
+        }
+    }
+
+    private Elicitation resolveElicitation(String address) {
+        Elicitation e = activeElicitations.get(address);
+        if (e != null) {
+            return e;
+        }
+        return defaultElicitation();
+    }
+
+    private ElicitationRequest.Builder buildElicitationRequest(Elicitation e, JsonNode params) {
+        ElicitationRequest.Builder builder = e.requestBuilder();
+
+        builder.setMessage(params.has("message") ? params.get("message").asText() : "");
+
+        JsonNode requestedSchema = params.path("requestedSchema");
+        Set<String> requiredProps = collectRequiredProperties(requestedSchema);
+
+        addSchemaProperties(builder, requestedSchema.path("properties"), requiredProps);
+
+        return builder;
+    }
+
+    private Set<String> collectRequiredProperties(JsonNode requestedSchema) {
+        Set<String> requiredProps = new HashSet<>();
+        JsonNode requiredArray = requestedSchema.path("required");
+        if (requiredArray.isArray()) {
+            requiredArray.forEach(n -> requiredProps.add(n.asText()));
+        }
+        return requiredProps;
+    }
+
+    private void addSchemaProperties(
+            ElicitationRequest.Builder builder, JsonNode schemaNode, Set<String> requiredProps) {
+        if (!schemaNode.isObject()) {
+            return;
+        }
+
+        schemaNode.properties().forEach(entry -> {
+            String key = entry.getKey();
+            JsonNode propNode = entry.getValue();
+            boolean required = requiredProps.contains(key);
+            ElicitationRequest.PrimitiveSchema schema = resolvePrimitiveSchema(propNode, required);
+            builder.addSchemaProperty(key, schema);
+        });
+    }
+
+    private ElicitationRequest.PrimitiveSchema resolvePrimitiveSchema(JsonNode propNode, boolean required) {
+        if (propNode.has("enum")) {
+            List<String> enumValues = new ArrayList<>();
+            propNode.get("enum").forEach(n -> enumValues.add(n.asText()));
+            return new ElicitationRequest.EnumSchema(enumValues, required);
+        }
+
+        String type = propNode.path("type").asText("string");
+        return switch (type) {
+            case "boolean" -> new ElicitationRequest.BooleanSchema(required);
+            case "integer", "number" -> new ElicitationRequest.NumberSchema(required);
+            default -> new ElicitationRequest.StringSchema(required);
+        };
+    }
+
+    private ObjectNode toElicitationResult(io.quarkiverse.mcp.server.ElicitationResponse resp) {
+        ObjectNode result = objectMapper.createObjectNode();
+        if (resp.action() != null) {
+            result.put("action", resp.action().toString().toLowerCase());
+        }
+        if (resp.content() != null) {
+            ObjectNode contentObj = result.putObject("content");
+            resp.content().asMap().forEach((k, v) -> putContentValue(contentObj, k, v));
+        }
+        return result;
+    }
+
+    private void putContentValue(ObjectNode contentObj, String key, Object v) {
+        if (v instanceof Boolean b) {
+            contentObj.put(key, b);
+        } else if (v instanceof Integer i) {
+            contentObj.put(key, i);
+        } else if (v instanceof Number n) {
+            contentObj.put(key, n.doubleValue());
+        } else if (v != null) {
+            contentObj.put(key, v.toString());
+        }
+    }
+
+    private Elicitation defaultElicitation() {
+        if (elicitation != null) {
+            return elicitation;
+        }
+        if (elicitationInstance != null && elicitationInstance.isResolvable()) {
+            return elicitationInstance.get();
+        }
+        return null;
+    }
+
+    // ---- Connection lifecycle ----
+
+    @Override
+    public void removeConnection(String address) {
+        activeSamplings.remove(address);
+        activeElicitations.remove(address);
+        LOG.infof("Removed active sampling and elicitation entries for address %s", address);
+    }
+
+    // ---- General helpers ----
 
     private String serializeArguments(Map<String, Object> arguments) {
         JsonObject content = new JsonObject();
-
         for (Map.Entry<String, Object> entry : arguments.entrySet()) {
             content.put(entry.getKey(), entry.getValue());
         }
-
         return content.toString();
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridgeElicitationTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridgeElicitationTest.java
@@ -1,0 +1,293 @@
+package ai.wanaku.backend.bridge.mcp;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest;
+import io.quarkiverse.mcp.server.ElicitationResponse;
+import io.smallrye.mutiny.Uni;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the elicitation support in {@link DefaultMcpBridge}.
+ * <p>
+ * These tests verify that the bridge correctly bridges {@code elicitation/create}
+ * JSON-RPC requests from remote MCP servers to the local Quarkus {@link Elicitation} API,
+ * and that the response is correctly serialized back to JSON.
+ */
+class DefaultMcpBridgeElicitationTest {
+
+    private DefaultMcpBridge bridge;
+    private Elicitation elicitation;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        bridge = new DefaultMcpBridge();
+        elicitation = mock(Elicitation.class);
+        bridge.elicitation = elicitation;
+    }
+
+    @Test
+    void shouldHandleElicitationRequestWithAcceptAction() throws Exception {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "What is your name?");
+        ObjectNode requestedSchema = params.putObject("requestedSchema");
+        ObjectNode properties = requestedSchema.putObject("properties");
+        ObjectNode nameProp = properties.putObject("name");
+        nameProp.put("type", "string");
+
+        ElicitationRequest.Builder builder = mock(ElicitationRequest.Builder.class);
+        ElicitationRequest request = mock(ElicitationRequest.class);
+        ElicitationResponse response = mock(ElicitationResponse.class);
+        ElicitationResponse.Content content = mock(ElicitationResponse.Content.class);
+
+        when(elicitation.isSupported()).thenReturn(true);
+        when(elicitation.requestBuilder()).thenReturn(builder);
+        when(builder.setMessage(anyString())).thenReturn(builder);
+        when(builder.addSchemaProperty(eq("name"), any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+
+        when(response.action()).thenReturn(ElicitationResponse.Action.ACCEPT);
+        when(response.content()).thenReturn(content);
+        when(content.asMap()).thenReturn(Map.of("name", "Alice"));
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createElicitationHandler(address).handleElicitation(params);
+        JsonNode result = future.get(5, TimeUnit.SECONDS);
+
+        // Assert
+        verify(elicitation).requestBuilder();
+        verify(builder).setMessage("What is your name?");
+        verify(builder).addSchemaProperty(eq("name"), any(ElicitationRequest.StringSchema.class));
+        verify(builder).build();
+
+        assertThat(result.get("action").asText()).isEqualTo("accept");
+        assertThat(result.get("content").get("name").asText()).isEqualTo("Alice");
+    }
+
+    @Test
+    void shouldHandleElicitationRequestWithDeclineAction() throws Exception {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Confirm operation?");
+        ObjectNode requestedSchema = params.putObject("requestedSchema");
+        ObjectNode properties = requestedSchema.putObject("properties");
+        ObjectNode confirmProp = properties.putObject("confirmed");
+        confirmProp.put("type", "boolean");
+
+        ElicitationRequest.Builder builder = mock(ElicitationRequest.Builder.class);
+        ElicitationRequest request = mock(ElicitationRequest.class);
+        ElicitationResponse response = mock(ElicitationResponse.class);
+        ElicitationResponse.Content content = mock(ElicitationResponse.Content.class);
+
+        when(elicitation.isSupported()).thenReturn(true);
+        when(elicitation.requestBuilder()).thenReturn(builder);
+        when(builder.setMessage(anyString())).thenReturn(builder);
+        when(builder.addSchemaProperty(eq("confirmed"), any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+
+        when(response.action()).thenReturn(ElicitationResponse.Action.DECLINE);
+        when(response.content()).thenReturn(content);
+        when(content.asMap()).thenReturn(Map.of());
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createElicitationHandler(address).handleElicitation(params);
+        JsonNode result = future.get(5, TimeUnit.SECONDS);
+
+        // Assert
+        verify(builder).addSchemaProperty(eq("confirmed"), any(ElicitationRequest.BooleanSchema.class));
+        assertThat(result.get("action").asText()).isEqualTo("decline");
+    }
+
+    @Test
+    void shouldMapNumericTypesToNumberSchema() throws Exception {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Enter a number");
+        ObjectNode requestedSchema = params.putObject("requestedSchema");
+        ObjectNode properties = requestedSchema.putObject("properties");
+        properties.putObject("count").put("type", "integer");
+        properties.putObject("ratio").put("type", "number");
+
+        ElicitationRequest.Builder builder = mock(ElicitationRequest.Builder.class);
+        ElicitationRequest request = mock(ElicitationRequest.class);
+        ElicitationResponse response = mock(ElicitationResponse.class);
+        ElicitationResponse.Content content = mock(ElicitationResponse.Content.class);
+
+        when(elicitation.isSupported()).thenReturn(true);
+        when(elicitation.requestBuilder()).thenReturn(builder);
+        when(builder.setMessage(anyString())).thenReturn(builder);
+        when(builder.addSchemaProperty(anyString(), any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+        when(response.action()).thenReturn(ElicitationResponse.Action.ACCEPT);
+        when(response.content()).thenReturn(content);
+        when(content.asMap()).thenReturn(Map.of());
+
+        // Act
+        bridge.createElicitationHandler(address).handleElicitation(params).get(5, TimeUnit.SECONDS);
+
+        // Assert — both integer and number map to NumberSchema (IntegerSchema absent in 1.10.1)
+        verify(builder).addSchemaProperty(eq("count"), any(ElicitationRequest.NumberSchema.class));
+        verify(builder).addSchemaProperty(eq("ratio"), any(ElicitationRequest.NumberSchema.class));
+    }
+
+    @Test
+    void shouldRespectRequiredArrayAtSchemaRoot() throws Exception {
+        // Arrange — 'name' is required, 'nickname' is optional
+        // Per the MCP spec the required list lives at requestedSchema root, NOT inside each property.
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Tell us about yourself");
+        ObjectNode requestedSchema = params.putObject("requestedSchema");
+        ObjectNode properties = requestedSchema.putObject("properties");
+        properties.putObject("name").put("type", "string");
+        properties.putObject("nickname").put("type", "string");
+        ArrayNode required = requestedSchema.putArray("required");
+        required.add("name"); // only 'name' is required
+
+        ElicitationRequest.Builder builder = mock(ElicitationRequest.Builder.class);
+        ElicitationRequest request = mock(ElicitationRequest.class);
+        ElicitationResponse response = mock(ElicitationResponse.class);
+        ElicitationResponse.Content content = mock(ElicitationResponse.Content.class);
+
+        when(elicitation.isSupported()).thenReturn(true);
+        when(elicitation.requestBuilder()).thenReturn(builder);
+        when(builder.setMessage(anyString())).thenReturn(builder);
+        when(builder.addSchemaProperty(anyString(), any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+        when(response.action()).thenReturn(ElicitationResponse.Action.ACCEPT);
+        when(response.content()).thenReturn(content);
+        when(content.asMap()).thenReturn(Map.of("name", "Alice"));
+
+        // Act
+        bridge.createElicitationHandler(address).handleElicitation(params).get(5, TimeUnit.SECONDS);
+
+        // Assert — 'name' required=true, 'nickname' required=false
+        verify(builder)
+                .addSchemaProperty(
+                        eq("name"), argThat(s -> s instanceof ElicitationRequest.StringSchema ss && ss.required()));
+        verify(builder)
+                .addSchemaProperty(
+                        eq("nickname"),
+                        argThat(s -> s instanceof ElicitationRequest.StringSchema ss && !ss.required()));
+    }
+
+    @Test
+    void shouldHandleEnumSchema() throws Exception {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Pick a color");
+        ObjectNode requestedSchema = params.putObject("requestedSchema");
+        ObjectNode properties = requestedSchema.putObject("properties");
+        ObjectNode colorProp = properties.putObject("color");
+        ArrayNode enums = colorProp.putArray("enum");
+        enums.add("red").add("green").add("blue");
+
+        ElicitationRequest.Builder builder = mock(ElicitationRequest.Builder.class);
+        ElicitationRequest request = mock(ElicitationRequest.class);
+        ElicitationResponse response = mock(ElicitationResponse.class);
+        ElicitationResponse.Content content = mock(ElicitationResponse.Content.class);
+
+        when(elicitation.isSupported()).thenReturn(true);
+        when(elicitation.requestBuilder()).thenReturn(builder);
+        when(builder.setMessage(anyString())).thenReturn(builder);
+        when(builder.addSchemaProperty(eq("color"), any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+        when(response.action()).thenReturn(ElicitationResponse.Action.ACCEPT);
+        when(response.content()).thenReturn(content);
+        when(content.asMap()).thenReturn(Map.of("color", "red"));
+
+        // Act
+        bridge.createElicitationHandler(address).handleElicitation(params).get(5, TimeUnit.SECONDS);
+
+        // Assert
+        verify(builder).addSchemaProperty(eq("color"), any(ElicitationRequest.EnumSchema.class));
+    }
+
+    @Test
+    void shouldFailForUrlMode() {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("mode", "url");
+        params.put("message", "Click here");
+
+        when(elicitation.isSupported()).thenReturn(true);
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createElicitationHandler(address).handleElicitation(params);
+
+        // Assert
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("URL mode elicitation is not supported yet");
+    }
+
+    @Test
+    void shouldFailWhenElicitationIsNotSupported() {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Are you there?");
+
+        when(elicitation.isSupported()).thenReturn(false);
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createElicitationHandler(address).handleElicitation(params);
+
+        // Assert
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("Elicitation not supported");
+    }
+
+    @Test
+    void shouldFailWhenNoElicitationIsAvailable() {
+        // Arrange
+        bridge.elicitation = null; // no injection
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("message", "Confirm?");
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createElicitationHandler(address).handleElicitation(params);
+
+        // Assert
+        assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("Elicitation not supported");
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/SamplingTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/SamplingTest.java
@@ -1,0 +1,82 @@
+package ai.wanaku.backend.bridge.mcp;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingRequest;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.TextContent;
+import io.smallrye.mutiny.Uni;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SamplingTest {
+
+    private DefaultMcpBridge bridge;
+    private Sampling sampling;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        bridge = new DefaultMcpBridge();
+        sampling = mock(Sampling.class);
+        bridge.sampling = sampling;
+    }
+
+    @Test
+    void shouldHandleSamplingRequest() throws Exception {
+        // Arrange
+        String address = "http://localhost:8080";
+        ObjectNode params = mapper.createObjectNode();
+        params.put("maxTokens", 100);
+        params.put("systemPrompt", "You are helpful");
+        ArrayNode messages = params.putArray("messages");
+        ObjectNode msg = messages.addObject();
+        msg.put("role", "user");
+        ObjectNode content = msg.putObject("content");
+        content.put("type", "text");
+        content.put("text", "hello");
+
+        SamplingRequest.Builder builder = mock(SamplingRequest.Builder.class);
+        SamplingRequest request = mock(SamplingRequest.class);
+        SamplingResponse response = mock(SamplingResponse.class);
+
+        when(sampling.isSupported()).thenReturn(true);
+        when(sampling.requestBuilder()).thenReturn(builder);
+        when(builder.setMaxTokens(100L)).thenReturn(builder);
+        when(builder.setSystemPrompt("You are helpful")).thenReturn(builder);
+        when(builder.addMessage(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(request);
+        when(request.send()).thenReturn(Uni.createFrom().item(response));
+
+        when(response.model()).thenReturn("test-model");
+        when(response.stopReason()).thenReturn("stop");
+        TextContent textContent = new TextContent("hi there");
+        when(response.content()).thenReturn(textContent);
+
+        // Act
+        CompletableFuture<JsonNode> future =
+                bridge.createSamplingHandler(address).handleSampling(params);
+        JsonNode result = future.get(5, TimeUnit.SECONDS);
+
+        // Assert
+        verify(sampling).requestBuilder();
+        verify(builder).setMaxTokens(100L);
+        verify(builder).setSystemPrompt("You are helpful");
+        verify(builder).build();
+
+        assertThat(result.get("model").asText()).isEqualTo("test-model");
+        assertThat(result.get("stopReason").asText()).isEqualTo("stop");
+        assertThat(result.get("content").get("text").asText()).isEqualTo("hi there");
+    }
+}

--- a/core/core-mcp-client/pom.xml
+++ b/core/core-mcp-client/pom.xml
@@ -21,6 +21,37 @@
             <artifactId>langchain4j-mcp</artifactId>
             <version>${langchain4j-mcp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
@@ -9,6 +9,31 @@ import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 public class ClientUtil {
 
     public static McpClient createClient(String address) {
+        return createClient(address, null, null);
+    }
+
+    public static McpClient createClient(String address, McpSamplingHandler samplingHandler) {
+        return createClient(address, samplingHandler, null);
+    }
+
+    /**
+     * Creates a new {@link McpClient} with optional sampling and elicitation support.
+     * <p>
+     * When a non-null {@code samplingHandler} is provided, the transport is wrapped with
+     * {@link SamplingMcpTransport} to handle server-initiated {@code sampling/createMessage}
+     * requests.
+     * <p>
+     * When a non-null {@code elicitationHandler} is provided, the transport is wrapped with
+     * {@link ElicitationMcpTransport} to handle server-initiated {@code elicitation/create}
+     * requests.
+     *
+     * @param address            the remote MCP server address
+     * @param samplingHandler    optional handler for sampling requests (may be {@code null})
+     * @param elicitationHandler optional handler for elicitation requests (may be {@code null})
+     * @return a new {@link McpClient} instance
+     */
+    public static McpClient createClient(
+            String address, McpSamplingHandler samplingHandler, McpElicitationHandler elicitationHandler) {
         McpTransport transport;
         if (address.endsWith("sse") || address.endsWith("sse/")) {
             transport = new HttpMcpTransport.Builder()
@@ -22,6 +47,14 @@ public class ClientUtil {
                     .logRequests(true)
                     .logResponses(true)
                     .build();
+        }
+
+        if (samplingHandler != null) {
+            transport = new SamplingMcpTransport(transport, samplingHandler);
+        }
+
+        if (elicitationHandler != null) {
+            transport = new ElicitationMcpTransport(transport, elicitationHandler);
         }
 
         return new DefaultMcpClient.Builder().transport(transport).build();

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ElicitationMcpTransport.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ElicitationMcpTransport.java
@@ -1,0 +1,177 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+
+/**
+ * A decorating {@link McpTransport} that intercepts {@code elicitation/create} server-to-client
+ * JSON-RPC requests and delegates them to a {@link McpElicitationHandler}.
+ *
+ * <p>The Wanaku bridge acts as an MCP client towards remote MCP servers. When one of those
+ * servers emits an {@code elicitation/create} request (asking the client for user input),
+ * this transport intercepts the message before it reaches the default handler, delegates
+ * the call to the configured {@link McpElicitationHandler}, and sends the JSON-RPC response
+ * back through the delegate transport.</p>
+ *
+ * <p>All other MCP messages are forwarded unchanged to the original {@link McpOperationHandler}.</p>
+ */
+public class ElicitationMcpTransport implements McpTransport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElicitationMcpTransport.class);
+    private static final String ELICITATION_CREATE_METHOD = "elicitation/create";
+
+    static {
+        try {
+            Class<?> capabilitiesClass = Class.forName("dev.langchain4j.mcp.protocol.McpInitializeParams$Capabilities");
+            int registered =
+                    McpOperationHandlerReflection.registerObjectMapperMixIn(capabilitiesClass, CapabilitiesMixIn.class);
+            if (registered > 0) {
+                LOG.debug("Elicitation capability mix-in registered on {} OBJECT_MAPPER instance(s)", registered);
+            }
+        } catch (ClassNotFoundException e) {
+            LOG.warn(
+                    "McpInitializeParams$Capabilities class not found; "
+                            + "langchain4j-mcp version may have changed. "
+                            + "Elicitation capability will not be announced: {}",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * A Mix-In to inject the elicitation capability into the MCP initialization request.
+     */
+    public interface CapabilitiesMixIn {
+        @com.fasterxml.jackson.annotation.JsonProperty("elicitation")
+        default Object getElicitation() {
+            return java.util.Map.of("form", java.util.Map.of(), "url", java.util.Map.of());
+        }
+    }
+
+    private final McpTransport delegate;
+    private final McpElicitationHandler elicitationHandler;
+
+    public ElicitationMcpTransport(McpTransport delegate, McpElicitationHandler elicitationHandler) {
+        this.delegate = delegate;
+        this.elicitationHandler = elicitationHandler;
+    }
+
+    @Override
+    public void start(McpOperationHandler originalHandler) {
+        try {
+            Consumer<JsonNode> interceptingHandle = this::handleElicitationRequest;
+            McpOperationHandler interceptingHandler = McpOperationHandlerReflection.createInterceptingHandler(
+                    originalHandler, this, interceptingHandle, ELICITATION_CREATE_METHOD);
+            delegate.start(interceptingHandler);
+        } catch (IllegalStateException e) {
+            LOG.error(
+                    "Failed to wrap McpOperationHandler for elicitation support. "
+                            + "This typically indicates an incompatible langchain4j-mcp version: {}",
+                    e.getMessage());
+            throw new RuntimeException("Failed to wrap McpOperationHandler for elicitation support", e);
+        }
+    }
+
+    private void handleElicitationRequest(JsonNode node) {
+        JsonNode id = node.get("id");
+        JsonNode params = node.get("params");
+
+        elicitationHandler
+                .handleElicitation(params)
+                .thenAccept(result -> {
+                    delegate.executeOperationWithoutResponse(new ElicitationResponseMessage(id.asLong(), result));
+                })
+                .exceptionally(ex -> {
+                    LOG.warn("Elicitation request failed: {}", ex.getMessage());
+                    ObjectNode errNode = JsonNodeFactory.instance.objectNode();
+                    errNode.put("code", -32603);
+                    errNode.put("message", ex.getMessage());
+                    delegate.executeOperationWithoutResponse(new ElicitationErrorMessage(id.asLong(), errNode));
+                    return null;
+                });
+    }
+
+    // ---- McpTransport delegation ----
+
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return delegate.initialize(request);
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+        return delegate.executeOperationWithResponse(operation);
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
+        delegate.executeOperationWithoutResponse(operation);
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(dev.langchain4j.mcp.client.McpCallContext context) {
+        return delegate.executeOperationWithResponse(context);
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(dev.langchain4j.mcp.client.McpCallContext context) {
+        delegate.executeOperationWithoutResponse(context);
+    }
+
+    @Override
+    public void checkHealth() {
+        delegate.checkHealth();
+    }
+
+    @Override
+    public void onFailure(Runnable runnable) {
+        delegate.onFailure(runnable);
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        delegate.close();
+    }
+
+    // ---- Inner message types ----
+
+    /**
+     * JSON-RPC success response for an {@code elicitation/create} request.
+     */
+    public static class ElicitationResponseMessage extends McpClientMessage {
+        private final JsonNode result;
+
+        public ElicitationResponseMessage(Long id, JsonNode result) {
+            super(id, null);
+            this.result = result;
+        }
+
+        public JsonNode getResult() {
+            return result;
+        }
+    }
+
+    /**
+     * JSON-RPC error response for an {@code elicitation/create} request.
+     */
+    public static class ElicitationErrorMessage extends McpClientMessage {
+        private final JsonNode error;
+
+        public ElicitationErrorMessage(Long id, JsonNode error) {
+            super(id, null);
+            this.error = error;
+        }
+
+        public JsonNode getError() {
+            return error;
+        }
+    }
+}

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpElicitationHandler.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpElicitationHandler.java
@@ -1,0 +1,25 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.concurrent.CompletableFuture;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Handler for MCP elicitation requests.
+ * <p>
+ * When a remote MCP server sends an {@code elicitation/create} request, this handler
+ * is responsible for delegating it to the client-side elicitation infrastructure
+ * (e.g., Quarkus MCP {@code Elicitation} API) and returning the structured response.
+ */
+@FunctionalInterface
+public interface McpElicitationHandler {
+
+    /**
+     * Handles an {@code elicitation/create} request.
+     *
+     * @param params The {@code "params"} object from the JSON-RPC request, containing
+     *               {@code "message"} and {@code "requestedSchema"}.
+     * @return A {@link CompletableFuture} that completes with the JSON-RPC {@code "result"}
+     *         object, containing {@code "action"} and {@code "content"} fields.
+     */
+    CompletableFuture<JsonNode> handleElicitation(JsonNode params);
+}

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpOperationHandlerReflection.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpOperationHandlerReflection.java
@@ -1,0 +1,172 @@
+package ai.wanaku.core.mcp.client;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.mcp.client.McpRoot;
+import dev.langchain4j.mcp.client.logging.McpLogMessage;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+
+/**
+ * Centralizes the reflection logic required to extract internal fields from
+ * {@link McpOperationHandler} and to register Jackson mix-ins on static
+ * {@code OBJECT_MAPPER} fields in langchain4j-mcp transport classes.
+ *
+ * <p>This class exists because langchain4j-mcp does not expose the internal
+ * state of {@code McpOperationHandler} through public API, so transport
+ * decorators (e.g. {@link SamplingMcpTransport}, {@link ElicitationMcpTransport})
+ * must use reflection to reconstruct a handler with the same wiring but an
+ * overridden {@code handle()} method. Centralizing this logic here ensures
+ * that version-related reflection failures are logged clearly and fail fast
+ * rather than surfacing as obscure runtime errors.</p>
+ */
+public final class McpOperationHandlerReflection {
+
+    private static final Logger LOG = LoggerFactory.getLogger(McpOperationHandlerReflection.class);
+
+    private static final String[] OBJECT_MAPPER_HOLDER_CLASSES = {
+        "dev.langchain4j.mcp.client.DefaultMcpClient",
+        "dev.langchain4j.mcp.client.transport.http.HttpMcpTransport",
+        "dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport"
+    };
+
+    private McpOperationHandlerReflection() {}
+
+    /**
+     * Extracts the internal state from an existing {@link McpOperationHandler}
+     * and creates a new one that delegates all non-intercepted messages to the
+     * original handler's {@code handle()} method, while routing intercepted
+     * method calls through the provided {@code interceptingHandle} consumer.
+     *
+     * @param original       the original handler whose fields will be extracted
+     * @param transport      the transport reference to embed in the new handler
+     *                       (typically the decorating transport)
+     * @param interceptingHandle a consumer that receives {@link JsonNode} messages
+     *                       matching the intercepted method; it is called instead
+     *                       of the original handler for those messages
+     * @param interceptedMethod the JSON-RPC method name to intercept (e.g.
+     *                       {@code "sampling/createMessage"} or
+     *                       {@code "elicitation/create"})
+     * @return a new {@link McpOperationHandler} with the intercepted handle logic
+     * @throws IllegalStateException if any required field cannot be extracted
+     *                               from the original handler (i.e. the
+     *                               langchain4j-mcp version has changed)
+     */
+    @SuppressWarnings("unchecked")
+    public static McpOperationHandler createInterceptingHandler(
+            McpOperationHandler original,
+            McpTransport transport,
+            Consumer<JsonNode> interceptingHandle,
+            String interceptedMethod) {
+
+        Map<Long, CompletableFuture<JsonNode>> pendingOperations = extractField(original, "pendingOperations");
+        Supplier<List<McpRoot>> roots = extractField(original, "roots");
+        Consumer<McpLogMessage> logMessageConsumer = extractField(original, "logMessageConsumer");
+        Runnable onToolListUpdate = extractField(original, "onToolListUpdate");
+        Runnable onResourceListUpdate = extractField(original, "onResourceListUpdate");
+        Runnable onPromptListUpdate = extractField(original, "onPromptListUpdate");
+        Consumer<String> onResourceUpdate = extractField(original, "onResourceUpdate");
+        McpProgressHandler progressHandler = extractField(original, "progressHandler");
+
+        return new McpOperationHandler(
+                pendingOperations,
+                roots,
+                transport,
+                logMessageConsumer,
+                onToolListUpdate,
+                onResourceListUpdate,
+                onPromptListUpdate,
+                onResourceUpdate,
+                progressHandler) {
+            @Override
+            public void handle(JsonNode node) {
+                if (node.has("method")
+                        && interceptedMethod.equals(node.get("method").asText())) {
+                    interceptingHandle.accept(node);
+                } else {
+                    original.handle(node);
+                }
+            }
+        };
+    }
+
+    /**
+     * Registers a Jackson mix-in on the static {@code OBJECT_MAPPER} fields of
+     * known langchain4j-mcp classes to inject additional serialization behavior
+     * (e.g. the elicitation capability into MCP initialization requests).
+     *
+     * <p>Each candidate class is attempted independently; if a class is not on
+     * the classpath or does not have the expected static field, it is silently
+     * skipped. If the field exists but cannot be accessed, a warning is logged.</p>
+     *
+     * @param mixInTargetClass the class to which the mix-in should be applied
+     * @param mixInClass       the mix-in interface/class that defines the
+     *                         additional or overridden Jackson annotations
+     * @return the number of classes where the mix-in was successfully registered
+     */
+    public static int registerObjectMapperMixIn(Class<?> mixInTargetClass, Class<?> mixInClass) {
+        int registered = 0;
+        for (String className : OBJECT_MAPPER_HOLDER_CLASSES) {
+            try {
+                Class<?> clazz = Class.forName(className);
+                Field field = clazz.getDeclaredField("OBJECT_MAPPER");
+                field.setAccessible(true);
+                com.fasterxml.jackson.databind.ObjectMapper mapper =
+                        (com.fasterxml.jackson.databind.ObjectMapper) field.get(null);
+                mapper.addMixIn(mixInTargetClass, mixInClass);
+                registered++;
+                LOG.debug("Registered mix-in {} on {} OBJECT_MAPPER", mixInClass.getSimpleName(), className);
+            } catch (ClassNotFoundException e) {
+                LOG.debug("Class {} not on classpath, skipping mix-in registration", className);
+            } catch (NoSuchFieldException e) {
+                LOG.warn(
+                        "Class {} does not have OBJECT_MAPPER field; "
+                                + "langchain4j-mcp version may have changed. "
+                                + "Mix-in registration skipped for this class.",
+                        className);
+            } catch (IllegalAccessException e) {
+                LOG.warn(
+                        "Cannot access OBJECT_MAPPER field on {}; " + "mix-in registration skipped: {}",
+                        className,
+                        e.getMessage());
+            } catch (Exception e) {
+                LOG.warn("Unexpected error registering mix-in on {}: {}", className, e.getMessage());
+            }
+        }
+        if (registered == 0) {
+            LOG.warn(
+                    "No OBJECT_MAPPER instances found for mix-in registration; "
+                            + "langchain4j-mcp version may have changed. "
+                            + "Expected fields on: {}",
+                    String.join(", ", OBJECT_MAPPER_HOLDER_CLASSES));
+        }
+        return registered;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T extractField(McpOperationHandler handler, String fieldName) {
+        try {
+            Field field = handler.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(handler);
+        } catch (NoSuchFieldException e) {
+            String msg = "McpOperationHandler does not have field '" + fieldName
+                    + "'; langchain4j-mcp version may have changed. "
+                    + "Please update the reflection logic in McpOperationHandlerReflection.";
+            LOG.error(msg);
+            throw new IllegalStateException(msg, e);
+        } catch (IllegalAccessException e) {
+            String msg = "Cannot access field '" + fieldName + "' on McpOperationHandler: " + e.getMessage();
+            LOG.error(msg);
+            throw new IllegalStateException(msg, e);
+        }
+    }
+}

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpSamplingHandler.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/McpSamplingHandler.java
@@ -1,0 +1,19 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.concurrent.CompletableFuture;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Handler for MCP sampling requests.
+ */
+@FunctionalInterface
+public interface McpSamplingHandler {
+
+    /**
+     * Handles a sampling/createMessage request.
+     *
+     * @param params The "params" object from the JSON-RPC request.
+     * @return A CompletableFuture that completes with the JSON-RPC "result" object.
+     */
+    CompletableFuture<JsonNode> handleSampling(JsonNode params);
+}

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/SamplingMcpTransport.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/SamplingMcpTransport.java
@@ -1,0 +1,129 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
+import dev.langchain4j.mcp.protocol.McpClientResponse;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+
+public class SamplingMcpTransport implements McpTransport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SamplingMcpTransport.class);
+    private static final String SAMPLING_CREATE_METHOD = "sampling/createMessage";
+
+    private final McpTransport delegate;
+    private final McpSamplingHandler samplingHandler;
+
+    public SamplingMcpTransport(McpTransport delegate, McpSamplingHandler samplingHandler) {
+        this.delegate = delegate;
+        this.samplingHandler = samplingHandler;
+    }
+
+    @Override
+    public void start(McpOperationHandler originalHandler) {
+        try {
+            Consumer<JsonNode> interceptingHandle = this::handleSamplingRequest;
+            McpOperationHandler interceptingHandler = McpOperationHandlerReflection.createInterceptingHandler(
+                    originalHandler, this, interceptingHandle, SAMPLING_CREATE_METHOD);
+            delegate.start(interceptingHandler);
+        } catch (IllegalStateException e) {
+            LOG.error(
+                    "Failed to wrap McpOperationHandler for sampling support. "
+                            + "This typically indicates an incompatible langchain4j-mcp version: {}",
+                    e.getMessage());
+            throw new RuntimeException("Failed to wrap McpOperationHandler for sampling support", e);
+        }
+    }
+
+    private void handleSamplingRequest(JsonNode node) {
+        JsonNode id = node.get("id");
+        JsonNode params = node.get("params");
+        samplingHandler
+                .handleSampling(params)
+                .thenAccept(result -> {
+                    delegate.executeOperationWithoutResponse(new SamplingResponseMessage(id.asLong(), result));
+                })
+                .exceptionally(ex -> {
+                    LOG.warn("Sampling request failed: {}", ex.getMessage());
+                    ObjectNode errNode = JsonNodeFactory.instance.objectNode();
+                    errNode.put("code", -32603);
+                    errNode.put("message", ex.getMessage());
+                    delegate.executeOperationWithoutResponse(new SamplingErrorMessage(id.asLong(), errNode));
+                    return null;
+                });
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+        return delegate.initialize(request);
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+        return delegate.executeOperationWithResponse(operation);
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(
+            dev.langchain4j.mcp.client.McpCallContext callContext) {
+        return delegate.executeOperationWithResponse(callContext);
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
+        delegate.executeOperationWithoutResponse(operation);
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(dev.langchain4j.mcp.client.McpCallContext callContext) {
+        delegate.executeOperationWithoutResponse(callContext);
+    }
+
+    @Override
+    public void checkHealth() {
+        delegate.checkHealth();
+    }
+
+    @Override
+    public void onFailure(Runnable runnable) {
+        delegate.onFailure(runnable);
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        delegate.close();
+    }
+
+    public static class SamplingResponseMessage extends McpClientResponse {
+        private final JsonNode result;
+
+        public SamplingResponseMessage(Long id, JsonNode result) {
+            super(id);
+            this.result = result;
+        }
+
+        public JsonNode getResult() {
+            return result;
+        }
+    }
+
+    public static class SamplingErrorMessage extends McpClientResponse {
+        private final JsonNode error;
+
+        public SamplingErrorMessage(Long id, JsonNode error) {
+            super(id);
+            this.error = error;
+        }
+
+        public JsonNode getError() {
+            return error;
+        }
+    }
+}

--- a/core/core-mcp-client/src/test/java/ai/wanaku/core/mcp/client/ElicitationMcpTransportTest.java
+++ b/core/core-mcp-client/src/test/java/ai/wanaku/core/mcp/client/ElicitationMcpTransportTest.java
@@ -1,0 +1,180 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.jspecify.annotations.NonNull;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.mcp.client.McpRoot;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ElicitationMcpTransportTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldInterceptElicitationRequest() throws Exception {
+        // Arrange
+        McpTransport delegate = mock(McpTransport.class);
+        McpElicitationHandler elicitationHandler = mock(McpElicitationHandler.class);
+        try (ElicitationMcpTransport transport = new ElicitationMcpTransport(delegate, elicitationHandler)) {
+
+            McpOperationHandler originalHandler = getOperationHandler(delegate);
+
+            // Start transport — installs the intercepting handler
+            transport.start(originalHandler);
+
+            // Capture the intercepting handler registered with the delegate
+            ArgumentCaptor<McpOperationHandler> handlerCaptor = ArgumentCaptor.forClass(McpOperationHandler.class);
+            verify(delegate).start(handlerCaptor.capture());
+            McpOperationHandler interceptingHandler = handlerCaptor.getValue();
+
+            // Build an elicitation/create request
+            ObjectNode request = mapper.createObjectNode();
+            request.put("id", 42L);
+            request.put("method", "elicitation/create");
+            ObjectNode params = request.putObject("params");
+            params.put("message", "What is your name?");
+            ObjectNode schema = params.putObject("requestedSchema");
+            ObjectNode properties = schema.putObject("properties");
+            ObjectNode nameProp = properties.putObject("name");
+            nameProp.put("type", "string");
+
+            // The handler returns a successful result
+            ObjectNode result = mapper.createObjectNode();
+            result.put("action", "accept");
+            ObjectNode content = result.putObject("content");
+            content.put("name", "Alice");
+
+            when(elicitationHandler.handleElicitation(any())).thenReturn(CompletableFuture.completedFuture(result));
+
+            // Act — feed the elicitation request to the intercepting handler
+            interceptingHandler.handle(request);
+
+            // Assert — handler was invoked
+            verify(elicitationHandler).handleElicitation(any());
+
+            // Assert — response was sent back through the delegate transport
+            ArgumentCaptor<ElicitationMcpTransport.ElicitationResponseMessage> responseCaptor =
+                    ArgumentCaptor.forClass(ElicitationMcpTransport.ElicitationResponseMessage.class);
+            verify(delegate).executeOperationWithoutResponse(responseCaptor.capture());
+
+            ElicitationMcpTransport.ElicitationResponseMessage response = responseCaptor.getValue();
+            assertThat(response.getId()).isEqualTo(42L);
+            assertThat(response.getResult().get("action").asText()).isEqualTo("accept");
+            assertThat(response.getResult().get("content").get("name").asText()).isEqualTo("Alice");
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldNotInterceptNonElicitationMessages() throws Exception {
+        // Arrange
+        McpTransport delegate = mock(McpTransport.class);
+        McpElicitationHandler elicitationHandler = mock(McpElicitationHandler.class);
+        try (ElicitationMcpTransport transport = new ElicitationMcpTransport(delegate, elicitationHandler)) {
+
+            McpOperationHandler originalHandler = getOperationHandler(delegate);
+
+            transport.start(originalHandler);
+
+            ArgumentCaptor<McpOperationHandler> handlerCaptor = ArgumentCaptor.forClass(McpOperationHandler.class);
+            verify(delegate).start(handlerCaptor.capture());
+            McpOperationHandler interceptingHandler = handlerCaptor.getValue();
+
+            // Build a sampling request (a different method — should NOT be intercepted)
+            ObjectNode request = mapper.createObjectNode();
+            request.put("id", 99L);
+            request.put("method", "sampling/createMessage");
+            request.putObject("params");
+
+            // Act
+            interceptingHandler.handle(request);
+
+            // Assert — elicitation handler was NOT called
+            verify(elicitationHandler, never()).handleElicitation(any());
+        }
+    }
+
+    private static @NonNull McpOperationHandler getOperationHandler(McpTransport delegate) {
+        Map<Long, CompletableFuture<JsonNode>> pendingOperations = new HashMap<>();
+        Supplier<List<McpRoot>> roots = Collections::emptyList;
+        Consumer<JsonNode> logMessageConsumer = node -> {};
+        Runnable onToolListUpdate = () -> {};
+
+        McpOperationHandler originalHandler = new McpOperationHandler(
+                (Map) pendingOperations,
+                (Supplier) roots,
+                delegate,
+                (Consumer) logMessageConsumer,
+                onToolListUpdate,
+                () -> {},
+                () -> {},
+                (str) -> {},
+                null);
+        return originalHandler;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldSendErrorResponseWhenHandlerFails() throws Exception {
+        // Arrange
+        McpTransport delegate = mock(McpTransport.class);
+        McpElicitationHandler elicitationHandler = mock(McpElicitationHandler.class);
+        try (ElicitationMcpTransport transport = new ElicitationMcpTransport(delegate, elicitationHandler)) {
+
+            McpOperationHandler originalHandler = getMcpOperationHandler(delegate);
+
+            transport.start(originalHandler);
+
+            ArgumentCaptor<McpOperationHandler> handlerCaptor = ArgumentCaptor.forClass(McpOperationHandler.class);
+            verify(delegate).start(handlerCaptor.capture());
+            McpOperationHandler interceptingHandler = handlerCaptor.getValue();
+
+            // Build a request
+            ObjectNode request = mapper.createObjectNode();
+            request.put("id", 7L);
+            request.put("method", "elicitation/create");
+            request.putObject("params").put("message", "confirm?");
+
+            // Handler throws
+            when(elicitationHandler.handleElicitation(any()))
+                    .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Elicitation not supported")));
+
+            // Act
+            interceptingHandler.handle(request);
+
+            // Assert — error response was sent
+            ArgumentCaptor<ElicitationMcpTransport.ElicitationErrorMessage> errorCaptor =
+                    ArgumentCaptor.forClass(ElicitationMcpTransport.ElicitationErrorMessage.class);
+            verify(delegate).executeOperationWithoutResponse(errorCaptor.capture());
+
+            ElicitationMcpTransport.ElicitationErrorMessage error = errorCaptor.getValue();
+            assertThat(error.getId()).isEqualTo(7L);
+            assertThat(error.getError().get("code").asInt()).isEqualTo(-32603);
+            assertThat(error.getError().get("message").asText()).contains("not supported");
+        }
+    }
+
+    private static @NonNull McpOperationHandler getMcpOperationHandler(McpTransport delegate) {
+        McpOperationHandler originalHandler = getOperationHandler(delegate);
+        return originalHandler;
+    }
+}

--- a/core/core-mcp-client/src/test/java/ai/wanaku/core/mcp/client/SamplingMcpTransportTest.java
+++ b/core/core-mcp-client/src/test/java/ai/wanaku/core/mcp/client/SamplingMcpTransportTest.java
@@ -1,0 +1,87 @@
+package ai.wanaku.core.mcp.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.mcp.client.McpRoot;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SamplingMcpTransportTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldInterceptSamplingRequest() throws Exception {
+        // Arrange
+        McpTransport delegate = mock(McpTransport.class);
+        McpSamplingHandler samplingHandler = mock(McpSamplingHandler.class);
+        try (SamplingMcpTransport transport = new SamplingMcpTransport(delegate, samplingHandler)) {
+
+            Map<Long, CompletableFuture<JsonNode>> pendingOperations = new HashMap<>();
+            Supplier<List<McpRoot>> roots = Collections::emptyList;
+            Consumer<JsonNode> logMessageConsumer = node -> {};
+            Runnable onToolListUpdate = () -> {};
+
+            McpOperationHandler originalHandler = new McpOperationHandler(
+                    (Map) pendingOperations,
+                    (Supplier) roots,
+                    delegate,
+                    (Consumer) logMessageConsumer,
+                    onToolListUpdate,
+                    () -> {},
+                    () -> {},
+                    (str) -> {},
+                    null);
+
+            // When
+            transport.start(originalHandler);
+
+            // Capture the intercepting handler
+            ArgumentCaptor<McpOperationHandler> handlerCaptor = ArgumentCaptor.forClass(McpOperationHandler.class);
+            verify(delegate).start(handlerCaptor.capture());
+            McpOperationHandler interceptingHandler = handlerCaptor.getValue();
+
+            // Simulate a sampling request
+            ObjectNode request = mapper.createObjectNode();
+            request.put("id", 123L);
+            request.put("method", "sampling/createMessage");
+            ObjectNode params = request.putObject("params");
+            params.put("prompt", "hello");
+
+            ObjectNode result = mapper.createObjectNode();
+            result.put("text", "hi");
+            when(samplingHandler.handleSampling(any())).thenReturn(CompletableFuture.completedFuture(result));
+
+            // Act
+            interceptingHandler.handle(request);
+
+            // Assert
+            verify(samplingHandler).handleSampling(any());
+
+            ArgumentCaptor<SamplingMcpTransport.SamplingResponseMessage> responseCaptor =
+                    ArgumentCaptor.forClass(SamplingMcpTransport.SamplingResponseMessage.class);
+            verify(delegate).executeOperationWithoutResponse(responseCaptor.capture());
+
+            SamplingMcpTransport.SamplingResponseMessage response = responseCaptor.getValue();
+            assertThat(response.getId()).isEqualTo(123L);
+            assertThat(response.getResult()).isEqualTo(result);
+        }
+    }
+}


### PR DESCRIPTION
This pull request follows the specification: https://modelcontextprotocol.io/specification/2025-11-25/client/sampling and  https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation

Closes: #611 and Closes: #612

## Summary by Sourcery

Add MCP sampling support across the router backend and core MCP client, wiring sampling handlers through the transport layer so servers can initiate sampling/createMessage requests and have them fulfilled by the local sampling implementation.

New Features:
- Support MCP sampling/createMessage requests via a new sampling-aware transport wrapper and handler interface.
- Propagate sampling context from tool and resource operations to the MCP bridge so responses can be generated using the correct sampling configuration.

Enhancements:
- Extend ForwardClient and client utility creation to accept optional sampling handlers and wrap transports when provided.

Build:
- Add JUnit 5, AssertJ, Mockito, and Surefire plugin configuration to the core MCP client module to support new unit tests.

Tests:
- Add unit tests for the sampling-aware MCP transport interceptor and the backend MCP bridge sampling handler behavior.

## Summary by Sourcery

Add end-to-end support for MCP sampling and elicitation requests by wiring local Quarkus sampling/elicitation infrastructure through the MCP client, transport, and router backend bridge.

New Features:
- Support MCP sampling/createMessage requests via a sampling-aware transport wrapper and bridge-level handler that delegate to the local Sampling API.
- Support MCP elicitation/create requests via an elicitation-aware transport wrapper and bridge-level handler that delegate to the local Elicitation API.
- Allow ForwardClient and core MCP client utilities to be constructed with optional sampling and elicitation handlers so remote servers can initiate these flows over existing transports.

Enhancements:
- Track active sampling and elicitation contexts per MCP connection in the router backend so tool and resource operations use the correct client-side configuration.

Build:
- Configure JUnit 5, AssertJ, Mockito, and Maven Surefire in the core MCP client module to enable new unit tests.

Tests:
- Add unit tests for sampling handling in the router MCP bridge and sampling-aware client transport.
- Add unit tests for elicitation handling in the router MCP bridge and elicitation-aware client transport.