### PR TITLE
Fixed namespace displaying in tables

### DIFF
--- a/apps/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
+++ b/apps/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
@@ -13,7 +13,7 @@ import {
 } from "@carbon/react"
 import {Add, Edit, Renew, TrashCan} from "@carbon/icons-react"
 import {ForwardReference} from "../../models"
-import {getNamespacePathById} from "../../hooks/api/use-namespaces.ts"
+import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import React from "react"
 
 interface ForwardsTableProps {

--- a/apps/ui/admin/src/Pages/Prompts/PromptsTable.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsTable.tsx
@@ -14,7 +14,7 @@ import {
 } from "@carbon/react";
 import {FunctionComponent} from "react";
 import {PromptReference} from "../../models";
-import {getNamespacePathById} from "../../hooks/api/use-namespaces";
+import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 
 interface PromptsListProps {
   fetchedData: PromptReference[];
@@ -55,7 +55,7 @@ export const PromptsTable: FunctionComponent<PromptsListProps> = ({
       messages: formatMessages(prompt.messages),
       arguments: formatArguments(prompt.arguments),
       toolReferences: prompt.toolReferences?.join(", ") || "None",
-      namespace: getNamespacePathById(prompt.namespace) || "default",
+      namespace: getNamespacePathById(prompt.namespace),
     }));
   }
 

--- a/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -17,7 +17,7 @@ import {
 import {Add, Edit, TrashCan} from "@carbon/icons-react";
 import React from "react";
 import {Param, ResourceReference} from "../../models";
-import {getNamespacePathById} from "../../hooks/api/use-namespaces";
+import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 
 interface ResourcesTableProps {
   resources: ResourceReference[];
@@ -72,7 +72,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({
         <TableCell>{resource.type}</TableCell>
         <TableCell>{resource.mimeType}</TableCell>
         <TableCell>{resource.description}</TableCell>
-        <TableCell>{getNamespacePathById(resource.namespace) || "default"}</TableCell>
+        <TableCell>{getNamespacePathById(resource.namespace)}</TableCell>
         <TableCell>
           <Button
             kind="ghost"

--- a/apps/ui/admin/src/Pages/Tools/ToolsTable.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ToolsTable.tsx
@@ -17,7 +17,7 @@ import {
 } from "@carbon/react";
 import React, {FunctionComponent, useState} from "react";
 import {ToolReference} from "../../models";
-import {getNamespacePathById} from "../../hooks/api/use-namespaces";
+import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import {InputSchemaModal} from "./InputSchemaModal";
 
 interface ToolListProps {
@@ -80,7 +80,7 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
             <span style={{ color: "var(--cds-text-secondary)" }}>&mdash;</span>
           )}
         </TableCell>
-        <TableCell>{getNamespacePathById(tool.namespace) || "default"}</TableCell>
+        <TableCell>{getNamespacePathById(tool.namespace)}</TableCell>
         <TableCell>
           <Button
             kind="ghost"

--- a/apps/ui/admin/src/hooks/api/use-namespaces.ts
+++ b/apps/ui/admin/src/hooks/api/use-namespaces.ts
@@ -89,16 +89,11 @@ export const clearNamespacesCache = () => {
 
 export const getNamespacePathById = (id?: string): string | undefined => {
   if (!id) {
-    return undefined;
+    return "default"
   }
-
   if (namespacesCache) {
-    const data = namespacesCache.data.data.data as Namespace[];
-    // Look up by name first (since ToolReference.namespace stores the name)
-    // If not found by name, fall back to lookup by id
-    const path = data.find(namespace => namespace.name === id || namespace.id === id)?.path;
-    return path;
+    const data = namespacesCache.data.data.data as Namespace[]
+    return data.find(namespace => namespace.id === id)?.path
   }
-
   return undefined;
 }


### PR DESCRIPTION
I've fixed the function _getNamespacePathById_ 

I believe the info that namespaces are stored as names no longer applies. In my case, it was causing displaying wrong namespaces in the four tables.

## Summary by Sourcery

Correct namespace resolution and display across admin tables by updating namespace lookup logic and centralising default handling.

Bug Fixes:
- Fix namespace path lookup to resolve namespaces by ID only instead of incorrectly attempting name-based matching, preventing wrong namespaces from appearing in tables.

Enhancements:
- Centralise the default namespace fallback within getNamespacePathById and simplify table components to rely on this shared behaviour.