### PR TITLE
Fix #1078: extract shared validation and provisioning logic

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/PayloadValidator.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/PayloadValidator.java
@@ -1,0 +1,34 @@
+package ai.wanaku.backend.api.v1.common;
+
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
+
+/**
+ * Shared validation logic for {@link ProvisionAwarePayload} objects.
+ * <p>
+ * This utility extracts the null-checking boilerplate that was previously duplicated
+ * across {@code ToolsResource}, {@code ResourcesResource}, and {@code PromptsResource}.
+ * Type-specific validation (e.g. checking a tool or resource name) remains in the
+ * respective resource classes.
+ */
+public final class PayloadValidator {
+
+    private PayloadValidator() {
+        // utility class
+    }
+
+    /**
+     * Validates that the given provision-aware payload and its nested payload are non-null.
+     *
+     * @param resource the payload to validate
+     * @throws WanakuException if {@code resource} is null or its {@link ProvisionAwarePayload#getPayload()} is null
+     */
+    public static void validate(ProvisionAwarePayload<?> resource) throws WanakuException {
+        if (resource == null) {
+            throw new WanakuException("The request itself must not be null");
+        }
+        if (resource.getPayload() == null) {
+            throw new WanakuException("The 'payload' is required for this request");
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
@@ -1,0 +1,60 @@
+package ai.wanaku.backend.api.v1.common;
+
+import java.util.function.BiConsumer;
+import ai.wanaku.backend.bridge.ProvisionerBridge;
+import ai.wanaku.backend.support.ProvisioningReference;
+import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+
+/**
+ * Shared provisioning logic extracted from {@code ToolsBean} and {@code ResourcesBean}.
+ * <p>
+ * Both beans follow the same four-step pattern when provisioning a capability:
+ * <ol>
+ *   <li>Resolve the target service via {@link ProvisionerBridge#resolveService}</li>
+ *   <li>Call {@link ProvisionerBridge#provision} with the configuration and secrets data</li>
+ *   <li>Set the configuration URI on the reference</li>
+ *   <li>Set the secrets URI on the reference</li>
+ * </ol>
+ * This helper encapsulates those steps so callers only supply the type-specific parts
+ * (reference name, type, service-type value, and URI setters).
+ */
+public final class ProvisioningHelper {
+
+    private ProvisioningHelper() {
+        // utility class
+    }
+
+    /**
+     * Provisions a capability and applies the resulting URIs to the reference.
+     *
+     * @param provisionerBridge the bridge used for service resolution and provisioning
+     * @param payload           the provision-aware payload carrying configuration and secrets data
+     * @param referenceName     the name of the reference being provisioned (used as a key)
+     * @param referenceType     the type of the reference (e.g. "http", "camel")
+     * @param serviceTypeValue  the service-type value (e.g. {@code ServiceType.TOOL_INVOKER.asValue()})
+     * @param uriSetter         a callback that receives the configuration URI and secrets URI strings;
+     *                          the first argument is the configuration URI, the second is the secrets URI
+     * @return the {@link ProvisioningReference} produced by the bridge, in case the caller needs
+     *         access to additional data such as the property map
+     */
+    public static ProvisioningReference provision(
+            ProvisionerBridge provisionerBridge,
+            ProvisionAwarePayload<?> payload,
+            String referenceName,
+            String referenceType,
+            String serviceTypeValue,
+            BiConsumer<String, String> uriSetter) {
+
+        ServiceTarget service = provisionerBridge.resolveService(referenceType, serviceTypeValue);
+
+        ProvisioningReference provisioningReference = provisionerBridge.provision(
+                referenceName, payload.getConfigurationData(), payload.getSecretsData(), service);
+
+        uriSetter.accept(
+                provisioningReference.configurationURI().toString(),
+                provisioningReference.secretsURI().toString());
+
+        return provisioningReference;
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
@@ -15,12 +15,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
+import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.capabilities.sdk.api.exceptions.PromptNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.PromptReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.PromptPayload;
-import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
 
 @ApplicationScoped
 @Path("/api/v1/prompts")
@@ -41,18 +41,9 @@ public class PromptsResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<PromptReference> addWithPayload(PromptPayload resource) throws WanakuException {
-        validatePayload(resource);
+        PayloadValidator.validate(resource);
         var ret = promptsBean.add(resource);
         return new WanakuResponse<>(ret);
-    }
-
-    private void validatePayload(ProvisionAwarePayload<?> resource) throws WanakuException {
-        if (resource == null) {
-            throw new WanakuException("The request itself must not be null");
-        }
-        if (resource.getPayload() == null) {
-            throw new WanakuException("The 'payload' is required for this request");
-        }
     }
 
     @GET

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ResourceManager;
 import io.quarkus.runtime.StartupEvent;
+import ai.wanaku.backend.api.v1.common.ProvisioningHelper;
 import ai.wanaku.backend.api.v1.namespaces.NamespacesBean;
 import ai.wanaku.backend.bridge.ProvisionerBridge;
 import ai.wanaku.backend.bridge.ResourceBridge;
@@ -17,12 +18,10 @@ import ai.wanaku.backend.common.AbstractBean;
 import ai.wanaku.backend.common.ResourceHelper;
 import ai.wanaku.backend.core.persistence.api.ResourceReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.WanakuRepository;
-import ai.wanaku.backend.support.ProvisioningReference;
 import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.io.ResourcePayload;
-import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 import ai.wanaku.core.util.StringHelper;
 
@@ -60,17 +59,17 @@ public class ResourcesBean extends AbstractBean<ResourceReference> {
 
     public ResourceReference expose(ResourcePayload resourcePayload) {
         ResourceReference resourceReference = resourcePayload.getPayload();
-        ServiceTarget service =
-                provisionerBridge.resolveService(resourceReference.getType(), ServiceType.RESOURCE_PROVIDER.asValue());
-        final ProvisioningReference provisioningReference = provisionerBridge.provision(
-                resourceReference.getName(),
-                resourcePayload.getConfigurationData(),
-                resourcePayload.getSecretsData(),
-                service);
 
-        resourceReference.setConfigurationURI(
-                provisioningReference.configurationURI().toString());
-        resourceReference.setSecretsURI(provisioningReference.secretsURI().toString());
+        ProvisioningHelper.provision(
+                provisionerBridge,
+                resourcePayload,
+                resourceReference.getName(),
+                resourceReference.getType(),
+                ServiceType.RESOURCE_PROVIDER.asValue(),
+                (configURI, secretsURI) -> {
+                    resourceReference.setConfigurationURI(configURI);
+                    resourceReference.setSecretsURI(secretsURI);
+                });
 
         return expose(resourcePayload.getPayload());
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -15,12 +15,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
+import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.backend.api.v1.forwards.ForwardsBean;
 import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
-import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
 import ai.wanaku.capabilities.sdk.api.types.io.ResourcePayload;
 import ai.wanaku.core.util.CollectionsHelper;
 import ai.wanaku.core.util.StringHelper;
@@ -62,28 +62,13 @@ public class ResourcesResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ResourceReference> exposeWithPayload(ResourcePayload resource) throws WanakuException {
-        validatePayload(resource);
-        ResourceReference ret = resourcesBean.expose(resource);
-        return new WanakuResponse<>(ret);
-    }
-
-    /**
-     * Validates that a provision-aware payload is not null and contains a payload object.
-     *
-     * @param resource the payload to validate
-     * @throws WanakuException if the payload or its nested payload object is null
-     */
-    private void validatePayload(ProvisionAwarePayload<?> resource) throws WanakuException {
-        if (resource == null) {
-            throw new WanakuException("The request itself must not be null");
-        }
-        if (resource.getPayload() == null) {
-            throw new WanakuException("The 'payload' is required for this request");
-        }
+        PayloadValidator.validate(resource);
         if (resource.getPayload() instanceof ResourceReference resourceReference
                 && StringHelper.isEmpty(resourceReference.getName())) {
             throw new WanakuException("The 'payload.name' is required for this request");
         }
+        ResourceReference ret = resourcesBean.expose(resource);
+        return new WanakuResponse<>(ret);
     }
 
     /**

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkus.runtime.StartupEvent;
+import ai.wanaku.backend.api.v1.common.ProvisioningHelper;
 import ai.wanaku.backend.api.v1.namespaces.NamespacesBean;
 import ai.wanaku.backend.bridge.ProvisionerBridge;
 import ai.wanaku.backend.bridge.ToolsBridge;
@@ -25,7 +26,6 @@ import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.io.ToolPayload;
-import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
 import ai.wanaku.core.exchange.v1.PropertySchema;
 import ai.wanaku.core.util.StringHelper;
@@ -73,23 +73,25 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
 
     private void provision(ToolPayload toolPayload) {
         ToolReference toolReference = toolPayload.getPayload();
-        ServiceTarget service =
-                provisionerBridge.resolveService(toolReference.getType(), ServiceType.TOOL_INVOKER.asValue());
-        final ProvisioningReference provisioningReference = provisionerBridge.provision(
-                toolReference.getName(), toolPayload.getConfigurationData(), toolPayload.getSecretsData(), service);
+
+        final ProvisioningReference provisioningReference = ProvisioningHelper.provision(
+                provisionerBridge,
+                toolPayload,
+                toolReference.getName(),
+                toolReference.getType(),
+                ServiceType.TOOL_INVOKER.asValue(),
+                (configURI, secretsURI) -> {
+                    toolReference.setConfigurationURI(configURI);
+                    toolReference.setSecretsURI(secretsURI);
+                });
 
         final Map<String, PropertySchema> serviceProperties = provisioningReference.properties();
-
         final Map<String, Property> clientProperties =
                 toolReference.getInputSchema().getProperties();
         for (var serviceProperty : serviceProperties.entrySet()) {
             clientProperties.computeIfAbsent(
                     serviceProperty.getKey(), v -> toProperty(serviceProperty, serviceProperties));
         }
-
-        toolReference.setConfigurationURI(
-                provisioningReference.configurationURI().toString());
-        toolReference.setSecretsURI(provisioningReference.secretsURI().toString());
     }
 
     private static Property toProperty(

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -15,12 +15,12 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
+import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.backend.api.v1.forwards.ForwardsBean;
 import ai.wanaku.capabilities.sdk.api.exceptions.ToolNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
-import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
 import ai.wanaku.capabilities.sdk.api.types.io.ToolPayload;
 import ai.wanaku.core.util.CollectionsHelper;
 import ai.wanaku.core.util.StringHelper;
@@ -75,28 +75,13 @@ public class ToolsResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ToolReference> addWithPayload(ToolPayload resource) throws WanakuException {
-        validatePayload(resource);
-        var ret = toolsBean.add(resource);
-        return new WanakuResponse<>(ret);
-    }
-
-    /**
-     * Validates that a provision-aware payload is not null and contains a payload object.
-     *
-     * @param resource the payload to validate
-     * @throws WanakuException if the payload or its nested payload object is null
-     */
-    private void validatePayload(ProvisionAwarePayload<?> resource) throws WanakuException {
-        if (resource == null) {
-            throw new WanakuException("The request itself must not be null");
-        }
-        if (resource.getPayload() == null) {
-            throw new WanakuException("The 'payload' is required for this request");
-        }
+        PayloadValidator.validate(resource);
         if (resource.getPayload() instanceof ToolReference toolReference
                 && StringHelper.isEmpty(toolReference.getName())) {
             throw new WanakuException("The 'payload.name' is required for this request");
         }
+        var ret = toolsBean.add(resource);
+        return new WanakuResponse<>(ret);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extract duplicated `validatePayload()` into a shared `PayloadValidator` utility class in `ai.wanaku.backend.api.v1.common`
- Extract duplicated provisioning logic (resolveService, provision, setConfigurationURI/setSecretsURI) into a shared `ProvisioningHelper` utility
- Type-specific validation (tool/resource name checks) remains in respective resource classes
- `ToolsBean.provision()` retains its tool-specific property merging logic after calling the shared helper

Fixes #1078

## Summary by Sourcery

Extract shared validation and provisioning utilities and adopt them across tools, resources, and prompts APIs.

Enhancements:
- Introduce a reusable PayloadValidator for common ProvisionAwarePayload null-checking across resource, tool, and prompt endpoints.
- Introduce a ProvisioningHelper to centralize service resolution, provisioning, and URI assignment logic used by ToolsBean and ResourcesBean.
- Simplify ResourcesResource, ToolsResource, and PromptsResource to delegate to the shared validator while keeping type-specific checks local.
- Refactor ToolsBean and ResourcesBean to use the shared provisioning helper while preserving existing tool-specific property merging behavior.