### PR TITLE
Use ServiceCatalogService REST client in service catalog reconciler

### DIFF
--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -29,10 +29,23 @@
             <artifactId>core-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-services-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
@@ -1,12 +1,9 @@
 package ai.wanaku.operator.wanaku;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +21,10 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.services.api.ServiceCatalogService;
 
 import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
 import static ai.wanaku.operator.util.OperatorUtil.findCondition;
@@ -44,10 +44,6 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
     private static final Logger LOG = Logger.getLogger(WanakuServiceCatalogReconciler.class);
 
     private static final String CATALOG_DATA_KEY = "catalog.zip";
-    private static final String DEPLOY_PATH = "/api/v1/service-catalog/deploy";
-    private static final String REMOVE_PATH = "/api/v1/service-catalog/remove";
-
-    private final HttpClient httpClient = HttpClient.newHttpClient();
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -167,38 +163,32 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
     }
 
     private void deployServiceCatalog(String routerBaseUrl, String name, String data) throws WanakuException {
-        String json = "{\"name\":\"" + name + "\",\"data\":\"" + data + "\"}";
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(routerBaseUrl + DEPLOY_PATH))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(json))
-                .build();
+        DataStore dataStore = new DataStore();
+        dataStore.setName(name);
+        dataStore.setData(data);
 
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new WanakuException(String.format(
-                        "Failed to deploy service catalog '%s': HTTP %d - %s",
-                        name, response.statusCode(), response.body()));
-            }
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw new WanakuException("Failed to deploy service catalog '" + name + "': " + e.getMessage());
+            ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl);
+            service.deploy(dataStore);
+        } catch (WebApplicationException e) {
+            throw new WanakuException(
+                    String.format(
+                            "Failed to deploy service catalog '%s': HTTP %d - %s",
+                            name, e.getResponse().getStatus(), e.getResponse().readEntity(String.class)),
+                    e);
+        } catch (Exception e) {
+            throw new WanakuException("Failed to deploy service catalog '" + name + "'", e);
         }
     }
 
-    private void removeServiceCatalog(String routerBaseUrl, String name) throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(routerBaseUrl + REMOVE_PATH + "?name=" + name))
-                .DELETE()
-                .build();
+    private void removeServiceCatalog(String routerBaseUrl, String name) {
+        ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl);
+        service.remove(name);
+    }
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() < 200 || response.statusCode() >= 300) {
-            LOG.warnf("Remove service catalog '%s' returned HTTP %d: %s", name, response.statusCode(), response.body());
-        }
+    private static ServiceCatalogService createServiceCatalogClient(String routerBaseUrl) {
+        return QuarkusRestClientBuilder.newBuilder()
+                .baseUri(URI.create(routerBaseUrl))
+                .build(ServiceCatalogService.class);
     }
 }


### PR DESCRIPTION
## Summary
- Replaced manual JSON construction and raw `java.net.http.HttpClient` calls with the typed `ServiceCatalogService` interface via `QuarkusRestClientBuilder`
- Fixes NPE in error handling where `e.getMessage()` returned null and the exception cause was lost, producing `"Failed to deploy service catalog 'X': null"`
- Exception cause is now always preserved: `new WanakuException(msg, e)`
- Added `core-services-api`, `quarkus-rest-client`, and `quarkus-rest-client-jackson` dependencies to the operator

## Test plan
- [x] `mvn -pl apps/wanaku-operator compile` passes
- [x] All existing operator tests pass
- [ ] Deploy operator and verify service catalog deployment via WanakuServiceCatalog CR

## Summary by Sourcery

Switch operator service catalog reconciliation to use the typed ServiceCatalogService REST client instead of manual HTTP calls and improve error propagation when deploying catalogs.

Bug Fixes:
- Preserve underlying exceptions when service catalog deployment fails, avoiding null messages and retaining the original cause.

Enhancements:
- Replace manual HttpClient JSON calls for deploying and removing service catalogs with the typed ServiceCatalogService REST client built via QuarkusRestClientBuilder.

Build:
- Add core-services-api and Quarkus REST client dependencies (including Jackson integration) to the operator module.