### PR TITLE
Fix #1087: improve logging consistency

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
@@ -126,7 +126,7 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
                 if ("camel-integration-capability".equals(capabilitiesSpec.getType())) {
                     desiredDeployment = makeDesiredCiCCapabilityDeployment(resource, context, capabilitiesSpec);
                 } else {
-                    LOG.error("Invalid capability type: " + capabilitiesSpec.getType());
+                    LOG.errorf("Invalid capability type: %s", capabilitiesSpec.getType());
                     throw new WanakuException("Invalid capability type: " + capabilitiesSpec.getType());
                 }
             }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
@@ -21,7 +21,7 @@ public class WanakuExceptionMapper implements ExceptionMapper<WanakuException> {
             content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
     @Override
     public Response toResponse(WanakuException e) {
-        LOG.error(e);
+        LOG.error("Request failed", e);
 
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(new WanakuResponse<Void>(e.getMessage()))

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
@@ -95,6 +95,7 @@ public class ResourcesBean extends AbstractBean<ResourceReference> {
                 expose(resourceReference);
             } catch (EntityAlreadyExistsException e) {
                 LOG.errorf(
+                        e,
                         "Error registering a resource named %s during startup, but it already exists",
                         resourceReference.getName());
             }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -132,6 +132,7 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
                 registerTool(toolReference);
             } catch (EntityAlreadyExistsException e) {
                 LOG.errorf(
+                        e,
                         "Error registering a tool named %s during startup, but it already exists",
                         toolReference.getName());
             }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -56,7 +56,7 @@ public class ToolsetReposBean {
     private void registerDefaultRepo() {
         try {
             if (findByName(DEFAULT_REPO_NAME) == null) {
-                LOG.info("Registering default toolset repository: " + DEFAULT_REPO_NAME);
+                LOG.infof("Registering default toolset repository: %s", DEFAULT_REPO_NAME);
                 add(DEFAULT_REPO_NAME, DEFAULT_REPO_URL, DEFAULT_REPO_DESCRIPTION, null, DEFAULT_BRANCH);
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Fix string concatenation in log calls to use parameterized logging
- Include exception objects in log calls where they were previously swallowed
- Add descriptive message to exception mapper log call

## Changes
- WanakuCapabilityReconciler: change string concat log to parameterized `errorf`
- ToolsBean/ResourcesBean: include exception in `errorf` calls during startup load
- WanakuExceptionMapper: add descriptive message to `LOG.error` call
- ToolsetReposBean: change string concat `LOG.info` to parameterized `LOG.infof`

Fixes #1087

## Summary by Sourcery

Improve consistency and clarity of logging across operator and backend components.

Bug Fixes:
- Log Wanaku exception responses with a descriptive message instead of logging the exception alone.

Enhancements:
- Standardize log messages to use parameterized logging instead of string concatenation.
- Include exception objects in startup logging for tools and resources to preserve stack traces.