### PR TITLE
Add noauth profile for running Wanaku without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ South America.
 - **Unified Access** - Centralized routing and resource management for AI agents
 - **MCP-to-MCP Bridge** - Act as a gateway or proxy for other MCP servers
 - **Extensive Connectivity** - Leverage 300+ Apache Camel components for integration
-- **Secure by Default** - Built-in authentication and authorization via Keycloak
+- **Secure by Default** - Built-in authentication and authorization via Keycloak (optional — can run without auth)
 - **Kubernetes-Native** - First-class support for OpenShift and Kubernetes deployments
 - **Extensible Architecture** - Easy to add custom tools and resource providers
 - **Multi-Namespace Support** - Organize tools and resources across isolated namespaces

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -5,6 +5,11 @@ import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +32,8 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
 
     private final AuthCredentialStore credentialStore;
     private final TokenRefresher tokenRefresher;
+
+    private volatile Boolean routerAuthEnabled;
 
     public AuthenticationInterceptor() {
         this.credentialStore = new AuthCredentialStore();
@@ -51,10 +58,45 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             return;
         }
 
+        if (!isRouterAuthEnabled(requestContext.getUri())) {
+            LOG.debug("Router is running without authentication, skipping auth header");
+            return;
+        }
+
         String apiToken = getValidAccessToken();
         if (apiToken != null && !apiToken.trim().isEmpty()) {
             requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + apiToken);
         }
