### PR TITLE
Update baseline-browser-mapping to latest version

### DIFF
--- a/apps/ui/admin/package.json
+++ b/apps/ui/admin/package.json
@@ -27,6 +27,7 @@
     "sass": "^1.98.0"
   },
   "devDependencies": {
+    "baseline-browser-mapping": "^2.10.27",
     "@eslint/js": "^9.39.4",
     "@types/node": "^22.19.15",
     "@types/react": "^19.2.14",

--- a/apps/ui/admin/yarn.lock
+++ b/apps/ui/admin/yarn.lock
@@ -1925,6 +1925,11 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
+baseline-browser-mapping@^2.10.27:
+  version "2.10.27"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz#fee941c2a0b42cdf83c6427e4c830b1d0bdab2c3"
+  integrity sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==
+
 baseline-browser-mapping@^2.8.3:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz#e553e12272c4965682743705efd8b4b4cf0d709b"


### PR DESCRIPTION
Closes: #1007

## Summary by Sourcery

Build:
- Add baseline-browser-mapping as a dev dependency in the admin UI package.json.