### PR TITLE
Fix #1082: add missing media type annotations to REST endpoints

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -27,6 +27,8 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
  */
 @ApplicationScoped
 @Path("/api/v1/data-store")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class DataStoresResource {
     private static final Logger LOG = Logger.getLogger(DataStoresResource.class);
 
@@ -42,8 +44,6 @@ public class DataStoresResource {
      * @throws WanakuException if addition fails
      */
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> add(DataStore dataStore) throws WanakuException {
         LOG.debugf("REST: Adding data store: %s", dataStore);
         DataStore result = dataStoresBean.add(dataStore);
@@ -59,7 +59,6 @@ public class DataStoresResource {
      * @throws WanakuException if update fails
      */
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(DataStore dataStore) throws WanakuException {
         LOG.debugf("REST: Updating data store: %s", dataStore);
         dataStoresBean.update(dataStore);
@@ -76,7 +75,6 @@ public class DataStoresResource {
      * @throws WanakuException if listing or label expression parsing fails
      */
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<DataStore>> listOrGetByName(
             @QueryParam("labelFilter") String labelFilter, @QueryParam("name") String name) throws WanakuException {
         if (name != null && !name.isEmpty()) {
@@ -107,7 +105,6 @@ public class DataStoresResource {
      */
     @Path("/{id}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> getById(@PathParam("id") String id) throws WanakuException {
         LOG.debugf("REST: Getting data store by ID: %s", id);
         DataStore dataStore = dataStoresBean.findById(id);
@@ -169,7 +166,6 @@ public class DataStoresResource {
      */
     @Path("/labels")
     @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression)
             throws WanakuException {
         LOG.debugf("REST: Removing data stores by label expression: %s", labelExpression);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -22,13 +22,13 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
 @ApplicationScoped
 @Path("/api/v1/forwards")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ForwardsResource {
     @Inject
     ForwardsBean forwardsBean;
 
     @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response addForward(ForwardReference reference) throws WanakuException {
         forwardsBean.forward(reference);
         return Response.ok().build();
@@ -48,7 +48,6 @@ public class ForwardsResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public RestResponse<WanakuResponse<List<ForwardReference>>> listForwards(
             @jakarta.ws.rs.QueryParam("labelFilter") String labelFilter) {
         return RestResponse.ok(new WanakuResponse<>(forwardsBean.listForwards(labelFilter)));
@@ -56,7 +55,6 @@ public class ForwardsResource {
 
     @Path("/{name}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ForwardReference> getByName(@PathParam("name") String name) {
         List<ForwardReference> references = forwardsBean.listForwards();
         for (ForwardReference reference : references) {
@@ -69,7 +67,6 @@ public class ForwardsResource {
 
     @Path("/{name}")
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("name") String name, ForwardReference resource) throws WanakuException {
         if (resource != null
                 && (resource.getName() == null || resource.getName().isBlank())) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/discovery/DiscoveryResource.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -22,6 +23,8 @@ import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 
 @ApplicationScoped
 @Path("/api/v1/management/discovery")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class DiscoveryResource {
     private static final Logger LOG = Logger.getLogger(DiscoveryResource.class);
 
@@ -37,7 +40,6 @@ public class DiscoveryResource {
     EventBus eventBus;
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     public RestResponse<WanakuResponse<ServiceTarget>> register(ServiceTarget serviceTarget) {
         var ret = discoveryBean.registerService(serviceTarget);
 
@@ -47,7 +49,6 @@ public class DiscoveryResource {
     }
 
     @DELETE
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response deregister(ServiceTarget serviceTarget) {
         discoveryBean.deregisterService(serviceTarget);
         emitEvent(ServiceTargetEvent.deregister(serviceTarget));
@@ -56,7 +57,6 @@ public class DiscoveryResource {
 
     @Path("/heartbeats")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
     @Deprecated
     public Response ping(String id) {
         LOG.tracef("Service %s is pinging", id);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesResource.java
@@ -21,6 +21,8 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
 @ApplicationScoped
 @Path("/api/v1/namespaces")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class NamespacesResource {
     private static final long DEFAULT_MAX_AGE_SECONDS = 604800; // 7 days
 
@@ -28,15 +30,12 @@ public class NamespacesResource {
     NamespacesBean namespacesBean;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<Namespace>> list(@QueryParam("labelFilter") String labelFilter) {
         List<Namespace> namespaces = namespacesBean.list(labelFilter);
         return new WanakuResponse<>(namespaces);
     }
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Namespace> create(Namespace namespace) {
         Namespace created = namespacesBean.create(namespace);
         return new WanakuResponse<>(created);
@@ -50,7 +49,6 @@ public class NamespacesResource {
      */
     @Path("/{id}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Namespace> getById(@PathParam("id") String id) {
         Namespace namespace = namespacesBean.getById(id);
         if (namespace == null) {
@@ -67,7 +65,6 @@ public class NamespacesResource {
      */
     @PUT
     @Path("/{id}")
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("id") String id, Namespace namespace) {
         if (!namespacesBean.exists(id)) {
             throw NamespaceNotFoundException.forId(id);
@@ -89,7 +86,6 @@ public class NamespacesResource {
 
     @Path("/stale")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<Namespace>> listStale(
             @QueryParam("maxAgeSeconds") Long maxAgeSeconds,
             @QueryParam("unassignedOnly") Boolean unassignedOnly,
@@ -104,7 +100,6 @@ public class NamespacesResource {
 
     @Path("/stale")
     @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Integer> cleanupStale(
             @QueryParam("maxAgeSeconds") Long maxAgeSeconds,
             @QueryParam("unassignedOnly") Boolean unassignedOnly,

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
@@ -24,13 +24,13 @@ import ai.wanaku.capabilities.sdk.api.types.io.ProvisionAwarePayload;
 
 @ApplicationScoped
 @Path("/api/v1/prompts")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class PromptsResource {
     @Inject
     PromptsBean promptsBean;
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<PromptReference> add(PromptReference resource) throws WanakuException {
         var ret = promptsBean.add(resource);
         return new WanakuResponse<>(ret);
@@ -38,8 +38,6 @@ public class PromptsResource {
 
     @Path("/payloads")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<PromptReference> addWithPayload(PromptPayload resource) throws WanakuException {
         validatePayload(resource);
         var ret = promptsBean.add(resource);
@@ -56,7 +54,6 @@ public class PromptsResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<PromptReference>> list() throws WanakuException {
         List<PromptReference> prompts = promptsBean.list();
         return new WanakuResponse<>(prompts);
@@ -73,7 +70,6 @@ public class PromptsResource {
     }
 
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(PromptReference resource) throws WanakuException {
         promptsBean.update(resource);
         return Response.ok().build();
@@ -81,7 +77,6 @@ public class PromptsResource {
 
     @Path("/{name}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<PromptReference> getByName(@PathParam("name") String name) throws WanakuException {
         PromptReference prompt = promptsBean.getByName(name);
         if (prompt == null) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -39,6 +39,8 @@ import ai.wanaku.core.util.StringHelper;
  */
 @ApplicationScoped
 @Path("/api/v1/resources")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ResourcesResource {
 
     @Inject
@@ -59,8 +61,6 @@ public class ResourcesResource {
      */
     @Path("/payloads")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ResourceReference> exposeWithPayload(ResourcePayload resource) throws WanakuException {
         validatePayload(resource);
         ResourceReference ret = resourcesBean.expose(resource);
@@ -94,8 +94,6 @@ public class ResourcesResource {
      * @throws WanakuException if exposure fails
      */
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ResourceReference> expose(ResourceReference resource) throws WanakuException {
         ResourceReference ret = resourcesBean.expose(resource);
         return new WanakuResponse<>(ret);
@@ -112,7 +110,6 @@ public class ResourcesResource {
      * @throws WanakuException if listing fails
      */
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<ResourceReference>> list(@QueryParam("labelFilter") String labelFilter)
             throws WanakuException {
         List<ResourceReference> list = resourcesBean.list(labelFilter);
@@ -133,7 +130,6 @@ public class ResourcesResource {
      */
     @Path("/{name}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ResourceReference> getByName(@PathParam("name") String name) throws WanakuException {
         ResourceReference resource = resourcesBean.getByName(name);
         if (resource == null) {
@@ -169,7 +165,6 @@ public class ResourcesResource {
      */
     @Path("/{name}")
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("name") String name, ResourceReference resource) throws WanakuException {
         if (resource != null && StringHelper.isEmpty(resource.getName())) {
             resource.setName(name);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -29,6 +29,8 @@ import ai.wanaku.core.services.api.ServiceCatalogIndex;
  */
 @ApplicationScoped
 @Path("/api/v1/service-catalog")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ServiceCatalogResource {
     private static final Logger LOG = Logger.getLogger(ServiceCatalogResource.class);
 
@@ -48,7 +50,6 @@ public class ServiceCatalogResource {
      */
     @Path("/list")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<Map<String, Object>>> list(@QueryParam("search") String search) throws WanakuException {
         if (search != null && !search.isBlank()) {
             LOG.debugf("REST: Listing service catalogs with search: %s", search);
@@ -86,7 +87,6 @@ public class ServiceCatalogResource {
      */
     @Path("/get")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Getting service catalog: %s", name);
 
@@ -129,7 +129,6 @@ public class ServiceCatalogResource {
      */
     @Path("/download")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Downloading service catalog: %s", name);
 
@@ -154,8 +153,6 @@ public class ServiceCatalogResource {
      */
     @Path("/deploy")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> deploy(DataStore dataStore) throws WanakuException {
         LOG.debugf("REST: Deploying service catalog: %s", dataStore.getName());
         DataStore result = serviceCatalogBean.deploy(dataStore);
@@ -196,7 +193,6 @@ public class ServiceCatalogResource {
      */
     @Path("/instructions")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DeploymentInstructions> getDeploymentInstructions(
             @QueryParam("name") String name, @QueryParam("model") String model) throws WanakuException {
         LOG.debugf("REST: Getting deployment instructions for catalog '%s' with model '%s'", name, model);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -29,6 +29,8 @@ import ai.wanaku.core.services.api.ServiceTemplateService;
  */
 @ApplicationScoped
 @Path("/api/v1/service-template")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ServiceTemplateResource {
     private static final Logger LOG = Logger.getLogger(ServiceTemplateResource.class);
 
@@ -45,7 +47,6 @@ public class ServiceTemplateResource {
      */
     @Path("/list")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<Map<String, Object>>> list(@QueryParam("search") String search) {
         if (search != null && !search.isBlank()) {
             LOG.debugf("REST: Listing service templates with search: %s", search);
@@ -93,7 +94,6 @@ public class ServiceTemplateResource {
      */
     @Path("/get")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Getting service template: %s", name);
 
@@ -137,7 +137,6 @@ public class ServiceTemplateResource {
      */
     @Path("/download")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Downloading service template: %s", name);
 
@@ -162,8 +161,6 @@ public class ServiceTemplateResource {
      */
     @Path("/deploy")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> deploy(DataStore dataStore) throws WanakuException {
         LOG.debugf("REST: Deploying service template: %s", dataStore.getName());
         DataStore result = serviceTemplateBean.deploy(dataStore);
@@ -203,7 +200,6 @@ public class ServiceTemplateResource {
      */
     @Path("/properties")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name)
             throws WanakuException {
         LOG.debugf("REST: Getting properties for template: %s", name);
@@ -225,8 +221,6 @@ public class ServiceTemplateResource {
      */
     @Path("/instantiate")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<DataStore> instantiate(ServiceTemplateService.TemplateInstantiationRequest request)
             throws WanakuException {
         LOG.debugf("REST: Instantiating template: %s", request.getTemplateName());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -38,6 +38,8 @@ import ai.wanaku.core.util.StringHelper;
  */
 @ApplicationScoped
 @Path("/api/v1/tools")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ToolsResource {
     @Inject
     ToolsBean toolsBean;
@@ -53,8 +55,6 @@ public class ToolsResource {
      * @throws WanakuException if registration fails
      */
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ToolReference> add(ToolReference resource) throws WanakuException {
         var ret = toolsBean.add(resource);
         return new WanakuResponse<>(ret);
@@ -72,8 +72,6 @@ public class ToolsResource {
      */
     @Path("/payloads")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ToolReference> addWithPayload(ToolPayload resource) throws WanakuException {
         validatePayload(resource);
         var ret = toolsBean.add(resource);
@@ -109,7 +107,6 @@ public class ToolsResource {
      * @throws WanakuException if listing fails
      */
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<ToolReference>> list(@QueryParam("labelFilter") String labelFilter)
             throws WanakuException {
         List<ToolReference> forwardTools = forwardsBean.listAllAsTools(labelFilter);
@@ -145,7 +142,6 @@ public class ToolsResource {
      */
     @Path("/{name}")
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("name") String name, ToolReference resource) throws WanakuException {
         if (resource != null && StringHelper.isEmpty(resource.getName())) {
             resource.setName(name);
@@ -164,7 +160,6 @@ public class ToolsResource {
      */
     @Path("/{name}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ToolReference> getByName(@PathParam("name") String name) throws WanakuException {
         ToolReference tool = toolsBean.getByName(name);
         if (tool == null) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
@@ -26,6 +26,8 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
  */
 @ApplicationScoped
 @Path("/api/v1/toolset-repos")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class ToolsetReposResource {
     private static final Logger LOG = Logger.getLogger(ToolsetReposResource.class);
 
@@ -33,15 +35,12 @@ public class ToolsetReposResource {
     ToolsetReposBean toolsetReposBean;
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<Map<String, String>>> list() {
         LOG.debug("REST: Listing toolset repositories");
         return new WanakuResponse<>(toolsetReposBean.list());
     }
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, String>> add(Map<String, String> repo) throws WanakuException {
         LOG.debugf("REST: Adding toolset repository: %s", repo.get("name"));
         Map<String, String> result = toolsetReposBean.add(
@@ -51,8 +50,6 @@ public class ToolsetReposResource {
 
     @Path("/{name}")
     @PUT
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo)
             throws WanakuException {
         LOG.debugf("REST: Updating toolset repository: %s", name);
@@ -74,7 +71,6 @@ public class ToolsetReposResource {
 
     @Path("/{name}/browse")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<Map<String, Object>> browse(@PathParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Browsing toolset repository: %s", name);
         return new WanakuResponse<>(toolsetReposBean.browse(name));
@@ -82,7 +78,6 @@ public class ToolsetReposResource {
 
     @Path("/{name}/toolsets/{toolsetName}")
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<List<ToolReference>> fetchToolset(
             @PathParam("name") String name, @PathParam("toolsetName") String toolsetName) throws WanakuException {
         LOG.debugf("REST: Fetching toolset '%s' from repository: %s", toolsetName, name);


### PR DESCRIPTION
## Summary
- Add missing @Produces and @Consumes annotations to REST endpoint methods
- Promote media type annotations to class level on 10 resource classes for consistency, removing redundant method-level duplicates

Note: Bean Validation annotations on SDK entity types (ToolReference, ResourceReference) require changes in the SDK repo and will be addressed separately.

Fixes #1082

## Summary by Sourcery

Add consistent JSON media type declarations to REST resources and centralize them at the class level for relevant endpoints.

Enhancements:
- Declare @Produces and @Consumes application/json at the resource class level for multiple v1 REST endpoints.
- Remove redundant method-level media type annotations now covered by class-level configuration across affected resources.