+    }
+
+    /**
+     * Checks whether the router requires authentication by probing the OIDC well-known endpoint.
+     * The result is cached after the first check.
+     */
+    private boolean isRouterAuthEnabled(URI requestUri) {
+        if (routerAuthEnabled != null) {
+            return routerAuthEnabled;
+        }
+
+        URI wellKnown = requestUri.resolve("/.well-known/oauth-authorization-server");
+        try (HttpClient client =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build()) {
+            HttpRequest request = HttpRequest.newBuilder(wellKnown)
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            routerAuthEnabled = response.statusCode() == 200;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            routerAuthEnabled = false;
+        } catch (Exception e) {
+            LOG.debug("Could not reach OIDC endpoint at {}: {}", wellKnown, e.getMessage());
+            routerAuthEnabled = false;
+        }
+
+        return routerAuthEnabled;
     }
 
     /**

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -78,6 +78,10 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             return routerAuthEnabled;
         }
 
+        if (requestUri == null) {
+            return true;
+        }
+
         URI wellKnown = requestUri.resolve("/.well-known/oauth-authorization-server");
         try (HttpClient client =
                 HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build()) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -72,7 +72,7 @@ public class LocalRunner {
         CountDownLatch countDownLatch = new CountDownLatch(activeServices);
         int grpcPort = config.initialGrpcPort();
 
-        startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, executorService, countDownLatch);
+        startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, executorService, countDownLatch, environment);
         LOG.infof("Waiting %d seconds for the Wanaku Router Backend to start", config.routerStartWaitSecs());
         try {
             Thread.sleep(Duration.ofSeconds(config.routerStartWaitSecs()).toMillis());
@@ -96,12 +96,22 @@ public class LocalRunner {
         }
     }
 
-    private static void startRouter(String component, ExecutorService executorService, CountDownLatch countDownLatch) {
+    private static void startRouter(
+            String component,
+            ExecutorService executorService,
+            CountDownLatch countDownLatch,
+            LocalRunnerEnvironment environment) {
         File componentDir = new File(RuntimeConstants.WANAKU_LOCAL_DIR, component);
 
         executorService.submit(() -> {
             try {
-                ProcessRunner.run(componentDir, "java", "-jar", "quarkus-run.jar");
+                ProcessRunner.run(
+                        componentDir,
+                        environment.serviceOptions(),
+                        "java",
+                        "-Dquarkus.profile=noauth",
+                        "-jar",
+                        "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Router Service: %s", e.getMessage(), e);
             } finally {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -134,7 +134,13 @@ public class LocalRunner {
         executorService.submit(() -> {
             try {
                 ProcessRunner.run(
-                        componentDir, environment.serviceOptions(), "java", grpcPortOpt, "-jar", "quarkus-run.jar");
+                        componentDir,
+                        environment.serviceOptions(),
+                        "java",
+                        grpcPortOpt,
+                        "-Dquarkus.profile=noauth",
+                        "-jar",
+                        "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Service %s", component.getKey(), e);
             } finally {

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -102,6 +102,13 @@ quarkus.http.auth.permission.public.policy=permit
 quarkus.http.auth.permission.web.paths=/admin/*, /admin, /node_modules/*
 quarkus.http.auth.permission.web.policy=authenticated
 
+# No-auth profile: disables OIDC and permits all paths
+%noauth.quarkus.oidc.enabled=false
+%noauth.quarkus.oidc-proxy.enabled=false
+%noauth.quarkus.http.auth.permission.authenticated.policy=permit
+%noauth.quarkus.http.auth.permission.mcp-authenticated.policy=permit
+%noauth.quarkus.http.auth.permission.web.policy=permit
+
 # Logging configuration
 
 quarkus.http.access-log.enabled=true

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -31,14 +31,7 @@ wanaku.service.base-uri=${name.toLowerCase()}://
 # wanaku.service.registration.retry-wait-seconds=1
 # wanaku.service.registration.delay-seconds=3
 
-quarkus.oidc-client.enabled=true
-
-# Address of the KeyCloak authentication server - adjust to your KeyCloak instance
-quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
-
-# Client identifier configured in KeyCloak for capability services
-quarkus.oidc-client.client-id=wanaku-service
-
-# Client secret from KeyCloak for service authentication - replace with your actual secret
-#quarkus.oidc-client.credentials.secret=<the secret key>
+# Auth settings are inherited from wanaku-capabilities-base.
+# Override auth.server, quarkus.oidc-client.client-id, or
+# quarkus.oidc-client.credentials.secret here if needed.
 

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -22,13 +22,6 @@ wanaku.service.base-uri=${name.toLowerCase()}://
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
 
-quarkus.oidc-client.enabled=true
-
-# Address of the KeyCloak authentication server - adjust to your KeyCloak instance
-quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
-
-# Client identifier configured in KeyCloak for capability services
-quarkus.oidc-client.client-id=wanaku-service
-
-# Client secret from KeyCloak for service authentication - replace with your actual secret
-#quarkus.oidc-client.credentials.secret=<the secret key>
+# Auth settings are inherited from wanaku-capabilities-base.
+# Override auth.server, quarkus.oidc-client.client-id, or
+# quarkus.oidc-client.credentials.secret here if needed.

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -70,8 +70,8 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
      */
     @PostConstruct
     public void init() {
-        registrationManager =
-                ServicesHelper.newRegistrationManager(config, SERVICE_TYPE_RESOURCE_PROVIDER, tokensInstance.get());
+        registrationManager = ServicesHelper.newRegistrationManager(
+                config, SERVICE_TYPE_RESOURCE_PROVIDER, tokensInstance.isResolvable() ? tokensInstance.get() : null);
         initializeRegistrationManager(registrationManager);
     }
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
@@ -66,8 +66,8 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
      */
     @PostConstruct
     public void init() {
-        registrationManager =
-                ServicesHelper.newRegistrationManager(config, SERVICE_TYPE_TOOL_INVOKER, tokensInstance.get());
+        registrationManager = ServicesHelper.newRegistrationManager(
+                config, SERVICE_TYPE_TOOL_INVOKER, tokensInstance.isResolvable() ? tokensInstance.get() : null);
         initializeRegistrationManager(registrationManager);
     }
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -17,6 +17,9 @@ quarkus.oidc-client.refresh-token-time-skew=1m
 # Client secret from KeyCloak for service authentication - replace with your actual secret
 quarkus.oidc-client.credentials.secret=<insert key here>
 
