### PR TITLE
Add service templates for Jira, Mail, RabbitMQ, and Telegram

### DIFF
--- a/services/service-templates/src/main/services/jira-add-comment-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.jira-add-comment=jira-add-comment/jira-add-comment.dependencies.txt
+catalog.description=Add comments to Jira issues
+catalog.name=jira-add-comment-tool
+catalog.routes.jira-add-comment=jira-add-comment/jira-add-comment.camel.yaml
+catalog.rules.jira-add-comment=jira-add-comment/jira-add-comment.rules.yaml
+catalog.services=jira-add-comment

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.camel.yaml
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.camel.yaml
@@ -1,0 +1,11 @@
+- route:
+    description: Add a comment to a Jira issue
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: jira:addComment
+            parameters:
+              jiraUrl: "{{jira.url}}"
+              accessToken: "{{jira.access.token}}"
+    id: jira-add-comment

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-jira:4.18.2

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.rules.yaml
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - jira-add-comment:
+        route:
+          id: "jira-add-comment"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The comment text to add to the issue
+            required: true

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/service.properties
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/service.properties
@@ -1,0 +1,3 @@
+tool.description=Add a comment to a Jira issue
+jira.url=https://your-instance.atlassian.net
+jira.access.token={{jira.access.token}}

--- a/services/service-templates/src/main/services/jira-add-issue-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.jira-add-issue=jira-add-issue/jira-add-issue.dependencies.txt
+catalog.description=Create issues in Jira
+catalog.name=jira-add-issue-tool
+catalog.routes.jira-add-issue=jira-add-issue/jira-add-issue.camel.yaml
+catalog.rules.jira-add-issue=jira-add-issue/jira-add-issue.rules.yaml
+catalog.services=jira-add-issue

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.camel.yaml
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.camel.yaml
@@ -1,0 +1,13 @@
+- route:
+    description: Create an issue in Jira
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: jira:addIssue
+            parameters:
+              jiraUrl: "{{jira.url}}"
+              accessToken: "{{jira.access.token}}"
+              projectKey: "{{jira.project.key}}"
+              issueTypeName: "{{jira.issue.type}}"
+    id: jira-add-issue

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-jira:4.18.2

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.rules.yaml
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - jira-add-issue:
+        route:
+          id: "jira-add-issue"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The issue summary and description
+            required: true

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/service.properties
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/service.properties
@@ -1,0 +1,5 @@
+tool.description=Create an issue in Jira
+jira.url=https://your-instance.atlassian.net
+jira.access.token={{jira.access.token}}
+jira.project.key=PROJECT
+jira.issue.type=Task

--- a/services/service-templates/src/main/services/jira-update-issue-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.jira-update-issue=jira-update-issue/jira-update-issue.dependencies.txt
+catalog.description=Update issues in Jira
+catalog.name=jira-update-issue-tool
+catalog.routes.jira-update-issue=jira-update-issue/jira-update-issue.camel.yaml
+catalog.rules.jira-update-issue=jira-update-issue/jira-update-issue.rules.yaml
+catalog.services=jira-update-issue

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.camel.yaml
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.camel.yaml
@@ -1,0 +1,11 @@
+- route:
+    description: Update an existing Jira issue
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: jira:updateIssue
+            parameters:
+              jiraUrl: "{{jira.url}}"
+              accessToken: "{{jira.access.token}}"
+    id: jira-update-issue

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-jira:4.18.2

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.rules.yaml
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - jira-update-issue:
+        route:
+          id: "jira-update-issue"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The issue fields to update
+            required: true

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/service.properties
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/service.properties
@@ -1,0 +1,3 @@
+tool.description=Update an existing Jira issue
+jira.url=https://your-instance.atlassian.net
+jira.access.token={{jira.access.token}}

--- a/services/service-templates/src/main/services/mail-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/mail-sink-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.mail-sink=mail-sink/mail-sink.dependencies.txt
+catalog.description=Send emails via SMTP
+catalog.name=mail-sink-tool
+catalog.routes.mail-sink=mail-sink/mail-sink.camel.yaml
+catalog.rules.mail-sink=mail-sink/mail-sink.rules.yaml
+catalog.services=mail-sink

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.camel.yaml
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.camel.yaml
@@ -1,0 +1,14 @@
+- route:
+    description: Send an email via SMTP
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: smtp:{{smtp.host}}:{{smtp.port}}
+            parameters:
+              username: "{{smtp.username}}"
+              password: "{{smtp.password}}"
+              to: "{{mail.to}}"
+              from: "{{mail.from}}"
+              subject: "{{mail.subject}}"
+    id: mail-send

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-mail:4.18.2

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.rules.yaml
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - mail-send:
+        route:
+          id: "mail-send"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The email body content
+            required: true

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/service.properties
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/service.properties
@@ -1,0 +1,8 @@
+tool.description=Send an email via SMTP
+smtp.host=smtp.example.com
+smtp.port=587
+smtp.username={{smtp.username}}
+smtp.password={{smtp.password}}
+mail.to=recipient@example.com
+mail.from=sender@example.com
+mail.subject=Message from Wanaku

