### PR TITLE
feat: enable HTTP server and configure gRPC settings across multiple services

### DIFF
--- a/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-mcp-servers-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,11 +1,24 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+# Avoid hard-coding a fixed HTTP port in the archetype because multiple generated services
+# may run on the same host and conflict. Set this explicitly per service or via profiles.
+# Example:
+# quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -13,8 +26,8 @@ quarkus.log.category."ai.wanaku".level=INFO
 %test.quarkus.log.category."ai.wanaku".level=INFO
 
 wanaku.mcp.service.name=${name.toLowerCase()}
-wanaku.service.registration.uri=http://localhost:8080
 wanaku.mcp.service.namespace=test
+wanaku.service.registration.uri=http://localhost:8080
 wanaku.service.registration.interval=10s
 wanaku.service.registration.retry-wait-seconds=1
 wanaku.service.registration.retries=3

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,13 +1,24 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+# Avoid hard-coding a fixed HTTP port in the archetype because multiple generated services
+# may run on the same host and conflict. Set this explicitly per service or via profiles.
+# Example:
+# quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -26,14 +37,14 @@ wanaku.service.base-uri=${name.toLowerCase()}://
 # not set by the user
 # wanaku.service.service.defaults.noop=true
 
-# wanaku.service.registration.uri=http://localhost:8080
 # Registration settings
-# wanaku.service.registration.interval=10s
-# wanaku.service.registration.retries=3
-# wanaku.service.registration.retry-wait-seconds=1
-# wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr
 
 # Auth settings are inherited from wanaku-capabilities-base.
 # Override auth.server, quarkus.oidc-client.client-id, or
 # quarkus.oidc-client.credentials.secret here if needed.
-

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -1,13 +1,25 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+# Avoid hard-coding a fixed HTTP port in the archetype because multiple generated services
+# may run on the same host and conflict. Set this explicitly per service or via profiles.
+# Example:
+# quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
+quarkus.console.enabled = false
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -17,12 +29,13 @@ quarkus.log.category."ai.wanaku".level=INFO
 wanaku.service.name=${name.toLowerCase()}
 wanaku.service.base-uri=${name.toLowerCase()}://
 
-# wanaku.service.registration.uri=http://localhost:8080
 # Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
 #wanaku.service.registration.interval=10s
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr
 
 # Auth settings are inherited from wanaku-capabilities-base.
 # Override auth.server, quarkus.oidc-client.client-id, or

--- a/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
+++ b/capabilities/providers/wanaku-provider-performance-static-file/src/main/resources/application.properties
@@ -1,13 +1,22 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.non-application-root-path=/q
-quarkus.http.port=8081
+quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# When use-separate-server=true, set quarkus.grpc.server.port to match quarkus.http.port
+# When use-separate-server=false, quarkus.grpc.server.port is ignored (gRPC uses quarkus.http.port)
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -35,14 +44,14 @@ wanaku.service.performance.delay=100
 # not set by the user
 # wanaku.service.service.defaults.noop=true
 
-# wanaku.service.registration.uri=http://localhost:8080
 # Registration settings
-# wanaku.service.registration.interval=10s
-# wanaku.service.registration.retries=3
-# wanaku.service.registration.retry-wait-seconds=1
-# wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr
 
 # Auth settings are inherited from wanaku-capabilities-base.
 # Override auth.server, quarkus.oidc-client.client-id, or
 # quarkus.oidc-client.credentials.secret here if needed.
-

--- a/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-performance-noop/src/main/resources/application.properties
@@ -1,14 +1,23 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+quarkus.http.port=9010
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# When use-separate-server=true, set quarkus.grpc.server.port to match quarkus.http.port
+# When use-separate-server=false, quarkus.grpc.server.port is ignored (gRPC uses quarkus.http.port)
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9010
+# %test.quarkus.grpc.server.port=9010
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9010
-%test.quarkus.grpc.server.port=9010
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -25,6 +34,7 @@ wanaku.service.performance.delay=100
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr
 
 # Auth settings are inherited from wanaku-capabilities-base.
 # Override auth.server, quarkus.oidc-client.client-id, or

