### PR TITLE
chore: improve error handling in internal management tools

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/internal/InternalManagementToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/internal/InternalManagementToolsBean.java
@@ -103,9 +103,11 @@ public class InternalManagementToolsBean {
     }
 
     private void registerTool(ToolReference toolReference, ToolHandler handler) {
-        Namespace namespace = internalNamespace();
         ToolsHelper.registerTool(
-                toolReference, toolManager, namespace, (toolArguments, ignored) -> handler.apply(toolArguments.args()));
+                toolReference,
+                toolManager,
+                internalNamespace,
+                (toolArguments, ignored) -> handler.apply(toolArguments.args()));
     }
 
     private Uni<ToolResponse> jsonResponse(Supplier<Object> supplier) {
@@ -113,7 +115,8 @@ public class InternalManagementToolsBean {
             try {
                 return ToolResponse.success(List.of(new TextContent(objectMapper.writeValueAsString(supplier.get()))));
             } catch (Exception e) {
-                throw new RuntimeException("Failed to serialize internal management tool response", e);
+                LOG.errorf(e, "Internal management tool failed");
+                return ToolResponse.error(e.getMessage());
             }
         });
     }
@@ -363,7 +366,9 @@ public class InternalManagementToolsBean {
         return property("object", description);
     }
 
-    private Namespace internalNamespace() {
+    private static final Namespace internalNamespace = createInternalNamespace();
+
+    private static Namespace createInternalNamespace() {
         Namespace namespace = new Namespace();
         namespace.setName(INTERNAL_NAMESPACE);
         namespace.setPath(INTERNAL_NAMESPACE);
@@ -395,7 +400,12 @@ public class InternalManagementToolsBean {
     }
 
     private Namespace buildNamespaceGet(Map<String, Object> args) {
-        return namespacesBean.getById(toRequiredStringArg(args, "id"));
+        String id = toRequiredStringArg(args, "id");
+        Namespace namespace = namespacesBean.getById(id);
+        if (namespace == null) {
+            throw new IllegalArgumentException("Namespace not found: " + id);
+        }
+        return namespace;
     }
 
     private Namespace buildNamespaceCreate(Map<String, Object> args) {
@@ -467,11 +477,7 @@ public class InternalManagementToolsBean {
     }
 
     private Integer buildToolRemove(Map<String, Object> args) {
-        try {
-            return toolsBean.remove(toRequiredStringArg(args, "name"));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to remove tool", e);
-        }
+        return toolsBean.remove(toRequiredStringArg(args, "name"));
     }
 
     private List<ResourceReference> buildResources(Map<String, Object> args) {
@@ -549,11 +555,7 @@ public class InternalManagementToolsBean {
         if (dataStore == null || dataStore.getId() == null) {
             throw new IllegalArgumentException("Data store payload with id is required");
         }
-        try {
-            dataStoresBean.update(dataStore);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to update data store", e);
-        }
+        dataStoresBean.update(dataStore);
         return dataStoresBean.findById(dataStore.getId());
     }
 


### PR DESCRIPTION
## Summary

- Return `ToolResponse.error()` instead of throwing `RuntimeException` in `jsonResponse`, so MCP clients get a proper error response with logging
- Remove catch-and-rethrow-as-`RuntimeException` wrappers in `buildToolRemove` and `buildDataStoreUpdate` — exceptions now propagate naturally to the `jsonResponse` catch block
- Add null-check in `buildNamespaceGet` (consistent with `buildToolGet`, `buildResourceGet`, and `buildDataStoreGet`)
- Cache the internal namespace instance as a static field instead of recreating it per tool registration

## Test plan

- [ ] Existing `InternalManagementToolsTest` passes
- [ ] Verify error responses are properly returned as MCP error responses instead of server-side exceptions

## Summary by Sourcery

Improve robustness and consistency of internal management tools error handling and namespace management.

Bug Fixes:
- Return structured ToolResponse errors instead of throwing runtime exceptions when internal management tool responses fail to serialize.
- Throw an explicit error when a requested namespace cannot be found in buildNamespaceGet instead of returning null.
- Let tool removal and data store update operations propagate underlying exceptions directly for correct upstream handling.

Enhancements:
- Cache the internal management Namespace as a static instance instead of recreating it for each tool registration.
- Simplify internal tool registration to reuse the cached internal namespace instance.