### PR TITLE
chore: fix JReleaser artifact paths after CLI module rename

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -44,7 +44,7 @@ release:
 distributions:
   cli:
     artifacts:
-      - path: apps/wanaku-cli/target/distributions/cli-{{projectVersion}}.zip
+      - path: apps/wanaku-cli/target/distributions/wanaku-cli-{{projectVersion}}.zip
     type: JAVA_BINARY
   router:
     artifacts:
@@ -79,9 +79,9 @@ distributions:
 
   cli-native:
     artifacts:
-      - path: apps/wanaku-cli/target/distributions/cli-{{projectVersion}}-osx-aarch_64.zip
+      - path: apps/wanaku-cli/target/distributions/wanaku-cli-{{projectVersion}}-osx-aarch_64.zip
         platform: osx-aarch_64
-      - path: apps/wanaku-cli/target/distributions/cli-{{projectVersion}}-linux-x86_64.zip
+      - path: apps/wanaku-cli/target/distributions/wanaku-cli-{{projectVersion}}-linux-x86_64.zip
         platform: linux-x86_64
 
 packagers:


### PR DESCRIPTION
## Summary
- Fix early-access build failure caused by JReleaser looking for `cli-{version}.zip` instead of `wanaku-cli-{version}.zip`
- The CLI module was renamed from `cli` to `wanaku-cli` in #902, but the artifact filenames in `jreleaser.yml` were not updated to match the new artifactId

## Test plan
- [ ] Trigger early-access workflow and verify JReleaser finds the artifacts

## Summary by Sourcery

Build:
- Update JReleaser artifact paths to reference wanaku-cli ZIP filenames for standard and native CLI distributions.