### PR TITLE
Update quarkus to 3.33.1 and related dependencies

### DIFF
--- a/apps/ui/admin/src/api/wanaku-router-api.ts
+++ b/apps/ui/admin/src/api/wanaku-router-api.ts
@@ -306,7 +306,7 @@ export const getApiV1CapabilitiesToolsState = async (
  * @summary Update
  */
 export type putApiV1DataStoreResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -354,7 +354,7 @@ export const putApiV1DataStore = async (
  * @summary Remove By Name
  */
 export type deleteApiV1DataStoreResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -570,7 +570,7 @@ export const deleteApiV1DataStoreLabels = async (
  * @summary Remove By Id
  */
 export type deleteApiV1DataStoreIdResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -695,7 +695,7 @@ export const getApiV1Forwards = async (
  * @summary Add Forward
  */
 export type postApiV1ForwardsResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -743,7 +743,7 @@ export const postApiV1Forwards = async (
  * @summary Update
  */
 export type putApiV1ForwardsNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -796,7 +796,7 @@ export const putApiV1ForwardsName = async (
  * @summary Remove Forward
  */
 export type deleteApiV1ForwardsNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -859,7 +859,7 @@ export const getApiV1ForwardsName = async (
  * @summary Refresh
  */
 export type postApiV1ForwardsNameRefreshesResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -947,7 +947,7 @@ export const postApiV1ManagementDiscovery = async (
  * @summary Deregister
  */
 export type deleteApiV1ManagementDiscoveryResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -982,7 +982,7 @@ export const deleteApiV1ManagementDiscovery = async (
  * @summary Ping
  */
 export type postApiV1ManagementDiscoveryHeartbeatsResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1255,7 +1255,7 @@ export const deleteApiV1NamespacesStale = async (
  * @summary Update
  */
 export type putApiV1NamespacesIdResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1332,7 +1332,7 @@ export const getApiV1NamespacesId = async (
  * @summary Delete
  */
 export type deleteApiV1NamespacesIdResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1364,7 +1364,7 @@ export const deleteApiV1NamespacesId = async (
  * @summary Update
  */
 export type putApiV1PromptsResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1412,7 +1412,7 @@ export const putApiV1Prompts = async (
  * @summary Remove
  */
 export type deleteApiV1PromptsResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1800,7 +1800,7 @@ export const postApiV1ResourcesPayloads = async (
  * @summary Update
  */
 export type putApiV1ResourcesNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -1853,7 +1853,7 @@ export const putApiV1ResourcesName = async (
  * @summary Remove
  */
 export type deleteApiV1ResourcesNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -2139,7 +2139,7 @@ export const postApiV1ToolsPayloads = async (
  * @summary Update
  */
 export type putApiV1ToolsNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 
@@ -2188,7 +2188,7 @@ export const putApiV1ToolsName = async (
  * @summary Remove
  */
 export type deleteApiV1ToolsNameResponse200 = {
-  data: void;
+  data: unknown;
   status: 200;
 };
 

--- a/apps/wanaku-cli/pom.xml
+++ b/apps/wanaku-cli/pom.xml
@@ -159,7 +159,7 @@
         <!-- tests -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -68,12 +68,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -20,7 +20,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.openshift.api.model.Route;
-import io.javaoperatorsdk.operator.ReconcilerUtils;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import ai.wanaku.operator.wanaku.WanakuCapability;
 import ai.wanaku.operator.wanaku.WanakuCapabilityReconciler;
@@ -170,7 +170,7 @@ public final class OperatorUtil {
 
     public static Deployment makeDesiredRouterBackendDeployment(
             WanakuRouter resource, Context<WanakuRouter> context, String host) {
-        Deployment desiredDeployment = ReconcilerUtils.loadYaml(
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
                 Deployment.class, WanakuRouterReconciler.class, ROUTER_BACKEND_DEPLOYMENT_FILE);
 
         String deploymentName = resource.getMetadata().getName();
@@ -212,7 +212,7 @@ public final class OperatorUtil {
     }
 
     public static Service makeRouterInternalService(WanakuRouter resource) {
-        Service service = ReconcilerUtils.loadYaml(
+        Service service = ReconcilerUtilsInternal.loadYaml(
                 Service.class, WanakuRouterReconciler.class, ROUTER_BACKEND_INTERNAL_SERVICE_FILE);
 
         String deploymentName = resource.getMetadata().getName();
@@ -234,7 +234,7 @@ public final class OperatorUtil {
     }
 
     public static Route makeRouterExternalService(WanakuRouter resource) {
-        Route route = ReconcilerUtils.loadYaml(
+        Route route = ReconcilerUtilsInternal.loadYaml(
                 Route.class, WanakuRouterReconciler.class, ROUTER_BACKEND_EXTERNAL_SERVICE_FILE);
 
         String deploymentName = resource.getMetadata().getName();
@@ -253,7 +253,8 @@ public final class OperatorUtil {
     }
 
     public static Ingress makeRouterIngress(WanakuRouter resource, String host) {
-        Ingress ingress = ReconcilerUtils.loadYaml(Ingress.class, WanakuRouterReconciler.class, ROUTER_INGRESS_FILE);
+        Ingress ingress =
+                ReconcilerUtilsInternal.loadYaml(Ingress.class, WanakuRouterReconciler.class, ROUTER_INGRESS_FILE);
 
         String deploymentName = resource.getMetadata().getName();
         String ns = resource.getMetadata().getNamespace();
@@ -282,7 +283,7 @@ public final class OperatorUtil {
     }
 
     public static PersistentVolumeClaim makeRouterVolumePVC(WanakuRouter resource) {
-        PersistentVolumeClaim pvc = ReconcilerUtils.loadYaml(
+        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
                 PersistentVolumeClaim.class, WanakuRouterReconciler.class, SERVICES_VOLUME_PVC_FILE);
 
         String deploymentName = resource.getMetadata().getName();
@@ -302,7 +303,7 @@ public final class OperatorUtil {
     // ---- Capability methods ----
 
     public static PersistentVolumeClaim makeServicesVolumePVC(WanakuCapability resource, String serviceName) {
-        PersistentVolumeClaim pvc = ReconcilerUtils.loadYaml(
+        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
                 PersistentVolumeClaim.class, WanakuCapabilityReconciler.class, SERVICES_VOLUME_PVC_FILE);
 
         String deploymentName = resource.getMetadata().getName();
@@ -494,7 +495,7 @@ public final class OperatorUtil {
             WanakuCapability resource,
             Context<WanakuCapability> context,
             WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Deployment desiredDeployment = ReconcilerUtils.loadYaml(
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
                 Deployment.class, WanakuCapabilityReconciler.class, WANAKU_CAPABILITY_DEPLOYMENT_FILE);
 
         return configureCapabilityDeployment(
@@ -508,7 +509,7 @@ public final class OperatorUtil {
             WanakuCapability resource,
             Context<WanakuCapability> context,
             WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Deployment desiredDeployment = ReconcilerUtils.loadYaml(
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
                 Deployment.class, WanakuCapabilityReconciler.class, CAMEL_INTEGRATION_CAPABILITY_DEPLOYMENT_FILE);
 
         return configureCapabilityDeployment(
@@ -520,7 +521,7 @@ public final class OperatorUtil {
 
     public static Service makeCapabilityInternalService(
             WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Service service = ReconcilerUtils.loadYaml(
+        Service service = ReconcilerUtilsInternal.loadYaml(
                 Service.class, WanakuCapabilityReconciler.class, CAPABILITY_INTERNAL_SERVICE_FILE);
 
         String serviceName = capabilitiesSpec.getName();

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -119,7 +119,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -131,7 +131,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
+            <artifactId>quarkus-junit-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/AbstractWanakuSerializationContextInitializer.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/AbstractWanakuSerializationContextInitializer.java
@@ -1,23 +1,24 @@
 package ai.wanaku.backend.core.persistence.infinispan.protostream.schema;
 
 import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.ResourceUtils;
 import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
-import org.infinispan.protostream.impl.ResourceUtils;
+import org.infinispan.protostream.schema.Schema;
 
-public abstract class AbstractWanakuSerializationContextInitializer implements SerializationContextInitializer {
-
-    @Override
-    public abstract String getProtoFileName();
+public abstract class AbstractWanakuSerializationContextInitializer implements SerializationContextInitializer, Schema {
 
     @Override
-    public String getProtoFile() {
-        return ResourceUtils.getResourceAsString(getClass(), "/proto/" + getProtoFileName());
+    public abstract String getName();
+
+    @Override
+    public String getContent() {
+        return ResourceUtils.getResourceAsString(getClass(), "/proto/" + getName());
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ActivityRecordSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ActivityRecordSchema.java
@@ -9,14 +9,14 @@ public class ActivityRecordSchema extends AbstractWanakuSerializationContextInit
     private final ServiceStateSchema serviceState = new ServiceStateSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "activity_record.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         serviceState.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionRequestSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionRequestSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Code
 public class CodeExecutionRequestSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "code_execution_request.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionStatusSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionStatusSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Code
 public class CodeExecutionStatusSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "code_execution_status.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionTaskSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/CodeExecutionTaskSchema.java
@@ -10,7 +10,7 @@ public class CodeExecutionTaskSchema extends AbstractWanakuSerializationContextI
     private final CodeExecutionRequestSchema requestSchema = new CodeExecutionRequestSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "code_execution_task.proto";
     }
 
@@ -18,7 +18,7 @@ public class CodeExecutionTaskSchema extends AbstractWanakuSerializationContextI
     public void registerSchema(SerializationContext serCtx) {
         statusSchema.registerSchema(serCtx);
         requestSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ContentSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ContentSchema.java
@@ -20,14 +20,14 @@ public class ContentSchema extends AbstractWanakuSerializationContextInitializer
     private final ResourceReferenceSchema resourceReferenceSchema = new ResourceReferenceSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "content.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         resourceReferenceSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/DataStoreSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/DataStoreSchema.java
@@ -9,7 +9,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Data
 public class DataStoreSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "data_store.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ForwardReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ForwardReferenceSchema.java
@@ -7,13 +7,13 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Forw
 public class ForwardReferenceSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "forward_reference.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/InputSchemaSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/InputSchemaSchema.java
@@ -9,14 +9,14 @@ public class InputSchemaSchema extends AbstractWanakuSerializationContextInitial
     private final PropertySchema propertySchema = new PropertySchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "input_schema.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         propertySchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/NamespaceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/NamespaceSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Name
 public class NamespaceSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "namespace.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PromptReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PromptReferenceSchema.java
@@ -19,14 +19,14 @@ public class PromptReferenceSchema extends AbstractWanakuSerializationContextIni
     private final ContentSchema contentSchema = new ContentSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "prompt_reference.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         contentSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PropertySchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PropertySchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Prop
 public class PropertySchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "property.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/RemoteToolReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/RemoteToolReferenceSchema.java
@@ -9,14 +9,14 @@ public class RemoteToolReferenceSchema extends AbstractWanakuSerializationContex
     private final InputSchemaSchema inputSchemaSchema = new InputSchemaSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "remote_tool_reference.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         inputSchemaSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ResourceReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ResourceReferenceSchema.java
@@ -7,7 +7,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Reso
 public class ResourceReferenceSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "resource_reference.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceStateSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceStateSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Serv
 public class ServiceStateSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "service_state.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceTargetSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceTargetSchema.java
@@ -9,14 +9,14 @@ public class ServiceTargetSchema extends AbstractWanakuSerializationContextIniti
     private final ServiceTypeSchema serviceTypeSchema = new ServiceTypeSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "service_target.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         serviceTypeSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceTypeSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ServiceTypeSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Serv
 public class ServiceTypeSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "service_type.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ToolReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ToolReferenceSchema.java
@@ -17,14 +17,14 @@ public class ToolReferenceSchema extends AbstractWanakuSerializationContextIniti
     private final InputSchemaSchema inputSchema = new InputSchemaSchema();
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "tool_reference.proto";
     }
 
     @Override
     public void registerSchema(SerializationContext serCtx) {
         inputSchema.registerSchema(serCtx);
-        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getProtoFileName(), this.getProtoFile()));
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/WanakuErrorSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/WanakuErrorSchema.java
@@ -6,7 +6,7 @@ import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.Wana
 public class WanakuErrorSchema extends AbstractWanakuSerializationContextInitializer {
 
     @Override
-    public String getProtoFileName() {
+    public String getName() {
         return "wanaku_error.proto";
     }
 

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -1090,7 +1090,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1119,7 +1124,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1261,7 +1271,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1349,7 +1364,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1391,7 +1411,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1421,7 +1446,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           }
         },
         "summary" : "Remove Forward",
@@ -1464,7 +1494,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1524,7 +1559,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           }
         },
         "summary" : "Deregister",
@@ -1546,7 +1586,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           }
         },
         "summary" : "Ping",
@@ -1739,7 +1784,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "400" : {
             "description" : "Bad Request"
@@ -1783,7 +1833,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           }
         },
         "summary" : "Delete",
@@ -1804,7 +1859,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -1833,7 +1893,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -2129,7 +2194,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -2159,7 +2229,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -2380,7 +2455,12 @@
         },
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",
@@ -2410,7 +2490,12 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : { }
+              }
+            }
           },
           "500" : {
             "description" : "Wanaku error",

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -734,6 +734,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -754,6 +757,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -848,6 +854,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -907,6 +916,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -935,6 +947,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -956,6 +971,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
       summary: Remove Forward
       tags:
       - Forwards Resource
@@ -987,6 +1005,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1026,6 +1047,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
       summary: Deregister
       tags:
       - Discovery Resource
@@ -1041,6 +1065,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
       summary: Ping
       tags:
       - Discovery Resource
@@ -1172,6 +1199,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "400":
           description: Bad Request
       summary: Update
@@ -1204,6 +1234,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
       summary: Delete
       tags:
       - Namespaces Resource
@@ -1218,6 +1251,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1238,6 +1274,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1430,6 +1469,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1451,6 +1493,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1596,6 +1641,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:
@@ -1617,6 +1665,9 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema: {}
         "500":
           description: Wanaku error
           content:

--- a/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/pom.xml
@@ -46,7 +46,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-junit5</artifactId>
+                <artifactId>quarkus-junit</artifactId>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/capabilities/tools/wanaku-tool-service-tavily/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-tavily/pom.xml
@@ -97,7 +97,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,12 +43,12 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 
         <!-- Deps -->
-        <quarkus.platform.version>3.27.2</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <jackson.version>2.20.0</jackson.version>
         <junit-jupiter.version>5.14.3</junit-jupiter.version>
-        <quarkus-mcp-server.version>1.10.1</quarkus-mcp-server.version>
-        <quarkus-oidc-proxy.version>0.4.2</quarkus-oidc-proxy.version>
-        <camel.version>4.14.4</camel.version>
+        <quarkus-mcp-server.version>1.10.5</quarkus-mcp-server.version>
+        <quarkus-oidc-proxy.version>0.5.0</quarkus-oidc-proxy.version>
+        <camel.version>4.18.1</camel.version>
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.8.0</langchain4j.version>
         <langchain4j-mcp.version>1.10.0-beta18</langchain4j-mcp.version>
@@ -59,7 +59,12 @@
         <swagger-core.version>2.2.45</swagger-core.version>
         <jline.version>3.30.6</jline.version>
         <swagger-parser.version>2.1.36</swagger-parser.version>
-        <quarkus-infinispan-embedded.version>1.3.0</quarkus-infinispan-embedded.version>
+        <quarkus-infinispan-embedded.version>2.0.1</quarkus-infinispan-embedded.version>
+        <!-- TEMPORARY: quarkus-infinispan-embedded wrongly set infinispan to 16.0.9
+          remove this infinispan version and bom once there is a quarkus-infinispan-embedded release
+          to fix the infinispan version.
+          https://github.com/quarkiverse/quarkus-infinispan-embedded/discussions/68-->
+        <infinispan.version>16.0.8</infinispan.version>
         <assertj.version>3.27.7</assertj.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
         <jansi.version>2.4.2</jansi.version>
@@ -67,12 +72,12 @@
         <commons-logging.version>1.3.5</commons-logging.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
-        <quarkus-operator-sdk.version>7.4.0</quarkus-operator-sdk.version>
-        <quarkus-helm.version>1.2.7</quarkus-helm.version>
+        <quarkus-operator-sdk.version>7.7.3</quarkus-operator-sdk.version>
+        <quarkus-helm.version>1.3.0</quarkus-helm.version>
         <wanaku-capabilities-sdk.version>0.1.0</wanaku-capabilities-sdk.version>
         <commonmark.version>0.27.1</commonmark.version>
         <oauth2-oidc-sdk.version>11.34</oauth2-oidc-sdk.version>
-        <operator-framework.version>5.2.2</operator-framework.version>
+        <operator-framework.version>5.3.2</operator-framework.version>
         <palantir-format.version>2.71.0</palantir-format.version>
 
         <assembly.descriptor>src/main/assembly/assembly.xml</assembly.descriptor>
@@ -94,6 +99,14 @@
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-operator-sdk-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-bom</artifactId>
+                <version>${infinispan.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://github.com/wanaku-ai/wanaku/issues/713

- Other artifacts required updates: quarkus-mcp-server: 1.10.5 quarkus-oidc-proxy: 0.5.0 camel: 4.18.1 quarkus-infinispan-embedded: 2.0.1 quarkus-operator-sdk: 7.7.3 quarkus-helm: 1.3.0 operator-framework: 5.3.2

- quarkus-infinispan-embedded has wrongly set infinispan to 16.0.9 so we had to import the bom https://github.com/quarkiverse/quarkus-infinispan-embedded/discussions/68

- renamed junit5 artifacts to junit
- openapi files were regenerated due to changes in build

## Summary by Sourcery

Upgrade Quarkus and related dependencies and align application, operator, and SDK code with the new platform and Infinispan/Protostream APIs.

Bug Fixes:
- Pin the Infinispan BOM to a compatible version to work around an incorrect dependency version in quarkus-infinispan-embedded.
- Adjust Protostream serialization schemas and resource loading to the updated Infinispan Protostream API.
- Switch operator Kubernetes resource loading to use the updated reconciler utility class required by newer operator tooling.

Enhancements:
- Regenerate backend OpenAPI definitions and TypeScript client types so 200 responses consistently declare JSON content and use an unknown payload type.
- Rename Quarkus JUnit 5 test dependencies across modules to the new quarkus-junit and quarkus-junit-mockito artifacts.

Build:
- Bump Quarkus platform and related library versions (including MCP server, OIDC proxy, Camel, operator SDK, Helm plugin, and operator framework) and import the Infinispan BOM in the parent POM to control transitive versions.

Tests:
- Update test dependencies across services, SDKs, archetypes, and integration tests to use the new Quarkus JUnit artifacts.