### PR TITLE
[UI] LLM Chat overhaul

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/BaseUrlSelect.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/BaseUrlSelect.tsx
@@ -1,0 +1,62 @@
+import {Select, SelectItem, SelectSkeleton} from "@carbon/react"
+import React, {useEffect, useState} from "react"
+import {getUrl} from "../../custom-fetch.ts"
+
+
+interface BaseUrlSelectProps {
+  id?: string
+  labelText?: string
+  helperText?: string
+  value?: string
+  onChange: (baseUrl: string) => void
+}
+
+export const BaseUrlSelect : React.FC<BaseUrlSelectProps> = ({ id, labelText, helperText, value, onChange }) => {
+  
+  const [baseUrls, setBaseUrls] = useState<string[]>([])
+  const [isLoading, setLoading] = useState(true)
+  
+  useEffect(() => {
+    (async () => {
+      const response = await fetch(getUrl("/api/v1/chat/allowlist"))
+      if (response.ok) {
+        const data: string[] = await response.json()
+        setBaseUrls(data)
+        setLoading(false)
+        if (data.length > 0) {
+          onChange(selectedValue(data)!)
+        }
+      }
+    })()
+  }, [setBaseUrls, setLoading])
+  
+  function selectedValue(urls: string[]): string | undefined {
+    return value || (urls.length > 0 ? urls[0] : undefined)
+  }
+  
+  if (isLoading) {
+    return (<SelectSkeleton />)
+  } else {
+    return (
+      <Select
+        id={id || "baseUrl"}
+        labelText={labelText}
+        helperText={helperText}
+        value={selectedValue(baseUrls)}
+        onChange={(event) => {
+          const baseUrl = event.target.value
+          onChange(baseUrl)
+        }}
+      >
+        {baseUrls.map((url: string) => (
+          <SelectItem
+            id={url}
+            key={url}
+            text={url}
+            value={url}
+          />
+        ))}
+      </Select>
+    )
+  }
+}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -1,159 +1,243 @@
-import React from "react"
+import React, {useRef, useState} from "react"
 import {
   Button,
+  ButtonSet,
   Form,
   Stack,
   TextArea,
   Tile
 } from "@carbon/react"
-import {Bot, Function_2, InformationSquare, Reply} from "@carbon/icons-react"
-import hljs from "highlight.js/lib/core"
-import json from "highlight.js/lib/languages/json"
-import yaml from "highlight.js/lib/languages/yaml"
-import xml from "highlight.js/lib/languages/xml"
-import ReactMarkdown from "react-markdown"
-import {MessageResponse} from "./messages.ts";
-
-hljs.registerLanguage("json", json);
-hljs.registerLanguage("yaml", yaml);
-hljs.registerLanguage("xml", xml);
+import {Send, Stop} from "@carbon/icons-react"
+import {LlmConfig} from "./config"
+import {McpClient} from "./mcp"
+import {LLMChatMessage} from "./LLMChatMessage"
 
 
-const MessageItem = ({ message }) => {
-  let Icon
-  let title
-  
-  switch (message.role) {
-    case "assistant":
-      Icon = Bot
-      title = "Assistant"
-      break
-    case "tool-request":
-      Icon = Function_2
-      title = "Tool Request"
-      break
-    case "tool-response":
-      Icon = Reply
-      title = "Tool Response"
-      break
-    default:
-      Icon = InformationSquare
-      title = message.role
-  }
-  
-  return (
-    <div style={{ marginBottom: "2rem" }}>
-      <div style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5rem",
-          fontWeight: "bold",
-        }}
-      >
-        <Icon />
-        {title}
-      </div>
-      <div className="message">
-        {(message.role === "tool-response" && (
-          <p dangerouslySetInnerHTML={{
-              __html: hljs.highlightAuto(message.content).value
-            }}
-          />
-        )) || <MarkdownRenderer content={ message.content } />
-        }
-      </div>
-    </div>
-  )
+interface ChatMessage {
+  id?: string
+  role: string
+  content?: string
+  name?: string
+  tool_calls?: []
+  tool_call_id?: string
 }
 
