### PR TITLE
feature: readiness health checks

### DIFF
--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -38,22 +38,30 @@ spec:
           value: ""
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          initialDelaySeconds: 30
+          failureThreshold: 5
+          httpGet:
+            path: /q/health/live
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /q/health/ready
+            port: 8081
+          initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 9190
+          timeoutSeconds: 5
         ports:
         - containerPort: 9190
           name: grpc
           protocol: TCP
-        readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          tcpSocket:
-            port: 9190
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         volumeMounts:
-        - mountPath: /data
-          name: ""
+          - mountPath: /data
+            name: ""
       volumes:
         - name: ""
           persistentVolumeClaim:

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -15,23 +15,41 @@ spec:
         app: ""
     spec:
       containers:
-        - env:
-            - name: AUTH_SERVER
-              value: ""
-            - name: WANAKU_SERVICE_REGISTRATION_URI
-              # Comes from Wanaku route
-              value: ""
-            - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
-              value: ""
-          image: ""
-          imagePullPolicy: IfNotPresent
-          name: wanaku-capability
-          ports:
-            - containerPort: 9000
-              protocol: TCP
-          volumeMounts:
-            - mountPath: /home/default/.wanaku/services
-              name: ""
+      - env:
+        - name: AUTH_SERVER
+          value: ""
+        - name: WANAKU_SERVICE_REGISTRATION_URI
+          # Comes from Wanaku route
+          value: ""
+        - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
+          value: ""
+        image: ""
+        imagePullPolicy: IfNotPresent
+        name: wanaku-capability
+        ports:
+        - containerPort: 9000
+          protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /q/health/live
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /q/health/ready
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+          - mountPath: /home/default/.wanaku/services
+            name: ""
       volumes:
         - name: ""
           persistentVolumeClaim:

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/InfinispanReadinessCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/InfinispanReadinessCheck.java
@@ -1,0 +1,63 @@
+package ai.wanaku.backend.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Set;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.Health;
+import org.infinispan.health.HealthStatus;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+@Readiness
+@ApplicationScoped
+public class InfinispanReadinessCheck implements HealthCheck {
+
+    private static final Set<HealthStatus> UNHEALTHY_STATUSES = Set.of(HealthStatus.DEGRADED, HealthStatus.FAILED);
+
+    @Inject
+    EmbeddedCacheManager cacheManager;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder().name("infinispan");
+
+        try {
+            Health health = cacheManager.getHealth();
+            if (isDegraded(health)) {
+                builder.down();
+                appendDegradedCaches(builder, health);
+            } else {
+                builder.up();
+                appendHealthyData(builder, health);
+            }
+        } catch (Exception e) {
+            builder.down().withData("error", e.getMessage());
+        }
+
+        return builder.build();
+    }
+
+    private boolean isDegraded(Health health) {
+        return health.getCacheHealth().stream().anyMatch(ch -> UNHEALTHY_STATUSES.contains(ch.getStatus()));
+    }
+
+    private void appendDegradedCaches(HealthCheckResponseBuilder builder, Health health) {
+        String degradedCaches = health.getCacheHealth().stream()
+                .filter(ch -> UNHEALTHY_STATUSES.contains(ch.getStatus()))
+                .map(CacheHealth::getCacheName)
+                .reduce((a, b) -> a + "," + b)
+                .orElse("");
+        builder.withData("degradedCaches", degradedCaches);
+    }
+
+    private void appendHealthyData(HealthCheckResponseBuilder builder, Health health) {
+        builder.withData("cacheNames", String.join(",", cacheManager.getCacheNames()));
+        builder.withData(
+                "clusterHealth", health.getClusterHealth().getHealthStatus().toString());
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/LivenessHealthCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/LivenessHealthCheck.java
@@ -1,0 +1,24 @@
+package ai.wanaku.backend.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+@Liveness
+@ApplicationScoped
+public class LivenessHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.builder()
+                .name("wanaku-router")
+                .up()
+                .withData("availableProcessors", Runtime.getRuntime().availableProcessors())
+                .withData("maxMemory", Runtime.getRuntime().maxMemory())
+                .withData("totalMemory", Runtime.getRuntime().totalMemory())
+                .withData("freeMemory", Runtime.getRuntime().freeMemory())
+                .build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
@@ -1,0 +1,172 @@
+package ai.wanaku.backend.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+import org.jboss.logging.Logger;
+
+/**
+ * OIDC readiness health check that verifies the OIDC provider is reachable.
+ * When OIDC is enabled, this check attempts to connect to the OIDC discovery endpoint
+ * to confirm the provider is available and responding.
+ */
+@Readiness
+@ApplicationScoped
+public class OidcReadinessCheck implements HealthCheck {
+
+    private static final Logger LOG = Logger.getLogger(OidcReadinessCheck.class);
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 5000;
+    private static final int HTTP_OK = 200;
+
+    @ConfigProperty(name = "quarkus.oidc.enabled", defaultValue = "false")
+    boolean oidcEnabled;
+
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    String authServerUrl;
+
+    @ConfigProperty(name = "quarkus.oidc.discovery-enabled", defaultValue = "true")
+    boolean discoveryEnabled;
+
+    @Inject
+    HttpConnectionProvider httpConnectionProvider;
+
+    @Override
+    public HealthCheckResponse call() {
+        if (!oidcEnabled) {
+            return disabledResponse();
+        }
+
+        if (authServerUrl == null || authServerUrl.isBlank()) {
+            return configurationErrorResponse();
+        }
+
+        return checkOidcReachability();
+    }
+
+    private HealthCheckResponse disabledResponse() {
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .up()
+                .withData("status", "disabled")
+                .build();
+    }
+
+    private HealthCheckResponse configurationErrorResponse() {
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .down()
+                .withData("status", "error")
+                .withData("message", "OIDC is enabled but auth-server-url is not configured")
+                .build();
+    }
+
+    private HealthCheckResponse checkOidcReachability() {
+        try {
+            String discoveryUrl = buildDiscoveryUrl(authServerUrl);
+            HttpURLConnection connection = httpConnectionProvider.createConnection(discoveryUrl);
+            int responseCode = connection.getResponseCode();
+            return handleDiscoveryResponse(discoveryUrl, responseCode);
+        } catch (URISyntaxException e) {
+            return invalidUrlError(e);
+        } catch (IOException e) {
+            return connectionError(e);
+        }
+    }
+
+    private HealthCheckResponse handleDiscoveryResponse(String discoveryUrl, int responseCode) {
+        if (responseCode == HTTP_OK) {
+            return successResponse();
+        }
+
+        LOG.warnf("OIDC discovery endpoint returned HTTP %d for URL: %s", responseCode, discoveryUrl);
+        return unreachableResponse(responseCode);
+    }
+
+    private HealthCheckResponse successResponse() {
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .up()
+                .withData("status", "enabled")
+                .build();
+    }
+
+    private HealthCheckResponse unreachableResponse(int responseCode) {
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .down()
+                .withData("status", "unreachable")
+                .withData("httpStatus", String.valueOf(responseCode))
+                .build();
+    }
+
+    private HealthCheckResponse invalidUrlError(URISyntaxException e) {
+        LOG.errorf(e, "Invalid OIDC auth-server-url: %s", authServerUrl);
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .down()
+                .withData("status", "invalid-url")
+                .withData("error", e.getMessage())
+                .build();
+    }
+
+    private HealthCheckResponse connectionError(IOException e) {
+        LOG.warnf("Failed to connect to OIDC discovery endpoint: %s", e.getMessage());
+        return HealthCheckResponse.builder()
+                .name("oidc")
+                .down()
+                .withData("status", "unreachable")
+                .withData("error", e.getMessage())
+                .build();
+    }
+
+    /**
+     * Builds the OIDC discovery URL from the auth-server-url.
+     * The discovery endpoint is typically at: {auth-server-url}/.well-known/openid-configuration
+     */
+    private String buildDiscoveryUrl(String authServerUrl) throws URISyntaxException {
+        URI uri = new URI(authServerUrl);
+        String path = uri.getPath();
+
+        // If discovery is disabled, the path may already contain the full URL to the realm endpoint
+        if (!discoveryEnabled && path != null && !path.isEmpty()) {
+            return authServerUrl;
+        }
+
+        // Default discovery endpoint
+        String basePath = path != null && !path.isEmpty() ? path.replaceAll("/$", "") : "";
+        return uri.getScheme() + "://" + uri.getAuthority() + basePath + "/.well-known/openid-configuration";
+    }
+
+    /**
+     * Provider interface for HTTP connections to allow mocking in tests.
+     */
+    public interface HttpConnectionProvider {
+        HttpURLConnection createConnection(String urlString) throws IOException;
+    }
+
+    @ApplicationScoped
+    public static class DefaultHttpConnectionProvider implements HttpConnectionProvider {
+        @Override
+        public HttpURLConnection createConnection(String urlString) throws IOException {
+            try {
+                HttpURLConnection connection =
+                        (HttpURLConnection) new URI(urlString).toURL().openConnection();
+                connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+                connection.setReadTimeout(READ_TIMEOUT_MS);
+                connection.setRequestMethod("GET");
+                return connection;
+            } catch (URISyntaxException e) {
+                throw new IOException("Invalid URL: " + urlString, e);
+            }
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/ServiceRegistryReadinessCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/ServiceRegistryReadinessCheck.java
@@ -1,0 +1,40 @@
+package ai.wanaku.backend.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+import ai.wanaku.backend.core.mcp.providers.ServiceRegistry;
+
+@Readiness
+@ApplicationScoped
+public class ServiceRegistryReadinessCheck implements HealthCheck {
+
+    @Inject
+    Instance<ServiceRegistry> serviceRegistryInstance;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder().name("service-registry");
+
+        try {
+            if (serviceRegistryInstance.isUnsatisfied()) {
+                builder.down().withData("reason", "ServiceRegistry CDI bean not available");
+                return builder.build();
+            }
+
+            ServiceRegistry registry = serviceRegistryInstance.get();
+            int totalCapabilities = registry.getEntries().size();
+
+            builder.up().withData("totalCapabilities", totalCapabilities);
+        } catch (Exception e) {
+            builder.down().withData("error", e.getMessage());
+        }
+
+        return builder.build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -86,6 +86,10 @@ quarkus.oidc-proxy.tenant-id=mcp
 quarkus.http.auth.permission.oidcproxy.paths=/.well-known/oauth-protected-resource/*, /.well-known/oauth-authorization-server/*, /q/oidc/*
 quarkus.http.auth.permission.oidcproxy.policy=permit
 
+# Health check paths must be publicly accessible for K8s probes
+quarkus.http.auth.permission.health.paths=/q/health/*
+quarkus.http.auth.permission.health.policy=permit
+
 # Management APIs and the Data Store APIs
 quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*
 quarkus.http.auth.permission.authenticated.policy=authenticated

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/InfinispanReadinessCheckTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/InfinispanReadinessCheckTest.java
@@ -1,0 +1,229 @@
+package ai.wanaku.backend.health;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.ClusterHealth;
+import org.infinispan.health.Health;
+import org.infinispan.health.HealthStatus;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InfinispanReadinessCheckTest {
+
+    @Test
+    void call_returnsUp_whenAllCachesAreHealthy() {
+        CacheHealth healthyCache = mockCacheHealth("myCache", HealthStatus.HEALTHY);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.HEALTHY);
+        Health health = mockHealth(clusterHealth, List.of(healthyCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("myCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertTrue(response.getData().isPresent());
+        assertEquals("myCache", getDataValue(response, "cacheNames"));
+        assertEquals("HEALTHY", getDataValue(response, "clusterHealth"));
+    }
+
+    @Test
+    void call_returnsUp_whenCachesAreHealthyRebalancing() {
+        CacheHealth rebalancingCache = mockCacheHealth("rebalancingCache", HealthStatus.HEALTHY_REBALANCING);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.HEALTHY_REBALANCING);
+        Health health = mockHealth(clusterHealth, List.of(rebalancingCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("rebalancingCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+    }
+
+    @Test
+    void call_returnsDown_whenCacheIsDegraded() {
+        CacheHealth degradedCache = mockCacheHealth("degradedCache", HealthStatus.DEGRADED);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.DEGRADED);
+        Health health = mockHealth(clusterHealth, List.of(degradedCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("degradedCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("degradedCache", getDataValue(response, "degradedCaches"));
+    }
+
+    @Test
+    void call_returnsDown_whenCacheIsFailed() {
+        CacheHealth failedCache = mockCacheHealth("failedCache", HealthStatus.FAILED);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.FAILED);
+        Health health = mockHealth(clusterHealth, List.of(failedCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("failedCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("failedCache", getDataValue(response, "degradedCaches"));
+    }
+
+    @Test
+    void call_returnsDown_withMultipleDegradedCaches() {
+        CacheHealth degradedCache = mockCacheHealth("cacheA", HealthStatus.DEGRADED);
+        CacheHealth failedCache = mockCacheHealth("cacheB", HealthStatus.FAILED);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.DEGRADED);
+        Health health = mockHealth(clusterHealth, List.of(degradedCache, failedCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("cacheA", "cacheB"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        String degradedCaches = getDataValue(response, "degradedCaches");
+        assertNotNull(degradedCaches);
+        assertTrue(degradedCaches.contains("cacheA"));
+        assertTrue(degradedCaches.contains("cacheB"));
+    }
+
+    @Test
+    void call_returnsDown_whenExceptionThrown() {
+        EmbeddedCacheManager cacheManager = mock(EmbeddedCacheManager.class);
+        when(cacheManager.getHealth()).thenThrow(new RuntimeException("Infinispan not available"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("Infinispan not available", getDataValue(response, "error"));
+    }
+
+    @Test
+    void call_returnsUp_whenNoCachesExist() {
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.HEALTHY);
+        Health health = mockHealth(clusterHealth, Collections.emptyList());
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Collections.emptySet());
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("infinispan", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertEquals("", getDataValue(response, "cacheNames"));
+    }
+
+    @Test
+    void call_returnsUp_withMixedHealthyAndInitializingCaches() {
+        CacheHealth healthyCache = mockCacheHealth("readyCache", HealthStatus.HEALTHY);
+        CacheHealth initializingCache = mockCacheHealth("initCache", HealthStatus.INITIALIZING);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.HEALTHY);
+        Health health = mockHealth(clusterHealth, List.of(healthyCache, initializingCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("readyCache", "initCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+    }
+
+    @Test
+    void call_returnsDown_withMixedHealthyAndDegradedCaches() {
+        CacheHealth healthyCache = mockCacheHealth("healthyCache", HealthStatus.HEALTHY);
+        CacheHealth degradedCache = mockCacheHealth("degradedCache", HealthStatus.DEGRADED);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.DEGRADED);
+        Health health = mockHealth(clusterHealth, List.of(healthyCache, degradedCache));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("healthyCache", "degradedCache"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertFalse(response.getData().get().containsKey("cacheNames"));
+        assertEquals("degradedCache", getDataValue(response, "degradedCaches"));
+    }
+
+    @Test
+    void call_returnsUp_withMultipleCacheNames() {
+        CacheHealth cache1 = mockCacheHealth("cache1", HealthStatus.HEALTHY);
+        CacheHealth cache2 = mockCacheHealth("cache2", HealthStatus.HEALTHY);
+        ClusterHealth clusterHealth = mockClusterHealth(HealthStatus.HEALTHY);
+        Health health = mockHealth(clusterHealth, List.of(cache1, cache2));
+        EmbeddedCacheManager cacheManager = mockCacheManager(health, Set.of("cache1", "cache2"));
+
+        InfinispanReadinessCheck check = new InfinispanReadinessCheck();
+        check.cacheManager = cacheManager;
+
+        HealthCheckResponse response = check.call();
+
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        String cacheNames = getDataValue(response, "cacheNames");
+        assertTrue(cacheNames.contains("cache1"));
+        assertTrue(cacheNames.contains("cache2"));
+    }
+
+    private CacheHealth mockCacheHealth(String name, HealthStatus status) {
+        CacheHealth ch = mock(CacheHealth.class);
+        when(ch.getCacheName()).thenReturn(name);
+        when(ch.getStatus()).thenReturn(status);
+        return ch;
+    }
+
+    private ClusterHealth mockClusterHealth(HealthStatus status) {
+        ClusterHealth ch = mock(ClusterHealth.class);
+        when(ch.getHealthStatus()).thenReturn(status);
+        return ch;
+    }
+
+    private Health mockHealth(ClusterHealth clusterHealth, List<CacheHealth> cacheHealths) {
+        Health health = mock(Health.class);
+        when(health.getClusterHealth()).thenReturn(clusterHealth);
+        when(health.getCacheHealth()).thenReturn(cacheHealths);
+        return health;
+    }
+
+    private EmbeddedCacheManager mockCacheManager(Health health, Set<String> cacheNames) {
+        EmbeddedCacheManager cm = mock(EmbeddedCacheManager.class);
+        when(cm.getHealth()).thenReturn(health);
+        when(cm.getCacheNames()).thenReturn(cacheNames);
+        return cm;
+    }
+
+    private String getDataValue(HealthCheckResponse response, String key) {
+        return response.getData()
+                .map(data -> data.get(key))
+                .map(Object::toString)
+                .orElse(null);
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/OidcReadinessCheckTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/OidcReadinessCheckTest.java
@@ -1,0 +1,179 @@
+package ai.wanaku.backend.health;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import ai.wanaku.backend.health.OidcReadinessCheck.HttpConnectionProvider;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OidcReadinessCheckTest {
+
+    @Test
+    void call_returnsUp_whenOidcIsDisabled() {
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = false;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertTrue(response.getData().isPresent());
+        assertEquals("disabled", getDataValue(response, "status"));
+    }
+
+    @Test
+    void call_returnsUp_whenOidcIsEnabledAndDiscoverySucceeds() throws IOException {
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getResponseCode()).thenReturn(200);
+
+        HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
+        when(connectionProvider.createConnection(
+                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
+                .thenReturn(connection);
+
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.discoveryEnabled = true;
+        check.httpConnectionProvider = connectionProvider;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertEquals("enabled", getDataValue(response, "status"));
+        assertFalse(response.getData().get().containsKey("authServerUrl"));
+    }
+
+    @Test
+    void call_returnsDown_whenDiscoveryReturnsNon200() throws IOException {
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getResponseCode()).thenReturn(503);
+
+        HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
+        when(connectionProvider.createConnection(
+                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
+                .thenReturn(connection);
+
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.discoveryEnabled = true;
+        check.httpConnectionProvider = connectionProvider;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("unreachable", getDataValue(response, "status"));
+        assertEquals("503", getDataValue(response, "httpStatus"));
+        assertFalse(response.getData().get().containsKey("authServerUrl"));
+    }
+
+    @Test
+    void call_returnsDown_whenAuthServerUrlIsInvalid() throws IOException {
+        // For an invalid URL, buildDiscoveryUrl will construct a malformed URL like
+        // "null://nullnot-a-valid-url/.well-known/openid-configuration"
+        // which will cause an IOException when trying to open the connection
+        HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
+        when(connectionProvider.createConnection("null://nullnot-a-valid-url/.well-known/openid-configuration"))
+                .thenThrow(new IOException("Invalid URL"));
+
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = "not-a-valid-url";
+        check.discoveryEnabled = true;
+        check.httpConnectionProvider = connectionProvider;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("unreachable", getDataValue(response, "status"));
+        assertFalse(response.getData().get().containsKey("authServerUrl"));
+    }
+
+    @Test
+    void call_doesNotExposeAuthServerUrl_inDownResponses() throws IOException {
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getResponseCode()).thenReturn(500);
+
+        HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
+        when(connectionProvider.createConnection(
+                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
+                .thenReturn(connection);
+
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.discoveryEnabled = true;
+        check.httpConnectionProvider = connectionProvider;
+
+        HealthCheckResponse response = check.call();
+
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertFalse(response.getData().get().containsKey("authServerUrl"));
+    }
+
+    @Test
+    void call_returnsDown_whenAuthServerUrlIsNull() {
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = null;
+        check.discoveryEnabled = true;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("error", getDataValue(response, "status"));
+    }
+
+    @Test
+    void call_returnsDown_whenAuthServerUrlIsEmpty() {
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = " ";
+        check.discoveryEnabled = true;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("error", getDataValue(response, "status"));
+    }
+
+    @Test
+    void call_usesDirectUrl_whenDiscoveryIsDisabled() throws IOException {
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getResponseCode()).thenReturn(200);
+
+        HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
+        when(connectionProvider.createConnection("http://localhost:8543/realms/wanaku"))
+                .thenReturn(connection);
+
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.discoveryEnabled = false;
+        check.httpConnectionProvider = connectionProvider;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+    }
+
+    private String getDataValue(HealthCheckResponse response, String key) {
+        return response.getData()
+                .map(data -> data.get(key))
+                .map(Object::toString)
+                .orElse(null);
+    }
+}

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
@@ -70,6 +70,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityLivenessCheck.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityLivenessCheck.java
@@ -1,0 +1,36 @@
+package ai.wanaku.core.capabilities.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Liveness;
+import io.quarkus.grpc.runtime.GrpcServer;
+
+@Liveness
+@ApplicationScoped
+public class CapabilityLivenessCheck implements HealthCheck {
+
+    @Inject
+    GrpcServer grpcServer;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder().name("capability-grpc-liveness");
+
+        try {
+            int port = grpcServer.getPort();
+            if (port > 0) {
+                builder.up().withData("grpcPort", port);
+            } else {
+                builder.down().withData("grpcPort", "not available");
+            }
+        } catch (Exception e) {
+            builder.down().withData("grpcPort", "not available");
+        }
+
+        return builder.build();
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityReadinessCheck.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityReadinessCheck.java
@@ -1,0 +1,36 @@
+package ai.wanaku.core.capabilities.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+import io.quarkus.grpc.runtime.GrpcServer;
+
+@Readiness
+@ApplicationScoped
+public class CapabilityReadinessCheck implements HealthCheck {
+
+    @Inject
+    GrpcServer grpcServer;
+
+    @Override
+    public HealthCheckResponse call() {
+        HealthCheckResponseBuilder builder = HealthCheckResponse.builder().name("capability-grpc-readiness");
+
+        try {
+            int port = grpcServer.getPort();
+            if (port > 0) {
+                builder.up().withData("grpcPort", port);
+            } else {
+                builder.down().withData("grpcPort", "not available");
+            }
+        } catch (Exception e) {
+            builder.down().withData("grpcPort", "not available");
+        }
+
+        return builder.build();
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
@@ -1,21 +1,32 @@
 package ai.wanaku.core.capabilities.common;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+import io.quarkus.grpc.runtime.GrpcServer;
 import ai.wanaku.core.exchange.HealthProbeDelegate;
 import ai.wanaku.core.exchange.v1.RuntimeStatus;
 
-/**
- * Default health probe delegate implementation.
- * <p>
- * Returns {@link RuntimeStatus#RUNTIME_STATUS_STARTED} when the capability is responding.
- * If a capability can respond to the probe, it is considered started.
- */
 @ApplicationScoped
 public class DefaultHealthProbeDelegate implements HealthProbeDelegate {
 
+    private static final Logger LOG = Logger.getLogger(DefaultHealthProbeDelegate.class);
+
+    @Inject
+    GrpcServer grpcServer;
+
     @Override
     public RuntimeStatus getStatus(String id) {
-        return RuntimeStatus.RUNTIME_STATUS_STARTED;
+        try {
+            int port = grpcServer.getPort();
+            if (port > 0) {
+                return RuntimeStatus.RUNTIME_STATUS_STARTED;
+            }
+            return RuntimeStatus.RUNTIME_STATUS_STARTING;
+        } catch (Exception e) {
+            LOG.debugf(e, "Health probe check failed for %s: %s", id, e.getMessage());
+            return RuntimeStatus.RUNTIME_STATUS_STARTING;
+        }
     }
 }

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/CapabilityLivenessCheckTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/CapabilityLivenessCheckTest.java
@@ -1,0 +1,73 @@
+package ai.wanaku.core.capabilities.common;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import io.quarkus.grpc.runtime.GrpcServer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CapabilityLivenessCheckTest {
+
+    @Test
+    void call_returnsUp_whenGrpcServerIsRunning() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(9190);
+
+        CapabilityLivenessCheck check = new CapabilityLivenessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-liveness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertEquals(9190, ((Long) response.getData().get().get("grpcPort")).intValue());
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerPortIsZero() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(0);
+
+        CapabilityLivenessCheck check = new CapabilityLivenessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-liveness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerThrowsException() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenThrow(new RuntimeException("Server not started"));
+
+        CapabilityLivenessCheck check = new CapabilityLivenessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-liveness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerPortIsNegative() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(-1);
+
+        CapabilityLivenessCheck check = new CapabilityLivenessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-liveness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/CapabilityReadinessCheckTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/CapabilityReadinessCheckTest.java
@@ -1,0 +1,73 @@
+package ai.wanaku.core.capabilities.common;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import io.quarkus.grpc.runtime.GrpcServer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CapabilityReadinessCheckTest {
+
+    @Test
+    void call_returnsUp_whenGrpcServerIsRunning() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(9190);
+
+        CapabilityReadinessCheck check = new CapabilityReadinessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-readiness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertEquals(9190, ((Long) response.getData().get().get("grpcPort")).intValue());
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerPortIsZero() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(0);
+
+        CapabilityReadinessCheck check = new CapabilityReadinessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-readiness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerThrowsException() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenThrow(new RuntimeException("Server not started"));
+
+        CapabilityReadinessCheck check = new CapabilityReadinessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-readiness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+
+    @Test
+    void call_returnsDown_whenGrpcServerPortIsNegative() {
+        GrpcServer grpcServer = mock(GrpcServer.class);
+        when(grpcServer.getPort()).thenReturn(-1);
+
+        CapabilityReadinessCheck check = new CapabilityReadinessCheck();
+        check.grpcServer = grpcServer;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("capability-grpc-readiness", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.DOWN);
+        assertEquals("not available", response.getData().get().get("grpcPort"));
+    }
+}

--- a/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
+++ b/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
@@ -1,4 +1,5 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.non-application-root-path=/q
 quarkus.http.port=8081
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false

--- a/capabilities/tools/wanaku-tool-service-http/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-http/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false

--- a/capabilities/tools/wanaku-tool-service-tavily/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-tavily/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-quarkus.http.host-enabled=false
+quarkus.http.host-enabled=true
+quarkus.http.port=8081
+quarkus.http.non-application-root-path=/q
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -47,11 +47,12 @@ services:
     network_mode: host
     volumes:
       - wanaku-router:/home/jboss/.wanaku/router
-    healthcheck:
-      test: curl -f localhost:8080/api/v1/management/info/version || exit 1
-      interval: 10s
-      timeout: 10s
-      retries: 5
+  healthcheck:
+    test: curl -f localhost:8080/q/health/ready || exit 1
+    interval: 10s
+    timeout: 10s
+    retries: 5
+    start_period: 30s
 
 volumes:
   wanaku-router:


### PR DESCRIPTION
Closes: #610

## Summary by Sourcery

Introduce standardized HTTP-based health endpoints and readiness checks across router backend, operator deployments, and capabilities.

New Features:
- Expose Quarkus HTTP health endpoints on a dedicated port for capabilities, tools, and providers to support Kubernetes-style liveness and readiness probes.
- Add MicroProfile liveness and readiness health checks for the router backend, including Infinispan, service registry, and OIDC status checks.
- Provide capability-level liveness and readiness health checks based on the gRPC server state.

Enhancements:
- Refine the default capability health probe delegate to reflect actual gRPC port availability instead of always reporting started.
- Make health endpoints publicly accessible in the router backend security configuration.
- Align docker-compose healthcheck with the new readiness endpoint.

Build:
- Add the Quarkus SmallRye Health extension to the capabilities base module.

Deployment:
- Update operator deployment manifests to configure health ports and liveness/readiness probes for capability pods.
- Adjust router docker-compose configuration to use the new readiness health endpoint for container health.