+# No-auth profile: disables OIDC client so capabilities can run without Keycloak
+%noauth.quarkus.oidc-client.enabled=false
+
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 %dev.quarkus.log.category."ai.wanaku.core.capabilities".level=DEBUG

--- a/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
+++ b/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
@@ -41,14 +41,7 @@ wanaku.service.performance.delay=100
 # wanaku.service.registration.retry-wait-seconds=1
 # wanaku.service.registration.delay-seconds=3
 
-quarkus.oidc-client.enabled=true
-
-# Address of the KeyCloak authentication server - adjust to your KeyCloak instance
-quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
-
-# Client identifier configured in KeyCloak for capability services
-quarkus.oidc-client.client-id=wanaku-service
-
-# Client secret from KeyCloak for service authentication - replace with your actual secret
-#quarkus.oidc-client.credentials.secret=<the secret key>
+# Auth settings are inherited from wanaku-capabilities-base.
+# Override auth.server, quarkus.oidc-client.client-id, or
+# quarkus.oidc-client.credentials.secret here if needed.
 

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
@@ -24,13 +24,6 @@ wanaku.service.performance.delay=100
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
 
-quarkus.oidc-client.enabled=true
-
-# Address of the KeyCloak authentication server - adjust to your KeyCloak instance
-quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku
-
-# Client identifier configured in KeyCloak for capability services
-quarkus.oidc-client.client-id=wanaku-service
-
-# Client secret from KeyCloak for service authentication - replace with your actual secret
-#quarkus.oidc-client.credentials.secret=<the secret key>
+# Auth settings are inherited from wanaku-capabilities-base.
+# Override auth.server, quarkus.oidc-client.client-id, or
+# quarkus.oidc-client.credentials.secret here if needed.

--- a/deploy/docker-compose/docker-compose-noauth.yml
+++ b/deploy/docker-compose/docker-compose-noauth.yml
@@ -1,0 +1,18 @@
+services:
+  wanaku-router:
+    image: quay.io/wanaku/wanaku-router-backend:latest
+    environment:
+      QUARKUS_PROFILE: noauth
+      QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED: "true"
+      QUARKUS_HTTP_HOST: 0.0.0.0
+    network_mode: host
+    volumes:
+      - wanaku-router:/home/jboss/.wanaku/router
+    healthcheck:
+      test: curl -f localhost:8080/api/v1/management/info/version || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+volumes:
+  wanaku-router:

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -132,6 +132,9 @@ Configuration for the main Wanaku Router Backend (`wanaku-router-backend`), whic
 | `quarkus.http.auth.permission.*.paths`  | Defines path patterns for different security policies (`permit`, `authenticated`).       |
 | `quarkus.http.auth.permission.*.policy` | Assigns a security policy to the corresponding path pattern.                             |
 
