### PR TITLE
Use TCP socket health probes on gRPC ports for capabilities

### DIFF
--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -43,25 +43,20 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
-          httpGet:
-            path: /health/live
-            port: health
+          tcpSocket:
+            port: 9190
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 5
         readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: health
+          tcpSocket:
+            port: 9190
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5
         ports:
         - containerPort: 9190
           name: grpc
-          protocol: TCP
-        - containerPort: 8080
-          name: health
           protocol: TCP
         volumeMounts:
           - mountPath: /data

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -28,20 +28,18 @@ spec:
         name: wanaku-capability
         ports:
         - containerPort: 9000
-          name: http
+          name: grpc
           protocol: TCP
         livenessProbe:
           failureThreshold: 5
-          httpGet:
-            path: /q/health/live
-            port: http
+          tcpSocket:
+            port: 9000
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 5
         readinessProbe:
-          httpGet:
-            path: /q/health/ready
-            port: http
+          tcpSocket:
+            port: 9000
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- HTTP health probes fail because capabilities serve gRPC (HTTP/2) on their main port — kubelet's HTTP/1.1 probes get garbled binary responses
- Switch to tcpSocket probes that just check the gRPC port is accepting connections (9000 for wanaku capabilities, 9190 for CIC)
- Remove phantom `containerPort: 8081` health port declarations (nothing listens there)

## Test plan
- [ ] Deploy HTTP capability via operator and verify liveness/readiness probes pass
- [ ] Deploy a camel-integration-capability and verify probes pass
- [ ] Confirm no restart loops in `kubectl get events`

## Summary by Sourcery

Switch capability deployment health probes to TCP socket checks on gRPC ports and clean up unused health ports.

Bug Fixes:
- Ensure liveness and readiness probes correctly validate gRPC capability pods by probing the actual gRPC ports instead of HTTP endpoints.

Enhancements:
- Rename wanaku capability container port 9000 to indicate gRPC usage and remove unused health container ports from deployments.