### PR TITLE
chore: fix generated CRDs missing status conditions

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucapabilities.wanaku.ai-v1.yml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucapabilities.wanaku.ai-v1.yml
@@ -59,9 +59,6 @@ spec:
           status:
             properties:
               conditions:
-                x-kubernetes-list-type: "map"
-                x-kubernetes-list-map-keys:
-                  - "type"
                 items:
                   properties:
                     lastTransitionTime:
@@ -69,7 +66,6 @@ spec:
                     message:
                       type: "string"
                     observedGeneration:
-                      format: "int64"
                       type: "integer"
                     reason:
                       type: "string"

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakurouters.wanaku.ai-v1.yml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakurouters.wanaku.ai-v1.yml
@@ -56,9 +56,6 @@ spec:
           status:
             properties:
               conditions:
-                x-kubernetes-list-type: "map"
-                x-kubernetes-list-map-keys:
-                  - "type"
                 items:
                   properties:
                     lastTransitionTime:
@@ -66,7 +63,6 @@ spec:
                     message:
                       type: "string"
                     observedGeneration:
-                      format: "int64"
                       type: "integer"
                     reason:
                       type: "string"

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
-import io.fabric8.kubernetes.api.model.Condition;
-import io.fabric8.kubernetes.api.model.ConditionBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
@@ -22,6 +20,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.openshift.api.model.Route;
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import ai.wanaku.operator.wanaku.StatusCondition;
 import ai.wanaku.operator.wanaku.WanakuCapability;
 import ai.wanaku.operator.wanaku.WanakuCapabilityReconciler;
 import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
