### PR TITLE
Auto-load built-in service templates on router startup

### DIFF
--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -218,6 +218,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-service-templates</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/service-templates</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../../services/service-templates/src/main/services</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateInitializer.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateInitializer.java
@@ -1,0 +1,111 @@
+package ai.wanaku.backend.api.v1.servicecatalog;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.jboss.logging.Logger;
+import io.quarkus.runtime.StartupEvent;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+
+@ApplicationScoped
+public class ServiceTemplateInitializer {
+    private static final Logger LOG = Logger.getLogger(ServiceTemplateInitializer.class);
+    private static final String TEMPLATES_RESOURCE = "service-templates";
+
+    @Inject
+    ServiceTemplateBean serviceTemplateBean;
+
+    void loadBuiltInTemplates(@Observes StartupEvent ev) {
+        Path templatesDir = resolveTemplatesDir();
+        if (templatesDir == null || !Files.isDirectory(templatesDir)) {
+            LOG.debug("No built-in service templates directory found on classpath");
+            return;
+        }
+
+        int loaded = 0;
+        try (DirectoryStream<Path> dirs = Files.newDirectoryStream(templatesDir, Files::isDirectory)) {
+            for (Path templateDir : dirs) {
+                String name = templateDir.getFileName().toString();
+                try {
+                    if (serviceTemplateBean.get(name) != null) {
+                        LOG.debugf("Built-in template '%s' already deployed, skipping", name);
+                        continue;
+                    }
+
+                    byte[] zipBytes = zipDirectory(templateDir);
+                    DataStore dataStore = new DataStore();
+                    dataStore.setName(name);
+                    dataStore.setData(Base64.getEncoder().encodeToString(zipBytes));
+
+                    serviceTemplateBean.deploy(dataStore);
+                    loaded++;
+                    LOG.infof("Deployed built-in service template: %s", name);
+                } catch (Exception e) {
+                    LOG.errorf(e, "Failed to deploy built-in service template: %s", name);
+                }
+            }
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed to scan built-in service templates directory");
+        }
+
+        if (loaded > 0) {
+            LOG.infof("Loaded %d built-in service template(s)", loaded);
+        }
+    }
+
+    private Path resolveTemplatesDir() {
+        URL resource = Thread.currentThread().getContextClassLoader().getResource(TEMPLATES_RESOURCE);
+        if (resource == null) {
+            return null;
+        }
+        try {
+            return Path.of(resource.toURI());
+        } catch (URISyntaxException e) {
+            LOG.errorf(e, "Failed to resolve service templates directory");
+            return null;
+        }
+    }
+
+    private byte[] zipDirectory(Path dir) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            try (var walker = Files.walk(dir)) {
+                walker.filter(Files::isRegularFile).forEach(file -> {
+                    String entryName = dir.relativize(file).toString();
+                    try {
+                        zos.putNextEntry(new ZipEntry(entryName));
+                        Files.copy(file, zos);
+                        zos.closeEntry();
+                    } catch (IOException e) {
+                        throw new RuntimeIOException(e);
+                    }
+                });
+            }
+        } catch (RuntimeIOException e) {
+            throw e.getCause();
+        }
+        return baos.toByteArray();
+    }
+
+    private static class RuntimeIOException extends RuntimeException {
+        RuntimeIOException(IOException cause) {
+            super(cause);
+        }
+
+        @Override
+        public IOException getCause() {
+            return (IOException) super.getCause();
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.native.resources.includes=service-templates/**
 quarkus.banner.enabled=false
 quarkus.devservices.enabled=false
 quarkus.console.enabled=false


### PR DESCRIPTION
## Summary
- Pre-zips built-in service template directories (`activemq6-tool`, `tavily-search-tool`) during Maven build via `maven-antrun-plugin`
- New `ServiceTemplateInitializer` bean deploys them into the data store on `StartupEvent`
- Idempotent: skips templates that already exist in the data store
- Adds native image resource inclusion for the bundled ZIPs

## Test plan
- [ ] Run `mvn verify` — antrun creates ZIPs in `target/classes/service-templates/`
- [ ] Start router and verify logs show "Deployed built-in service template: activemq6-tool" and "tavily-search-tool"
- [ ] `GET /api/v1/service-template/list` returns both templates without manual upload
- [ ] Restart router — templates are skipped ("already deployed, skipping" in debug logs)

## Summary by Sourcery

Bundle built-in service templates into the router backend artifact and automatically deploy them to the service template store on startup.

Enhancements:
- Introduce a startup initializer that reads bundled service template ZIPs from the classpath and deploys any missing templates into the data store in an idempotent manner.

Build:
- Add maven-antrun step to package predefined service template directories into ZIPs and generate a templates index file during resource generation.

Deployment:
- Ensure bundled service template ZIPs are included as resources in native image builds.