### PR TITLE
Update OpenID Connect URL to use fixed Keycloak realm in security schemes

### DIFF
--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -942,7 +942,7 @@
     "securitySchemes" : {
       "SecurityScheme" : {
         "type" : "openIdConnect",
-        "openIdConnectUrl" : "http://localhost:8543/realms/${auth.realm}/.well-known/openid-configuration",
+        "openIdConnectUrl" : "http://localhost:8543/realms/wanaku/.well-known/openid-configuration",
         "description" : "Authentication"
       }
     }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -633,7 +633,7 @@ components:
   securitySchemes:
     SecurityScheme:
       type: openIdConnect
-      openIdConnectUrl: http://localhost:8543/realms/${auth.realm}/.well-known/openid-configuration
+      openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
       description: Authentication
 paths:
   /api/v1/capabilities:


### PR DESCRIPTION
This pull request is related to review comments, correcting this:

https://github.com/wanaku-ai/wanaku/pull/1032#discussion_r3181432672

https://github.com/wanaku-ai/wanaku/pull/1032#discussion_r3181432682

## Summary by Sourcery

Enhancements:
- Replace the templated realm placeholder in the OpenID Connect URL with the fixed 'wanaku' realm in the OpenAPI security scheme configuration.