### PR TITLE
fix: Zip Slip path traversal vulnerability in ZipHelper

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ZipHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ZipHelper.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -20,6 +21,9 @@ public class ZipHelper {
 
     public static void unzip(File zipFilePath, File destination, String componentName) throws IOException {
         // Create a ZipInputStream object from the specified ZIP file
+        Path destinationPath = destination.toPath().toAbsolutePath().normalize();
+        Path componentPath = destinationPath.resolve(componentName).normalize();
+
         try (ZipFile zipFile = new ZipFile(zipFilePath)) {
 
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
@@ -30,15 +34,20 @@ public class ZipHelper {
                 LOG.debugf("Unpacking %s", entry.getName());
 
                 String name = finalEntryName(componentName, entry);
+                Path unzippedPath = destinationPath.resolve(name).normalize();
 
-                // Create a file for the current entry in the unzip folder
-                File unzippedFile = new File(destination, name);
+                if (!unzippedPath.startsWith(componentPath)) {
+                    LOG.warnf("Rejected suspicious zip entry: %s", entry.getName());
+                    continue;
+                }
 
                 if (!entry.isDirectory()) {
                     // Open an input stream to read from the entry
                     try (InputStream in = zipFile.getInputStream(entry)) {
+                        Files.createDirectories(unzippedPath.getParent());
+
                         // Open an output stream to write to the local file
-                        try (OutputStream out = new FileOutputStream(unzippedFile)) {
+                        try (OutputStream out = new FileOutputStream(unzippedPath.toFile())) {
                             in.transferTo(out);
 
                         } catch (IOException e) {
@@ -48,11 +57,7 @@ public class ZipHelper {
                         LOG.errorf(e, "Error reading from entry: %s", e.getMessage());
                     }
                 } else {
-                    if (unzippedFile.exists()) {
-                        return;
-                    }
-
-                    Files.createDirectories(unzippedFile.toPath());
+                    Files.createDirectories(unzippedPath);
                 }
             }
         }
@@ -67,8 +72,12 @@ public class ZipHelper {
      * @return
      */
     private static String finalEntryName(String componentName, ZipEntry entry) {
-        int idx = entry.getName().indexOf("/");
-        String entryName = entry.getName().substring(idx);
+        String entryName = entry.getName().replace('\\', '/');
+        int idx = entryName.indexOf("/");
+        if (idx >= 0 && idx + 1 < entryName.length()) {
+            entryName = entryName.substring(idx + 1);
+        }
+
         return String.format("%s/%s", componentName, entryName);
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ZipHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ZipHelperTest.java
@@ -45,6 +45,51 @@ class ZipHelperTest {
         assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
     }
 
+    @Test
+    void unzipRejectsForwardSlashPathTraversalEntries() throws IOException {
+        Path zipFile = tempDir.resolve("malicious-forward-slash.zip");
+        createZip(zipFile, "component-1.0.0/bin/app.sh", "component-1.0.0/../evil.txt");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        assertTrue(Files.exists(tempDir.resolve("component/bin/app.sh")));
+        assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+        assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
+    }
+
+    @Test
+    void unzipKeepsFlatFilesInsideTheComponentDirectory() throws IOException {
+        Path zipFile = tempDir.resolve("flat-file.zip");
+        createZip(zipFile, "README.txt");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        assertTrue(Files.exists(tempDir.resolve("component/README.txt")));
+        assertFalse(Files.exists(tempDir.resolve("README.txt")));
+    }
+
+    @Test
+    void unzipKeepsDeeplyNestedEntriesInsideTheComponentDirectory() throws IOException {
+        Path zipFile = tempDir.resolve("nested.zip");
+        createZip(zipFile, "component-1.0.0/lib/internal/config/app.yml");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        assertTrue(Files.exists(tempDir.resolve("component/lib/internal/config/app.yml")));
+        assertFalse(Files.exists(tempDir.resolve("lib/internal/config/app.yml")));
+    }
+
+    @Test
+    void unzipRejectsDeepPathTraversalEntries() throws IOException {
+        Path zipFile = tempDir.resolve("deep-traversal.zip");
+        createZip(zipFile, "component-1.0.0/lib/../../evil.txt");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+        assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
+    }
+
     private static void createZip(Path zipFile, String... entryNames) throws IOException {
         try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zipFile))) {
             for (String entryName : entryNames) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ZipHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ZipHelperTest.java
@@ -1,0 +1,57 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZipHelperTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void unzipKeepsEntriesWithinTheComponentDirectory() throws IOException {
+        Path zipFile = tempDir.resolve("safe.zip");
+        createZip(zipFile, "component-1.0.0/bin/app.sh", "component-1.0.0/config/app.yml");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        Path appScript = tempDir.resolve("component/bin/app.sh");
+        Path configFile = tempDir.resolve("component/config/app.yml");
+
+        assertTrue(Files.exists(appScript));
+        assertTrue(Files.exists(configFile));
+        assertFalse(Files.exists(tempDir.resolve("bin/app.sh")));
+        assertFalse(Files.exists(tempDir.resolve("config/app.yml")));
+    }
+
+    @Test
+    void unzipRejectsPathTraversalEntries() throws IOException {
+        Path zipFile = tempDir.resolve("malicious.zip");
+        createZip(zipFile, "component-1.0.0/bin/app.sh", "component-1.0.0/..\\evil.txt");
+
+        ZipHelper.unzip(zipFile.toFile(), tempDir.toFile(), "component");
+
+        assertTrue(Files.exists(tempDir.resolve("component/bin/app.sh")));
+        assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+        assertFalse(Files.exists(tempDir.getParent().resolve("evil.txt")));
+    }
+
+    private static void createZip(Path zipFile, String... entryNames) throws IOException {
+        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(zipFile))) {
+            for (String entryName : entryNames) {
+                out.putNextEntry(new ZipEntry(entryName));
+                out.write(("content-for-" + entryName).getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #954

## Summary by Sourcery

Address a Zip Slip path traversal vulnerability in the CLI ZipHelper and add regression tests to ensure extracted files remain within the intended component directory.

Bug Fixes:
- Prevent ZipHelper from extracting ZIP entries outside the target component directory by validating normalized extraction paths against the component base path.

Tests:
- Add unit tests covering normal extraction, flat and nested paths, and multiple path traversal attempts using both backslash and forward slash separators.