### PR TITLE
[736] LLM page not showing available tools

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -1,6 +1,5 @@
 import React, {useRef, useState} from "react"
 import "highlight.js/styles/atom-one-dark.css"
-import {Tool} from "./tools.ts"
 import {LLMSetup} from "./LLMSetup.tsx"
 import {LLMTools} from "./LLMTools.tsx"
 import {LLMChatArea} from "./LLMChatArea.tsx"
@@ -8,6 +7,7 @@ import {MessageResponse} from "./messages.ts"
 import {Column, Grid} from "@carbon/react"
 import {connectedMCPClient} from "./mcp.ts"
 import {LlmConfig, loadConfig} from "./config.ts"
+import {ToolReference} from "../../models"
 
 
 export const LLMChatPage: React.FC = () => {
@@ -33,7 +33,7 @@ export const LLMChatPage: React.FC = () => {
   
   async function runPrompt() {
 
-    function transformTools(tools: Tool[]) {
+    function transformTools(tools: ToolReference[]) {
       return tools.map((tool) => {
         return {
           type: "function",

--- a/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
@@ -4,25 +4,26 @@ import {
   InlineLoading,
   Stack
 } from "@carbon/react"
-import {Tool} from "./tools.ts"
-import {useEffect, useState} from "react"
-import {getTools} from "./mcp.ts"
+import React, {useEffect, useState} from "react"
+import {useTools} from "../../hooks/api/use-tools"
+import {ToolReference} from "../../models"
 
 
 interface LLMToolsProps {
-  selectedTools: Tool[]
-  onSelectionChange: (tools: Tool[]) => void
+  selectedTools: ToolReference[]
+  onSelectionChange: (tools: ToolReference[]) => void
 }
 
 export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionChange }) => {
   
-  const [tools, setTools] = useState<Tool[]>([])
-  const [isLoading, setLoading] = useState<boolean>(true)
+  const [tools, setTools] = useState<ToolReference[]>([])
+  const [isLoading, setLoading] = useState(true)
+  const { listTools } = useTools()
   
   useEffect(() => {
     (async () => {
       try {
-        const tools = await getTools()
+        const tools = await fetchTools()
         setTools(tools)
       } catch (error) {
         console.error("Failed to load tools", error)
@@ -31,7 +32,15 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
         setLoading(false)
       }
     })()
-  }, [])
+  }, [listTools])
+  
+  async function fetchTools(): Promise<ToolReference[]> {
+    const response = await listTools()
+    if (response.status !== 200 || !Array.isArray(response.data.data)) {
+      throw new Error("Error while fetching tools: " + response.status)
+    }
+    return response.data.data
+  }
   
   function isAllSelected() {
     const selectedToolNames = selectedTools.map(tool => tool.name)
@@ -64,9 +73,9 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
           />
           {tools.map((tool) => (
             <Checkbox
-              id={tool.name}
+              id={tool.name!}
               key={tool.name}
-              labelText={tool.name}
+              labelText={tool.name!}
               helperText={tool.description}
               checked={selectedTools.map(tool => tool.name).includes(tool.name)}
               onChange={(_, { checked }) => {

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -1,4 +1,4 @@
-import {Tool} from "./tools.ts"
+import {ToolReference} from "../../models"
 
 
 export interface LlmConfig {
@@ -6,7 +6,7 @@ export interface LlmConfig {
   llmModel?: string
   apiKey?: string
   extraLlmParams?: string
-  tools: Tool[]
+  tools: ToolReference[]
 }
 
 export const baseUrlItems = [

--- a/apps/ui/admin/src/Pages/LLMChat/mcp.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/mcp.ts
@@ -1,6 +1,5 @@
 import {Client} from "@modelcontextprotocol/sdk/client/index.js"
 import {SSEClientTransport} from "@modelcontextprotocol/sdk/client/sse.js"
-import {Tool} from "./tools.ts";
 import {getUrl} from "../../custom-fetch.ts"
 
 
@@ -12,14 +11,4 @@ export async function connectedMCPClient() {
   const url = new URL(getUrl("/public/mcp/sse"))
   await mcpClient.connect(new SSEClientTransport(url))
   return mcpClient
-}
-
-export async function getTools(): Promise<Tool[]> {
-  const mcpClient = await connectedMCPClient()
-  try {
-    const { tools } = await mcpClient.listTools()
-    return [...tools]
-  } finally {
-    await mcpClient.close()
-  }
 }

--- a/apps/ui/admin/src/Pages/LLMChat/tools.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/tools.ts
@@ -1,6 +1,0 @@
-export interface Tool {
-  name: string
-  description?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inputSchema?: any
-}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/736

Available tools were obtained through the MCP Client. I believe better way is to load them from Wanaku backend.

## Summary by Sourcery

Load LLM tools for the admin chat page from the Wanaku backend instead of via the MCP client, updating types and configuration accordingly.

New Features:
- Expose LLM tools to the UI via the shared ToolReference model and use-tools API hook rather than the MCP client.

Enhancements:
- Update LLM chat configuration and selection components to use ToolReference types consistently.
- Remove the now-unused tools helper module and MCP-based tool listing logic.