### PR TITLE
[UI] Enhancement: Import toolset modal overhaul

### DIFF
--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
@@ -1,11 +1,17 @@
 import {
+  Column,
+  ContentSwitcher,
+  Grid,
   Modal,
   Stack,
+  Switch,
   TextArea,
   TextInput
 } from "@carbon/react"
-import {useState} from "react"
+import React, {useRef, useState} from "react"
 import {ToolReference} from "../../models"
+import {ToolParserError, Tools} from "./tools"
+import {ImportToolsetTable} from "./ImportToolsetTable"
 
 
 interface ImportToolsetModalProps {
@@ -15,30 +21,94 @@ interface ImportToolsetModalProps {
 
 export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit, onCancel }) => {
   
-  const [toolsetUrl, setToolsetUrl] = useState("")
-  const [toolsetJson, setToolsetJson] = useState("")
+  const FINAL_STEP = 1
+  const VIEW_MODE_TABLE = "table"
+  const VIEW_MODE_JSON = "json"
+  
+  const [toolsetUrl, setToolsetUrl] = useState<string>()
+  const [invalidUrl, setInvalidUrl] = useState(false)
+  const [toolset, setToolset] = useState<ToolReference[]>([])
+  const [toolsetJson, setToolsetJson] = useState<string>()
   const [invalidJson, setInvalidJson] = useState(false)
+  const [invalidJsonText, setInvalidJsonText] = useState<string>()
+  const [step, setStep] = useState(0)
+  const [contentSwitcherEnabled, setContentSwitcherEnabled] = useState(true)
+  const [viewMode, setViewMode] = useState(VIEW_MODE_TABLE)
+  const selectedTools = useRef<ToolReference[]>([])
+
   
+  function setSelectedTools(tools: ToolReference[]) {
+    selectedTools.current = tools
+    setToolsetJson(tools.length > 0 ? Tools.stringify(tools) : undefined)
+  }
   
-  async function handleFetchToolset() {
-    if (toolsetUrl) {
-      const response = await fetch(toolsetUrl)
-      if (response.ok) {
-        const tools = await response.json()
-        setToolsetJson(JSON.stringify(tools, null, 2))
+  function primaryButtonText(): string {
+    return step === FINAL_STEP ? "Import" : "Next"
+  }
+  
+  function primaryButtonDisabled(): boolean {
+    return step === FINAL_STEP && !toolsetJson
+  }
+  
+  function isToolsetUrlEmpty(): boolean {
+    return !toolsetUrl
+  }
+  
+  function isToolsetUrlValid(): boolean {
+    try {
+      new URL(toolsetUrl!)
+      return true
+    } catch (error) {
+      return false
+    }
+  }
+  
+  async function fetchToolset() {
+    const response = await fetch(toolsetUrl!)
+    if (response.ok) {
+      const tools = await response.json()
+      setToolset(tools)
+      setSelectedTools(tools)
+    } else {
+      throw new Error(`Error fetching toolset from ${toolsetUrl}: ${response.status}`)
+    }
+  }
+  
+  async function handlePrimaryButton() {
+    if (step === FINAL_STEP) {
+      handleSubmit()
+    } else {
+      if (isToolsetUrlEmpty()) {
+        // skip fetching toolset, user can copy-paste in the next step
+        setStep(step + 1)
+        setViewMode(VIEW_MODE_JSON)
+        setContentSwitcherEnabled(false)
+      } else if (isToolsetUrlValid()) {
+        // try to fetch toolset and proceed to next step
+        try {
+          await fetchToolset()
+          setStep(step + 1)
+        } catch (error) {
+          console.error(error)
+        }
       } else {
-        console.error(`Error fetching toolset from ${toolsetUrl}`)
+        // URL is invalid
+        setInvalidUrl(true)
       }
     }
   }
   
-  async function handleSubmit() {
+  function handleSubmit() {
     try {
-      const tools = JSON.parse(toolsetJson)
-      setInvalidJson(false)
+      const tools: ToolReference[] = Tools.parse(toolsetJson!)
       onSubmit(tools)
     } catch (error) {
-      setInvalidJson(true)
+      if (error instanceof SyntaxError || error instanceof ToolParserError) {
+        setInvalidJson(true)
+        setInvalidJsonText(error.message)
+      } else {
+        console.error(error)
+      }
     }
   }
   
@@ -46,35 +116,75 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
     <Modal
       open={true}
       modalHeading="Import Toolset"
-      primaryButtonText="Import"
+      primaryButtonText={primaryButtonText()}
+      primaryButtonDisabled={primaryButtonDisabled()}
       secondaryButtonText="Cancel"
-      onRequestSubmit={handleSubmit}
+      onRequestSubmit={handlePrimaryButton}
       onRequestClose={onCancel}
     >
       <Stack gap={7}>
-        <TextInput
-          id="toolset-url"
-          labelText="Fetch from Toolset URL"
-          placeholder="Enter the URL of the toolset JSON"
-          value={toolsetUrl}
-          onChange={(event) => {
-            setToolsetUrl(event.target.value)
-          }}
-          onBlur={handleFetchToolset}
-        />
-        <TextArea
-          id="toolset-json"
-          labelText="Toolset JSON"
-          placeholder="Paste your JSON array here"
-          rows={10}
-          required
-          value={toolsetJson}
-          onChange={(event) => {
-            setToolsetJson(event.target.value)
-          }}
-          invalid={invalidJson}
-          invalidText="Invalid JSON"
-        />
+        {step === 0 && (
+          <TextInput
+            id="toolset-url"
+            labelText="Fetch from Toolset URL"
+            placeholder="Enter the URL of the toolset JSON"
+            helperText="You can skip this step and enter the data manually"
+            invalid={invalidUrl}
+            invalidText="Invalid URL"
+            onChange={(event) => {
+              setToolsetUrl(event.target.value)
+              setInvalidUrl(false)
+            }}
+          />
+        )}
+        {step === 1 && (
+          <>
+            {contentSwitcherEnabled && (
+            <Grid>
+              <Column></Column>
+              <Column lg={{ span: 4, offset: 12 }} md={{ span: 4, offset: 4 }} sm={4}>
+                <ContentSwitcher
+                  onChange={({ name }) => { setViewMode(name as string) }}
+                  selectedIndex={viewMode === VIEW_MODE_TABLE ? 0 : 1}
+                >
+                  <Switch
+                    name={VIEW_MODE_TABLE}
+                    text="List view"
+                  />
+                  <Switch
+                    name={VIEW_MODE_JSON}
+                    text="Json"
+                  />
+                </ContentSwitcher>
+              </Column>
+            </Grid>
+            )}
+            {viewMode === VIEW_MODE_TABLE && (
+              <ImportToolsetTable
+                tools={toolset}
+                selectedTools={selectedTools.current}
+                onSelectionChange={(tools: ToolReference[]) => {
+                  setSelectedTools(tools)
+                }}
+              />
+            )}
+            {viewMode === VIEW_MODE_JSON && (
+              <TextArea
+                id="toolset-json"
+                labelText="Toolset JSON"
+                placeholder="Paste your JSON array here"
+                rows={10}
+                required
+                value={toolsetJson}
+                invalid={invalidJson}
+                invalidText={invalidJsonText}
+                onChange={(event) => {
+                  setToolsetJson(event.target.value)
+                }}
+              />
+            )}
+          </>
+        )}
       </Stack>
     </Modal>
   )

--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetTable.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetTable.tsx
@@ -1,0 +1,83 @@
+import React, {useEffect} from "react"
+import {ToolReference} from "../../models"
+import {
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSelectAll,
+  TableSelectRow
+} from "@carbon/react"
+
+
+interface ImportToolsetTableProps {
+  tools: ToolReference[]
+  selectedTools: ToolReference[]
+  onSelectionChange: (tools: ToolReference[]) => void
+}
+
+export const ImportToolsetTable: React.FC<ImportToolsetTableProps> = ({ tools, selectedTools, onSelectionChange }) => {
+  
+  function findTool(rowId: string) {
+    return tools.find(item => item.name === rowId)
+  }
+  
+  return (
+    <DataTable
+      headers={[
+        {key: "name", header: "Name"},
+        {key: "description", header: "Description"}
+      ]}
+      rows={tools.map((tool: ToolReference) => ({
+        ...tool,
+        id: tool.name!,
+        isSelected: selectedTools.includes(tool)
+      }))}
+    >
+    {({
+      headers,
+      rows,
+      selectedRows,
+      getTableProps,
+      getHeaderProps,
+      getRowProps,
+      getSelectionProps
+    }) => {
+      
+      // synchronize row selection with parent component
+      useEffect(() => {
+        onSelectionChange(selectedRows.map(row => findTool(row.id)!))
+      }, [selectedRows])
+      
+      return (
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              <TableSelectAll {...getSelectionProps()} />
+              {headers.map((header) => (
+                <TableHeader {...getHeaderProps({header})}>
+                  {header.header}
+                </TableHeader>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => {
+              const tool = tools.find(item => item.name === row.id)!
+              return (
+                <TableRow {...getRowProps({ row })} key={tool.name}>
+                  <TableSelectRow {...getSelectionProps({ row })} />
+                  <TableCell>{tool.name}</TableCell>
+                  <TableCell>{tool.description}</TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      )}}
+    </DataTable>
+  )
+}

--- a/apps/ui/admin/src/Pages/Tools/tools.ts
+++ b/apps/ui/admin/src/Pages/Tools/tools.ts
@@ -1,0 +1,45 @@
+import {ToolReference} from "../../models"
+
+
+export class ToolParserError extends Error {
+  
+  constructor(message: string) {
+    super(message)
+  }
+  
+}
+
+function convertToTool(json): ToolReference {
+  const tool: ToolReference = {}
+  if (!json.name) {
+    throw new ToolParserError("Tool must have a name")
+  }
+  if (typeof json.name !== "string") {
+    throw new ToolParserError("Tool name must be a string")
+  }
+  for (const key in json) {
+    tool[key] = json[key]
+  }
+  return tool
+}
+
+export class Tools {
+  
+  static stringify(tools: ToolReference | ToolReference[]): string {
+    return JSON.stringify(tools, null, 2)
+  }
+  
+  static parse(string: string): ToolReference[] {
+    const json: unknown = JSON.parse(string)
+    if (Array.isArray(json)) {
+      const tools: ToolReference[] = []
+      for (const object of json) {
+        tools.push(convertToTool(object))
+      }
+      return tools
+    } else {
+      return [convertToTool(json)]
+    }
+  }
+  
+}


### PR DESCRIPTION
For better user experience, I've enhanced the modal dialog for importing toolsets. 

The modal dialog is not two-step with the first step for providing remote URL for fetching a toolset. In second step, the fetched tools are listed and the user have an option to exclude them from the set before saving.

There is a possibility to skip the first step and copy-paste raw Json data. Also, if the tools were fetched from the remote server, it is still posible to edit them before saving if there is ever a need for it.

On top of that, I've added some (although limited) input validation both for the URL and the Json data.


<img width="929" height="265" alt="import-toolset-1" src="https://github.com/user-attachments/assets/c6af7236-6857-4a64-b492-bcb8f7c07013" />

<img width="937" height="406" alt="import-toolset-2" src="https://github.com/user-attachments/assets/ee9ed8c6-0521-4d62-abb1-6ff0a84cd165" />

<img width="932" height="505" alt="import-toolset-3" src="https://github.com/user-attachments/assets/b8d45c16-9f13-4769-ae68-4707b61c2e5d" />

## Summary by Sourcery

Overhaul the import toolset modal into a multi-step, validated workflow that supports fetching, reviewing, editing, and selectively importing tools.

New Features:
- Introduce a two-step import workflow that optionally fetches a toolset from a remote URL before review and import.
- Add a table-based list view for fetched tools that allows selecting which tools to include in the imported toolset.
- Allow switching between a list view and raw JSON view when preparing the toolset for import.

Bug Fixes:
- Improve robustness of toolset parsing by validating tool names and supporting both single-tool and array JSON payloads.

Enhancements:
- Add client-side validation for toolset URLs and JSON input, with surfaced error messages in the modal.
- Disable the final import action until valid toolset JSON is available, reducing the chance of invalid submissions.