### PR TITLE
Security: Enable Keycloak brute force protection in default configuration #956

### DIFF
--- a/deploy/auth/wanaku-config.json
+++ b/deploy/auth/wanaku-config.json
@@ -35,16 +35,16 @@
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": false,
   "editUsernameAllowed": true,
-  "bruteForceProtected": false,
+  "bruteForceProtected": true,
   "permanentLockout": false,
-  "maxTemporaryLockouts": 0,
+  "maxTemporaryLockouts": 5,
   "bruteForceStrategy": "MULTIPLE",
   "maxFailureWaitSeconds": 900,
   "minimumQuickLoginWaitSeconds": 60,
   "waitIncrementSeconds": 60,
   "quickLoginCheckMilliSeconds": 1000,
   "maxDeltaTimeSeconds": 43200,
-  "failureFactor": 30,
+  "failureFactor": 10,
   "roles": {
     "realm": [
       {


### PR DESCRIPTION
Fixes: #956

## Summary by Sourcery

Enhancements:
- Harden the default Keycloak configuration by turning on brute force protection for authentication.