### PR TITLE
Fix capability health probes targeting wrong ports

### DIFF
--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -45,14 +45,14 @@ spec:
           failureThreshold: 5
           httpGet:
             path: /health/live
-            port: 8080
+            port: health
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 8080
+            port: health
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
@@ -60,7 +60,7 @@ spec:
         - containerPort: 9190
           name: grpc
           protocol: TCP
-        - containerPort: 8081
+        - containerPort: 8080
           name: health
           protocol: TCP
         volumeMounts:

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -28,22 +28,20 @@ spec:
         name: wanaku-capability
         ports:
         - containerPort: 9000
-          protocol: TCP
-        - containerPort: 8081
-          name: health
+          name: http
           protocol: TCP
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /q/health/live
-            port: 8080
+            port: http
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /q/health/ready
-            port: 8080
+            port: http
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- Health probes in operator deployment templates used hardcoded port 8080, but wanaku capabilities listen on port 9000 — causing liveness/readiness failures and restart loops
- Removed phantom `containerPort: 8081` from wanaku-capability template (nothing listens there)
- Fixed camel-integration-capability `containerPort` from 8081 to 8080 to match actual health port
- Switched all probes to named port references so they stay in sync with declared container ports

## Test plan
- [ ] Deploy HTTP capability via operator and verify liveness/readiness probes pass
- [ ] Deploy a camel-integration-capability and verify probes pass
- [ ] Confirm no restart loops in `kubectl get events`

## Summary by Sourcery

Align capability deployment health probes and container ports to the actual listening ports to prevent failing health checks and restart loops.

Bug Fixes:
- Correct wanaku-capability liveness and readiness probes to target the named HTTP port instead of a hardcoded port.
- Remove an unused health container port from the wanaku-capability deployment template.
- Update camel-integration-capability health container port and probes to consistently use the correct health port via its name.