--- a/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-exec/src/main/resources/application.properties
@@ -1,14 +1,23 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+quarkus.http.port=9009
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# When use-separate-server=true, set quarkus.grpc.server.port to match quarkus.http.port
+# When use-separate-server=false, quarkus.grpc.server.port is ignored (gRPC uses quarkus.http.port)
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9009
+# %test.quarkus.grpc.server.port=9009
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9009
-%test.quarkus.grpc.server.port=9009
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -28,3 +37,4 @@ wanaku.service.exec.allowed-executables=
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/capabilities/tools/wanaku-tool-service-http/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-http/src/main/resources/application.properties
@@ -1,13 +1,23 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+quarkus.http.port=9000
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# When use-separate-server=true, set quarkus.grpc.server.port to match quarkus.http.port
+# When use-separate-server=false, quarkus.grpc.server.port is ignored (gRPC uses quarkus.http.port)
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9000
+# %test.quarkus.grpc.server.port=9000
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-%dev.quarkus.grpc.server.port=9000
-%test.quarkus.grpc.server.port=9000
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -23,5 +33,3 @@ wanaku.service.name=http
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
 #wanaku.service.registration.announce-address=my-custom-addr
-
-

--- a/capabilities/tools/wanaku-tool-service-tavily/src/main/resources/application.properties
+++ b/capabilities/tools/wanaku-tool-service-tavily/src/main/resources/application.properties
@@ -1,14 +1,23 @@
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
 quarkus.http.host-enabled=true
-quarkus.http.port=8081
-quarkus.http.non-application-root-path=/q
+quarkus.http.port=9006
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# When use-separate-server=true, set quarkus.grpc.server.port to match quarkus.http.port
+# When use-separate-server=false, quarkus.grpc.server.port is ignored (gRPC uses quarkus.http.port)
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9006
+# %test.quarkus.grpc.server.port=9006
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9006
-%test.quarkus.grpc.server.port=9006
 
 wanaku.service.name=tavily
 wanaku.service.base-uri=langchain4j-web-search:wanakuTavily?webSearchEngine=#tavily
@@ -34,3 +43,4 @@ wanaku.service.service.properties[1].required=false
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/core/core-service-discovery/src/main/resources/application.properties
+++ b/core/core-service-discovery/src/main/resources/application.properties
@@ -1,1 +1,3 @@
+# This module is a client library for service discovery
+# It does not expose an HTTP server or gRPC server
 quarkus.http.host-enabled=false

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -109,7 +109,7 @@ Configuration for the main Wanaku Router Backend (`wanaku-router-backend`), whic
 
 | Property                                           | Description                                                                                        |
 |----------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `quarkus.grpc.server.use-separate-server`          | `false` - The gRPC server shares the main HTTP server, avoiding the need for a separate port.      |
+| `quarkus.grpc.server.use-separate-server` | `false` - The gRPC server shares the main HTTP server, avoiding the need for a separate port. Both router and capabilities use this mode by default. |
 | `quarkus.mcp.server.wanaku-internal.sse.root-path` | `/wanaku-internal/mcp` - The SSE endpoint path for the internal MCP namespace.                     |
 | `quarkus.mcp.server.ns-*.sse.root-path`            | `/ns-*/mcp` - The SSE endpoint paths for the 10 available external namespaces (`ns-1` to `ns-10`). |
 | `quarkus.mcp.server.traffic-logging.enabled`       | `true` - Enables logging of all MCP traffic for debugging.                                         |
@@ -170,18 +170,43 @@ These `wanaku.router.health-check.*` properties control the periodic health prob
 
 These settings apply to most tool services and are foundational for their operation.
 
-| Property                                 | Description                                                                                            |
+#### Common Settings (All Modes)
+
+These settings apply regardless of whether you use the shared HTTP listener or a separate gRPC server:
+
+| Property | Description |
 |------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `quarkus.http.host-enabled`              | `false` - Disables the standard HTTP server for most capabilities, as they use gRPC for communication. |
