### PR TITLE
fix health check grpc

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -361,6 +361,15 @@ public class GrpcTransport implements WanakuBridgeTransport {
         Status status = e.getStatus();
         String description = status.getDescription();
 
+        if (status.getCode() == Status.Code.FAILED_PRECONDITION) {
+            LOG.errorf(e, "Service unavailable: %s", service.toAddress());
+            return new ServiceUnavailableException(
+                    "Service is not available at the address " + service.toAddress()
+                            + " due to temporary conditions (likely the service is starting up)",
+                    e,
+                    true);
+        }
+
         if (status.getCode() == Status.Code.UNAVAILABLE) {
             LOG.errorf(e, "Service unavailable: %s", service.toAddress());
             return new ServiceUnavailableException("Service is not available at the address " + service.toAddress(), e);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
@@ -35,6 +35,11 @@ class HealthProbeClient {
             HealthProbeReply reply = transport.probeHealth(request, target);
             return mapRuntimeStatus(reply.getStatus());
         } catch (ServiceUnavailableException e) {
+            if (e.isTransientCondition()) {
+                LOG.warnf("Service is temporarily unavailable at %s: %s", target.toAddress(), e.getMessage());
+                return HealthStatus.PENDING;
+            }
+
             LOG.warnf("Service is not available at %s: %s", target.toAddress(), e.getMessage());
             return HealthStatus.DOWN;
         } catch (Exception e) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -121,7 +121,7 @@ public class PeriodicHealthCheckService {
                 final Instant lastSeen = activityRecord.getLastSeen();
                 final Duration between = Duration.between(lastSeen, Instant.now());
 
-                if (between.toMinutes() < 1) {
+                if (between.toMinutes() < ActivityRecord.TIME_TO_LET_GO) {
                     LOG.infof("Recently registered capability %s is in pending health state. ", id);
                 } else {
                     LOG.warnf(e, "Error during health check for %s", id);

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
@@ -132,6 +132,8 @@ class PeriodicHealthCheckServiceTest {
 
     private ActivityRecord createActiveRecord() {
         ActivityRecord record = new ActivityRecord();
+        record.setHealthStatus(HealthStatus.HEALTHY);
+        record.setLastSeen(java.time.Instant.now());
         record.setStates(new java.util.ArrayList<>());
         return record;
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.0</quarkus-helm.version>
-        <wanaku-capabilities-sdk.version>0.1.0</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.1.1-SNAPSHOT</wanaku-capabilities-sdk.version>
         <commonmark.version>0.28.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37</oauth2-oidc-sdk.version>
         <operator-framework.version>5.3.3</operator-framework.version>


### PR DESCRIPTION
- **Version bump to SDK 0.1.1-SNAPSHOT**
- **Correctly handle transient service unavailability conditions**

## Summary by Sourcery

Handle transient gRPC service unavailability more gracefully in health checks and align health probe timing with configurable activity thresholds while updating the capabilities SDK version.

Bug Fixes:
- Treat transient gRPC FAILED_PRECONDITION errors as temporary service unavailability, mapping them to pending health status instead of hard down.

Enhancements:
- Adjust periodic health check pending window to use the ActivityRecord-defined threshold instead of a fixed one-minute duration.

Build:
- Bump wanaku capabilities SDK dependency to version 0.1.1-SNAPSHOT.