### PR TITLE
Extracted namespace select to its own component

### DIFF
--- a/apps/ui/admin/src/Pages/Forwards/ForwardModal.tsx
+++ b/apps/ui/admin/src/Pages/Forwards/ForwardModal.tsx
@@ -1,7 +1,7 @@
-import {Modal, Select, SelectItem, TextInput,} from "@carbon/react";
-import React, {useEffect, useState} from "react";
-import {ForwardReference, Namespace} from "../../models";
-import {listNamespaces} from "../../hooks/api/use-namespaces";
+import {Modal, TextInput,} from "@carbon/react";
+import React, {useState} from "react";
+import {ForwardReference} from "../../models";
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect.tsx";
 
 interface ForwardModalProps {
   forward?: ForwardReference
@@ -16,25 +16,14 @@ export const ForwardModal: React.FC<ForwardModalProps> = ({
 }) => {
   const [name, setName] = useState(forward?.name || "")
   const [address, setAddress] = useState(forward?.address || "")
-  const [namespaces, setNamespaces] = useState<Namespace[]>([])
-  const [selectedNamespace, setSelectedNamespace] = useState(forward?.namespace|| "")
-
-  useEffect(() => {
-    listNamespaces().then((result) => {
-      setNamespaces(result.data.data as Namespace[]);
-    });
-  }, []);
-
-  const handleSelectionChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedNamespace(event.target.value);
-  };
+  const [selectedNamespace, setSelectedNamespace] = useState(forward?.namespace)
 
   const handleSubmit = () => {
     onSubmit({
       id: forward?.id,
       name,
       address,
-      namespace: selectedNamespace || undefined,
+      namespace: selectedNamespace,
     });
   };
 
@@ -64,22 +53,13 @@ export const ForwardModal: React.FC<ForwardModalProps> = ({
         onChange={(e) => setAddress(e.target.value)}
         required
       />
-      <Select
+      <NamespaceSelect
         id="namespace"
         labelText="Select a Namespace"
         helperText="Choose a Namespace from the list (optional)"
         value={selectedNamespace}
-        onChange={handleSelectionChange}
-      >
-        <SelectItem text="Choose an option" value="" />
-        {namespaces.map((namespace) => (
-          <SelectItem
-            key={namespace.id}
-            text={namespace.path || "default"}
-            value={namespace.id}
-          />
-        ))}
-      </Select>
+        onChange={namespace => setSelectedNamespace(namespace.id!)}
+      />
     </Modal>
   );
 };

--- a/apps/ui/admin/src/Pages/Namespaces/NamespaceSelect.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespaceSelect.tsx
@@ -1,0 +1,76 @@
+import {Select, SelectItem} from "@carbon/react"
+import React, {useEffect, useState} from "react"
+import {Namespace} from "../../models"
+import {useNamespaces} from "../../hooks/api/use-namespaces"
+
+
+interface NamespaceSelectProps {
+  id?: string
+  labelText?: string
+  helperText?: string
+  value?: string
+  onChange: (namespace: Namespace) => void
+}
+
+export const NamespaceSelect : React.FC<NamespaceSelectProps> = ({ id, labelText, helperText, value, onChange }) => {
+  
+  const [namespaces, setNamespaces] = useState<Namespace[]>([])
+  const [selectedNamespace, setSelectedNamespace] = useState<Namespace>()
+  const { listNamespaces } = useNamespaces()
+  
+  useEffect(() => {
+    (async () => {
+      const response = await listNamespaces()
+      if (response.status == 200 && Array.isArray(response.data.data)) {
+        let selected = findDefaultNamespaceAmong(response.data.data)
+        if (value) {
+          selected = findNamespaceAmong(value, response.data.data)
+        }
+        setNamespaces(response.data.data)
+        setSelectedNamespace(selected)
+      }
+    })()
+  }, [])
+  
+  function findNamespace(id: string): Namespace | undefined {
+    return findNamespaceAmong(id, namespaces)
+  }
+  
+  function findNamespaceAmong(id: string, namespaces: readonly Namespace[]): Namespace | undefined {
+    return namespaces.find(namespace => namespace.id == id)
+  }
+  
+  function defaultNamespace(): Namespace | undefined {
+    return findDefaultNamespaceAmong(namespaces)
+  }
+  
+  function findDefaultNamespaceAmong(namespaces: readonly Namespace[]): Namespace | undefined {
+    return namespaces.find(namespace => namespace.path == "default")
+  }
+  
+  return (
+    <Select
+      id={id || "namespace"}
+      labelText={labelText || ""}
+      helperText={helperText || ""}
+      value={selectedNamespace?.id || defaultNamespace()?.id}
+      onChange={(event) => {
+        const namespace = findNamespace(event.target.value)
+        if (namespace) {
+          setSelectedNamespace(namespace)
+          onChange(namespace)
+        }
+      }}
+    >
+      <SelectItem disabled hidden text="Choose a namespace" value="" />
+      {namespaces.map((namespace: Namespace) => (
+        <SelectItem
+          key={namespace.id}
+          id={namespace.id}
+          text={namespace.path!}
+          value={namespace.id}
+        />
+      ))}
+    </Select>
+  )
+}

--- a/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -1,9 +1,9 @@
-import {Modal, Select, SelectItem, Stack, TextArea, TextInput, ToastNotification,} from "@carbon/react";
+import {Modal, Stack, TextArea, TextInput, ToastNotification,} from "@carbon/react";
 import React, {useCallback, useEffect, useState} from "react";
 import {usePrompts} from "../../hooks/api/use-prompts";
-import {Namespace, PromptReference} from "../../models";
+import {PromptReference} from "../../models";
 import {PromptsTable} from "./PromptsTable";
-import {listNamespaces} from "../../hooks/api/use-namespaces";
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect.tsx";
 
 export const PromptsPage: React.FC = () => {
   const [fetchedData, setFetchedData] = useState<PromptReference[]>([]);
@@ -118,18 +118,7 @@ const AddPromptModal: React.FC<AddPromptModalProps> = ({
   const [messagesJson, setMessagesJson] = useState("");
   const [argumentsJson, setArgumentsJson] = useState("");
   const [toolReferences, setToolReferences] = useState("");
-  const [fetchedNamespaceData, setFetchedNamespaceData] = useState<Namespace[]>([]);
-  const [selectedNamespace, setSelectedNamespace] = useState('');
-
-  useEffect(() => {
-    listNamespaces().then((result) => {
-      setFetchedNamespaceData(result.data.data as Namespace[]);
-    });
-  }, [listNamespaces]);
-
-  const handleSelectionChange = (event) => {
-    setSelectedNamespace(event.target.value);
-  };
+  const [selectedNamespace, setSelectedNamespace] = useState("");
 
   const handleSubmit = () => {
     try {
@@ -201,23 +190,13 @@ Resource: {"role": "user", "content": {"type": "resource", "resource": {"locatio
           value={toolReferences}
           onChange={(e) => setToolReferences(e.target.value)}
         />
-        <Select
+        <NamespaceSelect
           id="namespace"
           labelText="Select a Namespace"
           helperText="Choose a Namespace from the list"
           value={selectedNamespace}
-          onChange={handleSelectionChange}
-        >
-          <SelectItem text="Choose an option" value="" />
-          {fetchedNamespaceData.map((namespace) => (
-            <SelectItem
-              key={namespace.id}
-              id={namespace.id}
-              text={namespace.path || "default"}
-              value={namespace.id}
-            />
-          ))}
-        </Select>
+          onChange={namespace => setSelectedNamespace(namespace.id!)}
+        />
       </Stack>
     </Modal>
   );

--- a/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
@@ -1,11 +1,11 @@
-import {ComboBox, Modal, Select, SelectItem, Tab, TabList, TabPanel, TabPanels, Tabs, TextInput} from "@carbon/react";
-import React, {useEffect, useState} from "react";
-import {Namespace, Param, ResourceReference} from "../../models";
+import {ComboBox, Modal, Tab, TabList, TabPanel, TabPanels, Tabs, TextInput} from "@carbon/react";
+import React, { useState} from "react";
+import {Param, ResourceReference} from "../../models";
 import {commonMimeTypes, commonMimeTypesMapping} from "../../constants/mimeTypes.ts";
-import {listNamespaces} from "../../hooks/api/use-namespaces";
 import {useCapabilities} from "../../hooks/api/use-capabilities";
 import {TargetTypeSelect} from "../Targets/TargetTypeSelect";
 import {ParametersTable} from "./ParametersTable.tsx";
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect.tsx";
 
 interface ResourceModalProps {
   resource?: ResourceReference
@@ -23,22 +23,11 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({
   const [location, setLocation] = useState(resource?.location || "");
   const [resourceType, setResourceType] = useState(resource?.type || "file");
   const [mimeType, setMimeType] = useState(resource?.mimeType || "");
-  const [fetchedData, setFetchedData] = useState<Namespace[]>([]);
-  const [selectedNamespace, setSelectedNamespace] = useState(resource?.namespace || "");
+  const [selectedNamespace, setSelectedNamespace] = useState(resource?.namespace);
   const [params, setParams] = useState<Param[]>(resource?.params || []);
   const [configurationURI, setConfigurationURI] = useState(resource?.configurationURI || "")
   const [secretsURI, setSecretsURI] = useState(resource?.secretsURI || "")
   const { listManagementResources } = useCapabilities();
-  
-  useEffect(() => {
-    listNamespaces().then((result) => {
-      setFetchedData(result.data.data as Namespace[]);
-    });
-  }, [listNamespaces]);
-
-  const handleSelectionChange = (event) => {
-    setSelectedNamespace(event.target.value);
-  };
 
   const handleSubmit = () => {
     onSubmit({
@@ -144,22 +133,13 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({
                 }}
                 helperText="Content type of the resource (optional)"
             />
-            <Select
+            <NamespaceSelect
               id="namespace"
               labelText="Select a Namespace"
               helperText="Choose a Namespace from the list"
               value={selectedNamespace}
-              onChange={handleSelectionChange}
-            >
-              <SelectItem text="Choose an option" value="" />
-              {fetchedData.map((namespace) => (
-                <SelectItem
-                  id={namespace.id}
-                  text={namespace.path || "default"}
-                  value={namespace.id}
-                />
-              ))}
-            </Select>
+              onChange={namespace => setSelectedNamespace(namespace.id)}
+            />
           </TabPanel>
           <TabPanel>
             <ParametersTable

--- a/apps/ui/admin/src/Pages/Tools/ToolModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ToolModal.tsx
@@ -1,10 +1,18 @@
-import {Modal, Select, SelectItem, Tab, TabList, TabPanel, TabPanels, Tabs, TextInput} from "@carbon/react";
-import React, {useEffect, useState} from "react";
-import {Namespace, ToolReference} from "../../models";
-import {listNamespaces} from "../../hooks/api/use-namespaces";
+import {
+  Modal,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  TextInput
+} from "@carbon/react";
+import React, {useState} from "react";
+import {ToolReference} from "../../models";
 import {TargetTypeSelect} from "../Targets/TargetTypeSelect";
 import {useCapabilities} from "../../hooks/api/use-capabilities";
 import {formatInputSchema, parseInputSchema} from "./tools-utils.ts";
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect.tsx";
 
 
 interface ToolModalProps {
@@ -23,21 +31,10 @@ export const ToolModal: React.FC<ToolModalProps> = ({
   const [uri, setUri] = useState(tool?.uri || "")
   const [toolType, setToolType] = useState(tool?.type || "http")
   const [inputSchema, setInputSchema] = useState(formatInputSchema(tool?.inputSchema))
-  const [fetchedNamespaceData, setFetchedNamespaceData] = useState<Namespace[]>([])
-  const [selectedNamespace, setSelectedNamespace] = useState(tool?.namespace || "")
+  const [selectedNamespace, setSelectedNamespace] = useState(tool?.namespace)
   const [configurationURI, setConfigurationURI] = useState(tool?.configurationURI || "")
   const [secretsURI, setSecretsURI] = useState(tool?.secretsURI || "")
   const { listManagementTools } = useCapabilities()
-
-  useEffect(() => {
-    listNamespaces().then((result) => {
-      setFetchedNamespaceData(result.data.data as Namespace[])
-    })
-  }, [listNamespaces])
-
-  const handleSelectionChange = (event) => {
-    setSelectedNamespace(event.target.value)
-  }
 
   const handleSubmit = () => {
     try {
@@ -107,23 +104,13 @@ export const ToolModal: React.FC<ToolModalProps> = ({
               value={inputSchema}
               onChange={(event) => setInputSchema(event.target.value)}
             />
-            <Select
+            <NamespaceSelect
               id="namespace"
               labelText="Select a Namespace"
               helperText="Choose a Namespace from the list"
               value={selectedNamespace}
-              onChange={handleSelectionChange}
-            >
-              <SelectItem text="Choose an option" value="" />
-              {fetchedNamespaceData.map((namespace: Namespace) => (
-                <SelectItem
-                  key={namespace.id}
-                  id={namespace.id}
-                  text={namespace.path || "default"}
-                  value={namespace.id}
-                />
-              ))}
-            </Select>
+              onChange={namespace => setSelectedNamespace(namespace.id)}
+            />
           </TabPanel>
           <TabPanel>
             <TextInput


### PR DESCRIPTION
I've extracted namespace selection among various UI forms into its own component. 

Note that I've disabled the _Choose a namespace_ option since there is no need for it. The _default_ namespace is pre-selected instead.

## Summary by Sourcery

Extract namespace selection logic into a reusable NamespaceSelect component and adopt it across forms that require namespace choice.

New Features:
- Introduce a shared NamespaceSelect component that encapsulates namespace loading and default selection behavior across the admin UI.

Enhancements:
- Refactor tools, forwards, resources, and prompts modals/pages to consume the new NamespaceSelect component instead of duplicating namespace dropdown logic.