### PR TITLE
Compare valueFrom in Deployment env var matching

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
@@ -90,7 +90,8 @@ public final class Matchers {
         for (EnvVar desiredVar : desired) {
             boolean found = existing.stream()
                     .anyMatch(e -> Objects.equals(e.getName(), desiredVar.getName())
-                            && Objects.equals(e.getValue(), desiredVar.getValue()));
+                            && Objects.equals(e.getValue(), desiredVar.getValue())
+                            && Objects.equals(e.getValueFrom(), desiredVar.getValueFrom()));
             if (!found) {
                 return false;
             }

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/MatchersTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/MatchersTest.java
@@ -1,6 +1,8 @@
 package ai.wanaku.operator.util;
 
 import java.util.Map;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -235,6 +237,97 @@ class MatchersTest {
         Deployment desired = createDeployment(1, "myapp:1.0");
         Deployment existing = createDeployment(1, "myapp:1.0");
         assertTrue(Matchers.match(desired, existing));
+    }
+
+    private Deployment createDeploymentWithEnvVars(int replicas, String image, EnvVar... envVars) {
+        var builder = new DeploymentBuilder()
+                .withNewSpec()
+                .withReplicas(replicas)
+                .withNewTemplate()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("app")
+                .withImage(image);
+
+        for (EnvVar env : envVars) {
+            builder = builder.addToEnv(env);
+        }
+
+        return builder.endContainer().endSpec().endTemplate().endSpec().build();
+    }
+
+    @Test
+    void testMatchDeploymentWhenValueFromSecretsMatch() {
+        EnvVar desired = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withNewValueFrom()
+                .withNewSecretKeyRef("password", "db-secret", false)
+                .endValueFrom()
+                .build();
+        EnvVar existing = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withNewValueFrom()
+                .withNewSecretKeyRef("password", "db-secret", false)
+                .endValueFrom()
+                .build();
+        assertTrue(Matchers.match(
+                createDeploymentWithEnvVars(1, "myapp:1.0", desired),
+                createDeploymentWithEnvVars(1, "myapp:1.0", existing)));
+    }
+
+    @Test
+    void testMatchDeploymentWhenValueFromSecretsDiffer() {
+        EnvVar desired = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withNewValueFrom()
+                .withNewSecretKeyRef("password", "new-secret", false)
+                .endValueFrom()
+                .build();
+        EnvVar existing = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withNewValueFrom()
+                .withNewSecretKeyRef("password", "old-secret", false)
+                .endValueFrom()
+                .build();
+        assertFalse(Matchers.match(
+                createDeploymentWithEnvVars(1, "myapp:1.0", desired),
+                createDeploymentWithEnvVars(1, "myapp:1.0", existing)));
+    }
+
+    @Test
+    void testMatchDeploymentWhenValueFromConfigMapsDiffer() {
+        EnvVar desired = new EnvVarBuilder()
+                .withName("APP_CONFIG")
+                .withNewValueFrom()
+                .withNewConfigMapKeyRef("key", "new-config", false)
+                .endValueFrom()
+                .build();
+        EnvVar existing = new EnvVarBuilder()
+                .withName("APP_CONFIG")
+                .withNewValueFrom()
+                .withNewConfigMapKeyRef("key", "old-config", false)
+                .endValueFrom()
+                .build();
+        assertFalse(Matchers.match(
+                createDeploymentWithEnvVars(1, "myapp:1.0", desired),
+                createDeploymentWithEnvVars(1, "myapp:1.0", existing)));
+    }
+
+    @Test
+    void testMatchDeploymentWhenValueChangesToValueFrom() {
+        EnvVar desired = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withNewValueFrom()
+                .withNewSecretKeyRef("password", "db-secret", false)
+                .endValueFrom()
+                .build();
+        EnvVar existing = new EnvVarBuilder()
+                .withName("DB_PASSWORD")
+                .withValue("plaintext")
+                .build();
+        assertFalse(Matchers.match(
+                createDeploymentWithEnvVars(1, "myapp:1.0", desired),
+                createDeploymentWithEnvVars(1, "myapp:1.0", existing)));
     }
 
     // ---- Service helpers & tests ----


### PR DESCRIPTION
## Summary
- Env var comparison in `matchEnvVars` only checked `name` and `value`, ignoring `valueFrom`
- Two env vars sourced from different secrets/config maps would look identical as long as both had null `value`, causing the reconciler to skip deployment updates
- Added `valueFrom` to the equality check so secret/config map source changes trigger reconciliation

Depends on #1034.

## Test plan
- [x] New tests: matching secret refs, differing secret names, differing config map names, switching from literal value to valueFrom
- [x] All existing `MatchersTest` tests pass

## Summary by Sourcery

Update deployment matching logic to consider environment variable sources and expand corresponding test coverage.

Bug Fixes:
- Ensure deployment comparison detects changes when environment variables switch between different secret or config map sources or from literal values to valueFrom references.

Enhancements:
- Extend deployment matcher to compare environment variable lists, including name, value, and valueFrom fields, regardless of order.
- Add helper constructors for deployments with environment variables to simplify matcher tests.

Documentation:
- Clarify operator usage docs by adjusting wording in the section on deploying service catalogs with the operator.

Tests:
- Add deployment matcher tests covering env var equality, differing values, differing counts, secret-based valueFrom refs, config map-based valueFrom refs, and transitions between literal and valueFrom values.