### PR TITLE
feat: Wanaku-native auth configuration to replace Quarkus profile exposure

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -35,6 +35,7 @@ public class StartLocal extends StartBase {
         }
 
         LocalRunner.LocalRunnerEnvironment environment = new LocalRunner.LocalRunnerEnvironment()
+                .withAuthMode(config.auth().mode())
                 .withServiceOption("QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET", capabilitiesClientSecret);
 
         LocalRunner localRunner = new LocalRunner(config, environment);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -32,6 +32,11 @@ public class LocalRunner {
             return this;
         }
 
+    public LocalRunnerEnvironment withAuthMode(String authMode) {
+        servicesOptions.put("WANAKU_HTTP_AUTH", authMode);
+        return this;
+    }
+
         public Map<String, String> serviceOptions() {
             return servicesOptions;
         }
@@ -105,13 +110,7 @@ public class LocalRunner {
 
         executorService.submit(() -> {
             try {
-                ProcessRunner.run(
-                        componentDir,
-                        environment.serviceOptions(),
-                        "java",
-                        "-Dquarkus.profile=noauth",
-                        "-jar",
-                        "quarkus-run.jar");
+                ProcessRunner.run(componentDir, environment.serviceOptions(), "java", "-jar", "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Router Service: %s", e.getMessage(), e);
             } finally {
@@ -134,13 +133,7 @@ public class LocalRunner {
         executorService.submit(() -> {
             try {
                 ProcessRunner.run(
-                        componentDir,
-                        environment.serviceOptions(),
-                        "java",
-                        grpcPortOpt,
-                        "-Dquarkus.profile=noauth",
-                        "-jar",
-                        "quarkus-run.jar");
+                        componentDir, environment.serviceOptions(), "java", grpcPortOpt, "-jar", "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Service %s", component.getKey(), e);
             } finally {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/WanakuRouterConfig.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/WanakuRouterConfig.java
@@ -6,6 +6,9 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "wanaku.router")
 public interface WanakuRouterConfig {
 
+    @WithDefault("keycloak")
+    String httpAuth();
+
     HealthCheckConfig healthCheck();
 
     interface HealthCheckConfig {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
@@ -31,6 +31,9 @@ public class OidcReadinessCheck implements HealthCheck {
     @ConfigProperty(name = "quarkus.oidc.enabled", defaultValue = "false")
     boolean oidcEnabled;
 
+    @ConfigProperty(name = "wanaku.http.auth", defaultValue = "keycloak")
+    String httpAuth;
+
     @ConfigProperty(name = "quarkus.oidc.auth-server-url")
     String authServerUrl;
 
@@ -42,7 +45,7 @@ public class OidcReadinessCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
-        if (!oidcEnabled) {
+        if (!oidcEnabled || "none".equalsIgnoreCase(httpAuth)) {
             return disabledResponse();
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -1,0 +1,85 @@
+package ai.wanaku.backend.support;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class AuthConfigSource implements ConfigSource {
+
+    private static final String AUTH_PROPERTY = "wanaku.http.auth";
+    private static final String AUTH_NONE = "none";
+    private static final int ORDINAL = 260;
+
+    private static final String ENV_VAR = "WANAKU_HTTP_AUTH";
+
+    private static final int MAX_NAMESPACES = 10;
+
+    private volatile Map<String, String> noauthProperties;
+
+    @Override
+    public Set<String> getPropertyNames() {
+        if (isNoAuth()) {
+            return getNoauthProperties().keySet();
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        if (isNoAuth()) {
+            return getNoauthProperties().get(propertyName);
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (isNoAuth()) {
+            return getNoauthProperties();
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ORDINAL;
+    }
+
+    @Override
+    public String getName() {
+        return "wanaku-auth-config-source";
+    }
+
+    private boolean isNoAuth() {
+        return AUTH_NONE.equalsIgnoreCase(resolveAuthValue());
+    }
+
+    private String resolveAuthValue() {
+        String value = System.getProperty(AUTH_PROPERTY);
+        if (value != null) {
+            return value;
+        }
+
+        return System.getenv(ENV_VAR);
+    }
+
+    private Map<String, String> getNoauthProperties() {
+        if (noauthProperties == null) {
+            Map<String, String> props = new HashMap<>();
+            props.put("quarkus.oidc.enabled", "false");
+            props.put("quarkus.oidc.discovery-enabled", "false");
+            props.put("quarkus.oidc.mcp.discovery-enabled", "false");
+            for (int i = 1; i <= MAX_NAMESPACES; i++) {
+                props.put("quarkus.oidc.ns-" + i + ".discovery-enabled", "false");
+            }
+            props.put("quarkus.oidc-proxy.enabled", "false");
+            props.put("quarkus.http.auth.permission.authenticated.policy", "permit");
+            props.put("quarkus.http.auth.permission.mcp-authenticated.policy", "permit");
+            props.put("quarkus.http.auth.permission.web.policy", "permit");
+            noauthProperties = Collections.unmodifiableMap(props);
+        }
+        return noauthProperties;
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/apps/wanaku-router-backend/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+ai.wanaku.backend.support.AuthConfigSource

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -41,6 +41,9 @@ quarkus.mcp.server.traffic-logging.text-limit=1000000
 quarkus.mcp.server.server-info.name=Wanaku
 quarkus.mcp.server.client-logging.default-level=debug
 
+# Auth configuration: "keycloak" (default) enables OIDC, "none" disables authentication
+wanaku.http.auth=keycloak
+
 # Auth
 quarkus.oidc.enabled=true
 
@@ -190,13 +193,6 @@ quarkus.http.auth.permission.public.policy=permit
 ## Admin UI, which requires authentication for all paths in the web interface
 quarkus.http.auth.permission.web.paths=/admin/*, /admin, /node_modules/*
 quarkus.http.auth.permission.web.policy=authenticated
-
-# No-auth profile: disables OIDC and permits all paths
-%noauth.quarkus.oidc.enabled=false
-%noauth.quarkus.oidc-proxy.enabled=false
-%noauth.quarkus.http.auth.permission.authenticated.policy=permit
-%noauth.quarkus.http.auth.permission.mcp-authenticated.policy=permit
-%noauth.quarkus.http.auth.permission.web.policy=permit
 
 # Logging configuration
 

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -1077,13 +1077,6 @@
           }
         }
       }
-    },
-    "securitySchemes" : {
-      "SecurityScheme" : {
-        "type" : "openIdConnect",
-        "openIdConnectUrl" : "http://localhost:8543/realms/wanaku/.well-known/openid-configuration",
-        "description" : "Authentication"
-      }
     }
   },
   "paths" : {

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -720,11 +720,6 @@ components:
           $ref: "#/components/schemas/WanakuError"
         data:
           $ref: "#/components/schemas/ToolReference"
-  securitySchemes:
-    SecurityScheme:
-      type: openIdConnect
-      openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
-      description: Authentication
 paths:
   /api/v1/capabilities:
     get:

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResourceIT.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResourceIT.java
@@ -57,6 +57,7 @@ class OAuthProtectedResourceWellKnownResourceIT {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
+                    "wanaku.http.auth", "none",
                     "quarkus.oidc-proxy.enabled", "false",
                     "quarkus.oidc.enabled", "false",
                     "quarkus.oidc-proxy.root-path", "/q/oidc");

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/OidcReadinessCheckTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/OidcReadinessCheckTest.java
@@ -14,10 +14,29 @@ import static org.mockito.Mockito.when;
 
 class OidcReadinessCheckTest {
 
+    private static final String KEYCLOAK = "keycloak";
+    private static final String AUTH_SERVER_URL = "http://localhost:8543/realms/wanaku";
+    private static final String DISCOVERY_URL = AUTH_SERVER_URL + "/.well-known/openid-configuration";
+
     @Test
     void call_returnsUp_whenOidcIsDisabled() {
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = false;
+        check.httpAuth = KEYCLOAK;
+
+        HealthCheckResponse response = check.call();
+
+        assertEquals("oidc", response.getName());
+        assertTrue(response.getStatus() == HealthCheckResponse.Status.UP);
+        assertTrue(response.getData().isPresent());
+        assertEquals("disabled", getDataValue(response, "status"));
+    }
+
+    @Test
+    void call_returnsUp_whenHttpAuthIsNone() {
+        OidcReadinessCheck check = new OidcReadinessCheck();
+        check.oidcEnabled = true;
+        check.httpAuth = "none";
 
         HealthCheckResponse response = check.call();
 
@@ -33,13 +52,12 @@ class OidcReadinessCheckTest {
         when(connection.getResponseCode()).thenReturn(200);
 
         HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
-        when(connectionProvider.createConnection(
-                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
-                .thenReturn(connection);
+        when(connectionProvider.createConnection(DISCOVERY_URL)).thenReturn(connection);
 
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
-        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.httpAuth = KEYCLOAK;
+        check.authServerUrl = AUTH_SERVER_URL;
         check.discoveryEnabled = true;
         check.httpConnectionProvider = connectionProvider;
 
@@ -57,13 +75,12 @@ class OidcReadinessCheckTest {
         when(connection.getResponseCode()).thenReturn(503);
 
         HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
-        when(connectionProvider.createConnection(
-                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
-                .thenReturn(connection);
+        when(connectionProvider.createConnection(DISCOVERY_URL)).thenReturn(connection);
 
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
-        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.httpAuth = KEYCLOAK;
+        check.authServerUrl = AUTH_SERVER_URL;
         check.discoveryEnabled = true;
         check.httpConnectionProvider = connectionProvider;
 
@@ -87,6 +104,7 @@ class OidcReadinessCheckTest {
 
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
+        check.httpAuth = KEYCLOAK;
         check.authServerUrl = "not-a-valid-url";
         check.discoveryEnabled = true;
         check.httpConnectionProvider = connectionProvider;
@@ -105,13 +123,12 @@ class OidcReadinessCheckTest {
         when(connection.getResponseCode()).thenReturn(500);
 
         HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
-        when(connectionProvider.createConnection(
-                        "http://localhost:8543/realms/wanaku/.well-known/openid-configuration"))
-                .thenReturn(connection);
+        when(connectionProvider.createConnection(DISCOVERY_URL)).thenReturn(connection);
 
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
-        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.httpAuth = KEYCLOAK;
+        check.authServerUrl = AUTH_SERVER_URL;
         check.discoveryEnabled = true;
         check.httpConnectionProvider = connectionProvider;
 
@@ -125,6 +142,7 @@ class OidcReadinessCheckTest {
     void call_returnsDown_whenAuthServerUrlIsNull() {
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
+        check.httpAuth = KEYCLOAK;
         check.authServerUrl = null;
         check.discoveryEnabled = true;
 
@@ -139,6 +157,7 @@ class OidcReadinessCheckTest {
     void call_returnsDown_whenAuthServerUrlIsEmpty() {
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
+        check.httpAuth = KEYCLOAK;
         check.authServerUrl = " ";
         check.discoveryEnabled = true;
 
@@ -155,12 +174,12 @@ class OidcReadinessCheckTest {
         when(connection.getResponseCode()).thenReturn(200);
 
         HttpConnectionProvider connectionProvider = mock(HttpConnectionProvider.class);
-        when(connectionProvider.createConnection("http://localhost:8543/realms/wanaku"))
-                .thenReturn(connection);
+        when(connectionProvider.createConnection(AUTH_SERVER_URL)).thenReturn(connection);
 
         OidcReadinessCheck check = new OidcReadinessCheck();
         check.oidcEnabled = true;
-        check.authServerUrl = "http://localhost:8543/realms/wanaku";
+        check.httpAuth = KEYCLOAK;
+        check.authServerUrl = AUTH_SERVER_URL;
         check.discoveryEnabled = false;
         check.httpConnectionProvider = connectionProvider;
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -1,0 +1,127 @@
+package ai.wanaku.backend.support;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthConfigSourceTest {
+
+    private static final String AUTH_PROPERTY = "wanaku.http.auth";
+    private static final String ENV_VAR = "WANAKU_HTTP_AUTH";
+
+    private AuthConfigSource configSource;
+
+    @BeforeEach
+    void setUp() {
+        configSource = new AuthConfigSource();
+        clearAuthProperties();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearAuthProperties();
+    }
+
+    private void clearAuthProperties() {
+        System.clearProperty(AUTH_PROPERTY);
+    }
+
+    @Test
+    void getName_returnsExpectedValue() {
+        assertEquals("wanaku-auth-config-source", configSource.getName());
+    }
+
+    @Test
+    void getOrdinal_returnsExpectedValue() {
+        assertEquals(260, configSource.getOrdinal());
+    }
+
+    @Test
+    void getProperties_returnsEmptyMap_whenAuthNotConfigured() {
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertTrue(props.isEmpty());
+    }
+
+    @Test
+    void getProperties_returnsEmptyMap_whenAuthSetToKeycloak() {
+        System.setProperty(AUTH_PROPERTY, "keycloak");
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertTrue(props.isEmpty());
+    }
+
+    @Test
+    void getProperties_returnsNoAuthProperties_whenAuthSetToNoneViaProperty() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertEquals("false", props.get("quarkus.oidc.enabled"));
+        assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
+        for (int i = 1; i <= 10; i++) {
+            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
+        }
+        assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
+        assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
+        assertEquals("permit", props.get("quarkus.http.auth.permission.mcp-authenticated.policy"));
+        assertEquals("permit", props.get("quarkus.http.auth.permission.web.policy"));
+    }
+
+    @Test
+    void getValue_returnsNull_whenAuthNotConfigured() {
+        assertNull(configSource.getValue("quarkus.oidc.discovery-enabled"));
+    }
+
+    @Test
+    void getValue_returnsNoAuthValue_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-1.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-10.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
+        assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
+    }
+
+    @Test
+    void getValue_returnsNullForUnknownProperty_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertNull(configSource.getValue("unknown.property"));
+    }
+
+    @Test
+    void getPropertyNames_returnsEmptySet_whenAuthNotConfigured() {
+        assertTrue(configSource.getPropertyNames().isEmpty());
+    }
+
+    @Test
+    void getPropertyNames_returnsNoAuthKeys_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertTrue(configSource.getPropertyNames().size() > 5);
+    }
+
+    @Test
+    void isNoAuth_isCaseInsensitive() {
+        System.setProperty(AUTH_PROPERTY, "NONE");
+        assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+
+        clearAuthProperties();
+        System.setProperty(AUTH_PROPERTY, "None");
+        assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+    }
+
+    @Test
+    void envVar_fallsBack_whenSystemPropertyNotSet() {
+        assertNull(System.getProperty(AUTH_PROPERTY));
+        Map<String, String> props = configSource.getProperties();
+        assertTrue(props.isEmpty());
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
@@ -7,8 +7,6 @@ public class NoOidcTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of(
-                "quarkus.oidc.enabled", "false",
-                "quarkus.oidc-proxy.enabled", "false");
+        return Map.of("wanaku.http.auth", "none");
     }
 }

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/AuthConfigSource.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/AuthConfigSource.java
@@ -1,0 +1,74 @@
+package ai.wanaku.core.capabilities.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class AuthConfigSource implements ConfigSource {
+
+    private static final String AUTH_PROPERTY = "wanaku.http.auth";
+    private static final String AUTH_NONE = "none";
+    private static final int ORDINAL = 260;
+
+    private static final String ENV_VAR = "WANAKU_HTTP_AUTH";
+
+    private volatile Map<String, String> noauthProperties;
+
+    @Override
+    public Set<String> getPropertyNames() {
+        if (isNoAuth()) {
+            return getNoauthProperties().keySet();
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        if (isNoAuth()) {
+            return getNoauthProperties().get(propertyName);
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (isNoAuth()) {
+            return getNoauthProperties();
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ORDINAL;
+    }
+
+    @Override
+    public String getName() {
+        return "wanaku-auth-config-source";
+    }
+
+    private boolean isNoAuth() {
+        return AUTH_NONE.equalsIgnoreCase(resolveAuthValue());
+    }
+
+    private String resolveAuthValue() {
+        String value = System.getProperty(AUTH_PROPERTY);
+        if (value != null) {
+            return value;
+        }
+
+        return System.getenv(ENV_VAR);
+    }
+
+    private Map<String, String> getNoauthProperties() {
+        if (noauthProperties == null) {
+            Map<String, String> props = new HashMap<>();
+            props.put("quarkus.oidc-client.enabled", "false");
+            noauthProperties = Collections.unmodifiableMap(props);
+        }
+        return noauthProperties;
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+ai.wanaku.core.capabilities.common.AuthConfigSource

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 quarkus.qute.strict-rendering=false
 
+wanaku.http.auth=keycloak
+
 quarkus.oidc-client.enabled=true
 
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
@@ -18,9 +20,6 @@ quarkus.oidc-client.refresh-token-time-skew=1m
 
 # Client secret from Keycloak for service authentication - replace with your actual secret
 quarkus.oidc-client.credentials.secret=<insert key here>
-
-# No-auth profile: disables OIDC client so capabilities can run without Keycloak
-%noauth.quarkus.oidc-client.enabled=false
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku.core.capabilities".level=INFO

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/AuthConfigSourceTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/AuthConfigSourceTest.java
@@ -1,0 +1,116 @@
+package ai.wanaku.core.capabilities.common;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthConfigSourceTest {
+
+    private static final String AUTH_PROPERTY = "wanaku.http.auth";
+    private static final String ENV_VAR = "WANAKU_HTTP_AUTH";
+
+    private AuthConfigSource configSource;
+
+    @BeforeEach
+    void setUp() {
+        configSource = new AuthConfigSource();
+        clearAuthProperties();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearAuthProperties();
+    }
+
+    private void clearAuthProperties() {
+        System.clearProperty(AUTH_PROPERTY);
+    }
+
+    @Test
+    void getName_returnsExpectedValue() {
+        assertEquals("wanaku-auth-config-source", configSource.getName());
+    }
+
+    @Test
+    void getOrdinal_returnsExpectedValue() {
+        assertEquals(260, configSource.getOrdinal());
+    }
+
+    @Test
+    void getProperties_returnsEmptyMap_whenAuthNotConfigured() {
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertTrue(props.isEmpty());
+    }
+
+    @Test
+    void getProperties_returnsEmptyMap_whenAuthSetToKeycloak() {
+        System.setProperty(AUTH_PROPERTY, "keycloak");
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertTrue(props.isEmpty());
+    }
+
+    @Test
+    void getProperties_returnsNoAuthProperties_whenAuthSetToNoneViaProperty() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        Map<String, String> props = configSource.getProperties();
+        assertNotNull(props);
+        assertEquals(1, props.size());
+        assertEquals("false", props.get("quarkus.oidc-client.enabled"));
+    }
+
+    @Test
+    void getValue_returnsNull_whenAuthNotConfigured() {
+        assertNull(configSource.getValue("quarkus.oidc-client.enabled"));
+    }
+
+    @Test
+    void getValue_returnsNoAuthValue_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertEquals("false", configSource.getValue("quarkus.oidc-client.enabled"));
+    }
+
+    @Test
+    void getValue_returnsNullForUnknownProperty_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertNull(configSource.getValue("unknown.property"));
+    }
+
+    @Test
+    void getPropertyNames_returnsEmptySet_whenAuthNotConfigured() {
+        assertTrue(configSource.getPropertyNames().isEmpty());
+    }
+
+    @Test
+    void getPropertyNames_returnsNoAuthKeys_whenAuthSetToNone() {
+        System.setProperty(AUTH_PROPERTY, "none");
+        assertEquals(1, configSource.getPropertyNames().size());
+    }
+
+    @Test
+    void isNoAuth_isCaseInsensitive() {
+        System.setProperty(AUTH_PROPERTY, "NONE");
+        assertEquals("false", configSource.getValue("quarkus.oidc-client.enabled"));
+
+        clearAuthProperties();
+        System.setProperty(AUTH_PROPERTY, "None");
+        assertEquals("false", configSource.getValue("quarkus.oidc-client.enabled"));
+    }
+
+    @Test
+    void envVar_fallsBack_whenSystemPropertyNotSet() {
+        // This test verifies the fallback mechanism.
+        // Since we cannot reliably set env vars in Java, we verify the source
+        // returns empty when neither system property nor env var is set.
+        assertNull(System.getProperty(AUTH_PROPERTY));
+        Map<String, String> props = configSource.getProperties();
+        assertTrue(props.isEmpty());
+    }
+}

--- a/deploy/docker-compose/docker-compose-noauth.yml
+++ b/deploy/docker-compose/docker-compose-noauth.yml
@@ -2,7 +2,7 @@ services:
   wanaku-router:
     image: quay.io/wanaku/wanaku-router-backend:latest
     environment:
-      QUARKUS_PROFILE: noauth
+      WANAKU_HTTP_AUTH: none
       QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED: "true"
       QUARKUS_HTTP_HOST: 0.0.0.0
     network_mode: host

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -120,20 +120,52 @@ Configuration for the main Wanaku Router Backend (`wanaku-router-backend`), whic
 
 ### Authentication & Authorization (OIDC)
 
-| Property                                | Description                                                                              |
+| Property | Description |
 |-----------------------------------------|------------------------------------------------------------------------------------------|
-| `auth.server`                           | The base address of the Keycloak authentication server (e.g., `http://localhost:8543`).  |
-| `auth.proxy`                            | The public-facing address of the OIDC proxy (e.g., `http://localhost:8080`).             |
-| `quarkus.oidc.auth-server-url`          | The full URL to the Keycloak realm, derived from `auth.server`.                          |
-| `quarkus.oidc.client-id`                | `wanaku-mcp-router` - The OIDC client ID for the router backend itself.                  |
-| `quarkus.oidc.application-type`         | `hybrid` - Allows the backend to act as both a web app (for the admin UI) and a service. |
-| `quarkus.oidc.tls.verification`         | `none` - Disables TLS verification for the OIDC provider (for development).              |
-| `quarkus.oidc-proxy.enabled`            | `true` - Enables the OIDC proxy feature, which simplifies OIDC integration.              |
-| `quarkus.http.auth.permission.*.paths`  | Defines path patterns for different security policies (`permit`, `authenticated`).       |
-| `quarkus.http.auth.permission.*.policy` | Assigns a security policy to the corresponding path pattern.                             |
+| `wanaku.http.auth` | `keycloak` - Controls authentication mode. Set to `none` to disable authentication entirely. Also settable via `WANAKU_HTTP_AUTH` environment variable. |
+| `auth.server` | The base address of the Keycloak authentication server (e.g., `http://localhost:8543`). |
+| `auth.proxy` | The public-facing address of the OIDC proxy (e.g., `http://localhost:8080`). |
+| `quarkus.oidc.auth-server-url` | The full URL to the Keycloak realm, derived from `auth.server`. |
+| `quarkus.oidc.client-id` | `wanaku-mcp-router` - The OIDC client ID for the router backend itself. |
+| `quarkus.oidc.application-type` | `hybrid` - Allows the backend to act as both a web app (for the admin UI) and a service. |
+| `quarkus.oidc.tls.verification` | `none` - Disables TLS verification for the OIDC provider (for development). |
+| `quarkus.oidc-proxy.enabled` | `true` - Enables the OIDC proxy feature, which simplifies OIDC integration. |
+| `quarkus.http.auth.permission.*.paths` | Defines path patterns for different security policies (`permit`, `authenticated`). |
+| `quarkus.http.auth.permission.*.policy` | Assigns a security policy to the corresponding path pattern. |
 
-To run without authentication, activate the `noauth` Quarkus profile (e.g., `QUARKUS_PROFILE=noauth`). This disables
-OIDC and permits all paths. See the [Usage Guide](usage.md#running-without-authentication) for details.
+#### Running Without Authentication
+
+Set `wanaku.http.auth=none` (or export `WANAKU_HTTP_AUTH=none`) to run without Keycloak.
+No identity provider is required — all HTTP paths are opened via `policy=permit` automatically.
+
+```shell
+# Via environment variable (recommended for containers / wanaku start local)
+WANAKU_HTTP_AUTH=none java -jar quarkus-run.jar
+
+# Via system property
+java -Dwanaku.http.auth=none -jar quarkus-run.jar
+```
+
+> [!IMPORTANT]
+> `wanaku.http.auth` is a **Wanaku-native** property. Users do not need to know that Wanaku is
+> built on Quarkus to configure authentication — the Quarkus implementation details stay hidden.
+
+> [!NOTE]
+> **How it works internally (`AuthConfigSource`):** When `wanaku.http.auth=none`, a custom
+> MicroProfile `ConfigSource` (ordinal 260) injects the following runtime overrides:
+>
+> | Property injected | Value | Reason |
+> |---|---|---|
+> | `quarkus.oidc.enabled` | `false` | Disables OIDC entirely at runtime |
+> | `quarkus.oidc.discovery-enabled` | `false` | Prevents eager Keycloak connection at startup |
+> | `quarkus.oidc.mcp.discovery-enabled` | `false` | Same, for the MCP OIDC tenant used by OidcProxy |
+> | `quarkus.oidc.ns-{1..10}.discovery-enabled` | `false` | Same, for per-namespace OIDC tenants |
+> | `quarkus.oidc-proxy.enabled` | `false` | Disables the OIDC proxy |
+> | `quarkus.http.auth.permission.authenticated.policy` | `permit` | Opens management / data-store APIs |
+> | `quarkus.http.auth.permission.mcp-authenticated.policy` | `permit` | Opens MCP namespace endpoints |
+> | `quarkus.http.auth.permission.web.policy` | `permit` | Opens the admin web UI |
+
+See the [Usage Guide](usage.md#running-without-authentication) for end-to-end instructions.
 
 ### Health Check
 
@@ -176,6 +208,7 @@ These settings apply regardless of whether you use the shared HTTP listener or a
 
 | Property | Description |
 |------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `wanaku.http.auth` | `keycloak` - Controls authentication mode for capability services. Set to `none` to disable OIDC client. Also settable via `WANAKU_HTTP_AUTH` environment variable. |
 | `wanaku.service.name` | The unique, lowercase name of the service (e.g., `exec`, `http`). |
 | `wanaku.service.base-uri` | The base URI scheme for tools provided by this service (e.g., `exec://`). |
 | `wanaku.service.exec.allowed-executables` | Comma-separated absolute executable paths that the Exec tool may run. |
@@ -305,6 +338,26 @@ QUARKUS_HTTP_PORT=8080
 ```
 
 ## Configuration Examples
+
+### Example: Router Backend Without Authentication (No Keycloak)
+
+The quickest way to run Wanaku locally without setting up an identity provider:
+
+```shell
+# Environment variable — no changes to any properties file needed
+export WANAKU_HTTP_AUTH=none
+java -jar quarkus-run.jar
+```
+
+Or equivalently via a `config/application.properties` override file:
+
+```properties
+wanaku.http.auth=none
+```
+
+This automatically opens all protected endpoints (`/api/v1/management/*`, `/mcp/*`, `/admin/*`, etc.)
+without requiring a token, while OIDC infrastructure stays initialized (preventing startup errors from
+the embedded OIDC proxy extension).
 
 ### Example: Router Backend with Custom OIDC
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,11 +58,11 @@ Keycloak provides authentication and authorization for:
 **For development:**
 - Java 17 or later
 - Maven 3.x
-- Keycloak instance (optional — can run via Podman/Docker, or use the `noauth` profile)
+- Keycloak instance (optional — can run via Podman/Docker, or set `wanaku.http.auth=none`)
 
 **For production deployment:**
 - OpenShift or Kubernetes cluster (optional but recommended)
-- Keycloak instance (recommended for production; optional with `noauth` profile)
+- Keycloak instance (recommended for production; optional with `wanaku.http.auth=none`)
 - Container runtime (Podman/Docker)
 
 ### Do I need to install Keycloak separately?
@@ -72,7 +72,7 @@ Keycloak is required only if you want to run Wanaku with authentication enabled.
 - Deploy Keycloak to OpenShift/Kubernetes (for production)
 - Use an existing Keycloak instance
 
-If you don't need authentication (e.g., for local development or testing), you can run Wanaku with the `noauth` profile
+If you don't need authentication (e.g., for local development or testing), you can set `wanaku.http.auth=none`
 and skip the Keycloak setup entirely. See [Running Without Authentication](usage.md#running-without-authentication).
 
 ### Can I run Wanaku without Kubernetes?
@@ -216,7 +216,7 @@ Currently, all authenticated users have admin access to tools and resources. Fin
 
 ### Can I disable authentication for development?
 
-While not recommended, you can configure Keycloak in dev mode with simplified settings. However, authentication cannot be completely disabled.
+While not recommended for production, you can set `wanaku.http.auth=none` to disable authentication for development and testing.
 
 ## Troubleshooting
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,7 +79,7 @@ Wanaku with authentication enabled. This section covers the basics of getting Ke
 production purposes.
 
 > [!NOTE]
-> Wanaku can also run **without authentication** by using the `noauth` Quarkus profile. This is useful for local development,
+> Wanaku can also run **without authentication** by setting `wanaku.http.auth=none`. This is useful for local development,
 > testing, or air-gapped environments where an identity provider is not available. See
 > [Running Without Authentication](#running-without-authentication) for details.
 
@@ -171,15 +171,16 @@ Finally, for security, you must regenerate the client secret for the `wanaku-ser
 
 ## Running Without Authentication
 
-Wanaku can run without authentication by activating the `noauth` Quarkus profile. This disables OIDC and permits access
-to all API endpoints, the admin UI, and MCP namespaces without requiring a Bearer token or a Keycloak instance.
+Wanaku can run without authentication by setting `wanaku.http.auth=none` (or `WANAKU_HTTP_AUTH=none` via
+environment variable). This disables OIDC and permits access to all API endpoints, the admin UI, and MCP namespaces
+without requiring a Bearer token or a Keycloak instance.
 
 This is useful for:
 - **Local development and testing** — no need to set up Keycloak
 - **Air-gapped environments** — where an external identity provider is not available
 - **Quick prototyping** — get started with Wanaku immediately
 
-### Activating the No-Auth Profile
+### Disabling Authentication
 
 **Using the CLI (default for local):**
 
@@ -187,19 +188,19 @@ This is useful for:
 wanaku start local
 ```
 
-The `wanaku start local` command automatically uses the `noauth` profile, so no additional configuration is needed.
+The `wanaku start local` command automatically disables authentication, so no additional configuration is needed.
 
 **Using an environment variable:**
 
 ```shell
-export QUARKUS_PROFILE=noauth
+export WANAKU_HTTP_AUTH=none
 java -jar quarkus-run.jar
 ```
 
 **Using a system property:**
 
 ```shell
-java -Dquarkus.profile=noauth -jar quarkus-run.jar
+java -Dwanaku.http.auth=none -jar quarkus-run.jar
 ```
 
 **Using Docker Compose:**
@@ -211,9 +212,11 @@ without Keycloak:
 docker compose -f deploy/docker-compose/docker-compose-noauth.yml up
 ```
 
+If you extend that compose file with capability services, set `WANAKU_HTTP_AUTH=none` on those services as well.
+
 > [!WARNING]
-> The `noauth` profile disables all authentication. Do not use it in production environments where access control is
-> required.
+> Running without authentication disables all access control. Do not use it in production environments where
+> access control is required.
 
 # Installing Wanaku
 
@@ -288,7 +291,7 @@ and an HTTP provider.
 wanaku start local
 ```
 
-The local runner uses the `noauth` Quarkus profile by default, so **Keycloak is not required**. The router and all
+The local runner disables authentication by default, so **Keycloak is not required**. The router and all
 capability services will start without authentication.
 
 If that is successful, open your browser at http://localhost:8080, and you should have access to the UI.


### PR DESCRIPTION
Closes: #988

## Summary by Sourcery

Introduce Wanaku-native HTTP auth configuration flag to control OIDC usage and remove reliance on Quarkus noauth profiles.

New Features:
- Add wanaku.http.auth configuration (and WANAKU_HTTP_AUTH env var) to toggle between Keycloak-backed auth and no-auth mode for router and capabilities.
- Add custom MicroProfile ConfigSources that inject Quarkus OIDC and HTTP auth overrides when authentication is disabled.

Enhancements:
- Update CLI local runner and Docker compose to use wanaku.http.auth instead of Quarkus profiles for running without authentication.
- Extend OIDC readiness health check to respect the new auth mode and avoid Keycloak checks when auth is disabled.
- Hide Quarkus/OpenID specifics from user-facing docs and OpenAPI by documenting Wanaku-native auth controls and removing direct OIDC security scheme metadata.

Documentation:
- Revise configuration, usage, and FAQ docs to describe wanaku.http.auth / WANAKU_HTTP_AUTH for enabling or disabling authentication, including examples for no-auth setups.

Tests:
- Add unit tests for the new AuthConfigSource implementations and update existing tests to cover wanaku.http.auth-driven behavior and URLs in OIDC readiness checks.