### PR TITLE
Fix #1009: resolve AUTH_SERVER env var for OIDC client configuration

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -44,7 +44,7 @@ quarkus.mcp.server.client-logging.default-level=debug
 quarkus.oidc.enabled=true
 
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
-auth.server=http://localhost:8543
+auth.server=${AUTH_SERVER:http://localhost:8543}
 # Address used by the OIDC proxy -
 auth.proxy=http://localhost:${quarkus.http.port}
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.qute.strict-rendering=false
 quarkus.oidc-client.enabled=true
 
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
-auth.server=http://localhost:8543
+auth.server=${AUTH_SERVER:http://localhost:8543}
 
 # Address of the KeyCloak authentication server
 quarkus.oidc-client.auth-server-url=${auth.server}/realms/wanaku


### PR DESCRIPTION
## Summary

- Use explicit SmallRye Config expression `${AUTH_SERVER:http://localhost:8543}` instead of hardcoded `auth.server=http://localhost:8543` in both the capabilities base and router backend properties
- This ensures the `AUTH_SERVER` environment variable set by the operator is reliably picked up at runtime

## Test plan

- [ ] Deploy a capability with Keycloak auth enabled and verify it connects to the configured `AUTH_SERVER` instead of `localhost:8543`
- [ ] Verify local development still works (defaults to `localhost:8543` when `AUTH_SERVER` is not set)
- [ ] Verify `noauth` profile still disables OIDC correctly

Closes #1009

## Summary by Sourcery

Enhancements:
- Make router backend and capabilities base use a configurable AUTH_SERVER variable for the Keycloak auth server instead of a hardcoded localhost URL.