### PR TITLE
ci: revert testcontainers from 2.0.4 to 2.0.3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
         <langchain4j.version>1.13.0</langchain4j.version>
         <langchain4j-mcp.version>1.13.0-beta23</langchain4j-mcp.version>
         <quarkus-quinoa.version>2.7.2</quarkus-quinoa.version>
-        <testcontainers.version>2.0.4</testcontainers.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
         <commons-pool2.version>2.13.1</commons-pool2.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <swagger-core.version>2.2.45</swagger-core.version>


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/24550114285

### Errors Fixed
- `DataStoresResourceTest` and `ResourceCapabilityE2ETest` failing with `IllegalStateException: Could not find a valid Docker environment` due to Testcontainers 2.0.4 breaking Docker detection on GitHub Actions ubuntu runners
- Fix: revert `testcontainers.version` from 2.0.4 to 2.0.3

### Deferred Issues
- #985: Investigate Testcontainers 2.0.4 upgrade (upstream: https://github.com/testcontainers/testcontainers-java/issues/11582)