+To run without authentication, activate the `noauth` Quarkus profile (e.g., `QUARKUS_PROFILE=noauth`). This disables
+OIDC and permits all paths. See the [Usage Guide](usage.md#running-without-authentication) for details.
+
 ### Health Check
 
 These `wanaku.router.health-check.*` properties control the periodic health probing of registered capabilities.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,21 +58,22 @@ Keycloak provides authentication and authorization for:
 **For development:**
 - Java 17 or later
 - Maven 3.x
-- Keycloak instance (can run via Podman/Docker)
+- Keycloak instance (optional — can run via Podman/Docker, or use the `noauth` profile)
 
 **For production deployment:**
 - OpenShift or Kubernetes cluster (optional but recommended)
-- Keycloak instance
+- Keycloak instance (recommended for production; optional with `noauth` profile)
 - Container runtime (Podman/Docker)
 
 ### Do I need to install Keycloak separately?
 
-Yes, Wanaku requires a Keycloak instance for authentication. You can:
+Keycloak is required only if you want to run Wanaku with authentication enabled. You can:
 - Run Keycloak locally using Podman/Docker (for development)
 - Deploy Keycloak to OpenShift/Kubernetes (for production)
 - Use an existing Keycloak instance
 
-See the [Usage Guide](usage.md#keycloak-setup-for-wanaku) for setup instructions.
+If you don't need authentication (e.g., for local development or testing), you can run Wanaku with the `noauth` profile
+and skip the Keycloak setup entirely. See [Running Without Authentication](usage.md#running-without-authentication).
 
 ### Can I run Wanaku without Kubernetes?
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,9 +74,14 @@ These services can be implemented in any language that supports gRPC for communi
 Security in Wanaku involves controlling access to the management APIs and web interface while ensuring that only authorized
 users can modify tools, resources, and configurations. Wanaku also ensures secure access to the MCP tools and resources. 
 
-Wanaku uses [Keycloak](https://keycloak.org) for authentication and authorization. As such, a Keycloak instance needs to be up
-and running for Wanaku to work. This section covers the basics of getting Keycloak ready for Wanaku for development and production 
-purposes.
+Wanaku uses [Keycloak](https://keycloak.org) for authentication and authorization. A Keycloak instance is required when running
+Wanaku with authentication enabled. This section covers the basics of getting Keycloak ready for Wanaku for development and
+production purposes.
+
+> [!NOTE]
+> Wanaku can also run **without authentication** by using the `noauth` Quarkus profile. This is useful for local development,
+> testing, or air-gapped environments where an identity provider is not available. See
+> [Running Without Authentication](#running-without-authentication) for details.
 
 ## Keycloak Setup for Wanaku
 
@@ -164,6 +169,52 @@ Finally, for security, you must regenerate the client secret for the `wanaku-ser
 
 ![Screenshot of Keycloak admin console showing the wanaku-service client credentials tab with the Regenerate secret button](imgs/keycloak-service.png)
 
+## Running Without Authentication
+
+Wanaku can run without authentication by activating the `noauth` Quarkus profile. This disables OIDC and permits access
+to all API endpoints, the admin UI, and MCP namespaces without requiring a Bearer token or a Keycloak instance.
+
+This is useful for:
+- **Local development and testing** — no need to set up Keycloak
+- **Air-gapped environments** — where an external identity provider is not available
+- **Quick prototyping** — get started with Wanaku immediately
+
+### Activating the No-Auth Profile
+
+**Using the CLI (default for local):**
+
+```shell
+wanaku start local
+```
+
+The `wanaku start local` command automatically uses the `noauth` profile, so no additional configuration is needed.
+
+**Using an environment variable:**
+
+```shell
+export QUARKUS_PROFILE=noauth
+java -jar quarkus-run.jar
+```
+
+**Using a system property:**
+
+```shell
+java -Dquarkus.profile=noauth -jar quarkus-run.jar
+```
+
+**Using Docker Compose:**
+
+A dedicated compose file is provided at `deploy/docker-compose/docker-compose-noauth.yml` that runs the router
+without Keycloak:
+
+```shell
+docker compose -f deploy/docker-compose/docker-compose-noauth.yml up
+```
+
+> [!WARNING]
+> The `noauth` profile disables all authentication. Do not use it in production environments where access control is
+> required.
+
 # Installing Wanaku
 
 To run Wanaku, you need to first download and install the router and the command line client.
@@ -222,25 +273,39 @@ There are three ways to run the router. They work similarly, with the distinctio
 capabilities by default — continue reading the documentation below for details.
 
 > [!IMPORTANT]
-> Before the router can be executed, it still needs to be configured for secure access and control of its resources. Make sure 
-> you read the section [Securing the Wanaku MCP Router](# Securing the Wanaku MCP Router) **before** running or deploying the router. 
+> For production deployments with authentication, the router needs to be configured for secure access and control of its
+> resources. Make sure you read the section [Securing the Wanaku MCP Router](#securing-the-wanaku-mcp-router) **before**
+> running or deploying the router. For local development or testing, you can
+> [run without authentication](#running-without-authentication).
 
 ### Installing and Running Wanaku Locally Using "Wanaku Start Local"
 
-You can use the Wanaku CLI to start a small/simplified local instance. To do so, you need to run and configure a local Keycloak 
-instance and then use the `wanaku start local` command to run Wanaku pointing to that instance. Make sure you follow the steps
-described in [Option 1: Local Setup with Podman](## Option 1: Local Setup with Podman) the [Keycloak Setup For Wanaku](#Keycloak Setup for Wanaku).
+You can use the Wanaku CLI to start a small/simplified local instance. After downloading the CLI, simply run
+`wanaku start local` and the CLI should download, deploy and start Wanaku with the main server, a file provider
+and an HTTP provider.
 
-After downloading the CLI, simply run `wanaku start local` and the CLI should download, deploy and start Wanaku with the main
-server, a file provider and an HTTP provider. You will need to pass the client secret configured 
-so that the capabilities can connect to the router. 
+```shell
+wanaku start local
+```
 
-```wanaku start local --capabilities-client-secret=aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv```
+The local runner uses the `noauth` Quarkus profile by default, so **Keycloak is not required**. The router and all
+capability services will start without authentication.
 
 If that is successful, open your browser at http://localhost:8080, and you should have access to the UI.
 
 > [!NOTE]
-> You can use the command line to enable more services by using the `--services` option. Use the `--help` to see the details. 
+> You can use the command line to enable more services by using the `--services` option. Use the `--help` to see the details.
+
+#### Running with Authentication
+
+If you need authentication for your local instance, first set up Keycloak by following
+[Option 1: Local Setup with Podman](#option-1-local-setup-with-podman) in the
+[Keycloak Setup For Wanaku](#keycloak-setup-for-wanaku) section. Then pass the client secret so that the capabilities
+can authenticate with the router:
+
+```shell
+wanaku start local --capabilities-client-secret=aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
+```
 
 ### Installing and Running Wanaku on OpenShift or Kubernetes Using the Wanaku Operator
 


### PR DESCRIPTION
## Summary

- Add a `noauth` Quarkus profile to the router backend and capabilities SDK that disables OIDC and permits all API paths without a Bearer token or Keycloak instance
- Centralize OIDC client config in `wanaku-capabilities-base` and guard `Tokens` injection with `isResolvable()` so capabilities start cleanly without Keycloak
- Update `wanaku start local` CLI to use the `noauth` profile by default for both the router and capability services
- Add a `docker-compose-noauth.yml` for running the router without Keycloak
- Update documentation (usage guide, configuration reference, FAQ, README) to reflect that authentication is optional

## Test plan

- [ ] Run `mvn quarkus:dev -Dquarkus.profile=noauth` for the router backend without Keycloak — confirm it starts and all endpoints are accessible
- [ ] Run a capability service with `-Dquarkus.profile=noauth` — confirm no OIDC errors
- [ ] Run with the default profile and Keycloak — confirm authentication still works as before
- [ ] Run `mvn verify` to ensure existing tests pass

## Summary by Sourcery

Introduce a no-authentication runtime option for Wanaku and update tooling and docs to make Keycloak optional for local and non-secured environments.

New Features:
- Add a `noauth` Quarkus profile to the router backend that disables OIDC and permits all API paths without authentication.
- Add a `noauth` Quarkus profile for capability services via the shared capabilities base configuration so they can run without Keycloak.
- Provide a `docker-compose-noauth.yml` to run the router backend without a Keycloak dependency.

Enhancements:
- Update the `wanaku start local` CLI runner to start the router and capability services with the `noauth` profile by default.
- Centralize OIDC client configuration in `wanaku-capabilities-base` and make token injection optional so capabilities start cleanly when OIDC is disabled.

Documentation:
- Document running Wanaku without authentication in the usage guide, configuration reference, FAQ, and README, clarifying that Keycloak is optional and warning against using `noauth` in production.