### PR TITLE
Bugfix: storing addresses instead of whole ForwardClients in the registry

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -75,12 +75,12 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         final NameNamespacePair nameNamespacePair =
                 new NameNamespacePair(forwardReference.getName(), forwardReference.getNamespace());
 
-        final ForwardClient forwardClient = forwardRegistry.getClient(nameNamespacePair);
-        if (forwardClient == null) {
+        String address = forwardRegistry.getClientAddress(nameNamespacePair);
+        if (address == null) {
             return false;
         }
 
-        try {
+        try (var forwardClient = ForwardClient.newClient(address)) {
             removeRemoteTools(nameNamespacePair, forwardClient);
             removeRemoteResources(forwardClient);
         } finally {
@@ -209,7 +209,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             }
 
             registeredRemoteToolsByForward.put(nameNamespacePair, List.copyOf(locallyRegisteredTools));
-            forwardRegistry.link(nameNamespacePair, forwardClient);
+            forwardRegistry.link(nameNamespacePair, forwardClient.address());
         } catch (WanakuException e) {
             cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
 
@@ -239,8 +239,10 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
 
     public List<ResourceReference> listAllResources() {
         List<ResourceReference> references = new ArrayList<>();
-        for (ForwardClient forwardClient : forwardRegistry.clients().values()) {
-            references.addAll(mcpBridge.listResources(forwardClient));
+        for (String address : forwardRegistry.clients().values()) {
+            try (var client = ForwardClient.newClient(address)) {
+                references.addAll(mcpBridge.listResources(client));
+            }
         }
 
         return references;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardRegistry.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ForwardRegistry.java
@@ -18,28 +18,27 @@ import ai.wanaku.capabilities.sdk.api.types.NameNamespacePair;
 public class ForwardRegistry {
     private static final Logger LOG = Logger.getLogger(ForwardRegistry.class);
 
-    private final Map<NameNamespacePair, ForwardClient> clients = new ConcurrentHashMap<>();
+    private final Map<NameNamespacePair, String> clients = new ConcurrentHashMap<>();
 
     /**
      * Links a forward client to a service identifier.
      * <p>
-     * Registers the provided {@link ForwardClient} under the given {@link NameNamespacePair},
+     * Registers the provided address under the given {@link NameNamespacePair},
      * making it available for subsequent lookups. If a client already exists for the given
      * service identifier, it will be replaced without closing the previous client.
      *
      * @param service the service identifier (name and namespace pair)
-     * @param forwardClient the forward client to register
+     * @param forwardClientAddress the forward client address to register
+     * @see ForwardClient
      */
-    public void link(NameNamespacePair service, ForwardClient forwardClient) {
-        clients.put(service, forwardClient);
+    public void link(NameNamespacePair service, String forwardClientAddress) {
+        clients.put(service, forwardClientAddress);
     }
 
     /**
-     * Unlinks and closes a forward client associated with a service identifier.
+     * Unlinks and closes a forward client address associated with a service identifier.
      * <p>
-     * Removes the {@link ForwardClient} associated with the given {@link NameNamespacePair}
-     * and attempts to close the underlying MCP client connection. If the client cannot be
-     * closed cleanly, a warning is logged but the removal proceeds.
+     * Removes the address associated with the given {@link NameNamespacePair}
      * <p>
      * This method is idempotent - calling it multiple times with the same service identifier
      * has no effect after the first call.
@@ -47,39 +46,33 @@ public class ForwardRegistry {
      * @param service the service identifier (name and namespace pair)
      */
     public void unlink(NameNamespacePair service) {
-        ForwardClient removed = clients.remove(service);
-        if (removed != null) {
-            try {
-                removed.client().close();
-            } catch (Exception e) {
-                LOG.warnf("Failed to close MCP client for %s: %s", removed.address(), e.getMessage());
-            }
-        }
+        clients.remove(service);
     }
 
     /**
-     * Retrieves the forward client associated with a service identifier.
+     * Retrieves the forward client address associated with a service identifier.
      * <p>
-     * Returns the {@link ForwardClient} registered under the given {@link NameNamespacePair},
+     * Returns the address registered under the given {@link NameNamespacePair},
      * or {@code null} if no client is registered for that identifier.
      *
      * @param service the service identifier (name and namespace pair)
      * @return the forward client, or {@code null} if not found
+     * @see ForwardClient
      */
-    public ForwardClient getClient(NameNamespacePair service) {
+    public String getClientAddress(NameNamespacePair service) {
         return clients.get(service);
     }
 
     /**
      * Returns an unmodifiable view of all registered forward clients.
      * <p>
-     * The returned map contains all currently registered {@link ForwardClient} instances,
+     * The returned map contains all currently registered addresses for {@link ForwardClient} instances,
      * keyed by their {@link NameNamespacePair} identifiers. The map is a snapshot and
      * modifications to it will not affect the registry.
      *
-     * @return an unmodifiable map of all registered forward clients
+     * @return an unmodifiable map of all registered forward client addresses
      */
-    public Map<NameNamespacePair, ForwardClient> clients() {
+    public Map<NameNamespacePair, String> clients() {
         return clients;
     }
 }


### PR DESCRIPTION
There was a resource leak in MCPClients / ForwardClients. The ForwardClients were stored in a registry with possibly opened connections. The latest AutoCloseable interface fix solved this, but the issue manifested itself in not listing any remote resources (the connection was already closed by that time).

Storing addresses instead of the whole clients in the ForwardRegistry. Create new clients on demand and close them once done working.

## Summary by Sourcery

Store only forward client addresses in the registry and create short-lived ForwardClient instances on demand when accessing or cleaning up forwards.

Bug Fixes:
- Fix resource leak and stale closed connections caused by storing long-lived ForwardClient instances in the registry.

Enhancements:
- Update forward registry and API bean to work with client addresses, creating and closing ForwardClient instances per operation instead of sharing them globally.