### PR TITLE
Fix #1075: allow overriding service name and system when instantiating from a template

### DIFF
--- a/apps/ui/admin/src/Pages/ServiceCatalog/ServiceTemplateWizard.tsx
+++ b/apps/ui/admin/src/Pages/ServiceCatalog/ServiceTemplateWizard.tsx
@@ -31,6 +31,8 @@ export const ServiceTemplateWizard: React.FC<ServiceTemplateWizardProps> = ({
 }) => {
   const [properties, setProperties] = useState<TemplateProperties>({});
   const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [serviceName, setServiceName] = useState("");
+  const [serviceSystem, setServiceSystem] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -69,7 +71,7 @@ export const ServiceTemplateWizard: React.FC<ServiceTemplateWizardProps> = ({
     setError(null);
 
     try {
-      await instantiateTemplate(templateName, formValues);
+      await instantiateTemplate(templateName, formValues, serviceName, serviceSystem);
       onSuccess();
     } catch (err) {
       console.error("Error instantiating template:", err);
@@ -94,14 +96,28 @@ export const ServiceTemplateWizard: React.FC<ServiceTemplateWizardProps> = ({
             subtitle={error}
             hideCloseButton
           />
-        ) : !hasProperties ? (
-          <p>This template has no configurable properties. Click "Create" to instantiate it.</p>
         ) : (
           <div className="template-wizard-form">
             <p className="template-wizard-description">
               Fill in the configuration parameters below to create a new service catalog.
             </p>
-            {Object.entries(properties).map(([system, systemProps]) => (
+            <TextInput
+              id="service-name"
+              labelText="Service name"
+              placeholder="Leave empty to use template default"
+              value={serviceName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setServiceName(e.target.value)}
+              helperText="Optional: override the catalog name from the template"
+            />
+            <TextInput
+              id="service-system"
+              labelText="System identifier"
+              placeholder="Leave empty to use template default"
+              value={serviceSystem}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setServiceSystem(e.target.value)}
+              helperText="Optional: override the system identifier from the template"
+            />
+            {hasProperties && Object.entries(properties).map(([system, systemProps]) => (
               <div key={system} className="template-wizard-system">
                 <FormLabel className="template-wizard-system-label">
                   System: <strong>{system}</strong>

--- a/apps/ui/admin/src/hooks/api/use-service-template.ts
+++ b/apps/ui/admin/src/hooks/api/use-service-template.ts
@@ -67,14 +67,14 @@ export const useServiceTemplate = () => {
   );
 
   const instantiateTemplate = useCallback(
-    (templateName: string, properties: Record<string, string>, options?: RequestInit) => {
+    (templateName: string, properties: Record<string, string>, serviceName?: string, serviceSystem?: string, options?: RequestInit) => {
       return customFetch<{ data: unknown; status: number; headers: Headers }>(
         `${BASE_PATH}/instantiate`,
         {
           ...options,
           method: "POST",
           headers: { "Content-Type": "application/json", ...options?.headers },
-          body: JSON.stringify({ templateName, properties }),
+          body: JSON.stringify({ templateName, properties, serviceName: serviceName || undefined, serviceSystem: serviceSystem || undefined }),
         }
       );
     },

--- a/apps/ui/admin/src/models/templateInstantiationRequest.ts
+++ b/apps/ui/admin/src/models/templateInstantiationRequest.ts
@@ -9,4 +9,6 @@ import type { TemplateInstantiationRequestProperties } from "./templateInstantia
 export interface TemplateInstantiationRequest {
   templateName?: string;
   properties?: TemplateInstantiationRequestProperties;
+  serviceName?: string;
+  serviceSystem?: string;
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -35,6 +35,18 @@ public class ServiceTemplateInstantiate extends BaseCommand {
             arity = "0..1")
     private String properties;
 
+    @CommandLine.Option(
+            names = {"--service-name"},
+            description = "Override the service name from the template",
+            arity = "0..1")
+    private String serviceName;
+
+    @CommandLine.Option(
+            names = {"--service-system"},
+            description = "Override the system identifier from the template",
+            arity = "0..1")
+    private String serviceSystem;
+
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         ServiceTemplateService service = initService(ServiceTemplateService.class, host);
@@ -62,6 +74,8 @@ public class ServiceTemplateInstantiate extends BaseCommand {
                     new ServiceTemplateService.TemplateInstantiationRequest();
             request.setTemplateName(name);
             request.setProperties(propsMap);
+            request.setServiceName(serviceName);
+            request.setServiceSystem(serviceSystem);
 
             service.instantiate(request);
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -222,6 +222,23 @@ public class ServiceTemplateBean {
      * @throws WanakuException if instantiation fails
      */
     public DataStore instantiate(String templateName, Map<String, String> userProperties) throws WanakuException {
+        return instantiate(templateName, userProperties, null, null);
+    }
+
+    /**
+     * Instantiate a service template by filling in property values, with optional overrides
+     * for the service name and system identifier.
+     *
+     * @param templateName the template name
+     * @param userProperties flat map of property key → value (no system namespacing)
+     * @param serviceName optional override for the catalog name (null to use template default)
+     * @param serviceSystem optional override for the system identifier (null to use template default)
+     * @return the newly created service catalog DataStore
+     * @throws WanakuException if instantiation fails
+     */
+    public DataStore instantiate(
+            String templateName, Map<String, String> userProperties, String serviceName, String serviceSystem)
+            throws WanakuException {
         LOG.debugf(
                 "Instantiating template '%s' with %d properties",
                 templateName, userProperties != null ? userProperties.size() : 0);
@@ -234,12 +251,15 @@ public class ServiceTemplateBean {
         ServiceCatalogIndex index = parseIndex(template);
         byte[] originalZip = Base64.getDecoder().decode(template.getData());
 
+        String effectiveName = (serviceName != null && !serviceName.isBlank()) ? serviceName : index.getName();
+
         // Build a new ZIP with modified properties files
-        byte[] newZipBytes = buildCatalogZip(originalZip, index, userProperties != null ? userProperties : Map.of());
+        byte[] newZipBytes = buildCatalogZip(
+                originalZip, index, userProperties != null ? userProperties : Map.of(), effectiveName, serviceSystem);
 
         // Create a new DataStore for the catalog
         DataStore catalog = new DataStore();
-        catalog.setName(index.getName());
+        catalog.setName(effectiveName);
         catalog.setData(Base64.getEncoder().encodeToString(newZipBytes));
 
         // Deploy via ServiceCatalogBean
@@ -249,9 +269,15 @@ public class ServiceTemplateBean {
     /**
      * Build a new catalog ZIP from a template ZIP by:
      * - Removing catalog.properties.* entries from index.properties
+     * - Optionally overriding catalog.name and catalog.services
      * - Replacing property values in service.properties files
      */
-    private byte[] buildCatalogZip(byte[] templateZip, ServiceCatalogIndex index, Map<String, String> userProperties)
+    private byte[] buildCatalogZip(
+            byte[] templateZip,
+            ServiceCatalogIndex index,
+            Map<String, String> userProperties,
+            String catalogName,
+            String serviceSystem)
             throws WanakuException {
         try {
             Map<String, byte[]> entries = new HashMap<>();
@@ -279,6 +305,22 @@ public class ServiceTemplateBean {
             // Remove all catalog.properties.* entries
             for (String system : index.getServiceNames()) {
                 indexProps.remove("catalog.properties." + system);
+            }
+
+            // Override catalog.name if provided
+            if (catalogName != null && !catalogName.isBlank()) {
+                indexProps.setProperty("catalog.name", catalogName);
+            }
+
+            // Override catalog.services if provided, remapping per-system entries
+            if (serviceSystem != null && !serviceSystem.isBlank()) {
+                for (String oldSystem : index.getServiceNames()) {
+                    remapSystemProperty(indexProps, "catalog.routes.", oldSystem, serviceSystem);
+                    remapSystemProperty(indexProps, "catalog.rules.", oldSystem, serviceSystem);
+                    remapSystemProperty(indexProps, "catalog.dependencies.", oldSystem, serviceSystem);
+                    remapSystemProperty(indexProps, "catalog.properties.", oldSystem, serviceSystem);
+                }
+                indexProps.setProperty("catalog.services", serviceSystem);
             }
 
             StringWriter indexWriter = new StringWriter();
@@ -320,6 +362,15 @@ public class ServiceTemplateBean {
             return baos.toByteArray();
         } catch (IOException e) {
             throw new WanakuException("Failed to build catalog ZIP: " + e.getMessage());
+        }
+    }
+
+    private static void remapSystemProperty(Properties props, String prefix, String oldSystem, String newSystem) {
+        String oldKey = prefix + oldSystem;
+        String value = props.getProperty(oldKey);
+        if (value != null) {
+            props.remove(oldKey);
+            props.setProperty(prefix + newSystem, value);
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -318,7 +318,6 @@ public class ServiceTemplateBean {
                     remapSystemProperty(indexProps, "catalog.routes.", oldSystem, serviceSystem);
                     remapSystemProperty(indexProps, "catalog.rules.", oldSystem, serviceSystem);
                     remapSystemProperty(indexProps, "catalog.dependencies.", oldSystem, serviceSystem);
-                    remapSystemProperty(indexProps, "catalog.properties.", oldSystem, serviceSystem);
                 }
                 indexProps.setProperty("catalog.services", serviceSystem);
             }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -235,7 +235,9 @@ public class ServiceTemplateResource {
             throw new WanakuException("Template name is required");
         }
 
-        DataStore catalog = serviceTemplateBean.instantiate(request.getTemplateName(), request.getProperties());
+        DataStore catalog = serviceTemplateBean.instantiate(
+                request.getTemplateName(), request.getProperties(),
+                request.getServiceName(), request.getServiceSystem());
         return new WanakuResponse<>(catalog);
     }
 }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -659,6 +659,12 @@
             "additionalProperties" : {
               "type" : "string"
             }
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
+          "serviceSystem" : {
+            "type" : "string"
           }
         }
       },

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -452,6 +452,10 @@ components:
           type: object
           additionalProperties:
             type: string
+        serviceName:
+          type: string
+        serviceSystem:
+          type: string
     ToolPayload:
       type: object
       properties:

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBeanTest.java
@@ -1,0 +1,240 @@
+package ai.wanaku.backend.api.v1.servicecatalog;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceTemplateBeanTest {
+
+    @Mock
+    DataStoreRepository dataStoreRepository;
+
+    @Mock
+    ServiceCatalogBean serviceCatalogBean;
+
+    @InjectMocks
+    ServiceTemplateBean serviceTemplateBean;
+
+    private DataStore templateStore;
+
+    @BeforeEach
+    void setUp() {
+        templateStore = new DataStore();
+        templateStore.setId("tmpl-1");
+        templateStore.setName("test-template");
+        templateStore.setData(createTemplateZipBase64("my-service", "A template", "sys1"));
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("wanaku.type", "template");
+        templateStore.setLabels(labels);
+    }
+
+    @Test
+    void testInstantiateWithDefaultValues() throws Exception {
+        when(dataStoreRepository.findAllFilterByLabelExpression("wanaku.type=template"))
+                .thenReturn(List.of(templateStore));
+
+        DataStore deployed = new DataStore();
+        deployed.setId("catalog-1");
+        deployed.setName("my-service");
+        when(serviceCatalogBean.deploy(any())).thenReturn(deployed);
+
+        DataStore result = serviceTemplateBean.instantiate("my-service", Map.of());
+
+        assertNotNull(result);
+        assertEquals("catalog-1", result.getId());
+
+        ArgumentCaptor<DataStore> captor = ArgumentCaptor.forClass(DataStore.class);
+        verify(serviceCatalogBean).deploy(captor.capture());
+
+        DataStore catalogArg = captor.getValue();
+        assertEquals("my-service", catalogArg.getName());
+
+        Properties indexProps = extractIndexProperties(catalogArg.getData());
+        assertEquals("my-service", indexProps.getProperty("catalog.name"));
+        assertEquals("sys1", indexProps.getProperty("catalog.services"));
+    }
+
+    @Test
+    void testInstantiateWithServiceNameOverride() throws Exception {
+        when(dataStoreRepository.findAllFilterByLabelExpression("wanaku.type=template"))
+                .thenReturn(List.of(templateStore));
+
+        DataStore deployed = new DataStore();
+        deployed.setId("catalog-2");
+        deployed.setName("custom-name");
+        when(serviceCatalogBean.deploy(any())).thenReturn(deployed);
+
+        DataStore result = serviceTemplateBean.instantiate("my-service", Map.of(), "custom-name", null);
+
+        assertNotNull(result);
+
+        ArgumentCaptor<DataStore> captor = ArgumentCaptor.forClass(DataStore.class);
+        verify(serviceCatalogBean).deploy(captor.capture());
+
+        DataStore catalogArg = captor.getValue();
+        assertEquals("custom-name", catalogArg.getName());
+
+        Properties indexProps = extractIndexProperties(catalogArg.getData());
+        assertEquals("custom-name", indexProps.getProperty("catalog.name"));
+        assertEquals("sys1", indexProps.getProperty("catalog.services"));
+    }
+
+    @Test
+    void testInstantiateWithServiceSystemOverride() throws Exception {
+        when(dataStoreRepository.findAllFilterByLabelExpression("wanaku.type=template"))
+                .thenReturn(List.of(templateStore));
+
+        DataStore deployed = new DataStore();
+        deployed.setId("catalog-3");
+        deployed.setName("my-service");
+        when(serviceCatalogBean.deploy(any())).thenReturn(deployed);
+
+        DataStore result = serviceTemplateBean.instantiate("my-service", Map.of(), null, "custom-system");
+
+        assertNotNull(result);
+
+        ArgumentCaptor<DataStore> captor = ArgumentCaptor.forClass(DataStore.class);
+        verify(serviceCatalogBean).deploy(captor.capture());
+
+        DataStore catalogArg = captor.getValue();
+        assertEquals("my-service", catalogArg.getName());
+
+        Properties indexProps = extractIndexProperties(catalogArg.getData());
+        assertEquals("my-service", indexProps.getProperty("catalog.name"));
+        assertEquals("custom-system", indexProps.getProperty("catalog.services"));
+        assertEquals("sys1/sys1.camel.yaml", indexProps.getProperty("catalog.routes.custom-system"));
+        assertEquals("sys1/sys1.wanaku-rules.yaml", indexProps.getProperty("catalog.rules.custom-system"));
+        assertNull(indexProps.getProperty("catalog.routes.sys1"));
+        assertNull(indexProps.getProperty("catalog.rules.sys1"));
+    }
+
+    @Test
+    void testInstantiateWithBothOverrides() throws Exception {
+        when(dataStoreRepository.findAllFilterByLabelExpression("wanaku.type=template"))
+                .thenReturn(List.of(templateStore));
+
+        DataStore deployed = new DataStore();
+        deployed.setId("catalog-4");
+        deployed.setName("new-name");
+        when(serviceCatalogBean.deploy(any())).thenReturn(deployed);
+
+        DataStore result = serviceTemplateBean.instantiate("my-service", Map.of(), "new-name", "new-system");
+
+        assertNotNull(result);
+
+        ArgumentCaptor<DataStore> captor = ArgumentCaptor.forClass(DataStore.class);
+        verify(serviceCatalogBean).deploy(captor.capture());
+
+        DataStore catalogArg = captor.getValue();
+        assertEquals("new-name", catalogArg.getName());
+
+        Properties indexProps = extractIndexProperties(catalogArg.getData());
+        assertEquals("new-name", indexProps.getProperty("catalog.name"));
+        assertEquals("new-system", indexProps.getProperty("catalog.services"));
+    }
+
+    @Test
+    void testInstantiateWithBlankOverridesUsesDefaults() throws Exception {
+        when(dataStoreRepository.findAllFilterByLabelExpression("wanaku.type=template"))
+                .thenReturn(List.of(templateStore));
+
+        DataStore deployed = new DataStore();
+        deployed.setId("catalog-5");
+        deployed.setName("my-service");
+        when(serviceCatalogBean.deploy(any())).thenReturn(deployed);
+
+        DataStore result = serviceTemplateBean.instantiate("my-service", Map.of(), "", "  ");
+
+        assertNotNull(result);
+
+        ArgumentCaptor<DataStore> captor = ArgumentCaptor.forClass(DataStore.class);
+        verify(serviceCatalogBean).deploy(captor.capture());
+
+        DataStore catalogArg = captor.getValue();
+        assertEquals("my-service", catalogArg.getName());
+
+        Properties indexProps = extractIndexProperties(catalogArg.getData());
+        assertEquals("my-service", indexProps.getProperty("catalog.name"));
+        assertEquals("sys1", indexProps.getProperty("catalog.services"));
+    }
+
+    // --- Helpers ---
+
+    private String createTemplateZipBase64(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("index.properties"));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Properties extractIndexProperties(String base64Zip) throws Exception {
+        byte[] zipBytes = Base64.getDecoder().decode(base64Zip);
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if ("index.properties".equals(entry.getName())) {
+                    Properties props = new Properties();
+                    props.load(new StringReader(new String(zis.readAllBytes())));
+                    return props;
+                }
+                zis.closeEntry();
+            }
+        }
+        throw new AssertionError("index.properties not found in ZIP");
+    }
+}

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
@@ -126,6 +126,8 @@ public interface ServiceTemplateService {
     class TemplateInstantiationRequest {
         private String templateName;
         private Map<String, String> properties;
+        private String serviceName;
+        private String serviceSystem;
 
         public String getTemplateName() {
             return templateName;
@@ -141,6 +143,22 @@ public interface ServiceTemplateService {
 
         public void setProperties(Map<String, String> properties) {
             this.properties = properties;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public void setServiceName(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        public String getServiceSystem() {
+            return serviceSystem;
+        }
+
+        public void setServiceSystem(String serviceSystem) {
+            this.serviceSystem = serviceSystem;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `serviceName` and `serviceSystem` fields to `TemplateInstantiationRequest` DTO
- Update CLI with `--service-name` and `--service-system` options
- Backend applies overrides to `catalog.name` and `catalog.services` in `index.properties`, remapping per-system entries (routes, rules, dependencies) to the new system name
- UI adds two optional text inputs to the template instantiation wizard
- Auto-generated OpenAPI spec and TypeScript model updates included

## Test plan
- [ ] Unit tests: `ServiceTemplateBeanTest` covers default values, name override, system override, both overrides, and blank overrides
- [ ] Manual: instantiate a template via UI with overridden service name — verify catalog appears with new name
- [ ] Manual: instantiate with overridden system identifier — verify catalog deploys without validation errors
- [ ] Manual: instantiate without overrides — verify backward-compatible behavior (template defaults used)

## Summary by Sourcery

Allow service templates to be instantiated with optional overrides for catalog name and system identifier across backend, CLI, and UI.

New Features:
- Support overriding catalog name and system identifier when instantiating a service template via backend API.
- Expose --service-name and --service-system options in the CLI for template instantiation.
- Add optional service name and system identifier fields to the UI service template wizard.

Enhancements:
- Propagate service name and system identifier overrides through the template instantiation pipeline, including OpenAPI spec and TypeScript models.
- Adjust catalog ZIP building to apply name overrides and remap per-system catalog properties to the new system identifier.

Tests:
- Add unit tests for ServiceTemplateBean covering default behavior, name override, system override, combined overrides, and blank override handling.