### PR TITLE
Fix health check grace period for recently registered capabilities

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
@@ -51,9 +51,9 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
 
     @Override
     public ServiceTarget register(ServiceTarget serviceTarget) {
-        updateHealthStatus(serviceTarget.getId(), HealthStatus.PENDING);
-
-        return capabilitiesRepository.persist(serviceTarget);
+        ServiceTarget persisted = capabilitiesRepository.persist(serviceTarget);
+        updateHealthStatus(persisted.getId(), HealthStatus.PENDING);
+        return persisted;
     }
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
@@ -51,6 +51,8 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
 
     @Override
     public ServiceTarget register(ServiceTarget serviceTarget) {
+        updateHealthStatus(serviceTarget.getId(), HealthStatus.PENDING);
+
         return capabilitiesRepository.persist(serviceTarget);
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -95,7 +95,9 @@ public class PeriodicHealthCheckService {
         // and will still be probed and marked as DOWN.
         ActivityRecord activityRecord = serviceRegistry.getStates(id);
         if (activityRecord == null) {
-            LOG.debugf("Skipping health check for capability without activity record %s (%s)", target.getServiceName(), id);
+            LOG.debugf(
+                    "Skipping health check for capability without activity record %s (%s)",
+                    target.getServiceName(), id);
             return;
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -5,6 +5,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -91,8 +93,13 @@ public class PeriodicHealthCheckService {
         // Skip capabilities that were explicitly deregistered.
         // Capabilities that crashed without deregistering remain ACTIVE
         // and will still be probed and marked as DOWN.
-        ActivityRecord record = serviceRegistry.getStates(id);
-        if (record != null && !record.isActive()) {
+        ActivityRecord activityRecord = serviceRegistry.getStates(id);
+        if (activityRecord == null) {
+            LOG.debugf("Skipping health check for capability without activity record %s (%s)", target.getServiceName(), id);
+            return;
+        }
+
+        if (!activityRecord.isActive()) {
             LOG.debugf("Skipping health check for deregistered capability %s (%s)", target.getServiceName(), id);
             return;
         }
@@ -108,9 +115,22 @@ public class PeriodicHealthCheckService {
             serviceRegistry.updateHealthStatus(id, status);
             emitHealthStatusEvent(id, status);
         } catch (Exception e) {
-            LOG.warnf(e, "Error during health check for %s", id);
-            serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
-            emitHealthStatusEvent(id, HealthStatus.DOWN);
+            if (activityRecord.getHealthStatus() == HealthStatus.PENDING) {
+                final Instant lastSeen = activityRecord.getLastSeen();
+                final Duration between = Duration.between(lastSeen, Instant.now());
+
+                if (between.toMinutes() < 1) {
+                    LOG.infof("Recently registered capability %s is in pending health state. ", id);
+                } else {
+                    LOG.warnf(e, "Error during health check for %s", id);
+                    serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
+                    emitHealthStatusEvent(id, HealthStatus.DOWN);
+                }
+            } else {
+                LOG.warnf(e, "Error during health check for %s", id);
+                serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
+                emitHealthStatusEvent(id, HealthStatus.DOWN);
+            }
         } finally {
             inProgress.remove(id);
         }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/core/persistence/infinispan/discovery/ServiceRegistryTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/core/persistence/infinispan/discovery/ServiceRegistryTest.java
@@ -148,13 +148,13 @@ public class ServiceRegistryTest {
         Assertions.assertNotNull(record);
         final List<ServiceState> states = record.getStates();
         Assertions.assertNotNull(states);
-        assertEquals(2, record.getStates().size());
-        final ServiceState first = record.getStates().getFirst();
-        assertEquals(StandardMessages.HEALTHY, first.getReason());
-        assertTrue(first.isHealthy());
+        assertEquals(5, record.getStates().size());
+        final ServiceState healthy = record.getStates().get(3);
+        assertEquals(StandardMessages.HEALTHY, healthy.getReason());
+        assertTrue(healthy.isHealthy());
 
-        final ServiceState second = record.getStates().getLast();
-        assertEquals("test", second.getReason());
-        assertFalse(second.isHealthy());
+        final ServiceState unhealthy = record.getStates().getLast();
+        assertEquals("test", unhealthy.getReason());
+        assertFalse(unhealthy.isHealthy());
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
@@ -93,21 +93,20 @@ class PeriodicHealthCheckServiceTest {
     }
 
     @Test
-    void checkInstanceHealth_probesWhenNoActivityRecord() {
-        // Given: a service target with no activity record (newly registered)
+    void checkInstanceHealth_skipsWhenNoActivityRecord() {
+        // Given: a service target with no activity record
         ServiceTarget target =
                 new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
 
-        // And: no activity record exists yet
+        // And: no activity record exists
         when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(null);
-        when(probeClient.probe(target)).thenReturn(HealthStatus.HEALTHY);
 
         // When: checkInstanceHealth is called
         healthCheckService.checkInstanceHealth(target);
 
-        // Then: the probe should still be called (no record = not explicitly deregistered)
-        verify(probeClient).probe(target);
-        verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.HEALTHY);
+        // Then: the probe should NOT be called (no record = skip)
+        verify(probeClient, never()).probe(any());
+        verify(serviceRegistry, never()).updateHealthStatus(any(), any());
     }
 
     @Test
@@ -116,8 +115,10 @@ class PeriodicHealthCheckServiceTest {
         ServiceTarget target =
                 new ServiceTarget(SERVICE_ID, SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
 
-        // And: the capability is still marked as ACTIVE (because it crashed without deregistering)
+        // And: the capability was previously healthy but crashed without deregistering
         ActivityRecord crashedRecord = createActiveRecord();
+        crashedRecord.setHealthStatus(HealthStatus.HEALTHY);
+        crashedRecord.setLastSeen(java.time.Instant.now());
         when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(crashedRecord);
         when(probeClient.probe(target)).thenThrow(new RuntimeException("Connection refused"));
 


### PR DESCRIPTION
## Summary
- Set initial health status to PENDING when a capability registers, so the health checker can distinguish newly registered services from established ones
- Add a 1-minute grace period for capabilities in PENDING state before marking them as DOWN, preventing false failures during startup
- Handle missing activity records explicitly instead of silently skipping the deregistration check

## Test plan
- [ ] Register a new capability and verify it starts in PENDING health state
- [ ] Confirm the capability is not marked DOWN within the first minute if the health probe fails
- [ ] Confirm the capability is marked DOWN after the grace period expires if the probe still fails
- [ ] Verify already-healthy capabilities are still marked DOWN immediately on probe failure

## Summary by Sourcery

Adjust capability health registration and periodic checks to introduce a pending state with a startup grace period and to skip checks for capabilities without activity records.

New Features:
- Set newly registered capabilities to a PENDING health state in the service registry.

Bug Fixes:
- Skip health checks for capabilities that are missing an activity record instead of treating them as active and failing them.

Enhancements:
- Add a one-minute grace period for capabilities in PENDING health state before transitioning them to DOWN on health check errors, while keeping existing behaviour for established capabilities.