### PR TITLE
Add support for configurable Keycloak realm in authentication settings

### DIFF
--- a/apps/wanaku-operator/samples/wanaku-capability.yaml
+++ b/apps/wanaku-operator/samples/wanaku-capability.yaml
@@ -6,6 +6,8 @@ spec:
   auth:
 # This is the address of the authorization server (in the format: http://address)
     authServer: ""
+# The Keycloak realm name (defaults to "wanaku" if not set)
+#    authRealm: "wanaku"
   secrets:
 # This is the OIDC credentials secret for the services
     oidcCredentialsSecret: ""

--- a/apps/wanaku-operator/samples/wanaku-router.yaml
+++ b/apps/wanaku-operator/samples/wanaku-router.yaml
@@ -6,6 +6,8 @@ spec:
   auth:
 # This is the address of the authorization server (in the format: http://address)
     authServer: ""
+# The Keycloak realm name (defaults to "wanaku" if not set)
+#    authRealm: "wanaku"
 # Address of the proxy (in the format: http://address). It could be the same as the auth server - default) or "auto" (for using
 # Wanaku as the proxy via OIDC proxy.
 #    authProxy: ""

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariables.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariables.java
@@ -1,8 +1,10 @@
 package ai.wanaku.operator.util;
 
 public final class EnvironmentVariables {
+    public static final String DEFAULT_AUTH_REALM = "wanaku";
     public static final String AUTH_SERVER = "AUTH_SERVER";
     public static final String AUTH_PROXY = "AUTH_PROXY";
+    public static final String AUTH_REALM = "AUTH_REALM";
     public static final String QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED =
             "QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED";
     public static final String WANAKU_SERVICE_REGISTRATION_URI = "WANAKU_SERVICE_REGISTRATION_URI";

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -124,6 +124,8 @@ public final class OperatorUtil {
             }
         }
 
+        String realm = resolveAuthRealm(resource);
+
         EnvVar authServerEnv = new EnvVarBuilder()
                 .withName(EnvironmentVariables.AUTH_SERVER)
                 .withValue(authServer)
@@ -132,10 +134,15 @@ public final class OperatorUtil {
                 .withName(EnvironmentVariables.AUTH_PROXY)
                 .withValue(authProxy)
                 .build();
+        EnvVar authRealmEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_REALM)
+                .withValue(realm)
+                .build();
 
         List<EnvVar> envVars = new java.util.ArrayList<>();
         envVars.add(authServerEnv);
         envVars.add(authProxyEnv);
+        envVars.add(authRealmEnv);
 
         final WanakuRouterSpec.RouterSpec routerSpec = resource.getSpec().getRouter();
 
@@ -401,10 +408,10 @@ public final class OperatorUtil {
         // Build the registration URI - use the router ref for service discovery
         String registrationUri = getInternalRegistrationUri(resource);
 
-        // TODO: this one should be made more flexible, so it can accept different realms
+        String realm = resolveAuthRealm(resource);
         EnvVar authServerEnv = new EnvVarBuilder()
                 .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT)
-                .withValue(authServer + "/realms/wanaku")
+                .withValue(authServer + "/realms/" + realm)
                 .build();
         EnvVar registrationUriEnv = new EnvVarBuilder()
                 .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_REGISTRATION_URL)