-
-const MarkdownRenderer = ({ content }) => (
-  <ReactMarkdown
-    components={{
-      code({ className, children, ...props }) {
-        return (
-          <code className={className} {...props}>
-            {hljs.highlightAuto(String(children)).value}
-          </code>
-        )
-      }
-    }}
-  >
-    {content}
-  </ReactMarkdown>
-)
-
+interface DisplayMessage {
+  role: string
+  content: string
+}
 
 interface LLMChatAreaProps {
-  systemMessage: string
-  onSystemMessageChange: (message: string) => void
-  prompt: string
-  onPromptChange: (prompt: string) => void
-  response: string
-  messageHistory: MessageResponse[]
-  running: boolean
-  onSend: () => void
-  onStop: () => void
+  config: LlmConfig
 }
 
-
-export const LLMChatArea: React.FC<LLMChatAreaProps> = ({
-    systemMessage,
-    onSystemMessageChange,
-    prompt,
-    onPromptChange,
-    response,
-    messageHistory,
-    running,
-    onSend,
-    onStop
-  }) => {
+export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
+  
+  const [systemPrompt, setSystemPrompt] = useState("You are an assistant that can use tools.")
+  const [userPrompt, setUserPrompt] = useState("")
+  const [displayMessages, setDisplayMessages] = useState<DisplayMessage[]>([])
+  const [isRunning, setIsRunning] = useState(false)
+  
+  const stopRunning = useRef(false)
+  const chatMessages = useRef<ChatMessage[]>([])
+  
+  function clear() {
+    chatMessages.current = []
+    setDisplayMessages([])
+  }
+  
+  async function runPrompt() {
+    
+    const messages: DisplayMessage[] = [...displayMessages]
+    
+    const tools = config.tools.map(tool => {
+      return {
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description || "No description provided.",
+          parameters: tool.inputSchema || {}
+        }
+      }
+    })
+    
+    async function chat(): Promise<Response> {
+      return fetch(window.location.origin + "/api/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          baseUrl: config.baseUrl,
+          apiKey: config.apiKey,
+          chatParams: {
+            model: config.llmModel,
+            messages: chatMessages.current,
+            tools,
+            ...(config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {})
+          }
+        })
+      })
+    }
+    
+    function isFirstMessage() {
+      return chatMessages.current.length === 0
+    }
+    
+    function isToolAvailable(tool: string): boolean {
+      return config.tools.map(tool => tool.name).includes(tool)
+    }
+    
+    function displayMessage(message: DisplayMessage) {
+      messages.push(message)
+      setDisplayMessages([...messages])
+    }
+    
+    let mcpClient = new McpClient()
+    
+    if (isFirstMessage()) {
+      chatMessages.current.push({ role: "system", content: systemPrompt })
+      displayMessage({ role: "system", content: systemPrompt })
+    }
+    chatMessages.current.push({ role: "user", content: userPrompt })
+    displayMessage({ role: "user", content: userPrompt })
+    
+    setIsRunning(true)
+    
+    try {
+      while (!stopRunning.current) {
+        const response = await chat()
+        if (response.status != 200) {
+          displayMessage({ role: "error", content: "Error: " + response.status})
+          break
+        }
+        
+        const data = await response.json()
+        if (data?.choices[0]?.message?.content) {
+          const messageContent = data.choices[0].message.content
+          chatMessages.current.push({
+            role: data.choices[0].message.role,
+            content: messageContent
+          })
+          displayMessage({
+            role: data.choices[0].message.role,
+            content: messageContent
+          })
+        }
+        if (data?.choices[0]?.finish_reason === "stop") {
+          console.log("Stopping conversation from server side")
+          break
+        }
+        if (data?.choices[0]?.finish_reason === "tool_calls") {
+          chatMessages.current.push({
+            role: data.choices[0].message.role,
+            tool_calls: data.choices[0].message.tool_calls
+          })
+          displayMessage({
+            role: data.choices[0].message.role,
+            content: "tool_calls"
+          })
+          for (const toolCall of data.choices[0].message.tool_calls) {
+            if (isToolAvailable(toolCall.function.name)) {
+              const toolArgs = JSON.parse(toolCall.function.arguments || "{}")
+              displayMessage({
+                role: "tool-request",
+                content: toolCall.function.name + "(" + JSON.stringify(toolArgs) + ")"
+              })
+              const toolResult = await mcpClient.callTool(
+                toolCall.function.name,
+                toolArgs
+              )
+              const toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
+              chatMessages.current.push({
+                name: toolCall.function.name,
+                content: toolResultText,
+                role: "tool",
+                tool_call_id: toolCall.id
+              })
+              displayMessage({
+                content: toolResultText,
+                role: "tool-response"
+              })
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error during conversation:", error)
+    } finally {
+      if (mcpClient) {
+        await mcpClient.close()
+      }
+      stopRunning.current = false
+      setIsRunning(false)
+    }
+  }
   
   return (
     <Tile style={{ marginBottom: "1rem", padding: "1rem" }}>
       <Form>
+        <ButtonSet>
+          <Button
+            kind="ghost"
+            size="lg"
+            renderIcon={Send}
+            iconDescription="Send"
+            disabled={isRunning}
+            onClick={runPrompt}>
+            Send
+          </Button>
+          <Button
+            kind="ghost"
+            size="lg"
+            renderIcon={Stop}
+            iconDescription="Stop"
+            disabled={!isRunning}
+            onClick={() => {
+              stopRunning.current = true
+            }}>
+            Stop
+          </Button>
+          <Button
+            kind="ghost"
+            size="lg"
+            iconDescription="Clear chat"
+            disabled={displayMessages.length == 0}
+            onClick={clear}>
+            Clear
+          </Button>
+        </ButtonSet>
         <Stack gap={7}>
           <TextArea
             id="system-input"
             labelText="System message"
             placeholder="Type system message here..."
-            value={systemMessage}
-            onChange={(event) => onSystemMessageChange(event.target.value)}
+            value={systemPrompt}
+            onChange={(event) => {
+              setSystemPrompt(event.target.value)
+            }}
             rows={4}
           />
           <TextArea
             id="prompt-input"
             labelText="Enter Prompt"
             placeholder="Type your prompt here..."
-            value={prompt}
-            onChange={(event) => onPromptChange(event.target.value)}
+            value={userPrompt}
+            onChange={(event) => {
+              setUserPrompt(event.target.value)
+            }}
             rows={4}
           />
-          <Tile>
-            <Button
-              onClick={onSend}
-              disabled={running}
-            >
-              Run
-            </Button>
-            <Button
-              onClick={onStop}
-              disabled={!running}
-            >
-              Stop
-            </Button>
-          </Tile>
+        </Stack>
+        <Stack>
+          {displayMessages.map((message, index) => (
+            <LLMChatMessage
+              key={index}
+              message={message}
+            />
+          ))}
         </Stack>
       </Form>
-      <Tile style={{ padding: "1rem" }}>
-        {response}
-        {messageHistory.map((message) => (
-          <MessageItem
-            key={message.id + message.role}
-            message={message}
-          />
-        ))}
-      </Tile>
     </Tile>
   )
 }

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatMessage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatMessage.tsx
@@ -1,0 +1,93 @@
+import {
+  Bot,
+  Error,
+  Function_2,
+  InformationSquare,
+  Reply
+} from "@carbon/icons-react"
+import hljs from "highlight.js/lib/core"
+import json from "highlight.js/lib/languages/json"
+import yaml from "highlight.js/lib/languages/yaml"
+import xml from "highlight.js/lib/languages/xml"
+import ReactMarkdown from "react-markdown"
+
+
+hljs.registerLanguage("json", json)
+hljs.registerLanguage("yaml", yaml)
+hljs.registerLanguage("xml", xml)
+
+
+export const LLMChatMessage = ({ message }) => {
+  let Icon
+  let title
+  
+  switch (message.role) {
+    case "system":
+      Icon = InformationSquare
+      title = "System"
+      break
+    case "user":
+      Icon = InformationSquare
+      title = "User"
+      break
+    case "assistant":
+      Icon = Bot
+      title = "Assistant"
+      break
+    case "tool-request":
+      Icon = Function_2
+      title = "Tool Request"
+      break
+    case "tool-response":
+      Icon = Reply
+      title = "Tool Response"
+      break
+    case "error":
+      Icon = Error
+      title = "Error"
+      break
+    default:
+      Icon = InformationSquare
+      title = message.role
+  }
+  
+  return (
+    <div style={{ marginBottom: "2rem" }}>
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        fontWeight: "bold"
+      }}
+      >
+        <Icon />
+        {title}
+      </div>
+      <div className="message">
+        {(message.role === "tool-response" && (
+          <p dangerouslySetInnerHTML={{
+            __html: hljs.highlightAuto(message.content).value
+          }}
+          />
+        )) || <MarkdownRenderer content={ message.content } />
+        }
+      </div>
+    </div>
+  )
+}
+
+const MarkdownRenderer = ({ content }) => (
+  <ReactMarkdown
+    components={{
+      code({ className, children, ...props }) {
+        return (
+          <code className={className} {...props}>
+            {hljs.highlightAuto(String(children)).value}
+          </code>
+        )
+      }
+    }}
+  >
+    {content}
+  </ReactMarkdown>
+)

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -1,157 +1,15 @@
-import React, {useRef, useState} from "react"
+import React, {useState} from "react"
 import "highlight.js/styles/atom-one-dark.css"
 import {LLMSetup} from "./LLMSetup.tsx"
 import {LLMTools} from "./LLMTools.tsx"
 import {LLMChatArea} from "./LLMChatArea.tsx"
