### PR TITLE
Fix #946: Add --verified flag to CLI user creation

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/users/UsersAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/users/UsersAdd.java
@@ -38,6 +38,13 @@ public class UsersAdd extends BaseAdminCommand {
             description = "Last name for the new user (defaults to username)")
     private String lastName;
 
+    @CommandLine.Option(
+            names = {"--verified"},
+            description = "Mark the email address as verified (default: true)",
+            defaultValue = "true",
+            negatable = true)
+    private boolean verified;
+
     public UsersAdd() {
         super();
     }
@@ -50,7 +57,7 @@ public class UsersAdd extends BaseAdminCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         try {
             KeycloakAdminClient client = createAdminClient();
-            client.createUser(realm, username, password, email, firstName, lastName);
+            client.createUser(realm, username, password, email, firstName, lastName, verified);
             printer.printSuccessMessage("User '" + username + "' created successfully");
             return EXIT_OK;
         } catch (KeycloakAdminClient.KeycloakAdminException e) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClient.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClient.java
@@ -33,12 +33,18 @@ public class KeycloakAdminClient {
     // ---- User methods ----
 
     public void createUser(
-            String realm, String username, String password, String email, String firstName, String lastName)
+            String realm,
+            String username,
+            String password,
+            String email,
+            String firstName,
+            String lastName,
+            boolean emailVerified)
             throws KeycloakAdminException {
         Map<String, Object> userRep = new java.util.LinkedHashMap<>();
         userRep.put("username", username);
         userRep.put("enabled", true);
-        userRep.put("emailVerified", true);
+        userRep.put("emailVerified", emailVerified);
         userRep.put("firstName", (firstName != null && !firstName.isBlank()) ? firstName : username);
         userRep.put("lastName", (lastName != null && !lastName.isBlank()) ? lastName : username);
         userRep.put("email", (email != null && !email.isBlank()) ? email : username + "@wanaku.local");

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/users/UsersCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/users/UsersCommandsTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -41,7 +42,7 @@ class UsersCommandsTest {
 
     @Test
     void usersAddHappyPath() throws Exception {
-        doNothing().when(adminClient).createUser(any(), any(), any(), any(), any(), any());
+        doNothing().when(adminClient).createUser(any(), any(), any(), any(), any(), any(), anyBoolean());
 
         UsersAdd cmd = new UsersAdd(adminClient);
         int result = cmd.doCall(terminal, printer);
@@ -90,7 +91,7 @@ class UsersCommandsTest {
     void usersAddShouldReturnErrorOnKeycloakException() throws Exception {
         doThrow(new KeycloakAdminClient.KeycloakAdminException("user already exists"))
                 .when(adminClient)
-                .createUser(any(), any(), any(), any(), any(), any());
+                .createUser(any(), any(), any(), any(), any(), any(), anyBoolean());
 
         UsersAdd cmd = new UsersAdd(adminClient);
         int result = cmd.doCall(terminal, printer);

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClientTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClientTest.java
@@ -54,7 +54,7 @@ class KeycloakAdminClientTest {
     void createUserShouldPostToCorrectUrl() throws Exception {
         mockResponse(201, "");
 
-        adminClient.createUser(REALM, "testuser", "password123", "test@example.com", null, null);
+        adminClient.createUser(REALM, "testuser", "password123", "test@example.com", null, null, true);
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
         verify(httpClient).send(captor.capture(), any());
@@ -75,7 +75,7 @@ class KeycloakAdminClientTest {
 
         KeycloakAdminClient.KeycloakAdminException ex = assertThrows(
                 KeycloakAdminClient.KeycloakAdminException.class,
-                () -> adminClient.createUser(REALM, "testuser", "pass", null, null, null));
+                () -> adminClient.createUser(REALM, "testuser", "pass", null, null, null, true));
 
         assertTrue(ex.getMessage().contains("testuser"));
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1020,9 +1020,14 @@ wanaku admin users list
 wanaku admin users list --admin-username admin --admin-password admin
 
 # Create a new user (email, first-name, last-name are optional and default to username-based values)
+# By default, the email is marked as verified. Use --no-verified to leave it unverified.
 wanaku admin users add --admin-username admin --admin-password admin \
   --username alice --password secretpass \
   --email alice@example.com --first-name Alice --last-name Smith
+
+# Create a user with an unverified email
+wanaku admin users add --admin-username admin --admin-password admin \
+  --username bob --password secretpass --no-verified
 
 # Remove a user
 wanaku admin users remove --admin-username admin --admin-password admin \


### PR DESCRIPTION
## Summary
- Adds a negatable `--verified` CLI option to `users add` (defaults to `true`)
- Passes the flag through to `KeycloakAdminClient.createUser()` instead of hardcoding `emailVerified` to `true`
- Updates tests and documentation

This completes the work started in 7cf565ffc, which hardcoded `emailVerified` to `true` to unblock the release.

## Test plan
- [x] `mvn verify` passes (all tests green)
- [ ] Manual: `wanaku admin users add --username test --password pass` creates user with verified email
- [ ] Manual: `wanaku admin users add --username test --password pass --no-verified` creates user with unverified email

## Summary by Sourcery

Add a configurable email verification flag to CLI user creation and update related tests and docs.

New Features:
- Introduce a negatable --verified flag to the wanaku admin users add CLI command to control whether a new user's email is marked as verified.

Bug Fixes:
- Stop hardcoding emailVerified to true when creating users via KeycloakAdminClient and honor the value provided by the CLI flag.

Enhancements:
- Extend KeycloakAdminClient.createUser to accept an emailVerified parameter for more flexible user provisioning.
- Clean up OpenAPI configuration by removing an unused openIdConnect security scheme entry.

Documentation:
- Update CLI usage documentation to describe the new --verified/--no-verified behavior and show examples of creating users with verified or unverified emails.

Tests:
- Adjust CLI and KeycloakAdminClient tests to account for the new emailVerified parameter and ensure user creation still behaves as expected.