### PR TITLE
AutoCloseable for ForwardClient

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -169,10 +169,9 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
                 new NameNamespacePair(forwardReference.getName(), forwardReference.getNamespace());
 
         String address = forwardReference.getAddress();
-        ForwardClient forwardClient = ForwardClient.newClient(address);
 
         final List<RemoteToolReference> locallyRegisteredTools = new ArrayList<>();
-        try {
+        try (var forwardClient = ForwardClient.newClient(address)) {
             List<ResourceReference> resourceReferences = mcpBridge.listResources(forwardClient);
             for (ResourceReference reference : resourceReferences) {
                 LOG.debugf("Exposing remote resource %s", reference.getName());
@@ -222,13 +221,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             }
             registeredRemoteToolsByForward.remove(nameNamespacePair);
 
-            try {
-                forwardClient.client().close();
-            } catch (Exception ignored) {
-                LOG.debug("Failed to close forward client after registration error", ignored);
-            }
-
-            throw e;
+            throw new WanakuException(e);
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
@@ -19,7 +19,7 @@ import dev.langchain4j.mcp.client.McpClient;
  * @param address the remote MCP server address (e.g., "http://localhost:8080" or "stdio://path/to/server")
  * @param client  the MCP client used to communicate with the server
  */
-public record ForwardClient(String address, McpClient client) {
+public record ForwardClient(String address, McpClient client) implements AutoCloseable {
 
     /**
      * Creates a new ForwardClient with a fresh MCP client connection.
@@ -34,4 +34,10 @@ public record ForwardClient(String address, McpClient client) {
     public static ForwardClient newClient(String address) {
         return new ForwardClient(address, ClientUtil.createClient(address));
     }
+
+    @Override
+    public void close() throws Exception {
+        client.close();
+    }
+
 }


### PR DESCRIPTION
Consider AutoCloseable for ForwardClient to avoid possible resource leaks

## Summary by Sourcery

Ensure forward clients are automatically closed when registering forwards to prevent resource leaks and simplify error handling.

Bug Fixes:
- Prevent potential resource leaks by guaranteeing ForwardClient instances are closed after use during forward registration failures.

Enhancements:
- Make ForwardClient AutoCloseable and use try-with-resources in forward registration to centralize and simplify client cleanup logic.