-| `quarkus.grpc.server.host`               | `0.0.0.0` - Binds the gRPC server to all available network interfaces.                                 |
-| `quarkus.grpc.server.port`               | A unique port for each capability's gRPC server (e.g., `9009` for `exec`).                             |
-| `quarkus.qute.strict-rendering`          | `false` - Allows for more lenient Qute template rendering.                                             |
-| `wanaku.service.name`                    | The unique, lowercase name of the service (e.g., `exec`, `http`).                                      |
-| `wanaku.service.base-uri`                | The base URI scheme for tools provided by this service (e.g., `exec://`).                              |
-| `wanaku.service.exec.allowed-executables` | Comma-separated absolute executable paths that the Exec tool may run.                                 |
-| `quarkus.oidc-client.auth-server-url`    | The URL of the Keycloak realm for authentication.                                                      |
-| `quarkus.oidc-client.client-id`          | `wanaku-service` - The shared OIDC client ID for all capabilities.                                     |
-| `quarkus.oidc-client.credentials.secret` | The OIDC client secret for the capability. **Must be replaced with a real secret.**                    |
+| `wanaku.service.name` | The unique, lowercase name of the service (e.g., `exec`, `http`). |
+| `wanaku.service.base-uri` | The base URI scheme for tools provided by this service (e.g., `exec://`). |
+| `wanaku.service.exec.allowed-executables` | Comma-separated absolute executable paths that the Exec tool may run. |
+| `quarkus.qute.strict-rendering` | `false` - Allows for more lenient Qute template rendering. |
+| `quarkus.oidc-client.auth-server-url` | The URL of the Keycloak realm for authentication. |
+| `quarkus.oidc-client.client-id` | `wanaku-service` - The shared OIDC client ID for all capabilities. |
+| `quarkus.oidc-client.credentials.secret` | The OIDC client secret for the capability. **Must be replaced with a real secret.** |
+
+#### Shared HTTP Listener (Recommended)
+
+By default, capabilities are configured to share the HTTP listener with gRPC, avoiding the need for a separate gRPC server port. This simplifies deployment and configuration.
+
+| Property | Description |
+|------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `quarkus.http.host-enabled` | `true` - Enables the HTTP server for capabilities (required when using shared listener). |
+| `quarkus.http.port` | The HTTP port for the capability (e.g., `9000` for `http` service). |
+| `quarkus.http.host` | `0.0.0.0` - Binds the HTTP server to all available network interfaces. |
+| `quarkus.grpc.server.use-separate-server` | `false` - The gRPC server shares the HTTP listener (recommended for simpler deployment). |
+
+**Note:** When `use-separate-server=false`, the `quarkus.grpc.server.port` property is ignored because gRPC uses the HTTP port.
+
+#### Separate gRPC Server (Optional)
+
+If you prefer to use a separate gRPC server, set `quarkus.grpc.server.use-separate-server=true` and configure the gRPC-specific properties:
+
+| Property | Description |
+|------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `quarkus.http.host-enabled` | `false` - Disables the standard HTTP server (not needed with separate gRPC). |
+| `quarkus.grpc.server.use-separate-server` | `true` - Uses a separate gRPC server with its own port. |
+| `quarkus.grpc.server.host` | `0.0.0.0` - Binds the gRPC server to all available network interfaces. |
+| `quarkus.grpc.server.port` | A unique port for each capability's gRPC server (e.g., `9009` for `exec`). |
 
 ### Common Service Registration Settings
 
@@ -300,11 +325,37 @@ wanaku.persistence.infinispan.base-folder=/var/lib/wanaku/data
 wanaku.infinispan.max-state-count=20
 ```
 
-### Example: Tool Service with Custom Registration
+### Example: Tool Service with Shared HTTP Listener (Recommended)
 
 ```properties
-# application.properties for a tool service
+# application.properties for a tool service using shared HTTP listener
+quarkus.http.host-enabled=true
+quarkus.http.port=9010
+quarkus.http.host=0.0.0.0
+
+# gRPC shares the HTTP listener - no separate port needed
+quarkus.grpc.server.use-separate-server=false
+
+wanaku.service.name=my-custom-tool
+wanaku.service.base-uri=custom://
+
+wanaku.service.registration.enabled=true
+wanaku.service.registration.uri=http://wanaku-router:8080
+wanaku.service.registration.interval=15s
+wanaku.service.registration.announce-address=my-custom-tool.example.com:9010
+
+quarkus.oidc-client.auth-server-url=https://keycloak.example.com/realms/wanaku
+quarkus.oidc-client.client-id=wanaku-service
+quarkus.oidc-client.credentials.secret=${WANAKU_SERVICE_SECRET}
+```
+
+### Example: Tool Service with Separate gRPC Server
+
+```properties
+# application.properties for a tool service using separate gRPC server
 quarkus.http.host-enabled=false
+
+quarkus.grpc.server.use-separate-server=true
 quarkus.grpc.server.host=0.0.0.0
 quarkus.grpc.server.port=9010
 


### PR DESCRIPTION
Closes: #1006

## Summary by Sourcery

Document and enable shared HTTP listener mode for gRPC capabilities, while preserving an option for separate gRPC servers across services and archetypes.

Enhancements:
- Enable HTTP servers and shared HTTP/gRPC listener mode by default for multiple capability services and archetypes, documenting configuration comments and registration announce address usage.
- Simplify per-service gRPC port configuration by centralizing it behind the use-separate-server toggle and disabling unnecessary console output in tool service templates.

Documentation:
- Clarify default shared HTTP listener configuration for gRPC, add recommended and optional separate gRPC server sections, and extend configuration examples for tool services.