### PR TITLE
[737][UI] Refactor LLM page to single-view layout

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -1,0 +1,159 @@
+import React from "react"
+import {
+  Button,
+  Form,
+  Stack,
+  TextArea,
+  Tile
+} from "@carbon/react"
+import {Bot, Function_2, InformationSquare, Reply} from "@carbon/icons-react"
+import hljs from "highlight.js/lib/core"
+import json from "highlight.js/lib/languages/json"
+import yaml from "highlight.js/lib/languages/yaml"
+import xml from "highlight.js/lib/languages/xml"
+import ReactMarkdown from "react-markdown"
+import {MessageResponse} from "./messages.ts";
+
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerLanguage("xml", xml);
+
+
+const MessageItem = ({ message }) => {
+  let Icon
+  let title
+  
+  switch (message.role) {
+    case "assistant":
+      Icon = Bot
+      title = "Assistant"
+      break
+    case "tool-request":
+      Icon = Function_2
+      title = "Tool Request"
+      break
+    case "tool-response":
+      Icon = Reply
+      title = "Tool Response"
+      break
+    default:
+      Icon = InformationSquare
+      title = message.role
+  }
+  
+  return (
+    <div style={{ marginBottom: "2rem" }}>
+      <div style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+          fontWeight: "bold",
+        }}
+      >
+        <Icon />
+        {title}
+      </div>
+      <div className="message">
+        {(message.role === "tool-response" && (
+          <p dangerouslySetInnerHTML={{
+              __html: hljs.highlightAuto(message.content).value
+            }}
+          />
+        )) || <MarkdownRenderer content={ message.content } />
+        }
+      </div>
+    </div>
+  )
+}
+
+
+const MarkdownRenderer = ({ content }) => (
+  <ReactMarkdown
+    components={{
+      code({ className, children, ...props }) {
+        return (
+          <code className={className} {...props}>
+            {hljs.highlightAuto(String(children)).value}
+          </code>
+        )
+      }
+    }}
+  >
+    {content}
+  </ReactMarkdown>
+)
+
+
+interface LLMChatAreaProps {
+  systemMessage: string
+  onSystemMessageChange: (message: string) => void
+  prompt: string
+  onPromptChange: (prompt: string) => void
+  response: string
+  messageHistory: MessageResponse[]
+  running: boolean
+  onSend: () => void
+  onStop: () => void
+}
+
+
+export const LLMChatArea: React.FC<LLMChatAreaProps> = ({
+    systemMessage,
+    onSystemMessageChange,
+    prompt,
+    onPromptChange,
+    response,
+    messageHistory,
+    running,
+    onSend,
+    onStop
+  }) => {
+  
+  return (
+    <Tile style={{ marginBottom: "1rem", padding: "1rem" }}>
+      <Form>
+        <Stack gap={7}>
+          <TextArea
+            id="system-input"
+            labelText="System message"
+            placeholder="Type system message here..."
+            value={systemMessage}
+            onChange={(event) => onSystemMessageChange(event.target.value)}
+            rows={4}
+          />
+          <TextArea
+            id="prompt-input"
+            labelText="Enter Prompt"
+            placeholder="Type your prompt here..."
+            value={prompt}
+            onChange={(event) => onPromptChange(event.target.value)}
+            rows={4}
+          />
+          <Tile>
+            <Button
+              onClick={onSend}
+              disabled={running}
+            >
+              Run
+            </Button>
+            <Button
+              onClick={onStop}
+              disabled={!running}
+            >
+              Stop
+            </Button>
+          </Tile>
+        </Stack>
+      </Form>
+      <Tile style={{ padding: "1rem" }}>
+        {response}
+        {messageHistory.map((message) => (
+          <MessageItem
+            key={message.id + message.role}
+            message={message}
+          />
+        ))}
+      </Tile>
+    </Tile>
+  )
+}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -1,632 +1,190 @@
-import React, {useCallback, useEffect, useState} from "react";
-import ReactMarkdown from "react-markdown";
-import {
-    Accordion,
-    AccordionItem,
-    Button,
-    Checkbox,
-    Column,
-    ComboBox,
-    Form,
-    FormGroup,
-    Grid,
-    PasswordInput,
-    Stack,
-    Tab,
-    TabList,
-    TabPanel,
-    TabPanels,
-    Tabs,
-    TextArea,
-    TextInput,
-    Tile,
-    Toggle,
-} from "@carbon/react";
-import {Client} from "@modelcontextprotocol/sdk/client/index.js";
-import {getUrl} from "../../custom-fetch";
-import {SSEClientTransport} from "@modelcontextprotocol/sdk/client/sse.js";
-import hljs from "highlight.js/lib/core";
-import "highlight.js/styles/atom-one-dark.css";
-import json from "highlight.js/lib/languages/json";
-import yaml from "highlight.js/lib/languages/yaml";
-import xml from "highlight.js/lib/languages/xml";
-import {Bot, Function_2, InformationSquare, Reply} from "@carbon/icons-react";
+import React, {useRef, useState} from "react"
+import "highlight.js/styles/atom-one-dark.css"
+import {Tool} from "./tools.ts"
+import {LLMSetup} from "./LLMSetup.tsx"
+import {LLMTools} from "./LLMTools.tsx"
+import {LLMChatArea} from "./LLMChatArea.tsx"
+import {MessageResponse} from "./messages.ts"
+import {Column, Grid} from "@carbon/react"
+import {connectedMCPClient} from "./mcp.ts"
+import {LlmConfig, loadConfig} from "./config.ts"
+
 
 export const LLMChatPage: React.FC = () => {
-  hljs.registerLanguage("json", json);
-  hljs.registerLanguage("yaml", yaml);
-  hljs.registerLanguage("xml", xml);
-
-  const baseUrlItems = [
-    "http://localhost:11434",
-    "https://api.openai.com",
-    "https://api.mistral.ai",
-    "https://generativelanguage.googleapis.com/v1beta/openai/",
-    "https://api.anthropic.com",
-  ];
-
-  const [isStoreInLocalStorage, setIsStoreInLocalStorage] = useState<boolean>(
-    localStorage.getItem("isStoreInLocalStorage") === "true" || false
-  );
-
-  const [tabIndex, setTabIndex] = useState(
-    parseInt(localStorage.getItem("tabIndex") || "0", 10)
-  );
-
-  useEffect(() => {
-    localStorage.setItem("tabIndex", tabIndex.toString());
-  }, [tabIndex]);
-
-  const [baseUrl, setBaseUrl] = useState<string | null | undefined>(
-    isStoreInLocalStorage
-      ? localStorage.getItem("baseUrl") || baseUrlItems[2]
-      : baseUrlItems[2]
-  );
-  const [llmModel, setLLMModel] = useState(
-    isStoreInLocalStorage
-      ? localStorage.getItem("llmModel") || "mistral-small-latest"
-      : "mistral-small-latest"
-  );
-  const [apiKey, setApiKey] = useState(
-    isStoreInLocalStorage ? localStorage.getItem("apiKey") || "" : ""
-  );
-  const [extraLLMParams, setExtraLLMParams] = useState(
-    JSON.parse(
-      isStoreInLocalStorage
-        ? localStorage.getItem("extraLLMParams") ||
-            '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}'
-        : '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}'
-    )
-  );
-  const [rawExtraLLMParams, setRawExtraLLMParams] = useState(
-    JSON.stringify(extraLLMParams)
-  );
-
-  interface Tool {
-    name?: string;
-    description?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    inputSchema?: any;
+  
+  const [config, setConfig] = useState<LlmConfig>(loadConfig())
+  
+  // LLM Chat
+  const [response, setResponse] = useState("")
+  const [messageHistory, setMessageHistory] = useState<MessageResponse[]>([])
+  const [isRunning, setIsRunning] = useState(false)
+  const [systemMessage, setSystemMessage] = useState("You are an assistant that can use tools.")
+  const [prompt, setPrompt] = useState("")
+  
+  const stopRunning = useRef(false)
+  
+  type ConversationMessage = {
+    role: string
+    content?: string | null
+    name?: string
+    tool_calls?: []
+    tool_call_id?: string
   }
-  const [tools, setTools] = useState<Tool[]>([]);
-  const [selectedTools, setSelectedTools] = useState<string[]>(() => {
-    if (isStoreInLocalStorage) {
-      const stored = localStorage.getItem("selectedTools");
-      console.log(stored);
-      return stored ? JSON.parse(stored) : [];
-    }
-    return [];
-  });
-  const [isLoadingTools, setIsLoadingTools] = useState<boolean>(true);
+  
+  async function runPrompt() {
 
-  const [systemMessage, setSystemMessage] = useState(
-    "You are an assistant that can use tools."
-  );
-  const [prompt, setPrompt] = useState("");
-
-  type MessageResponse = {
-    id: string;
-    content: string;
-    role: string;
-  };
-  const [messageHistory, setMessageHistory] = useState<MessageResponse[]>([]);
-  const [response, setResponse] = useState("");
-  const [isRunning, setIsRunning] = useState(false);
-  const [isRunningTarget, setIsRunningTarget] = useState(false);
-
-  useEffect(() => {
-    if (isStoreInLocalStorage) {
-      localStorage.setItem("baseUrl", baseUrl || "");
-    }
-  }, [baseUrl, isStoreInLocalStorage]);
-
-  useEffect(() => {
-    localStorage.setItem(
-      "isStoreInLocalStorage",
-      String(isStoreInLocalStorage)
-    );
-  }, [isStoreInLocalStorage]);
-
-  useEffect(() => {
-    if (isStoreInLocalStorage) {
-      localStorage.setItem("apiKey", apiKey);
-    }
-  }, [apiKey, isStoreInLocalStorage]);
-
-  useEffect(() => {
-    if (isStoreInLocalStorage) {
-      localStorage.setItem("llmModel", llmModel || "");
-    }
-  }, [llmModel, isStoreInLocalStorage]);
-
-  useEffect(() => {
-    if (isStoreInLocalStorage) {
-      localStorage.setItem("extraLLMParams", JSON.stringify(extraLLMParams));
-    }
-  }, [extraLLMParams, isStoreInLocalStorage]);
-
-  useEffect(() => {
-    if (isStoreInLocalStorage) {
-      localStorage.setItem("selectedTools", JSON.stringify(selectedTools));
-    }
-  }, [selectedTools, isStoreInLocalStorage]);
-
-  const transformTools = useCallback(
-    (selectedToolNames: string[]) => {
-      return selectedToolNames.map((toolName) => {
-        const tool = tools.find((t) => t.name === toolName);
-        if (!tool) return null;
+    function transformTools(tools: Tool[]) {
+      return tools.map((tool) => {
         return {
           type: "function",
           function: {
             name: tool.name,
             description: tool.description || "No description provided.",
-            parameters: tool.inputSchema || {},
-          },
-        };
-      });
-    },
-    [tools]
-  );
-
-  const connectMCPClient = async () => {
-    const mcpClient = new Client(
-      { name: "wanaku-test-client", version: "0.0.2" },
-      { capabilities: {} }
-    );
-
-    try {
-      await mcpClient.connect(
-        // try with /mcp/sse
-        new SSEClientTransport(new URL(getUrl("mcp/sse")))
-      );
-      return mcpClient;
-    } catch (error) {
-      console.error("WebSocket connection error:", error);
-      setResponse("Connection error occurred");
+            parameters: tool.inputSchema || {}
+          }
+        }
+      })
     }
-    return null;
-  };
-
-  const getTools = useCallback(async (mcpClient?) => {
-    if (!mcpClient) {
-      mcpClient = await connectMCPClient();
-      if (mcpClient) {
-        const { tools } = await mcpClient.listTools();
-        return tools;
-      }
-      mcpClient.close();
-    } else {
-      const { tools } = await mcpClient.listTools();
-      return tools;
-    }
-  }, []);
-
-  useEffect(() => {
-    const fetchTools = async () => {
-      try {
-        const fetchedTools = await getTools();
-        setTools([...fetchedTools]);
-      } catch (error) {
-        console.error("Failed to load tools", error);
-      } finally {
-        setIsLoadingTools(false);
-      }
-    };
-
-    fetchTools();
-  }, [getTools]);
-
-  const isAllSelected =
-    tools.length > 0 &&
-    tools.every((tool) => selectedTools.includes(tool.name!));
-
-  const toggleSelectAll = (_event, { checked }) => {
-    setSelectedTools(checked ? tools.map((tool) => tool.name!) : []);
-  };
-
-  const toggleItem = (_event, { checked, id }) => {
-    setSelectedTools((prev) =>
-      checked ? [...prev, id] : prev.filter((toolName) => toolName !== id)
-    );
-  };
-
-  const runPrompt = useCallback(async () => {
-    const mcpClient = await connectMCPClient();
-    //const tools = await getTools(mcpClient);
-    if (!mcpClient) {
-      return;
-    }
-
-    setResponse(""); // clear previous response
-
-    type ConversationMessage = {
-      role: string;
-      content?: string | null;
-      name?: string;
-      tool_calls?: [];
-      tool_call_id?: string;
-    };
-
-    const conversationHistory: ConversationMessage[] = [
-      { role: "system", content: systemMessage },
-      { role: "user", content: prompt },
-    ];
-
-    const chat = async (messages) => {
+    
+    async function chat(messages) {
       console.log({
-        model: llmModel,
+        model: config.llmModel,
         messages,
-        tools: transformTools(selectedTools),
-        ...extraLLMParams,
-      });
-      return fetch(baseUrl + "/v1/chat/completions", {
+        tools: transformTools(config.tools),
+        extraLlmParams: config.extraLlmParams
+      })
+      return fetch(config.baseUrl + "/v1/chat/completions", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: "Bearer " + apiKey,
+          Authorization: "Bearer " + config.apiKey,
         },
         body: JSON.stringify({
-          model: llmModel,
+          model: config.llmModel,
           messages,
-          tools: transformTools(selectedTools),
-          ...extraLLMParams,
-        }),
-      });
-    };
-    console.log(conversationHistory);
-
-    setIsRunning(true);
-    const newMessageHistory: MessageResponse[] = [];
-
+          tools: transformTools(config.tools),
+          ...(config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {})
+        })
+      })
+    }
+    
+    const mcpClient = await connectedMCPClient()
+    
+    setResponse("") // clear previous response
+    setIsRunning(true)
+    
+    const conversationHistory: ConversationMessage[] = [
+      { role: "system", content: systemMessage },
+      { role: "user", content: prompt }
+    ]
+    console.log(conversationHistory)
+    
+    const newMessageHistory: MessageResponse[] = []
     try {
-      while (isRunningTarget) {
-        const response = await chat(conversationHistory);
-        if (!response.body) break;
-
-        const data = await response.json();
+      while (!stopRunning.current) {
+        const response = await chat(conversationHistory)
+        if (!response.body) {
+          break
+        }
+        
+        const data = await response.json()
         if (data?.choices[0].message?.content) {
-          const messageContent = data.choices[0].message?.content;
+          const messageContent = data.choices[0].message?.content
           conversationHistory.push({
             role: data?.choices[0].message.role,
-            content: messageContent,
-          });
+            content: messageContent
+          })
           newMessageHistory.push({
             role: data?.choices[0].message.role,
             content: messageContent,
-            id: data.id,
-          });
-          setMessageHistory([...newMessageHistory]);
+            id: data.id
+          })
+          setMessageHistory([...newMessageHistory])
         }
         if (data?.choices[0].finish_reason === "stop") {
-          break;
+          break
         }
         if (data?.choices[0].finish_reason === "tool_calls") {
           newMessageHistory.push({
-            role: data?.choices[0].message.role,
-            content: "tool_calls",
             id: data.id,
-          });
+            role: data?.choices[0].message.role,
+            content: "tool_calls"
+          })
           conversationHistory.push({
             role: data?.choices[0].message.role,
-            tool_calls: data.choices[0].message.tool_calls,
-          });
+            tool_calls: data.choices[0].message.tool_calls
+          })
           for (const toolCall of data.choices[0].message.tool_calls) {
-            if (selectedTools.includes(toolCall.function.name)) {
-              const toolArgs = JSON.parse(toolCall.function.arguments || "{}");
+            if (config.tools.map(tool => tool.name).includes(toolCall.function.name)) {
+              const toolArgs = JSON.parse(toolCall.function.arguments || "{}")
               newMessageHistory.push({
-                role: "tool-request",
-                content:
-                  toolCall.function.name + "(" + JSON.stringify(toolArgs) + ")",
                 id: toolCall.id,
-              });
+                role: "tool-request",
+                content: toolCall.function.name + "(" + JSON.stringify(toolArgs) + ")"
+              })
               const toolResult = await mcpClient.callTool({
                 name: toolCall.function.name,
-                arguments: toolArgs,
-              });
-              const toolResultText = (
-                toolResult.content as Array<{ text: string }>
-              )[0].text;
+                arguments: toolArgs
+              })
+              const toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
               conversationHistory.push({
-                role: "tool",
                 name: toolCall.function.name,
-                tool_call_id: toolCall.id,
                 content: toolResultText,
-              });
+                role: "tool",
+                tool_call_id: toolCall.id
+              })
               newMessageHistory.push({
-                role: "tool-response",
-                content: toolResultText,
                 id: toolCall.id,
-              });
-              setMessageHistory([...newMessageHistory]);
+                content: toolResultText,
+                role: "tool-response"
+              })
+              setMessageHistory([...newMessageHistory])
             }
           }
         }
       }
     } catch (error) {
-      console.error("Error calling OpenAI API:", error);
+      console.error("Error calling OpenAI API:", error)
     } finally {
-      await mcpClient.close();
+      await mcpClient.close()
     }
