### PR TITLE
fix: Capabilities only work with the separate grpc server

### DIFF
--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
@@ -6,12 +6,14 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.jboss.logging.Logger;
 import io.quarkus.oidc.client.Tokens;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.capabilities.discovery.DefaultRegistrationManager;
@@ -153,14 +155,31 @@ public class ServicesHelper {
     }
 
     private static ServiceTarget newServiceTarget(WanakuServiceConfig config, String service, String serviceType) {
-        String portStr = ConfigProvider.getConfig()
-                .getConfigValue("quarkus.grpc.server.port")
-                .getValue();
-        final int port = Integer.parseInt(portStr);
+        final int port = resolveRegistrationPort();
 
         String address = resolveRegistrationAddress(config.registration().announceAddress());
 
         return ServiceTarget.newEmptyTarget(service, address, port, serviceType);
+    }
+
+    static int resolveRegistrationPort() {
+        Config config = ConfigProvider.getConfig();
+        boolean useSeparateServer = config.getOptionalValue("quarkus.grpc.server.use-separate-server", Boolean.class)
+                .orElse(Boolean.TRUE);
+
+        if (useSeparateServer) {
+            return config.getValue("quarkus.grpc.server.port", Integer.class);
+        }
+
+        boolean httpHostEnabled = config.getOptionalValue("quarkus.http.host-enabled", Boolean.class)
+                .orElse(Boolean.TRUE);
+        if (!httpHostEnabled) {
+            throw new WanakuException(
+                    "quarkus.grpc.server.use-separate-server=false requires quarkus.http.host-enabled=true "
+                            + "because the gRPC server shares the HTTP listener in that mode");
+        }
+
+        return config.getValue("quarkus.http.port", Integer.class);
     }
 
     private record ServiceClientHeadersFactory(Tokens accessToken) implements ClientHeadersFactory {

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/ServicesHelperTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/ServicesHelperTest.java
@@ -3,12 +3,27 @@ package ai.wanaku.core.capabilities.common;
 import java.io.File;
 import java.nio.file.Path;
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @QuarkusTest
 class ServicesHelperTest {
+    private static final String USE_SEPARATE_SERVER = "quarkus.grpc.server.use-separate-server";
+    private static final String GRPC_PORT = "quarkus.grpc.server.port";
+    private static final String HTTP_HOST_ENABLED = "quarkus.http.host-enabled";
+    private static final String HTTP_PORT = "quarkus.http.port";
+
+    @AfterEach
+    void clearConfigOverrides() {
+        System.clearProperty(USE_SEPARATE_SERVER);
+        System.clearProperty(GRPC_PORT);
+        System.clearProperty(HTTP_HOST_ENABLED);
+        System.clearProperty(HTTP_PORT);
+    }
 
     @Test
     void waitAndRetryDecrementsRetries() {
@@ -61,5 +76,35 @@ class ServicesHelperTest {
         TestServiceConfig config = new TestServiceConfig("my-service", "/opt/wanaku");
         String result = ServicesHelper.getCanonicalServiceHome(config);
         assertEquals(Path.of("/opt/wanaku", "my-service").toString(), result);
+    }
+
+    @Test
+    void resolveRegistrationPortUsesGrpcPortWhenSeparateServerIsEnabled() {
+        System.setProperty(USE_SEPARATE_SERVER, "true");
+        System.setProperty(GRPC_PORT, "9123");
+
+        assertEquals(9123, ServicesHelper.resolveRegistrationPort());
+    }
+
+    @Test
+    void resolveRegistrationPortUsesHttpPortWhenGrpcServerSharesTheHttpListener() {
+        System.setProperty(USE_SEPARATE_SERVER, "false");
+        System.setProperty(HTTP_HOST_ENABLED, "true");
+        System.setProperty(HTTP_PORT, "8085");
+
+        assertEquals(8085, ServicesHelper.resolveRegistrationPort());
+    }
+
+    @Test
+    void resolveRegistrationPortFailsFastWhenSharedGrpcNeedsAnHttpServer() {
+        System.setProperty(USE_SEPARATE_SERVER, "false");
+        System.setProperty(HTTP_HOST_ENABLED, "false");
+
+        WanakuException exception = assertThrows(WanakuException.class, ServicesHelper::resolveRegistrationPort);
+
+        assertEquals(
+                "quarkus.grpc.server.use-separate-server=false requires quarkus.http.host-enabled=true "
+                        + "because the gRPC server shares the HTTP listener in that mode",
+                exception.getMessage());
     }
 }


### PR DESCRIPTION
Fixes: #589

## Summary by Sourcery

Adjust service registration to select the correct port depending on whether gRPC runs on a separate server or shares the HTTP listener.

Bug Fixes:
- Fix service registration using the gRPC port only when a separate gRPC server is configured, and the HTTP port when gRPC shares the HTTP listener, failing fast if HTTP is disabled in that mode.

Tests:
- Add unit tests covering registration port resolution for separate gRPC server, shared HTTP listener, and misconfigured shared setup.