@@ -51,24 +50,24 @@ public final class OperatorUtil {
 
     private OperatorUtil() {}
 
-    public static Condition readyCondition(Long generation, Condition previousCondition, String message) {
+    public static StatusCondition readyCondition(Long generation, StatusCondition previousCondition, String message) {
         final boolean alreadyReady =
                 previousCondition != null && CONDITION_STATUS_TRUE.equals(previousCondition.getStatus());
         final String lastTransitionTime = alreadyReady && previousCondition.getLastTransitionTime() != null
                 ? previousCondition.getLastTransitionTime()
                 : OffsetDateTime.now(ZoneOffset.UTC).toString();
 
-        return new ConditionBuilder()
-                .withType(READY_CONDITION)
-                .withStatus(CONDITION_STATUS_TRUE)
-                .withObservedGeneration(generation)
-                .withLastTransitionTime(lastTransitionTime)
-                .withReason(CONDITION_REASON_READY)
-                .withMessage(message)
-                .build();
+        StatusCondition condition = new StatusCondition();
+        condition.setType(READY_CONDITION);
+        condition.setStatus(CONDITION_STATUS_TRUE);
+        condition.setObservedGeneration(generation);
+        condition.setLastTransitionTime(lastTransitionTime);
+        condition.setReason(CONDITION_REASON_READY);
+        condition.setMessage(message);
+        return condition;
     }
 
-    public static Condition findCondition(List<Condition> conditions, String type) {
+    public static StatusCondition findCondition(List<StatusCondition> conditions, String type) {
         if (conditions == null || conditions.isEmpty() || type == null) {
             return null;
         }

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/StatusCondition.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/StatusCondition.java
@@ -1,0 +1,58 @@
+package ai.wanaku.operator.wanaku;
+
+public class StatusCondition {
+    private String lastTransitionTime;
+    private String message;
+    private Long observedGeneration;
+    private String reason;
+    private String status;
+    private String type;
+
+    public String getLastTransitionTime() {
+        return lastTransitionTime;
+    }
+
+    public void setLastTransitionTime(String lastTransitionTime) {
+        this.lastTransitionTime = lastTransitionTime;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Long getObservedGeneration() {
+        return observedGeneration;
+    }
+
+    public void setObservedGeneration(Long observedGeneration) {
+        this.observedGeneration = observedGeneration;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
@@ -4,7 +4,6 @@ import jakarta.inject.Inject;
 
 import java.util.List;
 import org.jboss.logging.Logger;
-import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -93,7 +92,7 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
 
         deployCapabilities(resource, context, namespace);
         final WanakuCapabilityStatus status = new WanakuCapabilityStatus();
-        final Condition previousReadyCondition = findCondition(
+        final StatusCondition previousReadyCondition = findCondition(
                 resource.getStatus() != null ? resource.getStatus().getConditions() : null, READY_CONDITION);
         status.setConditions(List.of(readyCondition(
                 resource.getMetadata().getGeneration(),

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityStatus.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityStatus.java
@@ -1,16 +1,15 @@
 package ai.wanaku.operator.wanaku;
 
 import java.util.List;
-import io.fabric8.kubernetes.api.model.Condition;
 
 public class WanakuCapabilityStatus {
-    private List<Condition> conditions;
+    private List<StatusCondition> conditions;
 
-    public List<Condition> getConditions() {
+    public List<StatusCondition> getConditions() {
         return conditions;
     }
 
-    public void setConditions(List<Condition> conditions) {
+    public void setConditions(List<StatusCondition> conditions) {
         this.conditions = conditions;
     }
 }

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -4,7 +4,6 @@ import jakarta.inject.Inject;
 
 import java.util.List;
 import org.jboss.logging.Logger;
-import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -113,7 +112,7 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
 
         final WanakuRouterStatus wanakuStatus = new WanakuRouterStatus();
         deployRouter(resource, context, namespace, wanakuStatus);
-        final Condition previousReadyCondition = findCondition(
+        final StatusCondition previousReadyCondition = findCondition(
                 resource.getStatus() != null ? resource.getStatus().getConditions() : null, READY_CONDITION);
         wanakuStatus.setConditions(List.of(readyCondition(
                 resource.getMetadata().getGeneration(), previousReadyCondition, "WanakuRouter deployment is ready")));

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterStatus.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterStatus.java
@@ -1,13 +1,12 @@
 package ai.wanaku.operator.wanaku;
 
 import java.util.List;
-import io.fabric8.kubernetes.api.model.Condition;
 
 public class WanakuRouterStatus {
     private String host;
     private String sseEndpoint;
     private String streamableEndpoint;
-    private List<Condition> conditions;
+    private List<StatusCondition> conditions;
 
     public String getHost() {
         return host;
@@ -33,11 +32,11 @@ public class WanakuRouterStatus {
         this.streamableEndpoint = streamableEndpoint;
     }
 
-    public List<Condition> getConditions() {
+    public List<StatusCondition> getConditions() {
         return conditions;
     }
 
-    public void setConditions(List<Condition> conditions) {
+    public void setConditions(List<StatusCondition> conditions) {
         this.conditions = conditions;
     }
 }

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
@@ -1,7 +1,6 @@
 package ai.wanaku.operator.util;
 
-import io.fabric8.kubernetes.api.model.Condition;
-import io.fabric8.kubernetes.api.model.ConditionBuilder;
+import ai.wanaku.operator.wanaku.StatusCondition;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,13 +47,12 @@ class OperatorUtilTest {
 
     @Test
     void readyConditionReusesTransitionTimeWhenAlreadyReady() {
-        Condition previous = new ConditionBuilder()
-                .withType(OperatorUtil.READY_CONDITION)
-                .withStatus(OperatorUtil.CONDITION_STATUS_TRUE)
-                .withLastTransitionTime("2024-01-01T00:00:00Z")
-                .build();
+        StatusCondition previous = new StatusCondition();
+        previous.setType(OperatorUtil.READY_CONDITION);
+        previous.setStatus(OperatorUtil.CONDITION_STATUS_TRUE);
+        previous.setLastTransitionTime("2024-01-01T00:00:00Z");
 
-        Condition current = OperatorUtil.readyCondition(7L, previous, "ready");
+        StatusCondition current = OperatorUtil.readyCondition(7L, previous, "ready");
 
         assertEquals("2024-01-01T00:00:00Z", current.getLastTransitionTime());
         assertEquals(OperatorUtil.READY_CONDITION, current.getType());


### PR DESCRIPTION
## Summary

- The Fabric8 CRD generator does not expand `io.fabric8.kubernetes.api.model.Condition` (treats it as an opaque Kubernetes type), causing generated CRDs to omit the `status.conditions` schema
- Introduced a local `StatusCondition` POJO with the same fields that the CRD generator can properly introspect
- Updated status classes, `OperatorUtil`, reconcilers, and tests to use `StatusCondition`
- Regenerated and synced deploy CRDs so they match the generated output

## Test plan
- [x] All 31 operator tests pass
- [x] Generated CRDs now include `status.conditions` with all properties
- [x] Deploy CRDs match generated CRDs (no manual edits needed)

## Summary by Sourcery

Ensure Wanaku custom resources expose a full status.conditions schema in generated and deployed CRDs by switching operator status handling to a local StatusCondition model.

Bug Fixes:
- Restore the status.conditions schema in generated WanakuCapability and WanakuRouter CRDs so conditions are properly described.

Enhancements:
- Introduce a local StatusCondition POJO and update operator utilities, status objects, and reconcilers to use it instead of the Fabric8 Condition type.
- Align checked-in deploy CRDs with the newly generated CRDs so no manual edits are required.