### PR TITLE
[UI] Trash can icon for deleting namespaces

### DIFF
--- a/apps/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
@@ -1,4 +1,4 @@
-import {Add, Clean, Edit} from "@carbon/icons-react";
+import {Add, Edit, TrashCan} from "@carbon/icons-react";
 import {
     Button,
     DataTable,
@@ -122,9 +122,9 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
                       />
                       <Button
                         kind="ghost"
-                        renderIcon={Clean}
+                        renderIcon={TrashCan}
                         hasIconOnly
-                        iconDescription="Clean up"
+                        iconDescription="Delete"
                         disabled={nsProtected}
                         onClick={() => onDelete(namespace)}
                       />


### PR DESCRIPTION
I believe namespaces should use the same TrashCan icon (and Delete tooltip) as the rest of the editable entities.

## Summary by Sourcery

Enhancements:
- Replace the namespace delete button's Clean icon with the standard TrashCan icon and align its tooltip text to 'Delete' for consistency with other entities.