### PR TITLE
chore: update versions for 0.1.0 release

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/Chart.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/Chart.yaml
@@ -1,4 +1,4 @@
 ---
 name: wanaku-operator
-version: 0.1.0-SNAPSHOT
+version: 0.1.0
 apiVersion: v2

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -5,9 +5,9 @@
 Start by setting the versions. 
 
 ```shell
-export PREVIOUS_VERSION=0.0.8
-export CURRENT_DEVELOPMENT_VERSION=0.0.9
-export NEXT_DEVELOPMENT_VERSION=0.1.0
+export PREVIOUS_VERSION=0.0.9
+export CURRENT_DEVELOPMENT_VERSION=0.1.0
+export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
 Trigger a release build: 
@@ -68,9 +68,9 @@ gpg --list-public-keys --keyid-format LONG
 Repeat this for every machine to be used for the release.
 
 ```shell
-export PREVIOUS_VERSION=0.0.7
-export CURRENT_DEVELOPMENT_VERSION=0.0.8
-export NEXT_DEVELOPMENT_VERSION=0.0.9
+export PREVIOUS_VERSION=0.0.9
+export CURRENT_DEVELOPMENT_VERSION=0.1.0
+export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
 > [!NOTE]

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -7,7 +7,7 @@ Start by setting the versions.
 ```shell
 export PREVIOUS_VERSION=0.0.9
 export CURRENT_DEVELOPMENT_VERSION=0.1.0
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.1.1
 ```
 
 Trigger a release build: 
@@ -70,7 +70,7 @@ Repeat this for every machine to be used for the release.
 ```shell
 export PREVIOUS_VERSION=0.0.9
 export CURRENT_DEVELOPMENT_VERSION=0.1.0
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.1.1
 ```
 
 > [!NOTE]

--- a/tests/load/run-perf-evaluation.sh
+++ b/tests/load/run-perf-evaluation.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-WANAKU_VERSION="0.1.0-SNAPSHOT"
+WANAKU_VERSION="0.1.0"
 CI_BASE="http://integration-ci.usersys.redhat.com:8080/view/Wanaku/job/wanaku-automated-builds/job"
 BRANCH="${BASELINE_BRANCH:-main}"
 EVAL_DIR="${EVAL_DIR:-$HOME/perf-evaluation-$(date +%Y%m%d-%H%M%S)}"


### PR DESCRIPTION
## Summary
- Update release guide versions from 0.0.8/0.0.9/0.1.0 to 0.0.9/0.1.0/0.2.0 (both automated and manual sections)
- Remove `-SNAPSHOT` suffix from Helm Chart.yaml version
- Remove `-SNAPSHOT` suffix from performance evaluation script version

## Test plan
- [ ] Verify release guide instructions match the 0.1.0 release cycle
- [ ] Verify Helm chart version renders correctly
- [ ] Verify perf evaluation script references correct artifact version

## Summary by Sourcery

Update version references for the 0.1.0 release across documentation, Helm chart, and performance evaluation tooling.

Enhancements:
- Set the wanaku-operator Helm chart version to the 0.1.0 release instead of a -SNAPSHOT tag.
- Update the performance evaluation script to use the 0.1.0 artifact version instead of a -SNAPSHOT tag.

Documentation:
- Align release guide example version variables with the 0.1.0 release cycle and next 0.2.0 development version.