@@ -559,5 +566,21 @@ public final class OperatorUtil {
         service.addOwnerReference(resource);
 
         return service;
+    }
+
+    static String resolveAuthRealm(WanakuCapability resource) {
+        if (resource == null || resource.getSpec() == null || resource.getSpec().getAuth() == null) {
+            return EnvironmentVariables.DEFAULT_AUTH_REALM;
+        }
+        String realm = resource.getSpec().getAuth().getAuthRealm();
+        return (realm == null || realm.isBlank()) ? EnvironmentVariables.DEFAULT_AUTH_REALM : realm;
+    }
+
+    static String resolveAuthRealm(WanakuRouter resource) {
+        if (resource == null || resource.getSpec() == null || resource.getSpec().getAuth() == null) {
+            return EnvironmentVariables.DEFAULT_AUTH_REALM;
+        }
+        String realm = resource.getSpec().getAuth().getAuthRealm();
+        return (realm == null || realm.isBlank()) ? EnvironmentVariables.DEFAULT_AUTH_REALM : realm;
     }
 }

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuTypes.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuTypes.java
@@ -7,6 +7,7 @@ public final class WanakuTypes {
     public static class AuthSpec {
         private String authServer;
         private String authProxy;
+        private String authRealm;
 
         public String getAuthServer() {
             return authServer;
@@ -22,6 +23,14 @@ public final class WanakuTypes {
 
         public void setAuthProxy(String authProxy) {
             this.authProxy = authProxy;
+        }
+
+        public String getAuthRealm() {
+            return authRealm;
+        }
+
+        public void setAuthRealm(String authRealm) {
+            this.authRealm = authRealm;
         }
     }
 

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
@@ -2,6 +2,12 @@ package ai.wanaku.operator.util;
 
 import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+import ai.wanaku.operator.wanaku.WanakuRouter;
+import ai.wanaku.operator.wanaku.WanakuRouterSpec;
+import ai.wanaku.operator.wanaku.WanakuTypes;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,5 +71,139 @@ class OperatorUtilTest {
     @Test
     void findConditionReturnsNullWhenNoMatchExists() {
         assertNull(OperatorUtil.findCondition(null, OperatorUtil.READY_CONDITION));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsConfiguredRealm() {
+        WanakuCapability capability = createCapabilityWithRealm("myrealm");
+        assertEquals("myrealm", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuWhenNull() {
+        WanakuCapability capability = createCapabilityWithRealm(null);
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuWhenBlank() {
+        WanakuCapability capability = createCapabilityWithRealm("  ");
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuWhenEmpty() {
+        WanakuCapability capability = createCapabilityWithRealm("");
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenCapabilityIsNull() {
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm((WanakuCapability) null));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenSpecIsNull() {
+        WanakuCapability capability = new WanakuCapability();
+        capability.setMetadata(new ObjectMetaBuilder()
+                .withName("test-capability")
+                .withNamespace("default")
+                .build());
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenAuthIsNull() {
+        WanakuCapability capability = new WanakuCapability();
+        capability.setMetadata(new ObjectMetaBuilder()
+                .withName("test-capability")
+                .withNamespace("default")
+                .build());
+        capability.setSpec(new WanakuCapabilitySpec());
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(capability));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsConfiguredRealmForRouter() {
+        WanakuRouter router = createRouterWithRealm("myrealm");
+        assertEquals("myrealm", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuForRouterWhenNull() {
+        WanakuRouter router = createRouterWithRealm(null);
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuForRouterWhenBlank() {
+        WanakuRouter router = createRouterWithRealm(" ");
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void resolveAuthRealmDefaultsToWanakuForRouterWhenEmpty() {
+        WanakuRouter router = createRouterWithRealm("");
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenRouterIsNull() {
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm((WanakuRouter) null));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenRouterSpecIsNull() {
+        WanakuRouter router = new WanakuRouter();
+        router.setMetadata(new ObjectMetaBuilder()
+                .withName("test-router")
+                .withNamespace("default")
+                .build());
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void resolveAuthRealmReturnsDefaultWhenRouterAuthIsNull() {
+        WanakuRouter router = new WanakuRouter();
+        router.setMetadata(new ObjectMetaBuilder()
+                .withName("test-router")
+                .withNamespace("default")
+                .build());
+        router.setSpec(new WanakuRouterSpec());
+        assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    private static WanakuCapability createCapabilityWithRealm(String realm) {
+        WanakuCapability capability = new WanakuCapability();
+        capability.setMetadata(new ObjectMetaBuilder()
+                .withName("test-capability")
+                .withNamespace("default")
+                .build());
+
+        WanakuCapabilitySpec spec = new WanakuCapabilitySpec();
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+        auth.setAuthRealm(realm);
+        spec.setAuth(auth);
+        capability.setSpec(spec);
+
+        return capability;
+    }
+
+    private static WanakuRouter createRouterWithRealm(String realm) {
+        WanakuRouter router = new WanakuRouter();
+        router.setMetadata(new ObjectMetaBuilder()
+                .withName("test-router")
+                .withNamespace("default")
+                .build());
+
+        WanakuRouterSpec spec = new WanakuRouterSpec();
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+        auth.setAuthRealm(realm);
+        spec.setAuth(auth);
+        router.setSpec(spec);
+
+        return router;
     }
 }

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuTypesTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuTypesTest.java
@@ -1,0 +1,54 @@
+package ai.wanaku.operator.wanaku;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WanakuTypesTest {
+
+    @Test
+    void authRealmDefaultsToNull() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        assertNull(auth.getAuthRealm());
+    }
+
+    @Test
+    void authRealmGetterAndSetter() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthRealm("myrealm");
+        assertEquals("myrealm", auth.getAuthRealm());
+    }
+
+    @Test
+    void authRealmCanBeSetToNull() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthRealm("myrealm");
+        auth.setAuthRealm(null);
+        assertNull(auth.getAuthRealm());
+    }
+
+    @Test
+    void authServerGetterAndSetter() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+        assertEquals("http://keycloak:8080", auth.getAuthServer());
+    }
+
+    @Test
+    void authProxyGetterAndSetter() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthProxy("http://proxy:8080");
+        assertEquals("http://proxy:8080", auth.getAuthProxy());
+    }
+
+    @Test
+    void authRealmIsIndependentOfOtherFields() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://server:8080");
+        auth.setAuthProxy("http://proxy:8080");
+        auth.setAuthRealm("custom-realm");
+        assertEquals("http://server:8080", auth.getAuthServer());
+        assertEquals("http://proxy:8080", auth.getAuthProxy());
+        assertEquals("custom-realm", auth.getAuthRealm());
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -47,9 +47,11 @@ quarkus.oidc.enabled=true
 auth.server=${AUTH_SERVER:http://localhost:8543}
 # Address used by the OIDC proxy -
 auth.proxy=http://localhost:${quarkus.http.port}
+# Keycloak realm name - adjust to your Keycloak realm
+auth.realm=${AUTH_REALM:wanaku}
 
-# Address of the KeyCloak authentication server
-quarkus.oidc.auth-server-url=${auth.server}/realms/wanaku
+# Address of the Keycloak authentication server
+quarkus.oidc.auth-server-url=${auth.server}/realms/${auth.realm}
 
 # Client identifier configured in Keycloak for the backend service
 quarkus.oidc.client-id=wanaku-mcp-router
@@ -70,7 +72,7 @@ quarkus.oidc.resource-metadata.force-https-scheme=false
 
 # These configure the special rules for the restricted MCP namespaces
 quarkus.oidc.mcp.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.mcp.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.mcp.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.mcp.tenant-paths=/mcp/*
 quarkus.oidc.mcp.token.audience=wanaku-mcp-client
 quarkus.oidc.mcp.resource-metadata.enabled=true
@@ -80,7 +82,7 @@ quarkus.oidc.mcp.resource-metadata.force-https-scheme=false
 # Per-namespace OIDC tenant configurations so that each namespace
 # advertises the correct resource metadata URL in WWW-Authenticate headers
 quarkus.oidc.ns-1.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-1.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-1.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-1.tenant-paths=/ns-1/*
 quarkus.oidc.ns-1.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-1.resource-metadata.enabled=true
@@ -88,7 +90,7 @@ quarkus.oidc.ns-1.resource-metadata.resource=ns-1/mcp
 quarkus.oidc.ns-1.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-2.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-2.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-2.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-2.tenant-paths=/ns-2/*
 quarkus.oidc.ns-2.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-2.resource-metadata.enabled=true
@@ -96,7 +98,7 @@ quarkus.oidc.ns-2.resource-metadata.resource=ns-2/mcp
 quarkus.oidc.ns-2.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-3.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-3.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-3.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-3.tenant-paths=/ns-3/*
 quarkus.oidc.ns-3.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-3.resource-metadata.enabled=true
@@ -104,7 +106,7 @@ quarkus.oidc.ns-3.resource-metadata.resource=ns-3/mcp
 quarkus.oidc.ns-3.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-4.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-4.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-4.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-4.tenant-paths=/ns-4/*
 quarkus.oidc.ns-4.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-4.resource-metadata.enabled=true
@@ -112,7 +114,7 @@ quarkus.oidc.ns-4.resource-metadata.resource=ns-4/mcp
 quarkus.oidc.ns-4.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-5.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-5.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-5.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-5.tenant-paths=/ns-5/*
 quarkus.oidc.ns-5.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-5.resource-metadata.enabled=true
@@ -120,7 +122,7 @@ quarkus.oidc.ns-5.resource-metadata.resource=ns-5/mcp
 quarkus.oidc.ns-5.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-6.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-6.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-6.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-6.tenant-paths=/ns-6/*
 quarkus.oidc.ns-6.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-6.resource-metadata.enabled=true
@@ -128,7 +130,7 @@ quarkus.oidc.ns-6.resource-metadata.resource=ns-6/mcp
 quarkus.oidc.ns-6.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-7.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-7.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-7.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-7.tenant-paths=/ns-7/*
 quarkus.oidc.ns-7.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-7.resource-metadata.enabled=true
@@ -136,7 +138,7 @@ quarkus.oidc.ns-7.resource-metadata.resource=ns-7/mcp
 quarkus.oidc.ns-7.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-8.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-8.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-8.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-8.tenant-paths=/ns-8/*
 quarkus.oidc.ns-8.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-8.resource-metadata.enabled=true
@@ -144,7 +146,7 @@ quarkus.oidc.ns-8.resource-metadata.resource=ns-8/mcp
 quarkus.oidc.ns-8.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-9.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-9.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-9.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-9.tenant-paths=/ns-9/*
 quarkus.oidc.ns-9.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-9.resource-metadata.enabled=true
@@ -152,7 +154,7 @@ quarkus.oidc.ns-9.resource-metadata.resource=ns-9/mcp
 quarkus.oidc.ns-9.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.ns-10.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-10.auth-server-url=${auth.server}/realms/wanaku
+quarkus.oidc.ns-10.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-10.tenant-paths=/ns-10/*
 quarkus.oidc.ns-10.token.audience=wanaku-mcp-client
 quarkus.oidc.ns-10.resource-metadata.enabled=true

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -942,7 +942,7 @@
     "securitySchemes" : {
       "SecurityScheme" : {
         "type" : "openIdConnect",
-        "openIdConnectUrl" : "http://localhost:8543/realms/wanaku/.well-known/openid-configuration",
+        "openIdConnectUrl" : "http://localhost:8543/realms/${auth.realm}/.well-known/openid-configuration",
         "description" : "Authentication"
       }
     }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -633,7 +633,7 @@ components:
   securitySchemes:
     SecurityScheme:
       type: openIdConnect
-      openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
+      openIdConnectUrl: http://localhost:8543/realms/${auth.realm}/.well-known/openid-configuration
       description: Authentication
 paths:
   /api/v1/capabilities:

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -4,17 +4,19 @@ quarkus.oidc-client.enabled=true
 
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
 auth.server=${AUTH_SERVER:http://localhost:8543}
+# Keycloak realm name - adjust to your Keycloak realm
+auth.realm=${AUTH_REALM:wanaku}
 
-# Address of the KeyCloak authentication server
-quarkus.oidc-client.auth-server-url=${auth.server}/realms/wanaku
+# Address of the Keycloak authentication server
+quarkus.oidc-client.auth-server-url=${auth.server}/realms/${auth.realm}
 
-# Client identifier configured in KeyCloak for capability services
+# Client identifier configured in Keycloak for capability services
 quarkus.oidc-client.client-id=wanaku-service
 
 # This forces the token to be renewed 1 minute before expiration
 quarkus.oidc-client.refresh-token-time-skew=1m
 
-# Client secret from KeyCloak for service authentication - replace with your actual secret
+# Client secret from Keycloak for service authentication - replace with your actual secret
 quarkus.oidc-client.credentials.secret=<insert key here>
 
 # No-auth profile: disables OIDC client so capabilities can run without Keycloak

--- a/deploy/auth/configure-auth.sh
+++ b/deploy/auth/configure-auth.sh
@@ -5,6 +5,17 @@ if [ -z "${WANAKU_KEYCLOAK_HOST}" ]; then
   export WANAKU_KEYCLOAK_HOST=$(oc get routes keycloak -o json | jq -r .spec.host)
 fi
 
+# Configurable realm name (defaults to wanaku)
+WANAKU_KEYCLOAK_REALM=${WANAKU_KEYCLOAK_REALM:-wanaku}
+
+# Validate that the imported realm JSON matches the configured realm name
+JSON_REALM=$(jq -r '.realm' wanaku-config.json)
+if [ "${JSON_REALM}" != "${WANAKU_KEYCLOAK_REALM}" ]; then
+  echo "WARNING: wanaku-config.json defines realm '${JSON_REALM}' but WANAKU_KEYCLOAK_REALM is '${WANAKU_KEYCLOAK_REALM}'."
+  echo "Update the 'realm' field in wanaku-config.json (and all internal references) to match WANAKU_KEYCLOAK_REALM."
+  exit 1
+fi
+
 # Get the admin token
 TOKEN=$(curl -s -d 'client_id=admin-cli' -d 'username=admin' -d "password=$WANAKU_KEYCLOAK_PASS" -d 'grant_type=password' "http://${WANAKU_KEYCLOAK_HOST}/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
 
@@ -16,7 +27,7 @@ curl -X POST "http://${WANAKU_KEYCLOAK_HOST}/admin/realms" \
 echo ""
 
 echo "Regenerating secret"
-NEW_SECRET_REPLY=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "http://${WANAKU_KEYCLOAK_HOST}/admin/realms/wanaku/clients/${wanaku_service_client_uuid}/client-secret")
+NEW_SECRET_REPLY=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "http://${WANAKU_KEYCLOAK_HOST}/admin/realms/${WANAKU_KEYCLOAK_REALM}/clients/${wanaku_service_client_uuid}/client-secret")
 if [ -z "${NEW_SECRET_REPLY}" ] ; then
   echo "No secret was received"
   exit 1

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -349,6 +349,8 @@ quarkus.oidc-client.client-id=wanaku-service
 quarkus.oidc-client.credentials.secret=${WANAKU_SERVICE_SECRET}
 ```
 
+> The realm name defaults to `wanaku` and can be configured via the `AUTH_REALM` environment variable or the `auth.realm` property.
+
 ### Example: Tool Service with Separate gRPC Server
 
 ```properties

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -813,8 +813,11 @@ Some of the settings you may need to adjust are:
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
 auth.server=http://localhost:8543
 
-# Address of the KeyCloak authentication server
-quarkus.oidc-client.auth-server-url=${auth.server}/realms/wanaku
+# Keycloak realm name - adjust to your Keycloak realm (default: wanaku)
+auth.realm=${AUTH_REALM:wanaku}
+
+# Address of the Keycloak authentication server
+quarkus.oidc-client.auth-server-url=${auth.server}/realms/${auth.realm}
 
 # Client secret from Keycloak for service authentication - replace with your actual secret
 quarkus.oidc-client.credentials.secret=aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
@@ -3223,7 +3226,7 @@ This is particularly helpful when running a capability service in the cloud, beh
 
 ### Adjusting the authentication parameters
 
-* `quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/wanaku`
+* `quarkus.oidc-client.auth-server-url=http://localhost:8543/realms/${auth.realm}` (realm defaults to `wanaku`; configure via `AUTH_REALM`)
 * `quarkus.oidc-client.client-id=wanaku-service`
 * `quarkus.oidc-client.refresh-token-time-skew=1m`
 * `quarkus.oidc-client.credentials.secret=<insert key here>`

--- a/tests/load/run-perf-test.sh
+++ b/tests/load/run-perf-test.sh
@@ -361,6 +361,7 @@ done
 HOSTNAME_FQDN=$(hostname -f)
 ROUTER_URL="http://${HOSTNAME_FQDN}:8080"
 KEYCLOAK_URL="http://${HOSTNAME_FQDN}:8543"
+KEYCLOAK_REALM=${KEYCLOAK_REALM:-wanaku}
 
 # ---- Stop router & capabilities ----
 stop_services() {
@@ -425,7 +426,7 @@ start_services() {
             java $JAVA_OPTS -Dquarkus.profile=perf \
                 -Dquarkus.grpc.server.port="$GRPC_PORT" \
                 -Dwanaku.service.registration.uri="$ROUTER_URL" \
-                -Dquarkus.oidc-client.auth-server-url="$KEYCLOAK_URL/realms/wanaku" \
+                -Dquarkus.oidc-client.auth-server-url="$KEYCLOAK_URL/realms/$KEYCLOAK_REALM" \
                 -Dquarkus.oidc-client.client-id=wanaku-service \
                 -Dquarkus.oidc-client.credentials.secret="$CLIENT_SECRET" \
                 -jar "$cap_jar" \


### PR DESCRIPTION
Closes: #1028

## Summary by Sourcery

Make the Keycloak realm used for authentication configurable across the operator, router backend, SDK, deployment scripts, and tests while keeping `wanaku` as the default.

New Features:
- Allow Wanaku capabilities and router resources to specify a Keycloak realm via an `authRealm` field in their auth configuration.
- Introduce configurable `auth.realm`/`AUTH_REALM` properties for Quarkus OIDC client and router backend to control the realm used in auth server URLs.
- Enable perf/load test scripts and auth configuration scripts to work with a configurable Keycloak realm instead of a hard-coded one.

Enhancements:
- Derive the operator token endpoint realm from capability configuration via a new helper, falling back to the default realm when unset or blank.

Deployment:
- Update Keycloak configuration script to support a configurable realm when regenerating client secrets.

Documentation:
- Document the configurable Keycloak realm, its default value, and how to set it via properties or environment variables in usage and configuration guides.
- Update sample YAML manifests to demonstrate optional `authRealm` usage in capability and router specs.

Tests:
- Add unit tests for realm resolution logic in the operator utilities and for the new `authRealm` field behavior in `WanakuTypes`.
- Adjust performance test scripts to parameterize the Keycloak realm used in OIDC client configuration.