### PR TITLE
chore: add link to service-templates.md in usage guide

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2408,6 +2408,9 @@ wanaku service deploy --path=hr-system --host=http://localhost:8080
 
 The deployed service catalog is now visible in the admin UI and its routes are exposed as MCP tools.
 
+> [!TIP]
+> If you need parameterized, reusable service catalogs, see [Service Templates](service-templates.md) for details on creating and instantiating templates.
+
 ## Managing Capabilities
 
 Configurations in Wanaku have two distinct scopes:


### PR DESCRIPTION
## Summary

Adds a tip callout at the end of the "Managing Service Catalogs" section in `docs/usage.md` linking to the `service-templates.md` documentation. Previously there was no cross-reference from the usage guide to the service templates docs.

## Summary by Sourcery

Documentation:
- Cross-link the service catalog usage documentation to the Service Templates guide for parameterized, reusable catalogs.