-
-    setIsRunning(false);
-    setIsRunningTarget(false);
-  }, [
-    apiKey,
-    baseUrl,
-    extraLLMParams,
-    isRunningTarget,
-    llmModel,
-    prompt,
-    selectedTools,
-    systemMessage,
-    transformTools,
-  ]);
-
-  useEffect(() => {
-    if (isRunningTarget) {
-      setMessageHistory([]);
-      runPrompt();
-    }
-  }, [isRunningTarget, runPrompt]);
-
-  const MarkdownRenderer = ({ content }) => (
-    <ReactMarkdown
-      components={{
-        code({ className, children, ...props }) {
-          return (
-            <code className={className} {...props}>
-              {hljs.highlightAuto(String(children)).value}
-            </code>
-          );
-        },
-      }}
-    >
-      {content}
-    </ReactMarkdown>
-  );
-
-  const MessageItem = ({ message }) => {
-    let Icon, title;
-    switch (message.role) {
-      case "assistant":
-        Icon = Bot;
-        title = "Assistant";
-        break;
-      case "tool-request":
-        Icon = Function_2;
-        title = "Tool Request";
-        break;
-      case "tool-response":
-        Icon = Reply;
-        title = "Tool Response";
-        break;
-      default:
-        Icon = InformationSquare;
-        title = message.role;
-    }
-
-    return (
-      <div style={{ marginBottom: "2rem" }}>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "0.5rem",
-            fontWeight: "bold",
-          }}
-        >
-          <Icon />
-          {title}
-        </div>
-        <div className="message">
-          {(message.role === "tool-response" && (
-            <p
-              dangerouslySetInnerHTML={{
-                __html: hljs.highlightAuto(message.content).value,
-              }}
-            />
-          )) || <MarkdownRenderer content={message.content} />}
-        </div>
-      </div>
-    );
-  };
-
+    
+    setIsRunning(false)
+    stopRunning.current = false
+  }
+  
   return (
     <div>
       <h1 className="title">LLM Chat for testing</h1>
-      <Tabs
-        selectedIndex={tabIndex}
-        onChange={({ selectedIndex }) => setTabIndex(selectedIndex)}
-      >
-        <TabList scrollDebounceWait={200} style={{ padding: "0 2rem" }}>
-          <Tab>LLM Setup</Tab>
-          <Tab>Tools Selection</Tab>
-          <Tab>Chat</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel className="tabbg">
-            <Grid fullWidth>
-              <Column sm={4} md={8} lg={8}>
-                <Tile style={{ marginBottom: "1rem", padding: "1rem" }}>
-                  <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                    <Toggle
-                      labelText="Store in LocalStorage"
-                      labelA="Off"
-                      labelB="On"
-                      toggled={isStoreInLocalStorage}
-                      onToggle={(e) => setIsStoreInLocalStorage(e.valueOf())}
-                      id="enabledLocalStorage"
-                    />
-                  </div>
-                  <Form aria-label="sample form">
-                    <Grid fullWidth>
-                      <Column sm={4} md={4} lg={4}>
-                        <Stack gap={7}>
-                          <ComboBox
-                            allowCustomValue
-                            onChange={(data) => {
-                              setBaseUrl(data.selectedItem);
-                            }}
-                            id="base-url"
-                            items={baseUrlItems}
-                            selectedItem={baseUrl}
-                            titleText="LLM API Base URL"
-                          />
-                          <TextInput
-                            id="llm-model"
-                            labelText="LLM Model"
-                            value={llmModel}
-                            placeholder="Type LLM model here..."
-                            onChange={(e) => setLLMModel(e.target.value)}
-                          />
-                        </Stack>
-                      </Column>
-                      <Column sm={4} md={4} lg={4}>
-                        <Stack gap={7}>
-                          <PasswordInput
-                            id="api-key"
-                            labelText="API Key"
-                            onChange={(e) => setApiKey(e.target.value)}
-                            value={apiKey}
-                            placeholder="Type your API key here..."
-                            size="md"
-                          />
-                          <TextArea
-                            labelText="Extra LLM Parameters"
-                            placeholder='{"max_tokens":400,"temperature":0.7,"tool_choice":"auto"}'
-                            id="extra-llm-input"
-                            rows={4}
-                            value={rawExtraLLMParams}
-                            onBlur={() => {
-                              try {
-                                const newParams = JSON.parse(rawExtraLLMParams);
-                                setExtraLLMParams(newParams);
-                              } catch (error) {
-                                console.error("Invalid JSON:", error);
-                                setRawExtraLLMParams(
-                                  JSON.stringify(extraLLMParams)
-                                );
-                              }
-                            }}
-                            onChange={(e) =>
-                              setRawExtraLLMParams(e.target.value)
-                            }
-                          />
-                        </Stack>
-                      </Column>
-                    </Grid>
-                  </Form>
-                </Tile>
-              </Column>
-            </Grid>
-          </TabPanel>
-          <TabPanel className="tabbg">
-            <Tile style={{ marginBottom: "1rem", padding: "1rem" }}>
-              <Stack gap={7}>
-                {isLoadingTools && <p>Loading tools...</p>}
-                {!isLoadingTools && (
-                  <FormGroup legendText="Select tools">
-                    <Checkbox
-                      id="select-all"
-                      labelText="Select All"
-                      checked={isAllSelected}
-                      onChange={toggleSelectAll}
-                    />
-                    {/* Grid layout for 100 tools */}
-                    <div
-                      style={{
-                        display: "grid",
-                        gridTemplateColumns:
-                          "repeat(auto-fit, minmax(200px, 1fr))",
-                        gap: "1rem",
-                        marginTop: "1rem",
-                      }}
-                    >
-                      {tools.map((tool) => (
-                        <Checkbox
-                          key={tool.name}
-                          id={tool.name + ""}
-                          labelText={tool.name + ""}
-                          helperText={tool.description}
-                          checked={selectedTools.includes(tool.name!)}
-                          onChange={toggleItem}
-                        />
-                      ))}
-                    </div>
-                  </FormGroup>
-                )}
-              </Stack>
-            </Tile>
-          </TabPanel>
-          <TabPanel className="tabbg">
-            <Grid fullWidth>
-              <Column sm={4} md={8} lg={5}>
-                <Tile style={{ marginBottom: "1rem", padding: "1rem" }}>
-                  <p style={{ fontWeight: "bold", marginBottom: "0.5rem" }}>
-                    LLM Model: {llmModel}
-                  </p>
-                  <Form
-                    aria-label="sample form"
-                    style={{ marginBottom: "2rem" }}
-                  >
-                    <Stack gap={7}>
-                      <TextArea
-                        labelText="System message"
-                        placeholder="Type system message here..."
-                        id="system-input"
-                        rows={4}
-                        value={systemMessage}
-                        onChange={(e) => setSystemMessage(e.target.value)}
-                      />
-                      <TextArea
-                        labelText="Enter Prompt"
-                        placeholder="Type your prompt here..."
-                        id="prompt-input"
-                        rows={4}
-                        value={prompt}
-                        onChange={(e) => setPrompt(e.target.value)}
-                      />
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "flex-end",
-                        }}
-                      >
-                        <Button onClick={() => setIsRunningTarget(!isRunning)}>
-                          {isRunning ? "Stop" : "Send"}
-                        </Button>
-                      </div>
-                    </Stack>
-                  </Form>
-                  <Accordion>
-                    <AccordionItem
-                      title={`List of Selected Tools (${selectedTools.length})`}
-                    >
-                      <ul style={{ paddingLeft: "1rem" }}>
-                        {selectedTools.map((toolName, index) => (
-                          <li key={index}>{toolName}</li>
-                        ))}
-                      </ul>
-                    </AccordionItem>
-                  </Accordion>
-                </Tile>
-              </Column>
-              <Column sm={4} md={8} lg={11}>
-                <Tile style={{ padding: "1rem" }}>
-                  {response}
-                  {messageHistory.map((message) => (
-                    <MessageItem
-                      key={message.id + message.role}
-                      message={message}
-                    />
-                  ))}
-                </Tile>
-              </Column>
-            </Grid>
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Grid fullWidth>
+        <Column lg={4}>
+          <LLMSetup config={config} onChange={setConfig} />
+          <LLMTools
+            selectedTools={config.tools}
+            onSelectionChange={(tools) => {
+              setConfig({ ...config, tools })
+            }}
+          />
+        </Column>
+        <Column lg={12}>
+          <LLMChatArea
+            systemMessage={systemMessage}
+            onSystemMessageChange={setSystemMessage}
+            prompt={prompt}
+            onPromptChange={setPrompt}
+            response={response}
+            messageHistory={messageHistory}
+            running={isRunning}
+            onSend={() => {
+              setMessageHistory([])
+              runPrompt()
+            }}
+            onStop={() => {
+              stopRunning.current = true
+            }}
+          />
+        </Column>
+      </Grid>
     </div>
