### PR TITLE
Rethrowing exception as before in forwards registration

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -158,7 +158,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         }
     }
 
-    private void registerForward(ForwardReference forwardReference) {
+    private void registerForward(ForwardReference forwardReference) throws Exception {
         Namespace ns = null;
 
         if (!StringHelper.isEmpty(forwardReference.getNamespace())) {
@@ -221,7 +221,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             }
             registeredRemoteToolsByForward.remove(nameNamespacePair);
 
-            throw new WanakuException(e);
+            throw e;
         }
     }
 
@@ -292,7 +292,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         forwardReferenceRepository.update(forwardReference.getId(), forwardReference);
     }
 
-    public void refresh(ForwardReference forwardReferenceHint) {
+    public void refresh(ForwardReference forwardReferenceHint) throws Exception {
         List<ForwardReference> references = forwardReferenceRepository.findByName(forwardReferenceHint.getName());
         if (references.isEmpty()) {
             throw new WanakuException("Forward reference not found: " + forwardReferenceHint.getName());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -82,9 +82,13 @@ public class ForwardsResource {
     @Path("/{name}/refreshes")
     @POST
     public Response refresh(@PathParam("name") String name) throws WanakuException {
-        ForwardReference reference = new ForwardReference();
-        reference.setName(name);
-        forwardsBean.refresh(reference);
-        return Response.ok().build();
+        try {
+            ForwardReference reference = new ForwardReference();
+            reference.setName(name);
+            forwardsBean.refresh(reference);
+            return Response.ok().build();
+        } catch (Exception ex) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }


### PR DESCRIPTION
Trying to fix exception handling from https://github.com/wanaku-ai/wanaku/pull/979

@orpiske What do you think?

## Summary by Sourcery

Adjust forward registration error handling to propagate underlying exceptions while mapping refresh failures to HTTP 500 responses.

Bug Fixes:
- Restore rethrowing of the original exception from forward registration instead of wrapping it in a WanakuException.
- Ensure the forwards refresh API responds with an HTTP 500 status when an unexpected exception occurs during refresh.

Enhancements:
- Declare checked exceptions on forward registration and refresh methods to reflect their error behavior.