### PR TITLE
Fix #1079: standardize error handling across REST API

### DIFF
--- a/apps/ui/admin/src/api/wanaku-router-api.ts
+++ b/apps/ui/admin/src/api/wanaku-router-api.ts
@@ -45,7 +45,6 @@ import type {
   TemplateInstantiationRequest,
   ToolPayload,
   ToolReference,
-  WanakuResponse,
   WanakuResponseDataStore,
   WanakuResponseDeploymentInstructions,
   WanakuResponseFleetStatus,
@@ -399,18 +398,10 @@ export type putApiV1DataStoreResponse400 = {
   status: 400;
 };
 
-export type putApiV1DataStoreResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1DataStoreResponseSuccess = putApiV1DataStoreResponse200 & {
   headers: Headers;
 };
-export type putApiV1DataStoreResponseError = (
-  | putApiV1DataStoreResponse400
-  | putApiV1DataStoreResponse500
-) & {
+export type putApiV1DataStoreResponseError = putApiV1DataStoreResponse400 & {
   headers: Headers;
 };
 
@@ -442,23 +433,11 @@ export type deleteApiV1DataStoreResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1DataStoreResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1DataStoreResponseSuccess =
   deleteApiV1DataStoreResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1DataStoreResponseError =
-  deleteApiV1DataStoreResponse500 & {
-    headers: Headers;
-  };
-
-export type deleteApiV1DataStoreResponse =
-  | deleteApiV1DataStoreResponseSuccess
-  | deleteApiV1DataStoreResponseError;
+export type deleteApiV1DataStoreResponse = deleteApiV1DataStoreResponseSuccess;
 
 export const getDeleteApiV1DataStoreUrl = (
   params?: DeleteApiV1DataStoreParams,
@@ -499,21 +478,10 @@ export type getApiV1DataStoreResponse200 = {
   status: 200;
 };
 
-export type getApiV1DataStoreResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1DataStoreResponseSuccess = getApiV1DataStoreResponse200 & {
   headers: Headers;
 };
-export type getApiV1DataStoreResponseError = getApiV1DataStoreResponse500 & {
-  headers: Headers;
-};
-
-export type getApiV1DataStoreResponse =
-  | getApiV1DataStoreResponseSuccess
-  | getApiV1DataStoreResponseError;
+export type getApiV1DataStoreResponse = getApiV1DataStoreResponseSuccess;
 
 export const getGetApiV1DataStoreUrl = (params?: GetApiV1DataStoreParams) => {
   const normalizedParams = new URLSearchParams();
@@ -557,19 +525,11 @@ export type postApiV1DataStoreResponse400 = {
   status: 400;
 };
 
-export type postApiV1DataStoreResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1DataStoreResponseSuccess =
   postApiV1DataStoreResponse200 & {
     headers: Headers;
   };
-export type postApiV1DataStoreResponseError = (
-  | postApiV1DataStoreResponse400
-  | postApiV1DataStoreResponse500
-) & {
+export type postApiV1DataStoreResponseError = postApiV1DataStoreResponse400 & {
   headers: Headers;
 };
 
@@ -601,23 +561,12 @@ export type deleteApiV1DataStoreLabelsResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1DataStoreLabelsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1DataStoreLabelsResponseSuccess =
   deleteApiV1DataStoreLabelsResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1DataStoreLabelsResponseError =
-  deleteApiV1DataStoreLabelsResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1DataStoreLabelsResponse =
-  | deleteApiV1DataStoreLabelsResponseSuccess
-  | deleteApiV1DataStoreLabelsResponseError;
+  deleteApiV1DataStoreLabelsResponseSuccess;
 
 export const getDeleteApiV1DataStoreLabelsUrl = (
   params?: DeleteApiV1DataStoreLabelsParams,
@@ -658,23 +607,12 @@ export type deleteApiV1DataStoreIdResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1DataStoreIdResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1DataStoreIdResponseSuccess =
   deleteApiV1DataStoreIdResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1DataStoreIdResponseError =
-  deleteApiV1DataStoreIdResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1DataStoreIdResponse =
-  | deleteApiV1DataStoreIdResponseSuccess
-  | deleteApiV1DataStoreIdResponseError;
+  deleteApiV1DataStoreIdResponseSuccess;
 
 export const getDeleteApiV1DataStoreIdUrl = (id: string) => {
   return `/api/v1/data-store/${id}`;
@@ -701,23 +639,11 @@ export type getApiV1DataStoreIdResponse200 = {
   status: 200;
 };
 
-export type getApiV1DataStoreIdResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1DataStoreIdResponseSuccess =
   getApiV1DataStoreIdResponse200 & {
     headers: Headers;
   };
-export type getApiV1DataStoreIdResponseError =
-  getApiV1DataStoreIdResponse500 & {
-    headers: Headers;
-  };
-
-export type getApiV1DataStoreIdResponse =
-  | getApiV1DataStoreIdResponseSuccess
-  | getApiV1DataStoreIdResponseError;
+export type getApiV1DataStoreIdResponse = getApiV1DataStoreIdResponseSuccess;
 
 export const getGetApiV1DataStoreIdUrl = (id: string) => {
   return `/api/v1/data-store/${id}`;
@@ -788,18 +714,10 @@ export type postApiV1ForwardsResponse400 = {
   status: 400;
 };
 
-export type postApiV1ForwardsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ForwardsResponseSuccess = postApiV1ForwardsResponse200 & {
   headers: Headers;
 };
-export type postApiV1ForwardsResponseError = (
-  | postApiV1ForwardsResponse400
-  | postApiV1ForwardsResponse500
-) & {
+export type postApiV1ForwardsResponseError = postApiV1ForwardsResponse400 & {
   headers: Headers;
 };
 
@@ -836,21 +754,14 @@ export type putApiV1ForwardsNameResponse400 = {
   status: 400;
 };
 
-export type putApiV1ForwardsNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1ForwardsNameResponseSuccess =
   putApiV1ForwardsNameResponse200 & {
     headers: Headers;
   };
-export type putApiV1ForwardsNameResponseError = (
-  | putApiV1ForwardsNameResponse400
-  | putApiV1ForwardsNameResponse500
-) & {
-  headers: Headers;
-};
+export type putApiV1ForwardsNameResponseError =
+  putApiV1ForwardsNameResponse400 & {
+    headers: Headers;
+  };
 
 export type putApiV1ForwardsNameResponse =
   | putApiV1ForwardsNameResponseSuccess
@@ -947,23 +858,12 @@ export type postApiV1ForwardsNameRefreshesResponse200 = {
   status: 200;
 };
 
-export type postApiV1ForwardsNameRefreshesResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ForwardsNameRefreshesResponseSuccess =
   postApiV1ForwardsNameRefreshesResponse200 & {
     headers: Headers;
   };
-export type postApiV1ForwardsNameRefreshesResponseError =
-  postApiV1ForwardsNameRefreshesResponse500 & {
-    headers: Headers;
-  };
-
 export type postApiV1ForwardsNameRefreshesResponse =
-  | postApiV1ForwardsNameRefreshesResponseSuccess
-  | postApiV1ForwardsNameRefreshesResponseError;
+  postApiV1ForwardsNameRefreshesResponseSuccess;
 
 export const getPostApiV1ForwardsNameRefreshesUrl = (name: string) => {
   return `/api/v1/forwards/${name}/refreshes`;
@@ -1457,18 +1357,10 @@ export type putApiV1PromptsResponse400 = {
   status: 400;
 };
 
-export type putApiV1PromptsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1PromptsResponseSuccess = putApiV1PromptsResponse200 & {
   headers: Headers;
 };
-export type putApiV1PromptsResponseError = (
-  | putApiV1PromptsResponse400
-  | putApiV1PromptsResponse500
-) & {
+export type putApiV1PromptsResponseError = putApiV1PromptsResponse400 & {
   headers: Headers;
 };
 
@@ -1500,22 +1392,11 @@ export type deleteApiV1PromptsResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1PromptsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1PromptsResponseSuccess =
   deleteApiV1PromptsResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1PromptsResponseError = deleteApiV1PromptsResponse500 & {
-  headers: Headers;
-};
-
-export type deleteApiV1PromptsResponse =
-  | deleteApiV1PromptsResponseSuccess
-  | deleteApiV1PromptsResponseError;
+export type deleteApiV1PromptsResponse = deleteApiV1PromptsResponseSuccess;
 
 export const getDeleteApiV1PromptsUrl = (params?: DeleteApiV1PromptsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -1554,21 +1435,10 @@ export type getApiV1PromptsResponse200 = {
   status: 200;
 };
 
-export type getApiV1PromptsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1PromptsResponseSuccess = getApiV1PromptsResponse200 & {
   headers: Headers;
 };
-export type getApiV1PromptsResponseError = getApiV1PromptsResponse500 & {
-  headers: Headers;
-};
-
-export type getApiV1PromptsResponse =
-  | getApiV1PromptsResponseSuccess
-  | getApiV1PromptsResponseError;
+export type getApiV1PromptsResponse = getApiV1PromptsResponseSuccess;
 
 export const getGetApiV1PromptsUrl = () => {
   return `/api/v1/prompts`;
@@ -1596,18 +1466,10 @@ export type postApiV1PromptsResponse400 = {
   status: 400;
 };
 
-export type postApiV1PromptsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1PromptsResponseSuccess = postApiV1PromptsResponse200 & {
   headers: Headers;
 };
-export type postApiV1PromptsResponseError = (
-  | postApiV1PromptsResponse400
-  | postApiV1PromptsResponse500
-) & {
+export type postApiV1PromptsResponseError = postApiV1PromptsResponse400 & {
   headers: Headers;
 };
 
@@ -1644,21 +1506,14 @@ export type postApiV1PromptsPayloadsResponse400 = {
   status: 400;
 };
 
-export type postApiV1PromptsPayloadsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1PromptsPayloadsResponseSuccess =
   postApiV1PromptsPayloadsResponse200 & {
     headers: Headers;
   };
-export type postApiV1PromptsPayloadsResponseError = (
-  | postApiV1PromptsPayloadsResponse400
-  | postApiV1PromptsPayloadsResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1PromptsPayloadsResponseError =
+  postApiV1PromptsPayloadsResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1PromptsPayloadsResponse =
   | postApiV1PromptsPayloadsResponseSuccess
@@ -1691,23 +1546,11 @@ export type getApiV1PromptsNameResponse200 = {
   status: 200;
 };
 
-export type getApiV1PromptsNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1PromptsNameResponseSuccess =
   getApiV1PromptsNameResponse200 & {
     headers: Headers;
   };
-export type getApiV1PromptsNameResponseError =
-  getApiV1PromptsNameResponse500 & {
-    headers: Headers;
-  };
-
-export type getApiV1PromptsNameResponse =
-  | getApiV1PromptsNameResponseSuccess
-  | getApiV1PromptsNameResponseError;
+export type getApiV1PromptsNameResponse = getApiV1PromptsNameResponseSuccess;
 
 export const getGetApiV1PromptsNameUrl = (name: string) => {
   return `/api/v1/prompts/${name}`;
@@ -1734,21 +1577,10 @@ export type getApiV1ResourcesResponse200 = {
   status: 200;
 };
 
-export type getApiV1ResourcesResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ResourcesResponseSuccess = getApiV1ResourcesResponse200 & {
   headers: Headers;
 };
-export type getApiV1ResourcesResponseError = getApiV1ResourcesResponse500 & {
-  headers: Headers;
-};
-
-export type getApiV1ResourcesResponse =
-  | getApiV1ResourcesResponseSuccess
-  | getApiV1ResourcesResponseError;
+export type getApiV1ResourcesResponse = getApiV1ResourcesResponseSuccess;
 
 export const getGetApiV1ResourcesUrl = (params?: GetApiV1ResourcesParams) => {
   const normalizedParams = new URLSearchParams();
@@ -1792,19 +1624,11 @@ export type postApiV1ResourcesResponse400 = {
   status: 400;
 };
 
-export type postApiV1ResourcesResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ResourcesResponseSuccess =
   postApiV1ResourcesResponse200 & {
     headers: Headers;
   };
-export type postApiV1ResourcesResponseError = (
-  | postApiV1ResourcesResponse400
-  | postApiV1ResourcesResponse500
-) & {
+export type postApiV1ResourcesResponseError = postApiV1ResourcesResponse400 & {
   headers: Headers;
 };
 
@@ -1841,21 +1665,14 @@ export type postApiV1ResourcesPayloadsResponse400 = {
   status: 400;
 };
 
-export type postApiV1ResourcesPayloadsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ResourcesPayloadsResponseSuccess =
   postApiV1ResourcesPayloadsResponse200 & {
     headers: Headers;
   };
-export type postApiV1ResourcesPayloadsResponseError = (
-  | postApiV1ResourcesPayloadsResponse400
-  | postApiV1ResourcesPayloadsResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ResourcesPayloadsResponseError =
+  postApiV1ResourcesPayloadsResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ResourcesPayloadsResponse =
   | postApiV1ResourcesPayloadsResponseSuccess
@@ -1893,21 +1710,14 @@ export type putApiV1ResourcesNameResponse400 = {
   status: 400;
 };
 
-export type putApiV1ResourcesNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1ResourcesNameResponseSuccess =
   putApiV1ResourcesNameResponse200 & {
     headers: Headers;
   };
-export type putApiV1ResourcesNameResponseError = (
-  | putApiV1ResourcesNameResponse400
-  | putApiV1ResourcesNameResponse500
-) & {
-  headers: Headers;
-};
+export type putApiV1ResourcesNameResponseError =
+  putApiV1ResourcesNameResponse400 & {
+    headers: Headers;
+  };
 
 export type putApiV1ResourcesNameResponse =
   | putApiV1ResourcesNameResponseSuccess
@@ -1941,23 +1751,12 @@ export type deleteApiV1ResourcesNameResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ResourcesNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ResourcesNameResponseSuccess =
   deleteApiV1ResourcesNameResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1ResourcesNameResponseError =
-  deleteApiV1ResourcesNameResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1ResourcesNameResponse =
-  | deleteApiV1ResourcesNameResponseSuccess
-  | deleteApiV1ResourcesNameResponseError;
+  deleteApiV1ResourcesNameResponseSuccess;
 
 export const getDeleteApiV1ResourcesNameUrl = (name: string) => {
   return `/api/v1/resources/${name}`;
@@ -1984,23 +1783,12 @@ export type getApiV1ResourcesNameResponse200 = {
   status: 200;
 };
 
-export type getApiV1ResourcesNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ResourcesNameResponseSuccess =
   getApiV1ResourcesNameResponse200 & {
     headers: Headers;
   };
-export type getApiV1ResourcesNameResponseError =
-  getApiV1ResourcesNameResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ResourcesNameResponse =
-  | getApiV1ResourcesNameResponseSuccess
-  | getApiV1ResourcesNameResponseError;
+  getApiV1ResourcesNameResponseSuccess;
 
 export const getGetApiV1ResourcesNameUrl = (name: string) => {
   return `/api/v1/resources/${name}`;
@@ -2032,21 +1820,14 @@ export type postApiV1ServiceCatalogDeployResponse400 = {
   status: 400;
 };
 
-export type postApiV1ServiceCatalogDeployResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ServiceCatalogDeployResponseSuccess =
   postApiV1ServiceCatalogDeployResponse200 & {
     headers: Headers;
   };
-export type postApiV1ServiceCatalogDeployResponseError = (
-  | postApiV1ServiceCatalogDeployResponse400
-  | postApiV1ServiceCatalogDeployResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ServiceCatalogDeployResponseError =
+  postApiV1ServiceCatalogDeployResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ServiceCatalogDeployResponse =
   | postApiV1ServiceCatalogDeployResponseSuccess
@@ -2079,23 +1860,12 @@ export type getApiV1ServiceCatalogDownloadResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceCatalogDownloadResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceCatalogDownloadResponseSuccess =
   getApiV1ServiceCatalogDownloadResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceCatalogDownloadResponseError =
-  getApiV1ServiceCatalogDownloadResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceCatalogDownloadResponse =
-  | getApiV1ServiceCatalogDownloadResponseSuccess
-  | getApiV1ServiceCatalogDownloadResponseError;
+  getApiV1ServiceCatalogDownloadResponseSuccess;
 
 export const getGetApiV1ServiceCatalogDownloadUrl = (
   params?: GetApiV1ServiceCatalogDownloadParams,
@@ -2136,23 +1906,12 @@ export type getApiV1ServiceCatalogGetResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceCatalogGetResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceCatalogGetResponseSuccess =
   getApiV1ServiceCatalogGetResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceCatalogGetResponseError =
-  getApiV1ServiceCatalogGetResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceCatalogGetResponse =
-  | getApiV1ServiceCatalogGetResponseSuccess
-  | getApiV1ServiceCatalogGetResponseError;
+  getApiV1ServiceCatalogGetResponseSuccess;
 
 export const getGetApiV1ServiceCatalogGetUrl = (
   params?: GetApiV1ServiceCatalogGetParams,
@@ -2193,23 +1952,12 @@ export type getApiV1ServiceCatalogInstructionsResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceCatalogInstructionsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceCatalogInstructionsResponseSuccess =
   getApiV1ServiceCatalogInstructionsResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceCatalogInstructionsResponseError =
-  getApiV1ServiceCatalogInstructionsResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceCatalogInstructionsResponse =
-  | getApiV1ServiceCatalogInstructionsResponseSuccess
-  | getApiV1ServiceCatalogInstructionsResponseError;
+  getApiV1ServiceCatalogInstructionsResponseSuccess;
 
 export const getGetApiV1ServiceCatalogInstructionsUrl = (
   params?: GetApiV1ServiceCatalogInstructionsParams,
@@ -2250,23 +1998,12 @@ export type getApiV1ServiceCatalogListResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceCatalogListResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceCatalogListResponseSuccess =
   getApiV1ServiceCatalogListResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceCatalogListResponseError =
-  getApiV1ServiceCatalogListResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceCatalogListResponse =
-  | getApiV1ServiceCatalogListResponseSuccess
-  | getApiV1ServiceCatalogListResponseError;
+  getApiV1ServiceCatalogListResponseSuccess;
 
 export const getGetApiV1ServiceCatalogListUrl = (
   params?: GetApiV1ServiceCatalogListParams,
@@ -2307,23 +2044,12 @@ export type deleteApiV1ServiceCatalogRemoveResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ServiceCatalogRemoveResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ServiceCatalogRemoveResponseSuccess =
   deleteApiV1ServiceCatalogRemoveResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1ServiceCatalogRemoveResponseError =
-  deleteApiV1ServiceCatalogRemoveResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1ServiceCatalogRemoveResponse =
-  | deleteApiV1ServiceCatalogRemoveResponseSuccess
-  | deleteApiV1ServiceCatalogRemoveResponseError;
+  deleteApiV1ServiceCatalogRemoveResponseSuccess;
 
 export const getDeleteApiV1ServiceCatalogRemoveUrl = (
   params?: DeleteApiV1ServiceCatalogRemoveParams,
@@ -2369,21 +2095,14 @@ export type postApiV1ServiceTemplateDeployResponse400 = {
   status: 400;
 };
 
-export type postApiV1ServiceTemplateDeployResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ServiceTemplateDeployResponseSuccess =
   postApiV1ServiceTemplateDeployResponse200 & {
     headers: Headers;
   };
-export type postApiV1ServiceTemplateDeployResponseError = (
-  | postApiV1ServiceTemplateDeployResponse400
-  | postApiV1ServiceTemplateDeployResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ServiceTemplateDeployResponseError =
+  postApiV1ServiceTemplateDeployResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ServiceTemplateDeployResponse =
   | postApiV1ServiceTemplateDeployResponseSuccess
@@ -2416,23 +2135,12 @@ export type getApiV1ServiceTemplateDownloadResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceTemplateDownloadResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceTemplateDownloadResponseSuccess =
   getApiV1ServiceTemplateDownloadResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceTemplateDownloadResponseError =
-  getApiV1ServiceTemplateDownloadResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceTemplateDownloadResponse =
-  | getApiV1ServiceTemplateDownloadResponseSuccess
-  | getApiV1ServiceTemplateDownloadResponseError;
+  getApiV1ServiceTemplateDownloadResponseSuccess;
 
 export const getGetApiV1ServiceTemplateDownloadUrl = (
   params?: GetApiV1ServiceTemplateDownloadParams,
@@ -2473,23 +2181,12 @@ export type getApiV1ServiceTemplateGetResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceTemplateGetResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceTemplateGetResponseSuccess =
   getApiV1ServiceTemplateGetResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceTemplateGetResponseError =
-  getApiV1ServiceTemplateGetResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceTemplateGetResponse =
-  | getApiV1ServiceTemplateGetResponseSuccess
-  | getApiV1ServiceTemplateGetResponseError;
+  getApiV1ServiceTemplateGetResponseSuccess;
 
 export const getGetApiV1ServiceTemplateGetUrl = (
   params?: GetApiV1ServiceTemplateGetParams,
@@ -2535,21 +2232,14 @@ export type postApiV1ServiceTemplateInstantiateResponse400 = {
   status: 400;
 };
 
-export type postApiV1ServiceTemplateInstantiateResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ServiceTemplateInstantiateResponseSuccess =
   postApiV1ServiceTemplateInstantiateResponse200 & {
     headers: Headers;
   };
-export type postApiV1ServiceTemplateInstantiateResponseError = (
-  | postApiV1ServiceTemplateInstantiateResponse400
-  | postApiV1ServiceTemplateInstantiateResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ServiceTemplateInstantiateResponseError =
+  postApiV1ServiceTemplateInstantiateResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ServiceTemplateInstantiateResponse =
   | postApiV1ServiceTemplateInstantiateResponseSuccess
@@ -2628,23 +2318,12 @@ export type getApiV1ServiceTemplatePropertiesResponse200 = {
   status: 200;
 };
 
-export type getApiV1ServiceTemplatePropertiesResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ServiceTemplatePropertiesResponseSuccess =
   getApiV1ServiceTemplatePropertiesResponse200 & {
     headers: Headers;
   };
-export type getApiV1ServiceTemplatePropertiesResponseError =
-  getApiV1ServiceTemplatePropertiesResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ServiceTemplatePropertiesResponse =
-  | getApiV1ServiceTemplatePropertiesResponseSuccess
-  | getApiV1ServiceTemplatePropertiesResponseError;
+  getApiV1ServiceTemplatePropertiesResponseSuccess;
 
 export const getGetApiV1ServiceTemplatePropertiesUrl = (
   params?: GetApiV1ServiceTemplatePropertiesParams,
@@ -2685,23 +2364,12 @@ export type deleteApiV1ServiceTemplateRemoveResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ServiceTemplateRemoveResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ServiceTemplateRemoveResponseSuccess =
   deleteApiV1ServiceTemplateRemoveResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1ServiceTemplateRemoveResponseError =
-  deleteApiV1ServiceTemplateRemoveResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1ServiceTemplateRemoveResponse =
-  | deleteApiV1ServiceTemplateRemoveResponseSuccess
-  | deleteApiV1ServiceTemplateRemoveResponseError;
+  deleteApiV1ServiceTemplateRemoveResponseSuccess;
 
 export const getDeleteApiV1ServiceTemplateRemoveUrl = (
   params?: DeleteApiV1ServiceTemplateRemoveParams,
@@ -2742,21 +2410,10 @@ export type deleteApiV1ToolsResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ToolsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ToolsResponseSuccess = deleteApiV1ToolsResponse200 & {
   headers: Headers;
 };
-export type deleteApiV1ToolsResponseError = deleteApiV1ToolsResponse500 & {
-  headers: Headers;
-};
-
-export type deleteApiV1ToolsResponse =
-  | deleteApiV1ToolsResponseSuccess
-  | deleteApiV1ToolsResponseError;
+export type deleteApiV1ToolsResponse = deleteApiV1ToolsResponseSuccess;
 
 export const getDeleteApiV1ToolsUrl = (params?: DeleteApiV1ToolsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -2792,21 +2449,10 @@ export type getApiV1ToolsResponse200 = {
   status: 200;
 };
 
-export type getApiV1ToolsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ToolsResponseSuccess = getApiV1ToolsResponse200 & {
   headers: Headers;
 };
-export type getApiV1ToolsResponseError = getApiV1ToolsResponse500 & {
-  headers: Headers;
-};
-
-export type getApiV1ToolsResponse =
-  | getApiV1ToolsResponseSuccess
-  | getApiV1ToolsResponseError;
+export type getApiV1ToolsResponse = getApiV1ToolsResponseSuccess;
 
 export const getGetApiV1ToolsUrl = (params?: GetApiV1ToolsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -2847,18 +2493,10 @@ export type postApiV1ToolsResponse400 = {
   status: 400;
 };
 
-export type postApiV1ToolsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ToolsResponseSuccess = postApiV1ToolsResponse200 & {
   headers: Headers;
 };
-export type postApiV1ToolsResponseError = (
-  | postApiV1ToolsResponse400
-  | postApiV1ToolsResponse500
-) & {
+export type postApiV1ToolsResponseError = postApiV1ToolsResponse400 & {
   headers: Headers;
 };
 
@@ -2895,21 +2533,14 @@ export type postApiV1ToolsPayloadsResponse400 = {
   status: 400;
 };
 
-export type postApiV1ToolsPayloadsResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ToolsPayloadsResponseSuccess =
   postApiV1ToolsPayloadsResponse200 & {
     headers: Headers;
   };
-export type postApiV1ToolsPayloadsResponseError = (
-  | postApiV1ToolsPayloadsResponse400
-  | postApiV1ToolsPayloadsResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ToolsPayloadsResponseError =
+  postApiV1ToolsPayloadsResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ToolsPayloadsResponse =
   | postApiV1ToolsPayloadsResponseSuccess
@@ -2947,18 +2578,10 @@ export type putApiV1ToolsNameResponse400 = {
   status: 400;
 };
 
-export type putApiV1ToolsNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1ToolsNameResponseSuccess = putApiV1ToolsNameResponse200 & {
   headers: Headers;
 };
-export type putApiV1ToolsNameResponseError = (
-  | putApiV1ToolsNameResponse400
-  | putApiV1ToolsNameResponse500
-) & {
+export type putApiV1ToolsNameResponseError = putApiV1ToolsNameResponse400 & {
   headers: Headers;
 };
 
@@ -2991,23 +2614,11 @@ export type deleteApiV1ToolsNameResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ToolsNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ToolsNameResponseSuccess =
   deleteApiV1ToolsNameResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1ToolsNameResponseError =
-  deleteApiV1ToolsNameResponse500 & {
-    headers: Headers;
-  };
-
-export type deleteApiV1ToolsNameResponse =
-  | deleteApiV1ToolsNameResponseSuccess
-  | deleteApiV1ToolsNameResponseError;
+export type deleteApiV1ToolsNameResponse = deleteApiV1ToolsNameResponseSuccess;
 
 export const getDeleteApiV1ToolsNameUrl = (name: string) => {
   return `/api/v1/tools/${name}`;
@@ -3034,21 +2645,10 @@ export type getApiV1ToolsNameResponse200 = {
   status: 200;
 };
 
-export type getApiV1ToolsNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ToolsNameResponseSuccess = getApiV1ToolsNameResponse200 & {
   headers: Headers;
 };
-export type getApiV1ToolsNameResponseError = getApiV1ToolsNameResponse500 & {
-  headers: Headers;
-};
-
-export type getApiV1ToolsNameResponse =
-  | getApiV1ToolsNameResponseSuccess
-  | getApiV1ToolsNameResponseError;
+export type getApiV1ToolsNameResponse = getApiV1ToolsNameResponseSuccess;
 
 export const getGetApiV1ToolsNameUrl = (name: string) => {
   return `/api/v1/tools/${name}`;
@@ -3107,21 +2707,14 @@ export type postApiV1ToolsetReposResponse400 = {
   status: 400;
 };
 
-export type postApiV1ToolsetReposResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type postApiV1ToolsetReposResponseSuccess =
   postApiV1ToolsetReposResponse200 & {
     headers: Headers;
   };
-export type postApiV1ToolsetReposResponseError = (
-  | postApiV1ToolsetReposResponse400
-  | postApiV1ToolsetReposResponse500
-) & {
-  headers: Headers;
-};
+export type postApiV1ToolsetReposResponseError =
+  postApiV1ToolsetReposResponse400 & {
+    headers: Headers;
+  };
 
 export type postApiV1ToolsetReposResponse =
   | postApiV1ToolsetReposResponseSuccess
@@ -3159,21 +2752,14 @@ export type putApiV1ToolsetReposNameResponse400 = {
   status: 400;
 };
 
-export type putApiV1ToolsetReposNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type putApiV1ToolsetReposNameResponseSuccess =
   putApiV1ToolsetReposNameResponse200 & {
     headers: Headers;
   };
-export type putApiV1ToolsetReposNameResponseError = (
-  | putApiV1ToolsetReposNameResponse400
-  | putApiV1ToolsetReposNameResponse500
-) & {
-  headers: Headers;
-};
+export type putApiV1ToolsetReposNameResponseError =
+  putApiV1ToolsetReposNameResponse400 & {
+    headers: Headers;
+  };
 
 export type putApiV1ToolsetReposNameResponse =
   | putApiV1ToolsetReposNameResponseSuccess
@@ -3207,23 +2793,12 @@ export type deleteApiV1ToolsetReposNameResponse200 = {
   status: 200;
 };
 
-export type deleteApiV1ToolsetReposNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type deleteApiV1ToolsetReposNameResponseSuccess =
   deleteApiV1ToolsetReposNameResponse200 & {
     headers: Headers;
   };
-export type deleteApiV1ToolsetReposNameResponseError =
-  deleteApiV1ToolsetReposNameResponse500 & {
-    headers: Headers;
-  };
-
 export type deleteApiV1ToolsetReposNameResponse =
-  | deleteApiV1ToolsetReposNameResponseSuccess
-  | deleteApiV1ToolsetReposNameResponseError;
+  deleteApiV1ToolsetReposNameResponseSuccess;
 
 export const getDeleteApiV1ToolsetReposNameUrl = (name: string) => {
   return `/api/v1/toolset-repos/${name}`;
@@ -3250,23 +2825,12 @@ export type getApiV1ToolsetReposNameBrowseResponse200 = {
   status: 200;
 };
 
-export type getApiV1ToolsetReposNameBrowseResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ToolsetReposNameBrowseResponseSuccess =
   getApiV1ToolsetReposNameBrowseResponse200 & {
     headers: Headers;
   };
-export type getApiV1ToolsetReposNameBrowseResponseError =
-  getApiV1ToolsetReposNameBrowseResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ToolsetReposNameBrowseResponse =
-  | getApiV1ToolsetReposNameBrowseResponseSuccess
-  | getApiV1ToolsetReposNameBrowseResponseError;
+  getApiV1ToolsetReposNameBrowseResponseSuccess;
 
 export const getGetApiV1ToolsetReposNameBrowseUrl = (name: string) => {
   return `/api/v1/toolset-repos/${name}/browse`;
@@ -3293,23 +2857,12 @@ export type getApiV1ToolsetReposNameToolsetsToolsetNameResponse200 = {
   status: 200;
 };
 
-export type getApiV1ToolsetReposNameToolsetsToolsetNameResponse500 = {
-  data: WanakuResponse;
-  status: 500;
-};
-
 export type getApiV1ToolsetReposNameToolsetsToolsetNameResponseSuccess =
   getApiV1ToolsetReposNameToolsetsToolsetNameResponse200 & {
     headers: Headers;
   };
-export type getApiV1ToolsetReposNameToolsetsToolsetNameResponseError =
-  getApiV1ToolsetReposNameToolsetsToolsetNameResponse500 & {
-    headers: Headers;
-  };
-
 export type getApiV1ToolsetReposNameToolsetsToolsetNameResponse =
-  | getApiV1ToolsetReposNameToolsetsToolsetNameResponseSuccess
-  | getApiV1ToolsetReposNameToolsetsToolsetNameResponseError;
+  getApiV1ToolsetReposNameToolsetsToolsetNameResponseSuccess;
 
 export const getGetApiV1ToolsetReposNameToolsetsToolsetNameUrl = (
   name: string,

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -42,10 +42,9 @@ public class DataStoresResource {
      *
      * @param dataStore the data store to add
      * @return response with the created data store
-     * @throws WanakuException if addition fails
      */
     @POST
-    public WanakuResponse<DataStore> add(DataStore dataStore) throws WanakuException {
+    public WanakuResponse<DataStore> add(DataStore dataStore) {
         LOG.debugf("REST: Adding data store: %s", dataStore);
         DataStore result = dataStoresBean.add(dataStore);
         return new WanakuResponse<>(result);
@@ -57,10 +56,9 @@ public class DataStoresResource {
      *
      * @param dataStore the data store to update (must include ID)
      * @return HTTP 200 if updated successfully
-     * @throws WanakuException if update fails
      */
     @PUT
-    public Response update(DataStore dataStore) throws WanakuException {
+    public Response update(DataStore dataStore) {
         LOG.debugf("REST: Updating data store: %s", dataStore);
         dataStoresBean.update(dataStore);
         return Response.ok().build();
@@ -73,11 +71,10 @@ public class DataStoresResource {
      *
      * @param labelFilter optional label expression to filter data stores
      * @return response with list of data stores
-     * @throws WanakuException if listing or label expression parsing fails
      */
     @GET
     public WanakuResponse<List<DataStore>> listOrGetByName(
-            @QueryParam("labelFilter") String labelFilter, @QueryParam("name") String name) throws WanakuException {
+            @QueryParam("labelFilter") String labelFilter, @QueryParam("name") String name) {
         if (name != null && !name.isEmpty()) {
             LOG.debugf("REST: Getting data stores by name: %s", name);
             List<DataStore> dataStores = dataStoresBean.findByName(name);
@@ -102,11 +99,10 @@ public class DataStoresResource {
      *
      * @param id the ID of the data store
      * @return response with the requested data store
-     * @throws WanakuException if retrieval fails
      */
     @Path("/{id}")
     @GET
-    public WanakuResponse<DataStore> getById(@PathParam("id") String id) throws WanakuException {
+    public WanakuResponse<DataStore> getById(@PathParam("id") String id) {
         LOG.debugf("REST: Getting data store by ID: %s", id);
         DataStore dataStore = dataStoresBean.findById(id);
         if (dataStore == null) {
@@ -121,17 +117,16 @@ public class DataStoresResource {
      *
      * @param id the ID of the data store to remove
      * @return HTTP 200 if removed, 404 if not found
-     * @throws WanakuException if removal fails
      */
     @Path("/{id}")
     @DELETE
-    public Response removeById(@PathParam("id") String id) throws WanakuException {
+    public Response removeById(@PathParam("id") String id) {
         LOG.debugf("REST: Removing data store by ID: %s", id);
         int deleteCount = dataStoresBean.removeById(id);
         if (deleteCount > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new DataStoreResourceNotFoundException(id);
         }
     }
 
@@ -141,10 +136,9 @@ public class DataStoresResource {
      *
      * @param name the name of the data store(s) to remove
      * @return HTTP 200 if removed, 404 if not found
-     * @throws WanakuException if removal fails
      */
     @DELETE
-    public Response removeByName(@QueryParam("name") String name) throws WanakuException {
+    public Response removeByName(@QueryParam("name") String name) {
         if (StringHelper.isEmpty(name)) {
             throw new WanakuException("The 'name' query parameter must be provided");
         }
@@ -154,7 +148,7 @@ public class DataStoresResource {
         if (deleteCount > 0) {
             return Response.ok().build();
         }
-        return Response.status(Response.Status.NOT_FOUND).build();
+        throw new DataStoreResourceNotFoundException(name);
     }
 
     /**
@@ -163,12 +157,11 @@ public class DataStoresResource {
      *
      * @param labelExpression the label expression to match data stores for removal
      * @return response with count of removed data stores
-     * @throws WanakuException if label expression is invalid or removal fails
      */
     @Path("/labels")
     @DELETE
     public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression)
-            throws WanakuException {
+            {
         LOG.debugf("REST: Removing data stores by label expression: %s", labelExpression);
         int removed = dataStoresBean.removeIf(labelExpression);
         return new WanakuResponse<>(removed);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.api.exceptions.ConfigurationNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.NamespaceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.PromptNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ToolNotFoundException;
@@ -56,6 +57,9 @@ class AddrNotFoundExceptionMapper extends NotFoundExceptionMapper<NotFoundExcept
 
 @Provider
 class NamespaceNotFoundExceptionMapper extends NotFoundExceptionMapper<NamespaceNotFoundException> {}
+
+@Provider
+class PromptNotFoundExceptionMapper extends NotFoundExceptionMapper<PromptNotFoundException> {}
 
 @Provider
 class DataStoreResourceNotFoundExceptionMapper extends NotFoundExceptionMapper<DataStoreResourceNotFoundException> {}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceUnavailableExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceUnavailableExceptionMapper.java
@@ -16,8 +16,8 @@ public class ServiceUnavailableExceptionMapper implements ExceptionMapper<Servic
     private static final Logger LOG = Logger.getLogger(ServiceUnavailableExceptionMapper.class);
 
     @APIResponse(
-            responseCode = "504",
-            description = "Service unavailable",
+            responseCode = "502",
+            description = "Bad Gateway — a downstream capability service is unreachable or returned an invalid response",
             content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
     @Override
     public Response toResponse(ServiceUnavailableException e) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
@@ -8,9 +8,29 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.exceptions.ConfigurationNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
+import ai.wanaku.capabilities.sdk.api.exceptions.NamespaceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.PromptNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ServiceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ToolNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
+/**
+ * Fallback exception mapper for {@link WanakuException} and its subtypes.
+ * <p>
+ * Dedicated {@link ExceptionMapper} providers exist for most subtypes (e.g.
+ * {@link ResourceNotFoundException}, {@link EntityAlreadyExistsException}).
+ * JAX-RS selects the most-specific mapper first, so this mapper only fires
+ * when no dedicated mapper matches.  The {@code instanceof} checks below are
+ * a safety net that ensures the correct HTTP status even if a dedicated
+ * mapper is accidentally removed or a new subclass is added without its own
+ * mapper.
+ */
 @Provider
 public class WanakuExceptionMapper implements ExceptionMapper<WanakuException> {
     private static final Logger LOG = Logger.getLogger(WanakuExceptionMapper.class);
@@ -23,7 +43,24 @@ public class WanakuExceptionMapper implements ExceptionMapper<WanakuException> {
     public Response toResponse(WanakuException e) {
         LOG.error("Request failed", e);
 
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        int status;
+        if (e instanceof ToolNotFoundException
+                || e instanceof ResourceNotFoundException
+                || e instanceof PromptNotFoundException
+                || e instanceof ServiceNotFoundException
+                || e instanceof ConfigurationNotFoundException
+                || e instanceof NamespaceNotFoundException
+                || e instanceof DataStoreResourceNotFoundException) {
+            status = 404;
+        } else if (e instanceof EntityAlreadyExistsException) {
+            status = 409;
+        } else if (e instanceof ServiceUnavailableException) {
+            status = 502;
+        } else {
+            status = 500;
+        }
+
+        return Response.status(status)
                 .entity(new WanakuResponse<Void>(e.getMessage()))
                 .build();
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -5,7 +5,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -30,7 +30,7 @@ public class ForwardsResource {
     ForwardsBean forwardsBean;
 
     @POST
-    public Response addForward(ForwardReference reference) throws WanakuException {
+    public Response addForward(ForwardReference reference) {
         forwardsBean.forward(reference);
         return Response.ok().build();
     }
@@ -45,7 +45,7 @@ public class ForwardsResource {
             return Response.ok().build();
         }
 
-        return Response.status(Response.Status.NOT_FOUND).build();
+        throw new ResourceNotFoundException(name);
     }
 
     @GET
@@ -63,12 +63,12 @@ public class ForwardsResource {
                 return new WanakuResponse<>(reference);
             }
         }
-        throw new NotFoundException("Forward not found with name: %s".formatted(name));
+        throw new ResourceNotFoundException("Forward not found with name: %s".formatted(name));
     }
 
     @Path("/{name}")
     @PUT
-    public Response update(@PathParam("name") String name, ForwardReference resource) throws WanakuException {
+    public Response update(@PathParam("name") String name, ForwardReference resource) {
         if (resource != null && StringHelper.isBlank(resource.getName())) {
             resource.setName(name);
         }
@@ -78,7 +78,7 @@ public class ForwardsResource {
 
     @Path("/{name}/refreshes")
     @POST
-    public Response refresh(@PathParam("name") String name) throws WanakuException {
+    public Response refresh(@PathParam("name") String name) {
         ForwardReference reference = new ForwardReference();
         reference.setName(name);
         forwardsBean.refresh(reference);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
@@ -31,44 +31,44 @@ public class PromptsResource {
     PromptsBean promptsBean;
 
     @POST
-    public WanakuResponse<PromptReference> add(PromptReference resource) throws WanakuException {
+    public WanakuResponse<PromptReference> add(PromptReference resource) {
         var ret = promptsBean.add(resource);
         return new WanakuResponse<>(ret);
     }
 
     @Path("/payloads")
     @POST
-    public WanakuResponse<PromptReference> addWithPayload(PromptPayload resource) throws WanakuException {
+    public WanakuResponse<PromptReference> addWithPayload(PromptPayload resource) {
         PayloadValidator.validate(resource);
         var ret = promptsBean.add(resource);
         return new WanakuResponse<>(ret);
     }
 
     @GET
-    public WanakuResponse<List<PromptReference>> list() throws WanakuException {
+    public WanakuResponse<List<PromptReference>> list() {
         List<PromptReference> prompts = promptsBean.list();
         return new WanakuResponse<>(prompts);
     }
 
     @DELETE
-    public Response remove(@QueryParam("prompt") String prompt) throws WanakuException {
+    public Response remove(@QueryParam("prompt") String prompt) {
         int deleteCount = promptsBean.remove(prompt);
         if (deleteCount > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new PromptNotFoundException(prompt);
         }
     }
 
     @PUT
-    public Response update(PromptReference resource) throws WanakuException {
+    public Response update(PromptReference resource) {
         promptsBean.update(resource);
         return Response.ok().build();
     }
 
     @Path("/{name}")
     @GET
-    public WanakuResponse<PromptReference> getByName(@PathParam("name") String name) throws WanakuException {
+    public WanakuResponse<PromptReference> getByName(@PathParam("name") String name) {
         PromptReference prompt = promptsBean.getByName(name);
         if (prompt == null) {
             throw new PromptNotFoundException(name);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -57,11 +57,10 @@ public class ResourcesResource {
      *
      * @param resource the resource payload containing the resource reference and provisioning data
      * @return a response containing the exposed resource reference
-     * @throws WanakuException if exposure fails or payload validation fails
      */
     @Path("/payloads")
     @POST
-    public WanakuResponse<ResourceReference> exposeWithPayload(ResourcePayload resource) throws WanakuException {
+    public WanakuResponse<ResourceReference> exposeWithPayload(ResourcePayload resource) {
         PayloadValidator.validate(resource);
         if (resource.getPayload() instanceof ResourceReference resourceReference
                 && StringHelper.isEmpty(resourceReference.getName())) {
@@ -76,10 +75,9 @@ public class ResourcesResource {
      *
      * @param resource the resource reference to expose
      * @return a response containing the exposed resource reference
-     * @throws WanakuException if exposure fails
      */
     @POST
-    public WanakuResponse<ResourceReference> expose(ResourceReference resource) throws WanakuException {
+    public WanakuResponse<ResourceReference> expose(ResourceReference resource) {
         ResourceReference ret = resourcesBean.expose(resource);
         return new WanakuResponse<>(ret);
     }
@@ -92,11 +90,10 @@ public class ResourcesResource {
      *
      * @param labelFilter optional label expression to filter resources by labels
      * @return a response containing a list of all resource references
-     * @throws WanakuException if listing fails
      */
     @GET
     public WanakuResponse<List<ResourceReference>> list(@QueryParam("labelFilter") String labelFilter)
-            throws WanakuException {
+            {
         List<ResourceReference> list = resourcesBean.list(labelFilter);
         List<ResourceReference> resourceReferences = forwardsBean.listAllResources();
 
@@ -111,11 +108,10 @@ public class ResourcesResource {
      * @param name the name of the resource to retrieve
      * @return a response containing the resource reference
      * @throws ResourceNotFoundException if the resource is not found
-     * @throws WanakuException if retrieval fails
      */
     @Path("/{name}")
     @GET
-    public WanakuResponse<ResourceReference> getByName(@PathParam("name") String name) throws WanakuException {
+    public WanakuResponse<ResourceReference> getByName(@PathParam("name") String name) {
         ResourceReference resource = resourcesBean.getByName(name);
         if (resource == null) {
             throw new ResourceNotFoundException(name);
@@ -128,16 +124,15 @@ public class ResourcesResource {
      *
      * @param name the name of the resource to remove
      * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the resource doesn't exist
-     * @throws WanakuException if removal fails
      */
     @Path("/{name}")
     @DELETE
-    public Response remove(@PathParam("name") String name) throws WanakuException {
+    public Response remove(@PathParam("name") String name) {
         int deleteCount = resourcesBean.remove(name);
         if (deleteCount > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new ResourceNotFoundException(name);
         }
     }
 
@@ -146,11 +141,10 @@ public class ResourcesResource {
      *
      * @param resource the updated resource reference
      * @return HTTP 200 OK if updated successfully
-     * @throws WanakuException if update fails
      */
     @Path("/{name}")
     @PUT
-    public Response update(@PathParam("name") String name, ResourceReference resource) throws WanakuException {
+    public Response update(@PathParam("name") String name, ResourceReference resource) {
         if (resource != null && StringHelper.isEmpty(resource.getName())) {
             resource.setName(name);
         }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -51,7 +52,7 @@ public class ServiceCatalogResource {
      */
     @Path("/list")
     @GET
-    public WanakuResponse<List<Map<String, Object>>> list(@QueryParam("search") String search) throws WanakuException {
+    public WanakuResponse<List<Map<String, Object>>> list(@QueryParam("search") String search) {
         if (search != null && !search.isBlank()) {
             LOG.debugf("REST: Listing service catalogs with search: %s", search);
         } else {
@@ -88,7 +89,7 @@ public class ServiceCatalogResource {
      */
     @Path("/get")
     @GET
-    public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
+    public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) {
         LOG.debugf("REST: Getting service catalog: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -130,7 +131,7 @@ public class ServiceCatalogResource {
      */
     @Path("/download")
     @GET
-    public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
+    public WanakuResponse<DataStore> download(@QueryParam("name") String name) {
         LOG.debugf("REST: Downloading service catalog: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -154,7 +155,7 @@ public class ServiceCatalogResource {
      */
     @Path("/deploy")
     @POST
-    public WanakuResponse<DataStore> deploy(DataStore dataStore) throws WanakuException {
+    public WanakuResponse<DataStore> deploy(DataStore dataStore) {
         LOG.debugf("REST: Deploying service catalog: %s", dataStore.getName());
         DataStore result = serviceCatalogBean.deploy(dataStore);
         return new WanakuResponse<>(result);
@@ -169,7 +170,7 @@ public class ServiceCatalogResource {
      */
     @Path("/remove")
     @DELETE
-    public Response remove(@QueryParam("name") String name) throws WanakuException {
+    public Response remove(@QueryParam("name") String name) {
         LOG.debugf("REST: Removing service catalog: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -180,7 +181,7 @@ public class ServiceCatalogResource {
         if (removed > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new DataStoreResourceNotFoundException(name);
         }
     }
 
@@ -195,7 +196,7 @@ public class ServiceCatalogResource {
     @Path("/instructions")
     @GET
     public WanakuResponse<DeploymentInstructions> getDeploymentInstructions(
-            @QueryParam("name") String name, @QueryParam("model") String model) throws WanakuException {
+            @QueryParam("name") String name, @QueryParam("model") String model) {
         LOG.debugf("REST: Getting deployment instructions for catalog '%s' with model '%s'", name, model);
 
         if (StringHelper.isBlank(name)) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -95,7 +96,7 @@ public class ServiceTemplateResource {
      */
     @Path("/get")
     @GET
-    public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
+    public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) {
         LOG.debugf("REST: Getting service template: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -138,7 +139,7 @@ public class ServiceTemplateResource {
      */
     @Path("/download")
     @GET
-    public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
+    public WanakuResponse<DataStore> download(@QueryParam("name") String name) {
         LOG.debugf("REST: Downloading service template: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -162,7 +163,7 @@ public class ServiceTemplateResource {
      */
     @Path("/deploy")
     @POST
-    public WanakuResponse<DataStore> deploy(DataStore dataStore) throws WanakuException {
+    public WanakuResponse<DataStore> deploy(DataStore dataStore) {
         LOG.debugf("REST: Deploying service template: %s", dataStore.getName());
         DataStore result = serviceTemplateBean.deploy(dataStore);
         return new WanakuResponse<>(result);
@@ -177,7 +178,7 @@ public class ServiceTemplateResource {
      */
     @Path("/remove")
     @DELETE
-    public Response remove(@QueryParam("name") String name) throws WanakuException {
+    public Response remove(@QueryParam("name") String name) {
         LOG.debugf("REST: Removing service template: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -188,7 +189,7 @@ public class ServiceTemplateResource {
         if (removed > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new DataStoreResourceNotFoundException(name);
         }
     }
 
@@ -202,7 +203,7 @@ public class ServiceTemplateResource {
     @Path("/properties")
     @GET
     public WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name)
-            throws WanakuException {
+            {
         LOG.debugf("REST: Getting properties for template: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -223,7 +224,7 @@ public class ServiceTemplateResource {
     @Path("/instantiate")
     @POST
     public WanakuResponse<DataStore> instantiate(ServiceTemplateService.TemplateInstantiationRequest request)
-            throws WanakuException {
+            {
         LOG.debugf("REST: Instantiating template: %s", request.getTemplateName());
 
         if (StringHelper.isBlank(request.getTemplateName())) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -52,10 +52,9 @@ public class ToolsResource {
      *
      * @param resource the tool reference to register
      * @return a response containing the registered tool reference
-     * @throws WanakuException if registration fails
      */
     @POST
-    public WanakuResponse<ToolReference> add(ToolReference resource) throws WanakuException {
+    public WanakuResponse<ToolReference> add(ToolReference resource) {
         var ret = toolsBean.add(resource);
         return new WanakuResponse<>(ret);
     }
@@ -68,11 +67,10 @@ public class ToolsResource {
      *
      * @param resource the tool payload containing the tool reference and provisioning data
      * @return a response containing the registered tool reference
-     * @throws WanakuException if registration fails or payload validation fails
      */
     @Path("/payloads")
     @POST
-    public WanakuResponse<ToolReference> addWithPayload(ToolPayload resource) throws WanakuException {
+    public WanakuResponse<ToolReference> addWithPayload(ToolPayload resource) {
         PayloadValidator.validate(resource);
         if (resource.getPayload() instanceof ToolReference toolReference
                 && StringHelper.isEmpty(toolReference.getName())) {
@@ -89,11 +87,10 @@ public class ToolsResource {
      * and tools available through forward proxies to remote MCP servers.
      *
      * @return a response containing a list of all tool references
-     * @throws WanakuException if listing fails
      */
     @GET
     public WanakuResponse<List<ToolReference>> list(@QueryParam("labelFilter") String labelFilter)
-            throws WanakuException {
+            {
         List<ToolReference> forwardTools = forwardsBean.listAllAsTools(labelFilter);
         List<ToolReference> tools = toolsBean.list(labelFilter);
         List<ToolReference> ret = CollectionsHelper.join(tools, forwardTools);
@@ -105,16 +102,15 @@ public class ToolsResource {
      *
      * @param name the name of the tool to remove
      * @return HTTP 200 OK if removed successfully, HTTP 404 NOT FOUND if the tool doesn't exist
-     * @throws WanakuException if removal fails
      */
     @Path("/{name}")
     @DELETE
-    public Response remove(@PathParam("name") String name) throws WanakuException {
+    public Response remove(@PathParam("name") String name) {
         int deleteCount = toolsBean.remove(name);
         if (deleteCount > 0) {
             return Response.ok().build();
         } else {
-            return Response.status(Response.Status.NOT_FOUND).build();
+            throw new ToolNotFoundException(name);
         }
     }
 
@@ -123,11 +119,10 @@ public class ToolsResource {
      *
      * @param resource the updated tool reference
      * @return HTTP 200 OK if updated successfully
-     * @throws WanakuException if update fails
      */
     @Path("/{name}")
     @PUT
-    public Response update(@PathParam("name") String name, ToolReference resource) throws WanakuException {
+    public Response update(@PathParam("name") String name, ToolReference resource) {
         if (resource != null && StringHelper.isEmpty(resource.getName())) {
             resource.setName(name);
         }
@@ -141,11 +136,10 @@ public class ToolsResource {
      * @param name the name of the tool to retrieve
      * @return a response containing the tool reference
      * @throws ToolNotFoundException if the tool is not found
-     * @throws WanakuException if retrieval fails
      */
     @Path("/{name}")
     @GET
-    public WanakuResponse<ToolReference> getByName(@PathParam("name") String name) throws WanakuException {
+    public WanakuResponse<ToolReference> getByName(@PathParam("name") String name) {
         ToolReference tool = toolsBean.getByName(name);
         if (tool == null) {
             throw new ToolNotFoundException(name);
@@ -161,7 +155,7 @@ public class ToolsResource {
      */
     @DELETE
     public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression)
-            throws WanakuException {
+            {
 
         int deleteCount = toolsBean.removeIf(labelExpression);
         return new WanakuResponse<>(deleteCount);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -41,7 +42,7 @@ public class ToolsetReposResource {
     }
 
     @POST
-    public WanakuResponse<Map<String, String>> add(Map<String, String> repo) throws WanakuException {
+    public WanakuResponse<Map<String, String>> add(Map<String, String> repo) {
         LOG.debugf("REST: Adding toolset repository: %s", repo.get("name"));
         Map<String, String> result = toolsetReposBean.add(
                 repo.get("name"), repo.get("url"), repo.get("description"), repo.get("icon"), repo.get("branch"));
@@ -51,7 +52,7 @@ public class ToolsetReposResource {
     @Path("/{name}")
     @PUT
     public WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo)
-            throws WanakuException {
+            {
         LOG.debugf("REST: Updating toolset repository: %s", name);
         Map<String, String> result = toolsetReposBean.update(
                 name, repo.get("url"), repo.get("description"), repo.get("icon"), repo.get("branch"));
@@ -60,18 +61,18 @@ public class ToolsetReposResource {
 
     @Path("/{name}")
     @DELETE
-    public Response remove(@PathParam("name") String name) throws WanakuException {
+    public Response remove(@PathParam("name") String name) {
         LOG.debugf("REST: Removing toolset repository: %s", name);
         int removed = toolsetReposBean.remove(name);
         if (removed > 0) {
             return Response.ok().build();
         }
-        return Response.status(Response.Status.NOT_FOUND).build();
+        throw new ResourceNotFoundException(name);
     }
 
     @Path("/{name}/browse")
     @GET
-    public WanakuResponse<Map<String, Object>> browse(@PathParam("name") String name) throws WanakuException {
+    public WanakuResponse<Map<String, Object>> browse(@PathParam("name") String name) {
         LOG.debugf("REST: Browsing toolset repository: %s", name);
         return new WanakuResponse<>(toolsetReposBean.browse(name));
     }
@@ -79,7 +80,7 @@ public class ToolsetReposResource {
     @Path("/{name}/toolsets/{toolsetName}")
     @GET
     public WanakuResponse<List<ToolReference>> fetchToolset(
-            @PathParam("name") String name, @PathParam("toolsetName") String toolsetName) throws WanakuException {
+            @PathParam("name") String name, @PathParam("toolsetName") String toolsetName) {
         LOG.debugf("REST: Fetching toolset '%s' from repository: %s", toolsetName, name);
         return new WanakuResponse<>(toolsetReposBean.fetchToolset(name, toolsetName));
     }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -1312,16 +1312,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -1343,16 +1333,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           }
@@ -1384,16 +1364,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "List Or Get By Name",
@@ -1417,16 +1387,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseDataStore"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -1458,16 +1418,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove If",
@@ -1492,16 +1442,6 @@
                 "schema" : { }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove By Id",
@@ -1523,16 +1463,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseDataStore"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -1586,16 +1516,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -1630,16 +1550,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           },
@@ -1713,16 +1623,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           }
@@ -2081,16 +1981,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -2114,16 +2004,6 @@
                 "schema" : { }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove",
@@ -2137,16 +2017,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseListPromptReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2173,16 +2043,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponsePromptReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2218,16 +2078,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -2256,16 +2106,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Get By Name",
@@ -2288,16 +2128,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseListResourceReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2324,16 +2154,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseResourceReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2365,16 +2185,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseResourceReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2416,16 +2226,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -2450,16 +2250,6 @@
                 "schema" : { }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove",
@@ -2481,16 +2271,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseResourceReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2523,16 +2303,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -2560,16 +2330,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Download",
@@ -2592,16 +2352,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseMapStringObject"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2636,16 +2386,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Get Deployment Instructions",
@@ -2671,16 +2411,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "List",
@@ -2702,16 +2432,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           }
@@ -2743,16 +2463,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -2777,16 +2487,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseDataStore"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2815,16 +2515,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Get",
@@ -2850,16 +2540,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseDataStore"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -2916,16 +2596,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Get Properties",
@@ -2947,16 +2617,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           }
@@ -2984,16 +2644,6 @@
                 }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove If",
@@ -3014,16 +2664,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseListToolReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -3050,16 +2690,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseToolReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -3091,16 +2721,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseToolReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -3142,16 +2762,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -3176,16 +2786,6 @@
                 "schema" : { }
               }
             }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
           }
         },
         "summary" : "Remove",
@@ -3207,16 +2807,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseToolReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -3268,16 +2858,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -3320,16 +2900,6 @@
               }
             }
           },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request"
           }
@@ -3352,16 +2922,6 @@
             "content" : {
               "application/json" : {
                 "schema" : { }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
-                }
               }
             }
           }
@@ -3387,16 +2947,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseMapStringObject"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }
@@ -3430,16 +2980,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/WanakuResponseListToolReference"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Wanaku error",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/WanakuResponse"
                 }
               }
             }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -877,12 +877,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -900,12 +894,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove By Name
       tags:
       - Data Stores Resource
@@ -926,12 +914,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: List Or Get By Name
       tags:
       - Data Stores Resource
@@ -949,12 +931,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add
@@ -974,12 +950,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseInteger"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove If
       tags:
       - Data Stores Resource
@@ -997,12 +967,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove By Id
       tags:
       - Data Stores Resource
@@ -1020,12 +984,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get By Id
       tags:
       - Data Stores Resource
@@ -1059,12 +1017,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add Forward
@@ -1090,12 +1042,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -1148,12 +1094,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Refresh
       tags:
       - Forwards Resource
@@ -1394,12 +1334,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -1417,12 +1351,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Prompts Resource
@@ -1434,12 +1362,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListPromptReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: List
       tags:
       - Prompts Resource
@@ -1457,12 +1379,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponsePromptReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add
@@ -1483,12 +1399,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponsePromptReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add With Payload
@@ -1509,12 +1419,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponsePromptReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get By Name
       tags:
       - Prompts Resource
@@ -1532,12 +1436,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListResourceReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: List
       tags:
       - Resources Resource
@@ -1555,12 +1453,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseResourceReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Expose
@@ -1581,12 +1473,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseResourceReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Expose With Payload
@@ -1612,12 +1498,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -1636,12 +1516,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Resources Resource
@@ -1659,12 +1533,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseResourceReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get By Name
       tags:
       - Resources Resource
@@ -1683,12 +1551,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Deploy
@@ -1708,12 +1570,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Download
       tags:
       - Service Catalog Resource
@@ -1731,12 +1587,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringObject"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get
       tags:
       - Service Catalog Resource
@@ -1758,12 +1608,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDeploymentInstructions"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get Deployment Instructions
       tags:
       - Service Catalog Resource
@@ -1781,12 +1625,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListMapStringObject"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: List
       tags:
       - Service Catalog Resource
@@ -1803,12 +1641,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Service Catalog Resource
@@ -1827,12 +1659,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Deploy
@@ -1852,12 +1678,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Download
       tags:
       - Service Template Resource
@@ -1875,12 +1695,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringObject"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get
       tags:
       - Service Template Resource
@@ -1899,12 +1713,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseDataStore"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Instantiate
@@ -1941,12 +1749,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringMapStringString"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get Properties
       tags:
       - Service Template Resource
@@ -1963,12 +1765,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Service Template Resource
@@ -1986,12 +1782,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseInteger"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove If
       tags:
       - Tools Resource
@@ -2008,12 +1798,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListToolReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: List
       tags:
       - Tools Resource
@@ -2031,12 +1815,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseToolReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add
@@ -2057,12 +1835,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseToolReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add With Payload
@@ -2088,12 +1860,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -2112,12 +1878,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Tools Resource
@@ -2135,12 +1895,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseToolReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Get By Name
       tags:
       - Tools Resource
@@ -2172,12 +1926,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringString"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Add
@@ -2206,12 +1954,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringString"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
         "400":
           description: Bad Request
       summary: Update
@@ -2230,12 +1972,6 @@ paths:
           content:
             application/json:
               schema: {}
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Remove
       tags:
       - Toolset Repos Resource
@@ -2254,12 +1990,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseMapStringObject"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Browse
       tags:
       - Toolset Repos Resource
@@ -2283,12 +2013,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WanakuResponseListToolReference"
-        "500":
-          description: Wanaku error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WanakuResponse"
       summary: Fetch Toolset
       tags:
       - Toolset Repos Resource


### PR DESCRIPTION
## Summary
- Add `instanceof` safety-net checks to `WanakuExceptionMapper` so that `WanakuException` subclasses always map to the correct HTTP status code, even if a dedicated `ExceptionMapper` is missing
- Add missing `PromptNotFoundExceptionMapper` to the `NotFoundExceptionMapper` family
- Replace JAX-RS `NotFoundException` with `ResourceNotFoundException` in `ForwardsResource`
- Replace raw `Response.status(404)` returns with typed exception throws (`PromptNotFoundException`, `ToolNotFoundException`, `ResourceNotFoundException`, `DataStoreResourceNotFoundException`) across all resource classes, so the exception mappers handle status codes consistently
- Use `DataStoreResourceNotFoundException` for service catalog and service template not-found cases
- Remove unnecessary `throws WanakuException` from REST resource method signatures (it is a `RuntimeException`, so the clause is redundant)
- Update auto-generated OpenAPI spec and TypeScript API client to reflect the cleaned-up signatures

Fixes #1079

## Summary by Sourcery

Standardize REST API error handling and not-found semantics across backend resources and client bindings.

Bug Fixes:
- Ensure WanakuException subclasses map to appropriate HTTP status codes via a fallback exception mapper.
- Return consistent 404 responses for missing prompts, tools, resources, data stores, service catalogs, and service templates using typed not-found exceptions instead of raw 404 responses or generic exceptions.

Enhancements:
- Introduce a PromptNotFoundException mapper and extend the WanakuExceptionMapper to classify common exception subtypes into HTTP 404, 409, 502, or 500 as a safety net.
- Simplify REST resource method signatures by removing redundant checked throws declarations for WanakuException.
- Align OpenAPI definitions and the generated TypeScript API client by removing explicit 500 response types in favor of centralized error handling.