### PR TITLE
refactor: GCache gRPC channels instead of recreating them on every request and add unit tests

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManager.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManager.java
@@ -16,41 +16,29 @@ import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
  * features like connection pooling, interceptors, and custom configurations
  * in the future.
  * <p>
- * Current implementation creates channels with plaintext communication.
- * Future enhancements may include:
- * <ul>
- *   <li>Connection pooling for reusing channels</li>
- *   <li>Interceptors for logging and metrics</li>
- *   <li>SSL/TLS configuration</li>
- *   <li>Retry policies and circuit breakers</li>
- * </ul>
+ * Channels are cached per service endpoint and reused across requests.
  */
 class GrpcChannelManager {
     private static final Logger LOG = Logger.getLogger(GrpcChannelManager.class);
-    private static final Map<ServiceTarget, ManagedChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
+    private static final Map<String, ManagedChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
 
     /**
-     * Creates a new gRPC channel for the specified service target.
+     * Returns a cached gRPC channel for the specified service target.
      * <p>
-     * The channel is configured with plaintext communication. The caller
-     * is responsible for managing the channel lifecycle, including shutdown.
+     * The channel is configured with plaintext communication and reused for
+     * subsequent requests to the same endpoint.
      *
      * @param service the service target containing the address to connect to
-     * @return a new ManagedChannel configured for the service
+     * @return a cached ManagedChannel configured for the service
      */
     public ManagedChannel createChannel(ServiceTarget service) {
-        if (CHANNEL_MAP.containsKey(service)) {
-            LOG.debugf("Reusing gRPC channel for service: %s", service.toAddress());
-            return CHANNEL_MAP.get(service);
-        }
-
-        LOG.debugf("Creating gRPC channel for service: %s", service.toAddress());
-        ManagedChannel channel = ManagedChannelBuilder.forTarget(service.toAddress())
-                .usePlaintext()
-                .build();
-
-        CHANNEL_MAP.put(service, channel);
-        return channel;
+        String target = service.toAddress();
+        return CHANNEL_MAP.computeIfAbsent(target, endpoint -> {
+            LOG.debugf("Creating gRPC channel for service: %s", endpoint);
+            return ManagedChannelBuilder.forTarget(endpoint)
+                    .usePlaintext()
+                    .build();
+        });
     }
 
     /**
@@ -73,10 +61,9 @@ class GrpcChannelManager {
     }
 
     /**
-     * Closes a gRPC channel gracefully.
+     * No-op for request-level cleanup.
      * <p>
-     * This method attempts to shutdown the channel. If an error occurs during
-     * shutdown, it is logged but not propagated to avoid disrupting the caller.
+     * Channels are cached and reused, so they are not closed after each request.
      *
      * @param channel the channel to close, may be null
      */
@@ -84,9 +71,13 @@ class GrpcChannelManager {
         // NO-OP
     }
 
+    /**
+     * Shuts down and removes all cached channels.
+     */
     public void shutdown() {
-        for (Map.Entry<ServiceTarget, ManagedChannel> entry : CHANNEL_MAP.entrySet()) {
+        for (Map.Entry<String, ManagedChannel> entry : CHANNEL_MAP.entrySet()) {
             doCloseChannel(entry.getValue());
         }
+        CHANNEL_MAP.clear();
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManagerTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManagerTest.java
@@ -1,0 +1,126 @@
+package ai.wanaku.backend.bridge.transports.grpc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import io.grpc.ManagedChannel;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+
+class GrpcChannelManagerTest {
+
+    private final GrpcChannelManager channelManager = new GrpcChannelManager();
+
+    @AfterEach
+    void tearDown() {
+        channelManager.shutdown();
+    }
+
+    @Test
+    void createChannel_reusesChannelForSameEndpoint() {
+        ServiceTarget firstTarget = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget secondTarget = new ServiceTarget(
+                "id-2", "service-b", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel firstChannel = channelManager.createChannel(firstTarget);
+        ManagedChannel secondChannel = channelManager.createChannel(secondTarget);
+
+        assertSame(firstChannel, secondChannel);
+        assertFalse(firstChannel.isShutdown());
+    }
+
+    @Test
+    void createChannel_returnsSameInstanceForRepeatedCallsWithSameTarget() {
+        ServiceTarget target = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel firstChannel = channelManager.createChannel(target);
+        ManagedChannel secondChannel = channelManager.createChannel(target);
+        ManagedChannel thirdChannel = channelManager.createChannel(target);
+
+        assertSame(firstChannel, secondChannel);
+        assertSame(secondChannel, thirdChannel);
+    }
+
+    @Test
+    void createChannel_reusesSameChannelForEquivalentTargets() {
+        ServiceTarget firstTarget = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget secondTarget = new ServiceTarget(
+                "id-2", "service-b", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel firstChannel = channelManager.createChannel(firstTarget);
+        ManagedChannel secondChannel = channelManager.createChannel(secondTarget);
+
+        assertSame(firstChannel, secondChannel);
+    }
+
+    @Test
+    void createChannel_createsDifferentChannelsForDifferentEndpoints() {
+        ServiceTarget firstTarget = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget secondTarget = new ServiceTarget(
+                "id-2", "service-b", "localhost", 9002, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel firstChannel = channelManager.createChannel(firstTarget);
+        ManagedChannel secondChannel = channelManager.createChannel(secondTarget);
+
+        assertNotSame(firstChannel, secondChannel);
+    }
+
+    @Test
+    void closeChannel_doesNotShutdownCachedChannel() {
+        ServiceTarget target = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel channel = channelManager.createChannel(target);
+        channelManager.closeChannel(channel);
+
+        assertFalse(channel.isShutdown());
+        assertSame(channel, channelManager.createChannel(target));
+    }
+
+    @Test
+    void closeChannel_acceptsNullWithoutThrowing() {
+        assertDoesNotThrow(() -> channelManager.closeChannel(null));
+    }
+
+    @Test
+    void shutdown_closesAndClearsCachedChannels() {
+        ServiceTarget target = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel firstChannel = channelManager.createChannel(target);
+        channelManager.shutdown();
+
+        assertTrue(firstChannel.isShutdown());
+
+        ManagedChannel secondChannel = channelManager.createChannel(target);
+        assertNotSame(firstChannel, secondChannel);
+    }
+
+    @Test
+    void shutdown_isIdempotent() {
+        ServiceTarget target = new ServiceTarget(
+                "id-1", "service-a", "localhost", 9001, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel channel = channelManager.createChannel(target);
+
+        channelManager.shutdown();
+        channelManager.shutdown();
+
+        assertTrue(channel.isShutdown());
+    }
+
+    @Test
+    void shutdown_onEmptyCacheDoesNotThrow() {
+        GrpcChannelManager emptyManager = new GrpcChannelManager();
+
+        assertDoesNotThrow(emptyManager::shutdown);
+    }
+}


### PR DESCRIPTION
Closes: #849

## Summary by Sourcery

Refactor gRPC channel management to cache and reuse channels per endpoint and add tests to verify the new lifecycle and reuse behavior.

Enhancements:
- Cache gRPC channels by endpoint string instead of ServiceTarget instances and reuse them across requests.
- Make request-level closeChannel a no-op while providing a shutdown method to close and clear all cached channels.

Tests:
- Add unit tests covering channel reuse across equivalent targets, creation for different endpoints, no-op close behavior, and shutdown semantics including idempotency and empty cache handling.