-import {MessageResponse} from "./messages.ts"
 import {Column, Grid} from "@carbon/react"
-import {connectedMCPClient} from "./mcp.ts"
 import {LlmConfig, loadConfig} from "./config.ts"
-import {ToolReference} from "../../models"
 
 
 export const LLMChatPage: React.FC = () => {
   
   const [config, setConfig] = useState<LlmConfig>(loadConfig())
-  
-  // LLM Chat
-  const [response, setResponse] = useState("")
-  const [messageHistory, setMessageHistory] = useState<MessageResponse[]>([])
-  const [isRunning, setIsRunning] = useState(false)
-  const [systemMessage, setSystemMessage] = useState("You are an assistant that can use tools.")
-  const [prompt, setPrompt] = useState("")
-  
-  const stopRunning = useRef(false)
-  
-  type ConversationMessage = {
-    role: string
-    content?: string | null
-    name?: string
-    tool_calls?: []
-    tool_call_id?: string
-  }
-  
-  async function runPrompt() {
-
-    function transformTools(tools: ToolReference[]) {
-      return tools.map((tool) => {
-        return {
-          type: "function",
-          function: {
-            name: tool.name,
-            description: tool.description || "No description provided.",
-            parameters: tool.inputSchema || {}
-          }
-        }
-      })
-    }
-    
-    async function chat(messages) {
-      console.log({
-        model: config.llmModel,
-        messages,
-        tools: transformTools(config.tools),
-        extraLlmParams: config.extraLlmParams
-      })
-      return fetch(config.baseUrl + "/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer " + config.apiKey,
-        },
-        body: JSON.stringify({
-          model: config.llmModel,
-          messages,
-          tools: transformTools(config.tools),
-          ...(config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {})
-        })
-      })
-    }
-    
-    const mcpClient = await connectedMCPClient()
-    
-    setResponse("") // clear previous response
-    setIsRunning(true)
-    
-    const conversationHistory: ConversationMessage[] = [
-      { role: "system", content: systemMessage },
-      { role: "user", content: prompt }
-    ]
-    console.log(conversationHistory)
-    
-    const newMessageHistory: MessageResponse[] = []
-    try {
-      while (!stopRunning.current) {
-        const response = await chat(conversationHistory)
-        if (!response.body) {
-          break
-        }
-        
-        const data = await response.json()
-        if (data?.choices[0].message?.content) {
-          const messageContent = data.choices[0].message?.content
-          conversationHistory.push({
-            role: data?.choices[0].message.role,
-            content: messageContent
-          })
-          newMessageHistory.push({
-            role: data?.choices[0].message.role,
-            content: messageContent,
-            id: data.id
-          })
-          setMessageHistory([...newMessageHistory])
-        }
-        if (data?.choices[0].finish_reason === "stop") {
-          break
-        }
-        if (data?.choices[0].finish_reason === "tool_calls") {
-          newMessageHistory.push({
-            id: data.id,
-            role: data?.choices[0].message.role,
-            content: "tool_calls"
-          })
-          conversationHistory.push({
-            role: data?.choices[0].message.role,
-            tool_calls: data.choices[0].message.tool_calls
-          })
-          for (const toolCall of data.choices[0].message.tool_calls) {
-            if (config.tools.map(tool => tool.name).includes(toolCall.function.name)) {
-              const toolArgs = JSON.parse(toolCall.function.arguments || "{}")
-              newMessageHistory.push({
-                id: toolCall.id,
-                role: "tool-request",
-                content: toolCall.function.name + "(" + JSON.stringify(toolArgs) + ")"
-              })
-              const toolResult = await mcpClient.callTool({
-                name: toolCall.function.name,
-                arguments: toolArgs
-              })
-              const toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
-              conversationHistory.push({
-                name: toolCall.function.name,
-                content: toolResultText,
-                role: "tool",
-                tool_call_id: toolCall.id
-              })
-              newMessageHistory.push({
-                id: toolCall.id,
-                content: toolResultText,
-                role: "tool-response"
-              })
-              setMessageHistory([...newMessageHistory])
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Error calling OpenAI API:", error)
-    } finally {
-      await mcpClient.close()
-    }
-    
-    setIsRunning(false)
-    stopRunning.current = false
-  }
   
   return (
     <div>
@@ -167,22 +25,7 @@ export const LLMChatPage: React.FC = () => {
           />
         </Column>
         <Column lg={12}>
-          <LLMChatArea
-            systemMessage={systemMessage}
-            onSystemMessageChange={setSystemMessage}
-            prompt={prompt}
-            onPromptChange={setPrompt}
-            response={response}
-            messageHistory={messageHistory}
-            running={isRunning}
-            onSend={() => {
-              setMessageHistory([])
-              runPrompt()
-            }}
-            onStop={() => {
-              stopRunning.current = true
-            }}
-          />
+          <LLMChatArea config={config} />
         </Column>
       </Grid>
     </div>

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from "react"
 import {
-  ComboBox,
   Form,
   PasswordInput, Stack,
   TextArea,
@@ -8,12 +7,12 @@ import {
   Toggle
 } from "@carbon/react"
 import {
-  baseUrlItems,
   isConfigStoredInLocalStorage,
   LLM_CONFIG,
   LlmConfig,
   STORE_IN_LOCAL_STORAGE
 } from "./config.ts"
+import {BaseUrlSelect} from "./BaseUrlSelect"
 
 
 interface LLMSetupProps {
@@ -51,14 +50,11 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
           }}
           id="enabledLocalStorage"
         />
-        <ComboBox
+        <BaseUrlSelect
           id="base-url"
-          titleText="LLM API Base URL"
-          items={baseUrlItems}
-          selectedItem={config.baseUrl}
-          allowCustomValue
-          onChange={(event) => {
-            const baseUrl = event.selectedItem
+          labelText="LLM API Base URL"
+          value={config.baseUrl || ""}
+          onChange={(baseUrl: string) => {
             applyConfigChange({ ...config, baseUrl })
           }}
         />

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -9,17 +9,9 @@ export interface LlmConfig {
   tools: ToolReference[]
 }
 
-export const baseUrlItems = [
-  "http://localhost:11434",
-  "https://api.openai.com",
-  "https://api.mistral.ai",
-  "https://generativelanguage.googleapis.com/v1beta/openai/",
-  "https://api.anthropic.com"
-]
-
 export function defaultLlmConfig(): LlmConfig {
   return {
-    baseUrl: baseUrlItems[2],
+    baseUrl: "https://api.mistral.ai",
     llmModel: "mistral-small-latest",
     extraLlmParams: '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}',
     tools: []

--- a/apps/ui/admin/src/Pages/LLMChat/mcp.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/mcp.ts
@@ -3,7 +3,27 @@ import {SSEClientTransport} from "@modelcontextprotocol/sdk/client/sse.js"
 import {getUrl} from "../../custom-fetch.ts"
 
 
-export async function connectedMCPClient() {
+export class McpClient {
+  
+  realMcpClient?: Client
+  
+  async callTool(name: string, args) {
+    if (!this.realMcpClient) {
+      this.realMcpClient = await connectedMCPClient()
+    }
+    return await this.realMcpClient.callTool({
+      name: name,
+      arguments: args
+    })
+  }
+  
+  async close() {
+    return this.realMcpClient?.close()
+  }
+  
+}
+
+async function connectedMCPClient() {
   const mcpClient = new Client(
     { name: "wanaku-test-client", version: "0.0.2" },
     { capabilities: {} }

--- a/apps/ui/admin/src/Pages/LLMChat/messages.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/messages.ts
@@ -1,5 +1,0 @@
-export interface MessageResponse {
-  id: string
-  content: string
-  role: string
-}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
@@ -1,0 +1,83 @@
+package ai.wanaku.backend.api.v1.chat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.TOO_MANY_REQUESTS;
+
+@ApplicationScoped
+@Path("/api/v1/chat")
+public class LlmChatResource {
+
+    /* Allowlist of chat URLs */
+    private final List<String> allowlist = List.of(
+            "http://localhost:11434",
+            "https://api.openai.com",
+            "https://api.mistral.ai",
+            "https://generativelanguage.googleapis.com/v1beta/openai/",
+            "https://api.anthropic.com");
+
+    @GET
+    @Path("/allowlist")
+    @Produces(APPLICATION_JSON)
+    public List<String> getBaseUrls() {
+        return allowlist;
+    }
+
+    @POST
+    @Path("/completions")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public String codeCompletions(String data) {
+        JsonObject json = Json.createReader(new StringReader(data)).readObject();
+        String baseUrl = json.getString("baseUrl");
+        String apiKey = json.getString("apiKey");
+        JsonObject llmParams = json.getJsonObject("chatParams");
+
+        if (!allowlist.contains(baseUrl)) {
+            throw new WebApplicationException("Base URL: " + baseUrl + " is not allowed", BAD_REQUEST);
+        }
+        try (var client = HttpClient.newHttpClient()) {
+            String url = baseUrl + "/v1/chat/completions";
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(new URI(url))
+                    .POST(BodyPublishers.ofString(llmParams.toString()))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + apiKey)
+                    .build();
+            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+            if (response.statusCode() == 429) {
+                throw new WebApplicationException(TOO_MANY_REQUESTS);
+            }
+            if (response.statusCode() != 200) {
+                throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+            }
+            return response.body();
+        } catch (URISyntaxException ex) {
+            throw new WebApplicationException("Malformed base URL", ex, BAD_REQUEST);
+        } catch (IOException | InterruptedException ex) {
+            throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+        }
+    }
+}


### PR DESCRIPTION
No associated issue

This is an overhaul of LLM Chat area. Contents are:

- backend for chat completions (in order to not suffer from CORS issues on frontend)
- slight UI changes for better user experience
- you can now continue in the chat if you want
- base URLs are now taken from allowlist

## Summary by Sourcery

Overhaul the LLM chat feature by routing chat completions through a new backend endpoint, improving the chat UI, and enabling multi‑turn conversations with tool usage.

New Features:
- Add a backend /chat/completions endpoint that proxies LLM chat completion requests to the configured provider using supplied base URL, API key, and parameters.
- Introduce a stateful LLM chat area that maintains conversation history, supports system and user prompts, and allows continuing existing chats with tool calls via MCP.

Enhancements:
- Refactor the LLM chat page to delegate chat logic into the LLMChatArea component and simplify the page to configuration concerns only.
- Extract message rendering into a dedicated LLMChatMessage component with role-specific styling and syntax-highlighted markdown/tool responses.
- Introduce an McpClient helper class to lazily manage MCP connections and tool invocation lifecycle from the UI.