### PR TITLE
Fix #843: Use dynamic version from VersionHelper instead of static server version

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
@@ -7,7 +7,6 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Logger;
-import io.quarkus.runtime.Startup;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.MutinyEmitter;
 import ai.wanaku.backend.bridge.EventNotifier;
@@ -25,11 +24,6 @@ import picocli.CommandLine;
 @ApplicationScoped
 public class ToolsProvider {
     private static final Logger LOG = Logger.getLogger(ToolsProvider.class);
-
-    @Startup
-    void setVersion() {
-        System.setProperty("wanaku.version", VersionHelper.VERSION);
-    }
 
     @Inject
     CommandLine.ParseResult parseResult;

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -39,7 +39,6 @@ quarkus.mcp.server.traffic-logging.enabled=true
 quarkus.mcp.server.traffic-logging.text-limit=1000000
 quarkus.mcp.server.server-info.name=Wanaku
 quarkus.mcp.server.client-logging.default-level=debug
-quarkus.mcp.server.server-info.version=${wanaku.version:0.1.0}
 
 # Auth
 quarkus.oidc.enabled=true


### PR DESCRIPTION
## Summary
- Replace static `0.1.0` in `quarkus.mcp.server.server-info.version` with a property expression `${wanaku.version:0.1.0}`
- Add a `@Startup` method in `ToolsProvider` that sets the `wanaku.version` system property from `VersionHelper.VERSION`

## Test plan
- [x] Full build passes (`mvn verify`)

## Summary by Sourcery

Use a dynamically configured application version for MCP server metadata instead of a hard-coded value.

Enhancements:
- Initialize a wanaku.version system property at startup from VersionHelper.VERSION for centralized version management.
- Reference the wanaku.version property in MCP server-info configuration with a default fallback version.