### PR TITLE
Fix #1083: clean up core-util module dependencies

### DIFF
--- a/core/core-util/pom.xml
+++ b/core/core-util/pom.xml
@@ -60,21 +60,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-qute</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/core-util/src/main/java/ai/wanaku/core/util/VersionHelper.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/VersionHelper.java
@@ -2,6 +2,7 @@ package ai.wanaku.core.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A utility class that provides a way to retrieve Wanaku current version
@@ -34,7 +35,7 @@ public final class VersionHelper {
                 throw new IllegalStateException("version.txt not found on classpath");
             }
             byte[] bytes = stream.readAllBytes();
-            return new String(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/core-util/src/main/java/ai/wanaku/core/util/VersionHelper.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/VersionHelper.java
@@ -30,7 +30,9 @@ public final class VersionHelper {
      */
     private static String initVersion() {
         try (InputStream stream = VersionHelper.class.getResourceAsStream("/version.txt")) {
-            assert stream != null;
+            if (stream == null) {
+                throw new IllegalStateException("version.txt not found on classpath");
+            }
             byte[] bytes = stream.readAllBytes();
             return new String(bytes);
         } catch (IOException e) {

--- a/core/core-util/src/test/java/ai/wanaku/test/assertions/WanakuAssertions.java
+++ b/core/core-util/src/test/java/ai/wanaku/test/assertions/WanakuAssertions.java
@@ -2,7 +2,6 @@ package ai.wanaku.test.assertions;
 
 import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.testcontainers.containers.GenericContainer;
 import io.restassured.response.Response;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
@@ -139,19 +138,6 @@ public final class WanakuAssertions {
         Assertions.assertThat(actual).isNotNull();
         Assertions.assertThat(actual.getName()).isEqualTo(expected.getName());
         Assertions.assertThat(actual.getAddress()).isEqualTo(expected.getAddress());
-    }
-
-    // ========== Container Assertions ==========
-
-    public static void assertContainerRunning(GenericContainer<?> container) {
-        Assertions.assertThat(container.isRunning())
-                .withFailMessage("Container %s is not running", container.getDockerImageName())
-                .isTrue();
-    }
-
-    public static void assertContainerHealthy(GenericContainer<?> container) {
-        assertContainerRunning(container);
-        // Additional health checks if needed
     }
 
     // ========== Namespace Assertions ==========


### PR DESCRIPTION
## Summary
- Remove duplicate `assertj-core` and `rest-assured` dependency declarations in `core/core-util/pom.xml`
- Remove unused `assertContainerRunning` and `assertContainerHealthy` test helpers from `WanakuAssertions` and the now-unused `testcontainers` dependency
- Replace `assert stream != null` with explicit `IllegalStateException` in `VersionHelper.initVersion()`

## Remaining Quarkus/SDK dependencies (analysis)

The following dependencies remain in `core-util` and require a larger refactoring to remove (tracked in #1083 acceptance criteria):

| Dependency | Used by |
|---|---|
| `quarkus-core` | Implicit framework dependency (CDI, etc.) |
| `quarkus-qute` | `URIParser` uses `io.quarkus.qute.Qute` for template rendering |
| `capabilities-api` | `ToolsetIndexHelper` uses `ToolReference` |
| `capabilities-common` | Transitive types used by `DiscoveryUtil` (`WanakuException`) |

Splitting `core-util` into `core-util` (pure Java) and `core-util-quarkus` (Quarkus-specific) as suggested in the issue would be a follow-up effort.

Fixes #1083

## Summary by Sourcery

Clean up core-util test dependencies and improve version initialization error handling.

Bug Fixes:
- Prevent silent failures in VersionHelper.initVersion() by throwing an IllegalStateException when version.txt is missing.

Enhancements:
- Remove unused container assertion helpers from WanakuAssertions to simplify the test utilities.

Build:
- Remove redundant AssertJ and RestAssured test dependencies and drop the unused Testcontainers dependency from core-util.