### PR TITLE
Sorting namespaces on UI

### DIFF
--- a/apps/ui/admin/src/Pages/Namespaces/NamespaceSelect.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespaceSelect.tsx
@@ -2,6 +2,7 @@ import {Select, SelectItem} from "@carbon/react"
 import React, {useEffect, useState} from "react"
 import {Namespace} from "../../models"
 import {useNamespaces} from "../../hooks/api/use-namespaces"
+import {sortedNamespaces} from "./namespaces.ts";
 
 
 interface NamespaceSelectProps {
@@ -22,15 +23,16 @@ export const NamespaceSelect : React.FC<NamespaceSelectProps> = ({ id, labelText
     (async () => {
       const response = await listNamespaces()
       if (response.status == 200 && Array.isArray(response.data.data)) {
-        let selected = findDefaultNamespaceAmong(response.data.data)
+        const namespaces = sortedNamespaces(response.data.data)
+        let selected = findDefaultNamespaceAmong(namespaces)
         if (value) {
-          selected = findNamespaceAmong(value, response.data.data)
+          selected = findNamespaceAmong(value, namespaces)
         }
-        setNamespaces(response.data.data)
+        setNamespaces(namespaces)
         setSelectedNamespace(selected)
       }
     })()
-  }, [])
+  }, [listNamespaces])
   
   function findNamespace(id: string): Namespace | undefined {
     return findNamespaceAmong(id, namespaces)

--- a/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
@@ -4,6 +4,7 @@ import {Namespace} from "../../models";
 import {NamespaceTable} from "./NamespacesTable";
 import {NamespaceModal} from "./NamespaceModal";
 import {useNamespaces} from "../../hooks/api/use-namespaces";
+import {sortedNamespaces} from "./namespaces"
 
 export const NamespacesPage: React.FC = () => {
   const [namespaces, setNamespaces] = useState<Namespace[]>([]);
@@ -19,7 +20,7 @@ export const NamespacesPage: React.FC = () => {
         setErrorMessage("Failed to fetch namespaces. Please try again later.");
         setNamespaces([]);
       } else {
-        setNamespaces(result.data.data);
+        setNamespaces(sortedNamespaces(result.data.data));
       }
       setIsLoading(false);
     });

--- a/apps/ui/admin/src/Pages/Namespaces/namespaces.ts
+++ b/apps/ui/admin/src/Pages/Namespaces/namespaces.ts
@@ -1,0 +1,24 @@
+import {Namespace} from "../../models"
+
+export function sortedNamespaces(namespaces: readonly Namespace[]): Namespace[] {
+  const result = [...namespaces]
+  result.sort((a, b) => {
+    // First is default namespace
+    if (a.path === "default") {
+      return -1
+    }
+    if (b.path === "default") {
+      return 1
+    }
+    // Second is public namespace
+    if (a.path === "public") {
+      return -1
+    }
+    if (b.path === "public") {
+      return 1
+    }
+    // Rest are sorte
+    return a.path!.localeCompare(b.path!)
+  })
+  return result
+}


### PR DESCRIPTION
Sorting namespaces on UI for better user experience.

Proposed order is:
1   default
2   public
3+ sorting based on display text (currently _path_)

## Summary by Sourcery

Sort namespaces consistently in the admin UI to prioritise default and public namespaces and alphabetise the rest.

New Features:
- Introduce a reusable utility to return namespaces sorted with default first, public second, and remaining entries alphabetically.

Enhancements:
- Apply the shared namespace sorting utility to namespace selection and listing views for a consistent user experience.
- Update the namespace selection effect dependencies to reflect its usage of the listNamespaces function.