--- a/services/service-templates/src/main/services/rabbitmq-tool/index.properties
+++ b/services/service-templates/src/main/services/rabbitmq-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.rabbitmq=rabbitmq/rabbitmq.dependencies.txt
+catalog.description=Send and receive messages to and from RabbitMQ
+catalog.name=rabbitmq-tool
+catalog.routes.rabbitmq=rabbitmq/rabbitmq.camel.yaml
+catalog.rules.rabbitmq=rabbitmq/rabbitmq.rules.yaml
+catalog.services=rabbitmq

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.camel.yaml
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.camel.yaml
@@ -1,0 +1,15 @@
+- route:
+    description: Send and receive messages to and from RabbitMQ
+    from:
+      uri: direct
+      parameters:
+        name: wanaku
+      steps:
+        - log: ${body}
+        - to:
+            uri: spring-rabbitmq:{{rabbitmq.exchange}}
+            parameters:
+              routingKey: "{{rabbitmq.routing.key}}"
+              queues: "{{rabbitmq.queue}}"
+      id: from-rabbitmq
+    id: rabbitmq-send

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-spring-rabbitmq:4.18.2

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.rules.yaml
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - send-message-to-rabbitmq:
+        route:
+          id: "rabbitmq-send"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The message to send to RabbitMQ
+            required: true

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/service.properties
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/service.properties
@@ -1,0 +1,4 @@
+tool.description=Send a message to RabbitMQ
+rabbitmq.exchange=my-exchange
+rabbitmq.routing.key=my-key
+rabbitmq.queue=my-queue

--- a/services/service-templates/src/main/services/telegram-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/telegram-sink-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.telegram-sink=telegram-sink/telegram-sink.dependencies.txt
+catalog.description=Send messages via Telegram Bot
+catalog.name=telegram-sink-tool
+catalog.routes.telegram-sink=telegram-sink/telegram-sink.camel.yaml
+catalog.rules.telegram-sink=telegram-sink/telegram-sink.rules.yaml
+catalog.services=telegram-sink

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/service.properties
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/service.properties
@@ -1,0 +1,3 @@
+tool.description=Send a message via Telegram Bot
+telegram.auth.token={{telegram.auth.token}}
+telegram.chat.id={{telegram.chat.id}}

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.camel.yaml
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.camel.yaml
@@ -1,0 +1,11 @@
+- route:
+    description: Send a message via Telegram Bot
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: telegram:bots
+            parameters:
+              authorizationToken: "{{telegram.auth.token}}"
+              chatId: "{{telegram.chat.id}}"
+    id: telegram-send

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-telegram:4.18.2

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.rules.yaml
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - telegram-send-message:
+        route:
+          id: "telegram-send"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The message text to send via Telegram
+            required: true


### PR DESCRIPTION
## Summary

- Add six new service templates based on Camel components: Jira (add issue, add comment, update issue), Mail (SMTP sink), RabbitMQ (request/reply via queues param), and Telegram (bot sink)
- All templates follow the existing pattern established by activemq6-tool and tavily-search-tool
- Each template includes Camel route, MCP tool rules, parameterized service properties, and Maven dependency declarations

## Test plan

- [ ] Verify `mvn verify` passes from root
- [ ] Inspect generated ZIP in `services/service-templates/target/` contains all new templates
- [ ] Deploy a template via `wanaku service template deploy` and verify instantiation with property substitution

## Summary by Sourcery

Add new Camel-based service templates for Jira operations, SMTP email sending, RabbitMQ messaging, and Telegram bot messaging, including their routing, MCP tool definitions, and catalog metadata.

New Features:
- Introduce Jira service templates for creating issues, adding comments, and updating issues via dedicated tools.
- Add a mail-sink service template to send emails through configurable SMTP settings.
- Add a rabbitmq service template to send messages to RabbitMQ with configurable exchange, routing key, and queue.
- Add a telegram-sink service template to send messages via a Telegram bot with configurable auth token and chat ID.

Enhancements:
- Define MCP tool rules, service properties, dependency placeholders, and catalog index metadata for all new Jira, mail, RabbitMQ, and Telegram service templates.