### PR TITLE
[UI] Race condition of loading target type select 

### DIFF
--- a/apps/ui/admin/src/Pages/Targets/TargetTypeSelect.tsx
+++ b/apps/ui/admin/src/Pages/Targets/TargetTypeSelect.tsx
@@ -1,4 +1,4 @@
-import {Select, SelectItem} from "@carbon/react";
+import {Select, SelectItem, SelectSkeleton} from "@carbon/react";
 import React, {useEffect, useState} from "react";
 import {ServiceTarget} from "../../models";
 
@@ -13,29 +13,46 @@ export const TargetTypeSelect: React.FC<TargetTypeSelectProps> = ({
   onChange,
   apiCall
 }) => {
-  const [targetTypes, settargetTypes] = useState<ServiceTarget[]>([]);
+  
+  const [targetTypes, setTargetTypes] = useState<ServiceTarget[]>([])
+  const [isLoading, setLoading] = useState(true)
 
   useEffect(() => {
-    apiCall().then((result) => {
-      settargetTypes(result.data.data as ServiceTarget[]);
-    });
+    (async () => {
+      try {
+        const result = await apiCall()
+        if (result.status === 200) {
+          const targetTypes: ServiceTarget[] = result.data.data
+          setTargetTypes(targetTypes)
+        } else {
+          console.error(`Error fetching target types: ${result.status}`)
+          setTargetTypes([])
+        }
+      } finally {
+        setLoading(false)
+      }
+    })()
   }, []);
 
-  return (
-    <Select
-      id="target-type"
-      labelText="Type"
-      defaultValue="file"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {targetTypes.map((targetType) => (
-        <SelectItem
-          key={targetType.id}
-          value={targetType.serviceName}
-          text={targetType.serviceName || ""}
-        />
-      ))}
-    </Select>
-  );
+  if (isLoading) {
+    return <SelectSkeleton />
+  } else {
+    return (
+      <Select
+        id="target-type"
+        labelText="Type"
+        defaultValue="file"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {targetTypes.map((targetType) => (
+          <SelectItem
+            key={targetType.id}
+            value={targetType.serviceName}
+            text={targetType.serviceName || ""}
+          />
+        ))}
+      </Select>
+    )
+  }
 };


### PR DESCRIPTION
There is a race condition in TargetTypeSelect. If the UI loads before `apiCall()` completes, the types would be empty. 

This fix displays `SelectSkeleton` if the data are still being loaded and redraws the `Select` once finished.

## Summary by Sourcery

Handle asynchronous loading of target types in the TargetTypeSelect component to avoid empty options on initial render.

Bug Fixes:
- Prevent TargetTypeSelect from rendering with empty options when the API call has not yet completed.

Enhancements:
- Show a loading skeleton while target types are being fetched and initialize the select value from the first available target type when none is provided.