### PR TITLE
Cleanup forward de-registration on error

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -210,19 +210,31 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
 
             registeredRemoteToolsByForward.put(nameNamespacePair, List.copyOf(locallyRegisteredTools));
             forwardRegistry.link(nameNamespacePair, forwardClient);
+        } catch (WanakuException e) {
+            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
+
+            throw e;
         } catch (Exception e) {
-            // Best-effort cleanup to avoid leaving partially-registered tools around
-            for (RemoteToolReference toolReference : locallyRegisteredTools) {
-                try {
-                    toolManager.removeTool(toolReference.getName());
-                } catch (Exception ignored) {
-                    LOG.warnf("Failed to remove forward tool %s after registration error", toolReference.getName());
-                }
-            }
-            registeredRemoteToolsByForward.remove(nameNamespacePair);
+            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
 
             throw new WanakuException(e);
         }
+    }
+
+    /*
+     * Best-effort cleanup to avoid leaving partially-registered tools around
+     */
+    private void cleanupPartiallyRegistered(
+            List<RemoteToolReference> locallyRegisteredTools, NameNamespacePair nameNamespacePair) {
+        // Best-effort cleanup to avoid leaving partially-registered tools around
+        for (RemoteToolReference toolReference : locallyRegisteredTools) {
+            try {
+                toolManager.removeTool(toolReference.getName());
+            } catch (Exception ignored) {
+                LOG.warnf("Failed to remove forward tool %s after registration error", toolReference.getName());
+            }
+        }
+        registeredRemoteToolsByForward.remove(nameNamespacePair);
     }
 
     public List<ResourceReference> listAllResources() {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardClient.java
@@ -1,5 +1,6 @@
 package ai.wanaku.backend.bridge;
 
+import io.quarkus.logging.Log;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
 
@@ -36,8 +37,11 @@ public record ForwardClient(String address, McpClient client) implements AutoClo
     }
 
     @Override
-    public void close() throws Exception {
-        client.close();
+    public void close() {
+        try {
+            client.close();
+        } catch (Exception e) {
+            Log.error("Failed to close ForwardClient: {}", e.getMessage(), e);
+        }
     }
-
 }


### PR DESCRIPTION
## Summary by Sourcery

Ensure forward registration errors consistently trigger cleanup and make ForwardClient closing more robust.

Bug Fixes:
- Clean up partially registered remote tools and registry entries for both WanakuException and generic exceptions during forward registration.
- Prevent failures when closing ForwardClient from propagating by catching and logging close errors.