### PR TITLE
[UI] Checking namespaces already in use

### DIFF
--- a/apps/ui/admin/src/Pages/Namespaces/NamespaceModal.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespaceModal.tsx
@@ -3,33 +3,50 @@ import React, {useState} from "react";
 import {Namespace} from "../../models";
 
 interface NamespaceModalProps {
-  namespace?: Namespace;
+  openedNamespace?: Namespace;
+  namespaces: Namespace[]
   onSubmit: (namespace: Namespace) => void;
   onRequestClose: () => void;
 }
 
 export const NamespaceModal: React.FC<NamespaceModalProps> = ({
-  namespace,
+  openedNamespace,
+  namespaces,
   onSubmit,
   onRequestClose,
 }) => {
-  const [name, setName] = useState(namespace?.name || "");
-  const [path, setPath] = useState(namespace?.path || "");
+  const [name, setName] = useState(openedNamespace?.name);
+  const [path, setPath] = useState(openedNamespace?.path);
+  const [invalidName, setInvalidName] = useState(false)
+  const [invalidPath, setInvalidPath] = useState(false)
 
+  function otherNamespaces(): Namespace[] {
+    return namespaces.filter(namespace => namespace.id !== openedNamespace?.id)
+  }
+  
+  function isInvalidName(name: string): boolean {
+    return otherNamespaces().some(namespace => namespace.name === name)
+  }
+  
+  function isInvalidPath(path: string): boolean {
+    return otherNamespaces().some(namespace => namespace.path === path)
+  }
+  
   const handleSubmit = () => {
     onSubmit({
-      id: namespace?.id,
-      name: name || undefined,
-      path: path || undefined,
-      labels: namespace?.labels,
+      id: openedNamespace?.id,
+      name: name,
+      path: path,
+      labels: openedNamespace?.labels,
     });
   };
 
   return (
     <Modal
       open={true}
-      modalHeading={namespace ? "Edit Namespace" : "Create Namespace"}
-      primaryButtonText={namespace ? "Save" : "Create"}
+      modalHeading={openedNamespace ? "Edit Namespace" : "Create Namespace"}
+      primaryButtonText={openedNamespace ? "Save" : "Create"}
+      primaryButtonDisabled={invalidName || invalidPath}
       secondaryButtonText="Cancel"
       onRequestSubmit={handleSubmit}
       onRequestClose={onRequestClose}
@@ -41,7 +58,13 @@ export const NamespaceModal: React.FC<NamespaceModalProps> = ({
           placeholder="e.g. my-namespace"
           helperText="A human-readable name for this namespace. Leave empty for a preallocated slot."
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          invalid={invalidName}
+          invalidText={`Invalid namespace name: ${name} is already in use.`}
+          onChange={(e) => {
+            const name = e.target.value
+            setName(name)
+            setInvalidName(isInvalidName(name))
+          }}
         />
         <TextInput
           id="namespace-path"
@@ -49,8 +72,14 @@ export const NamespaceModal: React.FC<NamespaceModalProps> = ({
           placeholder="e.g. ns-0"
           helperText="The physical path identifier for this namespace."
           value={path}
-          onChange={(e) => setPath(e.target.value)}
-          disabled={!!namespace}
+          invalid={invalidPath}
+          invalidText={`Invalid namespace path: ${path} is already in use.`}
+          onChange={(e) => {
+            const path = e.target.value
+            setPath(path)
+            setInvalidPath(isInvalidPath(path))
+          }}
+          disabled={!!openedNamespace}
         />
       </Stack>
     </Modal>

--- a/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
@@ -118,7 +118,8 @@ export const NamespacesPage: React.FC = () => {
         />
         {isModalOpen && (
           <NamespaceModal
-            namespace={openedNamespace}
+            namespaces={namespaces}
+            openedNamespace={openedNamespace}
             onRequestClose={handleModalClose}
             onSubmit={handleModalSubmit}
           />


### PR DESCRIPTION
While creating/editing a namespace on UI, reusing already registered names and paths is now disabled in order to avoid collisions (UI lists namespaces by paths, backend uses search by name)

## Summary by Sourcery

Prevent creating or editing namespaces with duplicate names or paths in the admin UI.

New Features:
- Add validation in the namespace modal to detect and block reuse of existing namespace names and paths.

Enhancements:
- Show inline error states and disable the primary action in the namespace modal when the chosen name or path is already taken.