-  );
-};
+  )
+}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -1,0 +1,100 @@
+import React, {useState} from "react"
+import {
+  ComboBox,
+  Form,
+  PasswordInput, Stack,
+  TextArea,
+  TextInput,
+  Toggle
+} from "@carbon/react"
+import {
+  baseUrlItems,
+  isConfigStoredInLocalStorage,
+  LLM_CONFIG,
+  LlmConfig,
+  STORE_IN_LOCAL_STORAGE
+} from "./config.ts"
+
+
+interface LLMSetupProps {
+  config: LlmConfig
+  onChange: (config: LlmConfig) => void
+}
+
+export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
+  
+  const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
+  
+  function applyConfigChange(config: LlmConfig) {
+    if (isStoredInLocalStorage) {
+      localStorage.setItem(LLM_CONFIG, JSON.stringify(config))
+    }
+    onChange(config)
+  }
+  
+  return (
+    <Form>
+      <Stack gap={5}>
+        <Toggle
+          labelText="Store in Local Storage"
+          labelA="Off"
+          labelB="On"
+          toggled={isStoredInLocalStorage}
+          onToggle={(value: boolean) => {
+            localStorage.setItem(STORE_IN_LOCAL_STORAGE, value.toString())
+            setStoreInLocalStorage(value)
+            if (value) {
+              localStorage.setItem(LLM_CONFIG, JSON.stringify(config))
+            } else {
+              localStorage.removeItem(LLM_CONFIG)
+            }
+          }}
+          id="enabledLocalStorage"
+        />
+        <ComboBox
+          id="base-url"
+          titleText="LLM API Base URL"
+          items={baseUrlItems}
+          selectedItem={config.baseUrl}
+          allowCustomValue
+          onChange={(event) => {
+            const baseUrl = event.selectedItem
+            applyConfigChange({ ...config, baseUrl })
+          }}
+        />
+        <TextInput
+          id="llm-model"
+          labelText="LLM Model"
+          placeholder="Type LLM model here..."
+          value={config.llmModel}
+          onChange={(event) => {
+            const llmModel = event.target.value
+            applyConfigChange({ ...config, llmModel })
+          }}
+        />
+        <PasswordInput
+          id="api-key"
+          labelText="API Key"
+          placeholder="Type your API key here..."
+          value={config.apiKey}
+          onChange={(event) => {
+            const apiKey = event.target.value
+            applyConfigChange({ ...config, apiKey })
+          }}
+          size="md"
+        />
+        <TextArea
+          id="extra-llm-input"
+          labelText="Extra LLM Parameters"
+          placeholder='Json format, e.g. {"max_tokens":400,"temperature":0.7,"tool_choice":"auto"}'
+          value={config.extraLlmParams}
+          onChange={(event) => {
+            const extraLlmParams = event.target.value
+            applyConfigChange({ ...config, extraLlmParams })
+          }}
+          rows={4}
+        />
+      </Stack>
+    </Form>
+  )
+}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
@@ -1,0 +1,84 @@
+import {
+  Checkbox,
+  CheckboxGroup,
+  InlineLoading,
+  Stack
+} from "@carbon/react"
+import {Tool} from "./tools.ts"
+import {useEffect, useState} from "react"
+import {getTools} from "./mcp.ts"
+
+
+interface LLMToolsProps {
+  selectedTools: Tool[]
+  onSelectionChange: (tools: Tool[]) => void
+}
+
+export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionChange }) => {
+  
+  const [tools, setTools] = useState<Tool[]>([])
+  const [isLoading, setLoading] = useState<boolean>(true)
+  
+  useEffect(() => {
+    (async () => {
+      try {
+        const tools = await getTools()
+        setTools(tools)
+      } catch (error) {
+        console.error("Failed to load tools", error)
+        setTools([])
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+  
+  function isAllSelected() {
+    const selectedToolNames = selectedTools.map(tool => tool.name)
+    return tools.length > 0 && tools.every((tool) => selectedToolNames.includes(tool.name))
+  }
+  
+  function isSomeSelected() {
+    return selectedTools.length > 0 && selectedTools.length < tools.length
+  }
+  
+  return (
+    <Stack gap={7}>
+      {isLoading &&
+        <InlineLoading description="Loading tools..." />
+      }
+      {!isLoading && tools.length == 0 &&
+        <div>No tools available</div>
+      }
+      {!isLoading && tools.length > 0 && (
+        <CheckboxGroup legendText="Select tools">
+          <Checkbox
+            id="select-all"
+            labelText="Select All"
+            checked={isAllSelected()}
+            indeterminate={isSomeSelected()}
+            onChange={(_, { checked }) => {
+              const selection = checked ? [...tools] : []
+              onSelectionChange(selection)
+            }}
+          />
+          {tools.map((tool) => (
+            <Checkbox
+              id={tool.name}
+              key={tool.name}
+              labelText={tool.name}
+              helperText={tool.description}
+              checked={selectedTools.map(tool => tool.name).includes(tool.name)}
+              onChange={(_, { checked }) => {
+                const selection = checked
+                  ? [...selectedTools, tool]
+                  : selectedTools.filter(item => item.name != tool.name)
+                onSelectionChange(selection)
+              }}
+            />
+          ))}
+        </CheckboxGroup>
+      )}
+    </Stack>
+  )
+}

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -1,0 +1,49 @@
+import {Tool} from "./tools.ts"
+
+
+export interface LlmConfig {
+  baseUrl?: string | null
+  llmModel?: string
+  apiKey?: string
+  extraLlmParams?: string
+  tools: Tool[]
+}
+
+export const baseUrlItems = [
+  "http://localhost:11434",
+  "https://api.openai.com",
+  "https://api.mistral.ai",
+  "https://generativelanguage.googleapis.com/v1beta/openai/",
+  "https://api.anthropic.com"
+]
+
+export function defaultLlmConfig(): LlmConfig {
+  return {
+    baseUrl: baseUrlItems[2],
+    llmModel: "mistral-small-latest",
+    extraLlmParams: '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}',
+    tools: []
+  }
+}
+
+export const STORE_IN_LOCAL_STORAGE = "storeInLocalStorage"
+export const LLM_CONFIG = "llmConfig"
+
+export function isConfigStoredInLocalStorage() {
+  return localStorage.getItem(STORE_IN_LOCAL_STORAGE) === "true"
+}
+
+export function loadConfig(): LlmConfig {
+  if (isConfigStoredInLocalStorage()) {
+    const config = localStorage.getItem(LLM_CONFIG)
+    if (config) {
+      try {
+        return JSON.parse(config)
+      } catch (error) {
+        console.log("Error loading config: " + config)
+        return defaultLlmConfig()
+      }
+    }
+  }
+  return defaultLlmConfig()
+}

--- a/apps/ui/admin/src/Pages/LLMChat/mcp.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/mcp.ts
@@ -1,0 +1,25 @@
+import {Client} from "@modelcontextprotocol/sdk/client/index.js"
+import {SSEClientTransport} from "@modelcontextprotocol/sdk/client/sse.js"
+import {Tool} from "./tools.ts";
+import {getUrl} from "../../custom-fetch.ts"
+
+
+export async function connectedMCPClient() {
+  const mcpClient = new Client(
+    { name: "wanaku-test-client", version: "0.0.2" },
+    { capabilities: {} }
+  )
+  const url = new URL(getUrl("/public/mcp/sse"))
+  await mcpClient.connect(new SSEClientTransport(url))
+  return mcpClient
+}
+
+export async function getTools(): Promise<Tool[]> {
+  const mcpClient = await connectedMCPClient()
+  try {
+    const { tools } = await mcpClient.listTools()
+    return [...tools]
+  } finally {
+    await mcpClient.close()
+  }
+}

--- a/apps/ui/admin/src/Pages/LLMChat/messages.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/messages.ts
@@ -1,0 +1,5 @@
+export interface MessageResponse {
+  id: string
+  content: string
+  role: string
+}

--- a/apps/ui/admin/src/Pages/LLMChat/tools.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/tools.ts
@@ -1,0 +1,6 @@
+export interface Tool {
+  name: string
+  description?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema?: any
+}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/737

On top of the issue request, it features code cleanup and split into several files.

## Summary by Sourcery

Refactor the LLM chat page into a single-view layout composed of smaller components and a shared configuration model for LLM settings and tools.

Enhancements:
- Split the monolithic LLMChatPage into dedicated components for setup, tool selection, and chat interaction to simplify the UI structure.
- Introduce a reusable configuration model for LLM connection settings, including optional persistence to local storage.
- Extract MCP client and tool-loading logic into separate utility modules to centralize integration with the MCP server.
- Adjust the chat flow to support start/stop controls using a ref-based cancellation flag instead of tab-driven state.