### PR TITLE
fix: Command injection vulnerability in ExecClient

### DIFF
--- a/capabilities/tools/README.md
+++ b/capabilities/tools/README.md
@@ -12,7 +12,7 @@ which provides access to more than 300 components.
 
 | Type         | Service Tool                                                                 | Description                                                                 |
 |--------------|------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| `exec`       | [wanaku-tool-service-exec](./wanaku-tool-service-exec/README.md)             | Executes a process as a tool (use carefully - there's no input validation)  |
+| `exec`       | [wanaku-tool-service-exec](./wanaku-tool-service-exec/README.md)             | Executes a process as a tool using an explicit executable allowlist         |
 | `http`       | [wanaku-tool-service-http](./wanaku-tool-service-http/README.md)             | Provides access to HTTP endpoints as tools via Wanaku                       | | Provides access to AWS SQS queues as tools via Wanaku                       |
 | `tavily`     | [wanaku-tool-service-tavily](./wanaku-tool-service-tavily/README.md)         | Provides search capabilities on the Web using [Tavily](https://tavily.com/) |
 

--- a/capabilities/tools/wanaku-tool-service-exec/README.md
+++ b/capabilities/tools/wanaku-tool-service-exec/README.md
@@ -2,6 +2,9 @@
 
 Write the description of the tool here
 
+This service now requires an explicit allowlist of executable paths via `wanaku.service.exec.allowed-executables`.
+Only commands whose first token matches one of the configured executables will run.
+
 Sample run for any tool:
 
 ```shell

--- a/capabilities/tools/wanaku-tool-service-exec/README.md
+++ b/capabilities/tools/wanaku-tool-service-exec/README.md
@@ -4,6 +4,11 @@ Write the description of the tool here
 
 This service now requires an explicit allowlist of executable paths via `wanaku.service.exec.allowed-executables`.
 Only commands whose first token matches one of the configured executables will run.
+Entries are normalized to absolute paths, so prefer configuring absolute paths in the allowlist.
+If an allowlisted executable does not exist yet, the service logs a warning during startup.
+
+You can configure the allowlist through MicroProfile Config, for example with the environment variable
+`WANAKU_SERVICE_EXEC_ALLOWED_EXECUTABLES=/bin/ls,/usr/bin/curl`.
 
 Sample run for any tool:
 

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/CommandExecutor.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/CommandExecutor.java
@@ -1,0 +1,5 @@
+package ai.wanaku.tool.exec;
+
+interface CommandExecutor {
+    Object run(String[] command);
+}

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecClient.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecClient.java
@@ -1,10 +1,11 @@
 package ai.wanaku.tool.exec;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
-import java.io.File;
+import java.util.List;
+
 import org.jboss.logging.Logger;
-import ai.wanaku.capabilities.sdk.common.ProcessRunner;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.core.capabilities.common.ParsedToolInvokeRequest;
 import ai.wanaku.core.capabilities.tool.Client;
@@ -14,18 +15,25 @@ import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 public class ExecClient implements Client {
     private static final Logger LOG = Logger.getLogger(ExecClient.class);
 
-    public ExecClient() {}
+    private final ExecCommandPolicy commandPolicy;
+    private final CommandExecutor commandExecutor;
+
+    @Inject
+    public ExecClient(ExecCommandPolicy commandPolicy, CommandExecutor commandExecutor) {
+        this.commandPolicy = commandPolicy;
+        this.commandExecutor = commandExecutor;
+    }
 
     @Override
     public Object exchange(ToolInvokeRequest request, ConfigResource configResource) {
         ParsedToolInvokeRequest parsedRequest = ParsedToolInvokeRequest.parseRequest(request, configResource);
 
+        List<String> command = commandPolicy.buildCommand(parsedRequest.uri());
+
         // Log at DEBUG level to avoid exposing sensitive data (API keys, tokens, credentials)
         // that may be embedded in the URI as query parameters
-        LOG.debugf("Invoking tool at URI: %s", parsedRequest.uri());
-        File fullCommand = new File(parsedRequest.uri());
+        LOG.debugf("Invoking allowlisted tool command: %s", command.get(0));
 
-        String[] arguments = fullCommand.getAbsolutePath().split(" ");
-        return ProcessRunner.runWithOutput(arguments);
+        return commandExecutor.run(command.toArray(String[]::new));
     }
 }

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
@@ -1,7 +1,7 @@
 package ai.wanaku.tool.exec;
 
-import jakarta.enterprise.context.Singleton;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
@@ -3,7 +3,9 @@ package ai.wanaku.tool.exec;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,6 +14,7 @@ import java.util.Set;
 
 @Singleton
 final class ExecCommandPolicy {
+    private static final Logger LOG = Logger.getLogger(ExecCommandPolicy.class);
     private static final Set<Character> DISALLOWED_CHARACTERS = Set.of(';', '|', '&', '<', '>', '`', '$');
 
     private final List<String> allowedExecutables;
@@ -25,7 +28,7 @@ final class ExecCommandPolicy {
 
     ExecCommandPolicy(List<String> allowedExecutables) {
         this.allowedExecutables = allowedExecutables.stream()
-                .map(ExecCommandPolicy::normalizeExecutable)
+                .map(ExecCommandPolicy::normalizeAllowlistedExecutable)
                 .toList();
     }
 
@@ -43,7 +46,7 @@ final class ExecCommandPolicy {
             throw new SecurityException("Command execution is denied because no executables are allowlisted");
         }
 
-        String executable = normalizeExecutable(command.get(0));
+        String executable = normalizeRequestedExecutable(command.get(0));
         if (!allowedExecutables.contains(executable)) {
             throw new SecurityException(
                     "Command execution is denied because the executable is not allowlisted: " + executable);
@@ -64,12 +67,32 @@ final class ExecCommandPolicy {
                 .toList();
     }
 
-    private static String normalizeExecutable(String executable) {
+    private static String normalizeRequestedExecutable(String executable) {
         if (executable == null || executable.isBlank()) {
             throw new SecurityException("Command execution is denied because the executable path is blank");
         }
 
         return Path.of(executable.trim()).toAbsolutePath().normalize().toString();
+    }
+
+    private static String normalizeAllowlistedExecutable(String executable) {
+        if (executable == null || executable.isBlank()) {
+            throw new SecurityException("Command execution is denied because the executable path is blank");
+        }
+
+        Path path = Path.of(executable.trim());
+        if (!path.isAbsolute()) {
+            throw new SecurityException(
+                    "Command execution is denied because the executable allowlist must use absolute paths: "
+                            + executable.trim());
+        }
+
+        Path normalizedPath = path.toAbsolutePath().normalize();
+        if (!Files.exists(normalizedPath)) {
+            LOG.warnf("Configured executable does not exist yet: %s", normalizedPath);
+        }
+
+        return normalizedPath.toString();
     }
 
     private static List<String> tokenize(String rawCommand) {

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
@@ -1,0 +1,122 @@
+package ai.wanaku.tool.exec;
+
+import jakarta.enterprise.context.Singleton;
+import jakarta.inject.Inject;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+@Singleton
+final class ExecCommandPolicy {
+    private static final Set<Character> DISALLOWED_CHARACTERS = Set.of(';', '|', '&', '<', '>', '`', '$');
+
+    private final List<String> allowedExecutables;
+
+    @Inject
+    ExecCommandPolicy(String allowedExecutables) {
+        this(parseAllowedExecutables(allowedExecutables));
+    }
+
+    ExecCommandPolicy(List<String> allowedExecutables) {
+        this.allowedExecutables = allowedExecutables.stream()
+                .map(ExecCommandPolicy::normalizeExecutable)
+                .toList();
+    }
+
+    List<String> buildCommand(String rawCommand) {
+        if (rawCommand == null || rawCommand.isBlank()) {
+            throw new SecurityException("Command execution is denied because the configured URI is blank");
+        }
+
+        List<String> command = tokenize(rawCommand);
+        if (command.isEmpty()) {
+            throw new SecurityException("Command execution is denied because the configured URI is empty");
+        }
+
+        if (allowedExecutables.isEmpty()) {
+            throw new SecurityException("Command execution is denied because no executables are allowlisted");
+        }
+
+        String executable = normalizeExecutable(command.get(0));
+        if (!allowedExecutables.contains(executable)) {
+            throw new SecurityException(
+                    "Command execution is denied because the executable is not allowlisted: " + executable);
+        }
+
+        command.set(0, executable);
+        return List.copyOf(command);
+    }
+
+    private static List<String> parseAllowedExecutables(String allowedExecutables) {
+        if (allowedExecutables == null || allowedExecutables.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(allowedExecutables.split(","))
+                .map(String::trim)
+                .filter(entry -> !entry.isEmpty())
+                .toList();
+    }
+
+    private static String normalizeExecutable(String executable) {
+        if (executable == null || executable.isBlank()) {
+            throw new SecurityException("Command execution is denied because the executable path is blank");
+        }
+
+        return Path.of(executable.trim()).toAbsolutePath().normalize().toString();
+    }
+
+    private static List<String> tokenize(String rawCommand) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        boolean inSingleQuotes = false;
+        boolean inDoubleQuotes = false;
+
+        for (int i = 0; i < rawCommand.length(); i++) {
+            char currentChar = rawCommand.charAt(i);
+
+            if (currentChar == '\n' || currentChar == '\r') {
+                throw new SecurityException("Command execution is denied because the URI contains a newline");
+            }
+
+            if (DISALLOWED_CHARACTERS.contains(currentChar)) {
+                throw new SecurityException(
+                        "Command execution is denied because the URI contains a shell metacharacter: " + currentChar);
+            }
+
+            if (currentChar == '\'' && !inDoubleQuotes) {
+                inSingleQuotes = !inSingleQuotes;
+                continue;
+            }
+
+            if (currentChar == '"' && !inSingleQuotes) {
+                inDoubleQuotes = !inDoubleQuotes;
+                continue;
+            }
+
+            if (!inSingleQuotes && !inDoubleQuotes && Character.isWhitespace(currentChar)) {
+                if (current.length() > 0) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+
+            current.append(currentChar);
+        }
+
+        if (inSingleQuotes || inDoubleQuotes) {
+            throw new SecurityException("Command execution is denied because the URI contains unbalanced quotes");
+        }
+
+        if (current.length() > 0) {
+            tokens.add(current.toString());
+        }
+
+        return tokens;
+    }
+}

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ExecCommandPolicy.java
@@ -2,6 +2,7 @@ package ai.wanaku.tool.exec;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,7 +17,9 @@ final class ExecCommandPolicy {
     private final List<String> allowedExecutables;
 
     @Inject
-    ExecCommandPolicy(String allowedExecutables) {
+    ExecCommandPolicy(
+            @ConfigProperty(name = "wanaku.service.exec.allowed-executables", defaultValue = "")
+            String allowedExecutables) {
         this(parseAllowedExecutables(allowedExecutables));
     }
 

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ProcessRunnerCommandExecutor.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ProcessRunnerCommandExecutor.java
@@ -1,6 +1,6 @@
 package ai.wanaku.tool.exec;
 
-import jakarta.enterprise.context.Singleton;
+import jakarta.inject.Singleton;
 
 import ai.wanaku.capabilities.sdk.common.ProcessRunner;
 

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ProcessRunnerCommandExecutor.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/java/ai/wanaku/tool/exec/ProcessRunnerCommandExecutor.java
@@ -1,0 +1,13 @@
+package ai.wanaku.tool.exec;
+
+import jakarta.enterprise.context.Singleton;
+
+import ai.wanaku.capabilities.sdk.common.ProcessRunner;
+
+@Singleton
+final class ProcessRunnerCommandExecutor implements CommandExecutor {
+    @Override
+    public Object run(String[] command) {
+        return ProcessRunner.runWithOutput(command);
+    }
+}

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
@@ -17,6 +17,7 @@ wanaku.service.name=exec
 wanaku.service.base-uri=exec://
 # Comma-separated allowlist of executables that the exec tool may run.
 # Leave empty to deny execution until an operator explicitly configures the service.
+# Entries should be absolute paths, for example via WANAKU_SERVICE_EXEC_ALLOWED_EXECUTABLES=/bin/ls,/usr/bin/curl.
 wanaku.service.exec.allowed-executables=
 
 # Registration settings

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
@@ -15,6 +15,9 @@ quarkus.log.category."ai.wanaku".level=INFO
 
 wanaku.service.name=exec
 wanaku.service.base-uri=exec://
+# Comma-separated allowlist of executables that the exec tool may run.
+# Leave empty to deny execution until an operator explicitly configures the service.
+wanaku.service.exec.allowed-executables=
 
 # Registration settings
 #wanaku.service.registration.uri=http://localhost:8080

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientIntegrationTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientIntegrationTest.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExecClientIntegrationTest {
 
-    private final ExecClient client = new ExecClient();
-
     @TempDir
     Path tempDir;
 
@@ -32,10 +30,9 @@ class ExecClientIntegrationTest {
 
         ToolInvokeRequest request =
                 ToolInvokeRequest.newBuilder().setUri(scriptPath.toString()).build();
-
         ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
-        Object response = client.exchange(request, configResource);
+        Object response = newClient(scriptPath).exchange(request, configResource);
 
         assertNotNull(response);
 
@@ -54,12 +51,17 @@ class ExecClientIntegrationTest {
 
         ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
-        Object response = client.exchange(request, configResource);
+        Object response = newClient(scriptPath).exchange(request, configResource);
 
         assertNotNull(response);
 
         String output = normalizeOutput(response);
         assertTrue(output.contains("exec-it-template"));
+    }
+
+    private static ExecClient newClient(Path scriptPath) {
+        return new ExecClient(
+                new ExecCommandPolicy(List.of(scriptPath.toString())), new ProcessRunnerCommandExecutor());
     }
 
     private static Path createScript(Path dir, String marker) throws IOException {

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientIntegrationTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientIntegrationTest.java
@@ -7,12 +7,13 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+import ai.wanaku.core.util.RuntimeInfo;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -67,8 +68,7 @@ class ExecClientIntegrationTest {
     private static Path createScript(Path dir, String marker) throws IOException {
         Files.createDirectories(dir);
 
-        boolean isWindows =
-                System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        boolean isWindows = RuntimeInfo.isWindows();
 
         String extension = isWindows ? ".cmd" : ".sh";
         Path scriptPath = dir.resolve("exec-it-" + marker + extension).toAbsolutePath();
@@ -76,7 +76,7 @@ class ExecClientIntegrationTest {
         String content =
                 isWindows ? "@echo off\r\necho " + marker + "\r\n" : "#!/usr/bin/env sh\n" + "echo " + marker + "\n";
 
-        Files.writeString(scriptPath, content, StandardCharsets.US_ASCII);
+        Files.writeString(scriptPath, content, StandardCharsets.UTF_8);
 
         if (!isWindows) {
             try {

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
@@ -1,0 +1,51 @@
+package ai.wanaku.tool.exec;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ExecClientSecurityTest {
+
+    @Test
+    void doesNotInvokeExecutorWhenExecutableIsNotAllowlisted() {
+        RecordingExecutor executor = new RecordingExecutor();
+        ExecClient client = new ExecClient(new ExecCommandPolicy(List.of("/bin/allowed")), executor);
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("/bin/denied --version").build();
+        ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
+
+        assertThrows(SecurityException.class, () -> client.exchange(request, configResource));
+        assertNull(executor.command);
+    }
+
+    @Test
+    void passesAllowlistedCommandToExecutor() {
+        RecordingExecutor executor = new RecordingExecutor();
+        ExecClient client = new ExecClient(new ExecCommandPolicy(List.of("/bin/allowed")), executor);
+
+        ToolInvokeRequest request =
+                ToolInvokeRequest.newBuilder().setUri("/bin/allowed --version").build();
+        ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
+
+        client.exchange(request, configResource);
+
+        assertArrayEquals(new String[] {"/bin/allowed", "--version"}, executor.command);
+    }
+
+    private static final class RecordingExecutor implements CommandExecutor {
+        private String[] command;
+
+        @Override
+        public Object run(String[] command) {
+            this.command = command;
+            return List.of(command);
+        }
+    }
+}

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
@@ -1,24 +1,40 @@
 package ai.wanaku.tool.exec;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ExecClientSecurityTest {
 
+    @TempDir
+    Path tempDir;
+
     @Test
-    void doesNotInvokeExecutorWhenExecutableIsNotAllowlisted() {
+    void doesNotInvokeExecutorWhenExecutableIsNotAllowlisted() throws Exception {
+        Path allowlistedExecutable = createScript(tempDir, "allowed");
+
         RecordingExecutor executor = new RecordingExecutor();
-        ExecClient client = new ExecClient(new ExecCommandPolicy(List.of("/bin/allowed")), executor);
+        ExecClient client = new ExecClient(
+                new ExecCommandPolicy(List.of(allowlistedExecutable.toString())), executor);
 
         ToolInvokeRequest request =
-                ToolInvokeRequest.newBuilder().setUri("/bin/denied --version").build();
+                ToolInvokeRequest.newBuilder().setUri(createScript(tempDir, "denied").toString() + " --version")
+                        .build();
         ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
         assertThrows(SecurityException.class, () -> client.exchange(request, configResource));
@@ -26,17 +42,45 @@ class ExecClientSecurityTest {
     }
 
     @Test
-    void passesAllowlistedCommandToExecutor() {
+    void passesAllowlistedCommandToExecutor() throws Exception {
+        Path allowlistedExecutable = createScript(tempDir, "allowed");
+
         RecordingExecutor executor = new RecordingExecutor();
-        ExecClient client = new ExecClient(new ExecCommandPolicy(List.of("/bin/allowed")), executor);
+        ExecClient client = new ExecClient(
+                new ExecCommandPolicy(List.of(allowlistedExecutable.toString())), executor);
 
         ToolInvokeRequest request =
-                ToolInvokeRequest.newBuilder().setUri("/bin/allowed --version").build();
+                ToolInvokeRequest.newBuilder().setUri(allowlistedExecutable.toString() + " --version").build();
         ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
         client.exchange(request, configResource);
 
-        assertArrayEquals(new String[] {"/bin/allowed", "--version"}, executor.command);
+        assertArrayEquals(new String[] {allowlistedExecutable.toAbsolutePath().normalize().toString(), "--version"},
+                executor.command);
+    }
+
+    private static Path createScript(Path dir, String marker) throws IOException {
+        Files.createDirectories(dir);
+
+        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+        String extension = isWindows ? ".cmd" : ".sh";
+        Path scriptPath = dir.resolve("exec-security-" + marker + extension).toAbsolutePath();
+
+        String content =
+                isWindows ? "@echo off\r\necho " + marker + "\r\n" : "#!/usr/bin/env sh\n" + "echo " + marker + "\n";
+
+        Files.writeString(scriptPath, content, StandardCharsets.US_ASCII);
+
+        if (!isWindows) {
+            try {
+                Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rwxr-xr-x");
+                Files.setPosixFilePermissions(scriptPath, permissions);
+            } catch (UnsupportedOperationException ignored) {
+            }
+        }
+
+        return scriptPath;
     }
 
     private static final class RecordingExecutor implements CommandExecutor {

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecClientSecurityTest.java
@@ -7,11 +7,12 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
+
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+import ai.wanaku.core.util.RuntimeInfo;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -62,7 +63,7 @@ class ExecClientSecurityTest {
     private static Path createScript(Path dir, String marker) throws IOException {
         Files.createDirectories(dir);
 
-        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        boolean isWindows = RuntimeInfo.isWindows();
 
         String extension = isWindows ? ".cmd" : ".sh";
         Path scriptPath = dir.resolve("exec-security-" + marker + extension).toAbsolutePath();
@@ -70,7 +71,7 @@ class ExecClientSecurityTest {
         String content =
                 isWindows ? "@echo off\r\necho " + marker + "\r\n" : "#!/usr/bin/env sh\n" + "echo " + marker + "\n";
 
-        Files.writeString(scriptPath, content, StandardCharsets.US_ASCII);
+        Files.writeString(scriptPath, content, StandardCharsets.UTF_8);
 
         if (!isWindows) {
             try {

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
@@ -33,11 +33,12 @@ class ExecCommandPolicyTest {
 
     @Test
     void rejectsNonAllowlistedExecutable() throws Exception {
-        Path scriptPath = createScript(tempDir, "policy-denied");
+        Path allowedScriptPath = createScript(tempDir, "policy-allowed");
+        Path deniedScriptPath = createScript(tempDir, "policy-denied");
 
-        ExecCommandPolicy policy = new ExecCommandPolicy(List.of("/bin/does-not-exist"));
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of(allowedScriptPath.toString()));
 
-        assertThrows(SecurityException.class, () -> policy.buildCommand(scriptPath.toString()));
+        assertThrows(SecurityException.class, () -> policy.buildCommand(deniedScriptPath.toString()));
     }
 
     @Test

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
@@ -7,9 +7,9 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
+import ai.wanaku.core.util.RuntimeInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +41,42 @@ class ExecCommandPolicyTest {
     }
 
     @Test
+    void rejectsRelativeAllowlistEntries() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-relative");
+
+        assertThrows(SecurityException.class, () -> new ExecCommandPolicy(List.of(scriptPath.getFileName().toString())));
+    }
+
+    @Test
+    void rejectsBlankCommands() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-blank");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of(scriptPath.toString()));
+
+        assertThrows(SecurityException.class, () -> policy.buildCommand("   "));
+    }
+
+    @Test
+    void rejectsCommandsWithUnbalancedQuotes() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-quotes");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of(scriptPath.toString()));
+
+        assertThrows(SecurityException.class, () -> policy.buildCommand("\"" + scriptPath + " --mode"));
+    }
+
+    @Test
+    void acceptsAllowlistEntriesWithSurroundingWhitespace() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-trim");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of("  " + scriptPath + "  "));
+
+        List<String> command = policy.buildCommand(scriptPath + " --version");
+
+        assertEquals(List.of(scriptPath.toAbsolutePath().normalize().toString(), "--version"), command);
+    }
+
+    @Test
     void rejectsShellMetacharacters() throws Exception {
         Path scriptPath = createScript(tempDir, "policy-meta");
 
@@ -52,8 +88,7 @@ class ExecCommandPolicyTest {
     private static Path createScript(Path dir, String marker) throws IOException {
         Files.createDirectories(dir);
 
-        boolean isWindows =
-                System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        boolean isWindows = RuntimeInfo.isWindows();
 
         String extension = isWindows ? ".cmd" : ".sh";
         Path scriptPath = dir.resolve("exec-it-" + marker + extension).toAbsolutePath();
@@ -61,7 +96,7 @@ class ExecCommandPolicyTest {
         String content =
                 isWindows ? "@echo off\r\necho " + marker + "\r\n" : "#!/usr/bin/env sh\n" + "echo " + marker + "\n";
 
-        Files.writeString(scriptPath, content, StandardCharsets.US_ASCII);
+        Files.writeString(scriptPath, content, StandardCharsets.UTF_8);
 
         if (!isWindows) {
             try {

--- a/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
+++ b/capabilities/tools/wanaku-tool-service-exec/src/test/java/ai/wanaku/tool/exec/ExecCommandPolicyTest.java
@@ -1,0 +1,76 @@
+package ai.wanaku.tool.exec;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ExecCommandPolicyTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void buildsAllowlistedCommandWithQuotedArguments() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-ok");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of(scriptPath.toString()));
+
+        List<String> command = policy.buildCommand("\"" + scriptPath + "\" --mode \"hello world\"");
+
+        assertEquals(List.of(scriptPath.toAbsolutePath().normalize().toString(), "--mode", "hello world"), command);
+    }
+
+    @Test
+    void rejectsNonAllowlistedExecutable() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-denied");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of("/bin/does-not-exist"));
+
+        assertThrows(SecurityException.class, () -> policy.buildCommand(scriptPath.toString()));
+    }
+
+    @Test
+    void rejectsShellMetacharacters() throws Exception {
+        Path scriptPath = createScript(tempDir, "policy-meta");
+
+        ExecCommandPolicy policy = new ExecCommandPolicy(List.of(scriptPath.toString()));
+
+        assertThrows(SecurityException.class, () -> policy.buildCommand(scriptPath + " ; whoami"));
+    }
+
+    private static Path createScript(Path dir, String marker) throws IOException {
+        Files.createDirectories(dir);
+
+        boolean isWindows =
+                System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+
+        String extension = isWindows ? ".cmd" : ".sh";
+        Path scriptPath = dir.resolve("exec-it-" + marker + extension).toAbsolutePath();
+
+        String content =
+                isWindows ? "@echo off\r\necho " + marker + "\r\n" : "#!/usr/bin/env sh\n" + "echo " + marker + "\n";
+
+        Files.writeString(scriptPath, content, StandardCharsets.US_ASCII);
+
+        if (!isWindows) {
+            try {
+                Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rwxr-xr-x");
+                Files.setPosixFilePermissions(scriptPath, permissions);
+            } catch (UnsupportedOperationException ignored) {
+            }
+        }
+
+        return scriptPath;
+    }
+}

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -175,6 +175,7 @@ These settings apply to most tool services and are foundational for their operat
 | `quarkus.qute.strict-rendering`          | `false` - Allows for more lenient Qute template rendering.                                             |
 | `wanaku.service.name`                    | The unique, lowercase name of the service (e.g., `exec`, `http`).                                      |
 | `wanaku.service.base-uri`                | The base URI scheme for tools provided by this service (e.g., `exec://`).                              |
+| `wanaku.service.exec.allowed-executables` | Comma-separated absolute executable paths that the Exec tool may run.                                 |
 | `quarkus.oidc-client.auth-server-url`    | The URL of the Keycloak realm for authentication.                                                      |
 | `quarkus.oidc-client.client-id`          | `wanaku-service` - The shared OIDC client ID for all capabilities.                                     |
 | `quarkus.oidc-client.credentials.secret` | The OIDC client secret for the capability. **Must be replaced with a real secret.**                    |


### PR DESCRIPTION
Fixes: #953 

My question is regarding the CDI.

## Summary by Sourcery

Introduce an allowlisted, policy-driven execution model for the Exec tool to prevent command injection and unsafe process invocation.

New Features:
- Add an Exec command policy that tokenizes URIs, enforces an explicit executable allowlist, and validates commands before execution.

Bug Fixes:
- Prevent command injection in ExecClient by disallowing shell metacharacters, enforcing balanced quotes, and only running configured executables.

Enhancements:
- Refactor ExecClient to depend on injectable command policy and executor abstractions for safer, testable process execution.

Documentation:
- Document the new Exec tool executable allowlist configuration and update tool descriptions to reflect the stricter execution model.

Tests:
- Add unit and integration tests for ExecCommandPolicy, ExecClient security behavior, and the new command executor wiring.

## Summary by Sourcery

Introduce a policy-driven, allowlisted execution model for the Exec tool and route all process invocations through injectable command and executor abstractions.

New Features:
- Add an Exec command policy that tokenizes URIs into commands, validates them, and enforces an explicit executable allowlist before execution.
- Introduce a command executor abstraction for running validated commands, with a ProcessRunner-backed implementation.

Bug Fixes:
- Prevent command injection in ExecClient by rejecting unsafe characters, unbalanced quotes, blank commands, and non-allowlisted executables before running any process.

Enhancements:
- Refactor ExecClient to depend on injectable ExecCommandPolicy and CommandExecutor components instead of constructing and running raw file commands.
- Improve OS handling and script creation in tests by using RuntimeInfo helpers and UTF-8 encoding.

Documentation:
- Document the Exec tool's executable allowlist configuration and update tool descriptions to reflect the stricter, allowlist-based execution model.
- Add configuration reference for the new wanaku.service.exec.allowed-executables property.

Tests:
- Add unit tests for ExecCommandPolicy covering allowlist handling, tokenization, quoting, and rejection of unsafe commands.
- Add tests for ExecClient security behavior to verify that only allowlisted commands are passed to the executor and denied commands are never executed.
- Update integration tests for ExecClient to construct clients with the new policy and executor wiring.