### PR TITLE
Bugfix: forwards look up namespace by id

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -159,10 +159,15 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
     }
 
     private void registerForward(ForwardReference forwardReference) {
-        Namespace ns = null;
+        Namespace ns;
 
-        if (!StringHelper.isEmpty(forwardReference.getNamespace())) {
-            ns = namespacesBean.alocateNamespace(forwardReference.getNamespace());
+        if (StringHelper.isEmpty(forwardReference.getNamespace())) {
+            ns = namespacesBean.getDefaultNamespace();
+        } else {
+            if (!namespacesBean.exists(forwardReference.getNamespace())) {
+                throw new WanakuException("Invalid namespace id: " + forwardReference.getNamespace());
+            }
+            ns = namespacesBean.getById(forwardReference.getNamespace());
         }
 
         final NameNamespacePair nameNamespacePair =
@@ -197,6 +202,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
 
                 RemoteToolReference localReference = ForwardToolHelper.copyRemoteToolReference(reference);
                 localReference.setName(localName);
+                localReference.setNamespace(forwardReference.getNamespace());
 
                 ToolsHelper.registerTool(
                         localReference,

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.WanakuRouterConfig;
@@ -140,6 +141,17 @@ public class NamespacesBean {
 
     public Namespace getById(String id) {
         return namespaceRepository.findById(id);
+    }
+
+    public Namespace getDefaultNamespace() {
+        List<Namespace> defaultList = namespaceRepository.findByName("default");
+        if (defaultList.isEmpty()) {
+            throw new NoSuchElementException("No default namespace exists");
+        }
+        if (defaultList.size() > 1) {
+            throw new IllegalStateException("Multiple default namespaces exist");
+        }
+        return defaultList.getFirst();
     }
 
     public boolean update(String id, Namespace namespace) {


### PR DESCRIPTION
The namespace for forwards is passed by id from the UI (always from a select box). Namespace allocation is no longer needed when adding forwards (in fact, it was causing a bug to me to save the forward with _different_ namespace than expected).

Defaults to **default** namespace for extra safety

## Summary by Sourcery

Adjust forward namespace resolution to use namespace IDs and fall back to the default namespace when none is provided.

Bug Fixes:
- Resolve forwards being saved under an unexpected namespace by using the namespace ID supplied by the UI instead of allocating by name.
- Prevent null or empty forward namespaces from causing inconsistent behavior by defaulting to the 'default' namespace.

Enhancements:
- Add a helper in NamespacesBean to retrieve the configured default namespace, failing fast if none exists.