### PR TITLE
Fix #1033: include env vars in Deployment matcher comparison

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
@@ -1,6 +1,8 @@
 package ai.wanaku.operator.util;
 
+import java.util.List;
 import java.util.Objects;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -58,8 +60,42 @@ public final class Matchers {
                                     .getSpec()
                                     .getContainers()
                                     .get(0)
-                                    .getImage());
+                                    .getImage())
+                    && matchEnvVars(
+                            desired.getSpec()
+                                    .getTemplate()
+                                    .getSpec()
+                                    .getContainers()
+                                    .get(0)
+                                    .getEnv(),
+                            existing.getSpec()
+                                    .getTemplate()
+                                    .getSpec()
+                                    .getContainers()
+                                    .get(0)
+                                    .getEnv());
         }
+    }
+
+    private static boolean matchEnvVars(List<EnvVar> desired, List<EnvVar> existing) {
+        if (desired == null && existing == null) {
+            return true;
+        }
+        if (desired == null || existing == null) {
+            return false;
+        }
+        if (desired.size() != existing.size()) {
+            return false;
+        }
+        for (EnvVar desiredVar : desired) {
+            boolean found = existing.stream()
+                    .anyMatch(e -> Objects.equals(e.getName(), desiredVar.getName())
+                            && Objects.equals(e.getValue(), desiredVar.getValue()));
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static boolean match(Service desired, Service existing) {

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/MatchersTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/MatchersTest.java
@@ -162,20 +162,24 @@ class MatchersTest {
 
     // ---- Deployment helpers & tests ----
 
-    private Deployment createDeployment(int replicas, String image) {
-        return new DeploymentBuilder()
+    private Deployment createDeployment(int replicas, String image, String... envPairs) {
+        var builder = new DeploymentBuilder()
                 .withNewSpec()
                 .withReplicas(replicas)
                 .withNewTemplate()
                 .withNewSpec()
                 .addNewContainer()
                 .withName("app")
-                .withImage(image)
-                .endContainer()
-                .endSpec()
-                .endTemplate()
-                .endSpec()
-                .build();
+                .withImage(image);
+
+        for (int i = 0; i < envPairs.length; i += 2) {
+            builder = builder.addNewEnv()
+                    .withName(envPairs[i])
+                    .withValue(envPairs[i + 1])
+                    .endEnv();
+        }
+
+        return builder.endContainer().endSpec().endTemplate().endSpec().build();
     }
 
     @Test
@@ -203,6 +207,34 @@ class MatchersTest {
         Deployment desired = createDeployment(3, "myapp:1.0");
         Deployment existing = createDeployment(3, "myapp:2.0");
         assertFalse(Matchers.match(desired, existing));
+    }
+
+    @Test
+    void testMatchDeploymentWhenEnvVarsMatch() {
+        Deployment desired = createDeployment(1, "myapp:1.0", "SERVICE_CATALOG", "my-catalog", "SERVICE_NAME", "svc");
+        Deployment existing = createDeployment(1, "myapp:1.0", "SERVICE_NAME", "svc", "SERVICE_CATALOG", "my-catalog");
+        assertTrue(Matchers.match(desired, existing));
+    }
+
+    @Test
+    void testMatchDeploymentWhenEnvVarValuesDiffer() {
+        Deployment desired = createDeployment(1, "myapp:1.0", "SERVICE_CATALOG", "new-catalog");
+        Deployment existing = createDeployment(1, "myapp:1.0", "SERVICE_CATALOG", "");
+        assertFalse(Matchers.match(desired, existing));
+    }
+
+    @Test
+    void testMatchDeploymentWhenEnvVarCountDiffers() {
+        Deployment desired = createDeployment(1, "myapp:1.0", "SERVICE_CATALOG", "my-catalog", "SERVICE_NAME", "svc");
+        Deployment existing = createDeployment(1, "myapp:1.0", "SERVICE_NAME", "svc");
+        assertFalse(Matchers.match(desired, existing));
+    }
+
+    @Test
+    void testMatchDeploymentWhenBothHaveNoEnvVars() {
+        Deployment desired = createDeployment(1, "myapp:1.0");
+        Deployment existing = createDeployment(1, "myapp:1.0");
+        assertTrue(Matchers.match(desired, existing));
     }
 
     // ---- Service helpers & tests ----

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2288,7 +2288,7 @@ This creates a `<catalog-name>.b64` file in the current directory. You can speci
 wanaku service package --path=my-service -o /tmp/my-service.b64
 ```
 
-The packaged file is useful for deploying via the Kubernetes operator (see [Deploying Service Catalogs via the Operator](#deploying-service-catalogs-via-the-operator)).
+The packaged file is useful for deploying via the Kubernetes operator (see [Deploying Service Catalogs with the Operator](#deploying-service-catalogs-via-the-operator)).
 
 ### Deploying a Service Catalog
 


### PR DESCRIPTION
## Summary
- The Deployment matcher only compared replicas and container image, so changes to env vars (e.g. `serviceCatalog`, `serviceCatalogSystem`) in the WanakuCapability CR were silently ignored on existing deployments
- Added `matchEnvVars` to compare environment variables (order-independent)
- Added 4 tests covering env var matching scenarios

## Test plan
- [x] Existing `MatchersTest` tests pass
- [x] New tests cover: matching env vars, differing values, differing count, no env vars
- [ ] Deploy operator with updated CRD and verify `SERVICE_CATALOG`/`SERVICE_CATALOG_SYSTEM` are set on CIC pods

## Summary by Sourcery

Update Deployment matcher to consider environment variables when determining if a Deployment has changed.

Bug Fixes:
- Ensure Deployment matcher detects changes in environment variables instead of only replicas and container image.

Tests:
- Extend Deployment test helper to configure env vars and add tests covering matching, differing values, differing counts, and absence of env vars.