### PR TITLE
Fix #1088: refactor operator - split OperatorUtil God Class

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
@@ -1,0 +1,226 @@
+package ai.wanaku.operator.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.jboss.logging.Logger;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilityReconciler;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+
+/**
+ * Factory for creating Kubernetes resources related to WanakuCapability deployments.
+ *
+ * <p>Handles the creation of capability deployments, internal services,
+ * and persistent volume claims.</p>
+ */
+public final class CapabilityResourceFactory {
+    private static final Logger LOG = Logger.getLogger(CapabilityResourceFactory.class);
+
+    public static final String WANAKU_CAPABILITY_DEPLOYMENT_FILE = "wanaku-capability-deployment.yaml";
+    public static final String CAMEL_INTEGRATION_CAPABILITY_DEPLOYMENT_FILE =
+            "camel-integration-capability-deployment.yaml";
+    public static final String CAPABILITY_INTERNAL_SERVICE_FILE = "wanaku-capability-service-internal.yaml";
+    public static final String SERVICES_VOLUME_PVC_FILE = "services-volume-pvc.yaml";
+
+    private CapabilityResourceFactory() {}
+
+    /**
+     * Creates a PersistentVolumeClaim for capability service storage.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param serviceName the name of the capability service
+     * @return a fully configured PersistentVolumeClaim
+     */
+    public static PersistentVolumeClaim makeServicesVolumePVC(WanakuCapability resource, String serviceName) {
+        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
+                PersistentVolumeClaim.class, WanakuCapabilityReconciler.class, SERVICES_VOLUME_PVC_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
+        pvc.getMetadata().setName(createVolumeClaimName(serviceName));
+        pvc.getMetadata().setNamespace(ns);
+        pvc.getMetadata().getLabels().put("app", deploymentName);
+        pvc.getMetadata().getLabels().put("component", "wanaku-services-storage");
+
+        pvc.addOwnerReference(resource);
+
+        return pvc;
+    }
+
+    /**
+     * Creates a volume claim name from a service name.
+     *
+     * @param serviceName the name of the service
+     * @return the volume claim name in the format "{serviceName}-volume-claim"
+     */
+    public static String createVolumeClaimName(String serviceName) {
+        return serviceName + "-volume-claim";
+    }
+
+    /**
+     * Creates a deployment for a Wanaku-native capability.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param context the reconciler context
+     * @param capabilitiesSpec the specific capability specification
+     * @return a fully configured Deployment
+     */
+    public static Deployment makeDesiredWanakuCapabilityDeployment(
+            WanakuCapability resource,
+            Context<WanakuCapability> context,
+            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
+                Deployment.class, WanakuCapabilityReconciler.class, WANAKU_CAPABILITY_DEPLOYMENT_FILE);
+
+        return configureCapabilityDeployment(
+                desiredDeployment,
+                resource,
+                capabilitiesSpec,
+                () -> EnvironmentVariableHelper.computeWanakuCapabilitiesEnvVars(resource, capabilitiesSpec));
+    }
+
+    /**
+     * Creates a deployment for a Camel Integration Capability.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param context the reconciler context
+     * @param capabilitiesSpec the specific capability specification
+     * @return a fully configured Deployment
+     */
+    public static Deployment makeDesiredCiCCapabilityDeployment(
+            WanakuCapability resource,
+            Context<WanakuCapability> context,
+            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
+                Deployment.class, WanakuCapabilityReconciler.class, CAMEL_INTEGRATION_CAPABILITY_DEPLOYMENT_FILE);
+
+        return configureCapabilityDeployment(
+                desiredDeployment,
+                resource,
+                capabilitiesSpec,
+                () -> EnvironmentVariableHelper.computeCamelIntegrationCapabilitiesEnvVars(resource, capabilitiesSpec));
+    }
+
+    /**
+     * Creates an internal (ClusterIP) service for a capability.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param capabilitiesSpec the specific capability specification
+     * @return a fully configured Service
+     */
+    public static Service makeCapabilityInternalService(
+            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
+        Service service = ReconcilerUtilsInternal.loadYaml(
+                Service.class, WanakuCapabilityReconciler.class, CAPABILITY_INTERNAL_SERVICE_FILE);
+
+        String serviceName = capabilitiesSpec.getName();
+        String ns = resource.getMetadata().getNamespace();
+        String parentName = resource.getMetadata().getName();
+
+        LOG.infof("Creating internal service for capability: %s", serviceName);
+        service.getMetadata().setName(serviceName);
+        service.getMetadata().setNamespace(ns);
+        service.getMetadata().getLabels().put("app", parentName);
+        service.getMetadata().getLabels().put("component", serviceName);
+
+        ServiceSpec serviceSpec2 = service.getSpec();
+        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
+
+        service.addOwnerReference(resource);
+
+        return service;
+    }
+
+    private static Deployment configureCapabilityDeployment(
+            Deployment desiredDeployment,
+            WanakuCapability resource,
+            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec,
+            Supplier<List<EnvVar>> envVarSupplier) {
+
+        String serviceName = capabilitiesSpec.getName();
+        String ns = resource.getMetadata().getNamespace();
+        String parentName = resource.getMetadata().getName();
+
+        desiredDeployment.getMetadata().setName(serviceName);
+        desiredDeployment.getMetadata().setNamespace(ns);
+        desiredDeployment.getMetadata().getLabels().put("app", parentName);
+        desiredDeployment.getMetadata().getLabels().put("component", serviceName);
+
+        final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
+
+        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
+        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
+        deploymentSpec
+                .getTemplate()
+                .getSpec()
+                .getContainers()
+                .getFirst()
+                .getVolumeMounts()
+                .getFirst()
+                .setName(serviceName + "-volume");
+        deploymentSpec.getTemplate().getSpec().getVolumes().getFirst().setName(serviceName + "-volume");
+        deploymentSpec
+                .getTemplate()
+                .getSpec()
+                .getVolumes()
+                .getFirst()
+                .getPersistentVolumeClaim()
+                .setClaimName(createVolumeClaimName(serviceName));
+
+        setupCapabilityContainer(resource, deploymentSpec, capabilitiesSpec, envVarSupplier);
+
+        desiredDeployment.addOwnerReference(resource);
+        return desiredDeployment;
+    }
+
+    private static void setupCapabilityContainer(
+            WanakuCapability resource,
+            DeploymentSpec spec,
+            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec,
+            Supplier<List<EnvVar>> envVarSupplier) {
+        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
+
+        final Container service = containers.get(0);
+        final String serviceName = capabilitiesSpec.getName();
+        service.setName(serviceName);
+
+        String serviceImage = capabilitiesSpec.getImage();
+        service.setImage(serviceImage);
+
+        // Resolve pull policy with fallback chain: component -> global -> default
+        String componentPolicy = capabilitiesSpec.getImagePullPolicy();
+        String globalPolicy = resource.getSpec().getImagePullPolicy();
+        String resolvedPolicy = OperatorUtil.resolveImagePullPolicy(componentPolicy, globalPolicy);
+        service.setImagePullPolicy(resolvedPolicy);
+
+        final List<EnvVar> userDefinedVars = envVarSupplier.get();
+        final List<EnvVar> templateEnvs = service.getEnv();
+
+        for (EnvVar templateVar : templateEnvs) {
+            final Optional<EnvVar> override = userDefinedVars.stream()
+                    .filter(envVar -> envVar.getName().equals(templateVar.getName()))
+                    .findFirst();
+
+            if (override.isEmpty()) {
+                userDefinedVars.add(templateVar);
+            }
+        }
+
+        service.setEnv(userDefinedVars);
+    }
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariableHelper.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariableHelper.java
@@ -1,0 +1,160 @@
+package ai.wanaku.operator.util;
+
+import java.util.List;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+import ai.wanaku.operator.wanaku.WanakuTypes;
+
+/**
+ * Helper for computing environment variables for capability deployments.
+ *
+ * <p>Both Wanaku-native and Camel Integration capabilities share a common structure:
+ * resolve auth server, OIDC secret, and registration URI, then build an {@link EnvVar} list.
+ * This class extracts the common logic and parameterizes the env var names.</p>
+ */
+public final class EnvironmentVariableHelper {
+
+    private EnvironmentVariableHelper() {}
+
+    /**
+     * Computes environment variables for Wanaku-native capability deployments.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param capabilitiesSpec the specific capability specification
+     * @return a mutable list of environment variables for the deployment
+     */
+    public static List<EnvVar> computeWanakuCapabilitiesEnvVars(
+            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
+
+        final String authServer = resource.getSpec().getAuth().getAuthServer();
+
+        List<EnvVar> envVars = buildCommonEnvVars(
+                resource,
+                authServer,
+                EnvironmentVariables.AUTH_SERVER,
+                EnvironmentVariables.WANAKU_SERVICE_REGISTRATION_URI,
+                EnvironmentVariables.QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET);
+
+        addCustomVars(capabilitiesSpec.getEnv(), envVars);
+        return envVars;
+    }
+
+    /**
+     * Computes environment variables for Camel Integration Capability deployments.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param capabilitiesSpec the specific capability specification
+     * @return a mutable list of environment variables for the deployment
+     */
+    public static List<EnvVar> computeCamelIntegrationCapabilitiesEnvVars(
+            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
+
+        String realm = OperatorUtil.resolveAuthRealm(resource);
+        String authServerValue = resource.getSpec().getAuth().getAuthServer() + "/realms/" + realm;
+
+        List<EnvVar> envVars = buildCommonEnvVars(
+                resource,
+                authServerValue,
+                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT,
+                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_REGISTRATION_URL,
+                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_SECRET);
+
+        envVars.add(new EnvVarBuilder()
+                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_NAME)
+                .withValue(capabilitiesSpec.getName())
+                .build());
+
+        if (capabilitiesSpec.getServiceCatalog() != null
+                && !capabilitiesSpec.getServiceCatalog().isBlank()) {
+            envVars.add(new EnvVarBuilder()
+                    .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_CATALOG)
+                    .withValue(capabilitiesSpec.getServiceCatalog())
+                    .build());
+        }
+        if (capabilitiesSpec.getServiceCatalogSystem() != null
+                && !capabilitiesSpec.getServiceCatalogSystem().isBlank()) {
+            envVars.add(new EnvVarBuilder()
+                    .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_CATALOG_SYSTEM)
+                    .withValue(capabilitiesSpec.getServiceCatalogSystem())
+                    .build());
+        }
+
+        addCustomVars(capabilitiesSpec.getEnv(), envVars);
+        return envVars;
+    }
+
+    /**
+     * Builds the common set of environment variables shared by all capability types.
+     *
+     * <p>This method extracts the duplicated structure: auth server, registration URI,
+     * and OIDC secret resolution. Only the env var names and auth server value differ
+     * between capability types.</p>
+     *
+     * @param resource the WanakuCapability custom resource
+     * @param authServerValue the resolved auth server value (raw URL or with realm path)
+     * @param authServerEnvName the env var name for the auth server
+     * @param registrationUriEnvName the env var name for the registration URI
+     * @param oidcSecretEnvName the env var name for the OIDC secret
+     * @return a mutable list of the common environment variables
+     */
+    private static List<EnvVar> buildCommonEnvVars(
+            WanakuCapability resource,
+            String authServerValue,
+            String authServerEnvName,
+            String registrationUriEnvName,
+            String oidcSecretEnvName) {
+
+        final String oidcSecret = resource.getSpec().getSecrets().getOidcCredentialsSecret();
+        String registrationUri = getInternalRegistrationUri(resource);
+
+        EnvVar authServerEnv = new EnvVarBuilder()
+                .withName(authServerEnvName)
+                .withValue(authServerValue)
+                .build();
+        EnvVar registrationUriEnv = new EnvVarBuilder()
+                .withName(registrationUriEnvName)
+                .withValue(registrationUri)
+                .build();
+        EnvVar oidcSecretEnv = new EnvVarBuilder()
+                .withName(oidcSecretEnvName)
+                .withValue(oidcSecret)
+                .build();
+
+        List<EnvVar> envVars = new java.util.ArrayList<>();
+        envVars.add(authServerEnv);
+        envVars.add(registrationUriEnv);
+        envVars.add(oidcSecretEnv);
+
+        return envVars;
+    }
+
+    /**
+     * Adds custom user-defined environment variables to the list.
+     *
+     * @param customEnv the custom environment variables from the spec (may be null)
+     * @param envVars the target list to add variables to
+     */
+    static void addCustomVars(List<WanakuTypes.EnvVar> customEnv, List<EnvVar> envVars) {
+        if (customEnv != null && !customEnv.isEmpty()) {
+            for (WanakuTypes.EnvVar env : customEnv) {
+                EnvVar customEnvVar = new EnvVarBuilder()
+                        .withName(env.getName())
+                        .withValue(env.getValue())
+                        .build();
+                envVars.add(customEnvVar);
+            }
+        }
+    }
+
+    /**
+     * Constructs the internal registration URI for a capability based on its router reference.
+     *
+     * @param resource the WanakuCapability custom resource
+     * @return the internal registration URI
+     */
+    private static String getInternalRegistrationUri(WanakuCapability resource) {
+        return OperatorUtil.getRouterBaseUrl(resource.getSpec().getRouterRef()) + "/";
+    }
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorConstants.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorConstants.java
@@ -1,0 +1,14 @@
+package ai.wanaku.operator.util;
+
+/**
+ * Shared constants used across operator reconcilers and resource factories.
+ */
+public final class OperatorConstants {
+
+    /**
+     * The capability type identifier for Camel Integration Capability deployments.
+     */
+    public static final String CAMEL_INTEGRATION_CAPABILITY_TYPE = "camel-integration-capability";
+
+    private OperatorConstants() {}
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -3,54 +3,43 @@ package ai.wanaku.operator.util;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 import org.jboss.logging.Logger;
 import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceSpec;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.openshift.api.model.Route;
-import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
-import io.javaoperatorsdk.operator.api.reconciler.Context;
 import ai.wanaku.operator.wanaku.WanakuCapability;
-import ai.wanaku.operator.wanaku.WanakuCapabilityReconciler;
-import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
 import ai.wanaku.operator.wanaku.WanakuRouter;
-import ai.wanaku.operator.wanaku.WanakuRouterReconciler;
-import ai.wanaku.operator.wanaku.WanakuRouterSpec;
-import ai.wanaku.operator.wanaku.WanakuTypes;
 
+/**
+ * Shared operator utilities for condition management, image pull policy resolution,
+ * auth realm resolution, and router URL construction.
+ *
+ * <p>Resource-specific factory methods have been extracted to:
+ * <ul>
+ *   <li>{@link RouterResourceFactory} for router K8s resources</li>
+ *   <li>{@link CapabilityResourceFactory} for capability K8s resources</li>
+ *   <li>{@link EnvironmentVariableHelper} for environment variable computation</li>
+ * </ul>
+ */
 public final class OperatorUtil {
     private static final Logger LOG = Logger.getLogger(OperatorUtil.class);
     public static final String READY_CONDITION = "Ready";
     public static final String CONDITION_STATUS_TRUE = "True";
     public static final String CONDITION_REASON_READY = "ReconciliationSucceeded";
-    public static final String ROUTER_BACKEND_DEPLOYMENT_FILE = "wanaku-router-deployment.yaml";
-    public static final String ROUTER_BACKEND_INTERNAL_SERVICE_FILE = "wanaku-router-service-internal.yaml";
-    public static final String ROUTER_BACKEND_EXTERNAL_SERVICE_FILE = "wanaku-router-service-external.yaml";
-    public static final String ROUTER_INGRESS_FILE = "wanaku-router-ingress.yaml";
-    public static final String WANAKU_CAPABILITY_DEPLOYMENT_FILE = "wanaku-capability-deployment.yaml";
-    public static final String CAMEL_INTEGRATION_CAPABILITY_DEPLOYMENT_FILE =
-            "camel-integration-capability-deployment.yaml";
-    public static final String CAPABILITY_INTERNAL_SERVICE_FILE = "wanaku-capability-service-internal.yaml";
-    public static final String SERVICES_VOLUME_PVC_FILE = "services-volume-pvc.yaml";
-    public static final String ROUTER_VOLUME_CLAIM = "router-volume-claim";
 
     public static final String DEFAULT_PULL_POLICY = "IfNotPresent";
     public static final Set<String> VALID_PULL_POLICIES = Set.of("Always", "IfNotPresent", "Never");
 
     private OperatorUtil() {}
 
+    /**
+     * Creates a Ready condition for a custom resource status.
+     *
+     * @param generation the observed generation
+     * @param previousCondition the previous condition (may be null)
+     * @param message the status message
+     * @return a new Ready condition
+     */
     public static Condition readyCondition(Long generation, Condition previousCondition, String message) {
         final boolean alreadyReady =
                 previousCondition != null && CONDITION_STATUS_TRUE.equals(previousCondition.getStatus());
@@ -68,6 +57,13 @@ public final class OperatorUtil {
                 .build();
     }
 
+    /**
+     * Finds a condition by type in a list of conditions.
+     *
+     * @param conditions the list of conditions (may be null or empty)
+     * @param type the condition type to find
+     * @return the matching condition, or null if not found
+     */
     public static Condition findCondition(List<Condition> conditions, String type) {
         if (conditions == null || conditions.isEmpty() || type == null) {
             return null;
@@ -101,473 +97,22 @@ public final class OperatorUtil {
         return resolved;
     }
 
-    // ---- Router methods ----
-
-    private static void setupBackendContainer(WanakuRouter resource, DeploymentSpec spec, String host) {
-        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
-
-        final Container service = containers.stream()
-                .filter(c -> c.getName().equals("wanaku-mcp-router"))
-                .findFirst()
-                .get();
-
-        final String authServer = resource.getSpec().getAuth().getAuthServer();
-
-        // If a proxy is not defined,
-        String authProxy = resource.getSpec().getAuth().getAuthProxy();
-        if ("auto".equals(authProxy)) {
-            // TODO: needs to support https
-            authProxy = String.format("http://%s", host);
-        } else {
-            if (authProxy == null) {
-                authProxy = authServer;
-            }
-        }
-
-        String realm = resolveAuthRealm(resource);
-
-        EnvVar authServerEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_SERVER)
-                .withValue(authServer)
-                .build();
-        EnvVar authProxyEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_PROXY)
-                .withValue(authProxy)
-                .build();
-        EnvVar authRealmEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_REALM)
-                .withValue(realm)
-                .build();
-
-        List<EnvVar> envVars = new java.util.ArrayList<>();
-        envVars.add(authServerEnv);
-        envVars.add(authProxyEnv);
-        envVars.add(authRealmEnv);
-
-        final WanakuRouterSpec.RouterSpec routerSpec = resource.getSpec().getRouter();
-
-        // Resolve pull policy with fallback chain: component -> global -> default
-        String componentPolicy = routerSpec != null ? routerSpec.getImagePullPolicy() : null;
-        String globalPolicy = resource.getSpec().getImagePullPolicy();
-        String resolvedPolicy = resolveImagePullPolicy(componentPolicy, globalPolicy);
-        service.setImagePullPolicy(resolvedPolicy);
-
-        if (routerSpec != null) {
-            // Set a custom image
-            final String image = routerSpec.getImage();
-
-            if (image != null) {
-                service.setImage(image);
-            }
-
-            // Add custom environment variables from router spec if provided
-            if (routerSpec.getEnv() != null && !routerSpec.getEnv().isEmpty()) {
-                for (WanakuTypes.EnvVar env : routerSpec.getEnv()) {
-                    EnvVar customEnvVar = new EnvVarBuilder()
-                            .withName(env.getName())
-                            .withValue(env.getValue())
-                            .build();
-                    envVars.add(customEnvVar);
-                }
-            }
-        }
-
-        service.setEnv(envVars);
-    }
-
-    public static Deployment makeDesiredRouterBackendDeployment(
-            WanakuRouter resource, Context<WanakuRouter> context, String host) {
-        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
-                Deployment.class, WanakuRouterReconciler.class, ROUTER_BACKEND_DEPLOYMENT_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        desiredDeployment.getMetadata().setName(routerName(deploymentName));
-        desiredDeployment.getMetadata().setNamespace(ns);
-
-        final DeploymentSpec serviceSpec = desiredDeployment.getSpec();
-
-        serviceSpec.getSelector().getMatchLabels().put("app", routerName(deploymentName));
-        serviceSpec.getSelector().getMatchLabels().put("component", "wanaku-router-backend");
-        serviceSpec.getTemplate().getMetadata().getLabels().put("app", routerName(deploymentName));
-        serviceSpec.getTemplate().getMetadata().getLabels().put("component", "wanaku-router-backend");
-
-        setupBackendContainer(resource, serviceSpec, host);
-
-        final Container routerContainer = serviceSpec.getTemplate().getSpec().getContainers().stream()
-                .filter(c -> c.getName().equals("wanaku-mcp-router"))
-                .findFirst()
-                .get();
-
-        // Override image if specified in router spec
-        if (resource.getSpec().getRouter() != null
-                && resource.getSpec().getRouter().getImage() != null
-                && !resource.getSpec().getRouter().getImage().isEmpty()) {
-            routerContainer.setImage(resource.getSpec().getRouter().getImage());
-            LOG.infof(
-                    "Using custom router image: %s",
-                    resource.getSpec().getRouter().getImage());
-        }
-
-        desiredDeployment.addOwnerReference(resource);
-        return desiredDeployment;
-    }
-
-    private static String routerName(String deploymentName) {
-        return deploymentName + "-mcp-router";
-    }
-
-    public static Service makeRouterInternalService(WanakuRouter resource) {
-        Service service = ReconcilerUtilsInternal.loadYaml(
-                Service.class, WanakuRouterReconciler.class, ROUTER_BACKEND_INTERNAL_SERVICE_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        LOG.infof("Creating new external service for deployment: %s", deploymentName);
-        service.getMetadata().setName("internal-" + deploymentName);
-        service.getMetadata().setNamespace(ns);
-        service.getMetadata().getLabels().put("app", routerName(deploymentName));
-        service.getMetadata().getLabels().put("component", "wanaku-router-backend");
-        service.getSpec().getSelector().put("app", routerName(deploymentName));
-
-        ServiceSpec serviceSpec = service.getSpec();
-        serviceSpec.setSelector(Map.of("app", routerName(deploymentName), "component", "wanaku-router-backend"));
-
-        service.addOwnerReference(resource);
-
-        return service;
-    }
-
-    public static Route makeRouterExternalService(WanakuRouter resource) {
-        Route route = ReconcilerUtilsInternal.loadYaml(
-                Route.class, WanakuRouterReconciler.class, ROUTER_BACKEND_EXTERNAL_SERVICE_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        LOG.infof("Creating new external service for deployment: %s", deploymentName);
-        route.getMetadata().setName(deploymentName);
-        route.getMetadata().setNamespace(ns);
-        route.getMetadata().getLabels().put("app", routerName(deploymentName));
-        route.getMetadata().getLabels().put("component", "wanaku-router-backend");
-        route.getSpec().getTo().setName("internal-" + deploymentName);
-
-        route.addOwnerReference(resource);
-
-        return route;
-    }
-
-    public static Ingress makeRouterIngress(WanakuRouter resource, String host) {
-        Ingress ingress =
-                ReconcilerUtilsInternal.loadYaml(Ingress.class, WanakuRouterReconciler.class, ROUTER_INGRESS_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        LOG.infof("Creating new ingress for deployment: %s", deploymentName);
-        ingress.getMetadata().setName(deploymentName);
-        ingress.getMetadata().setNamespace(ns);
-        ingress.getMetadata().getLabels().put("app", routerName(deploymentName));
-        ingress.getMetadata().getLabels().put("component", "wanaku-router-backend");
-
-        // Set the host and backend service
-        ingress.getSpec().getRules().getFirst().setHost(host);
-        ingress.getSpec()
-                .getRules()
-                .getFirst()
-                .getHttp()
-                .getPaths()
-                .getFirst()
-                .getBackend()
-                .getService()
-                .setName("internal-" + deploymentName);
-
-        ingress.addOwnerReference(resource);
-
-        return ingress;
-    }
-
-    public static PersistentVolumeClaim makeRouterVolumePVC(WanakuRouter resource) {
-        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
-                PersistentVolumeClaim.class, WanakuRouterReconciler.class, SERVICES_VOLUME_PVC_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
-        pvc.getMetadata().setName(ROUTER_VOLUME_CLAIM);
-        pvc.getMetadata().setNamespace(ns);
-        pvc.getMetadata().getLabels().put("app", routerName(deploymentName));
-        pvc.getMetadata().getLabels().put("component", "wanaku-router-storage");
-
-        pvc.addOwnerReference(resource);
-
-        return pvc;
-    }
-
-    // ---- Capability methods ----
-
-    public static PersistentVolumeClaim makeServicesVolumePVC(WanakuCapability resource, String serviceName) {
-        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
-                PersistentVolumeClaim.class, WanakuCapabilityReconciler.class, SERVICES_VOLUME_PVC_FILE);
-
-        String deploymentName = resource.getMetadata().getName();
-        String ns = resource.getMetadata().getNamespace();
-
-        LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
-        pvc.getMetadata().setName(createVolumeClaimName(serviceName));
-        pvc.getMetadata().setNamespace(ns);
-        pvc.getMetadata().getLabels().put("app", deploymentName);
-        pvc.getMetadata().getLabels().put("component", "wanaku-services-storage");
-
-        pvc.addOwnerReference(resource);
-
-        return pvc;
-    }
-
-    public static String createVolumeClaimName(String serviceName) {
-        return serviceName + "-volume-claim";
-    }
-
-    private static void setupCapabilityContainer(
-            WanakuCapability resource,
-            DeploymentSpec spec,
-            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec,
-            Supplier<List<EnvVar>> envVarSupplier) {
-        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
-
-        final Container service = containers.get(0);
-        final String serviceName = capabilitiesSpec.getName();
-        service.setName(serviceName);
-
-        String serviceImage = capabilitiesSpec.getImage();
-        service.setImage(serviceImage);
-
-        // Resolve pull policy with fallback chain: component -> global -> default
-        String componentPolicy = capabilitiesSpec.getImagePullPolicy();
-        String globalPolicy = resource.getSpec().getImagePullPolicy();
-        String resolvedPolicy = resolveImagePullPolicy(componentPolicy, globalPolicy);
-        service.setImagePullPolicy(resolvedPolicy);
-
-        final List<EnvVar> userDefinedVars = envVarSupplier.get();
-        final List<EnvVar> templateEnvs = service.getEnv();
-
-        for (EnvVar templateVar : templateEnvs) {
-            final Optional<EnvVar> override = userDefinedVars.stream()
-                    .filter(envVar -> envVar.getName().equals(templateVar.getName()))
-                    .findFirst();
-
-            if (override.isEmpty()) {
-                userDefinedVars.add(templateVar);
-            }
-        }
-
-        service.setEnv(userDefinedVars);
-    }
-
-    private static List<EnvVar> computeWanakuCapabilitiesEnvVars(
-            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        List<WanakuTypes.EnvVar> customEnv = capabilitiesSpec.getEnv();
-        final String authServer = resource.getSpec().getAuth().getAuthServer();
-        final String oidcSecret = resource.getSpec().getSecrets().getOidcCredentialsSecret();
-
-        // Build the registration URI - use the router ref for service discovery
-        String registrationUri = getInternalRegistrationUri(resource);
-
-        EnvVar authServerEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_SERVER)
-                .withValue(authServer)
-                .build();
-        EnvVar registrationUriEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.WANAKU_SERVICE_REGISTRATION_URI)
-                .withValue(registrationUri)
-                .build();
-        EnvVar oidcSecretEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET)
-                .withValue(oidcSecret)
-                .build();
-
-        List<EnvVar> envVars = new java.util.ArrayList<>();
-        envVars.add(authServerEnv);
-        envVars.add(registrationUriEnv);
-        envVars.add(oidcSecretEnv);
-
-        // Add custom environment variables if provided
-        addCustomVars(customEnv, envVars);
-        return envVars;
-    }
-
-    private static List<EnvVar> computeCamelIntegrationCapabilitiesEnvVars(
-            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        List<WanakuTypes.EnvVar> customEnv = capabilitiesSpec.getEnv();
-        final String authServer = resource.getSpec().getAuth().getAuthServer();
-        final String oidcSecret = resource.getSpec().getSecrets().getOidcCredentialsSecret();
-
-        // Build the registration URI - use the router ref for service discovery
-        String registrationUri = getInternalRegistrationUri(resource);
-
-        String realm = resolveAuthRealm(resource);
-        EnvVar authServerEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT)
-                .withValue(authServer + "/realms/" + realm)
-                .build();
-        EnvVar registrationUriEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_REGISTRATION_URL)
-                .withValue(registrationUri)
-                .build();
-        EnvVar oidcSecretEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_SECRET)
-                .withValue(oidcSecret)
-                .build();
-
-        EnvVar serviceName = new EnvVarBuilder()
-                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_NAME)
-                .withValue(capabilitiesSpec.getName())
-                .build();
-
-        List<EnvVar> envVars = new java.util.ArrayList<>();
-        envVars.add(authServerEnv);
-        envVars.add(registrationUriEnv);
-        envVars.add(oidcSecretEnv);
-        envVars.add(serviceName);
-
-        if (capabilitiesSpec.getServiceCatalog() != null
-                && !capabilitiesSpec.getServiceCatalog().isBlank()) {
-            envVars.add(new EnvVarBuilder()
-                    .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_CATALOG)
-                    .withValue(capabilitiesSpec.getServiceCatalog())
-                    .build());
-        }
-        if (capabilitiesSpec.getServiceCatalogSystem() != null
-                && !capabilitiesSpec.getServiceCatalogSystem().isBlank()) {
-            envVars.add(new EnvVarBuilder()
-                    .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_CATALOG_SYSTEM)
-                    .withValue(capabilitiesSpec.getServiceCatalogSystem())
-                    .build());
-        }
-
-        addCustomVars(customEnv, envVars);
-        return envVars;
-    }
-
-    private static void addCustomVars(List<WanakuTypes.EnvVar> customEnv, List<EnvVar> envVars) {
-        // Add custom environment variables if provided
-        if (customEnv != null && !customEnv.isEmpty()) {
-            for (WanakuTypes.EnvVar env : customEnv) {
-                EnvVar customEnvVar = new EnvVarBuilder()
-                        .withName(env.getName())
-                        .withValue(env.getValue())
-                        .build();
-                envVars.add(customEnvVar);
-            }
-        }
-    }
-
+    /**
+     * Constructs the internal base URL for a router.
+     *
+     * @param routerRef the router reference name
+     * @return the base URL in the format "http://internal-{routerRef}:8080"
+     */
     public static String getRouterBaseUrl(String routerRef) {
         return "http://internal-" + routerRef + ":8080";
     }
 
-    private static String getInternalRegistrationUri(WanakuCapability resource) {
-        return getRouterBaseUrl(resource.getSpec().getRouterRef()) + "/";
-    }
-
-    private static Deployment configureCapabilityDeployment(
-            Deployment desiredDeployment,
-            WanakuCapability resource,
-            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec,
-            Supplier<List<EnvVar>> envVarSupplier) {
-
-        String serviceName = capabilitiesSpec.getName();
-        String ns = resource.getMetadata().getNamespace();
-        String parentName = resource.getMetadata().getName();
-
-        desiredDeployment.getMetadata().setName(serviceName);
-        desiredDeployment.getMetadata().setNamespace(ns);
-        desiredDeployment.getMetadata().getLabels().put("app", parentName);
-        desiredDeployment.getMetadata().getLabels().put("component", serviceName);
-
-        final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
-
-        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
-        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
-        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
-        deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
-        deploymentSpec
-                .getTemplate()
-                .getSpec()
-                .getContainers()
-                .getFirst()
-                .getVolumeMounts()
-                .getFirst()
-                .setName(serviceName + "-volume");
-        deploymentSpec.getTemplate().getSpec().getVolumes().getFirst().setName(serviceName + "-volume");
-        deploymentSpec
-                .getTemplate()
-                .getSpec()
-                .getVolumes()
-                .getFirst()
-                .getPersistentVolumeClaim()
-                .setClaimName(createVolumeClaimName(serviceName));
-
-        setupCapabilityContainer(resource, deploymentSpec, capabilitiesSpec, envVarSupplier);
-
-        desiredDeployment.addOwnerReference(resource);
-        return desiredDeployment;
-    }
-
-    public static Deployment makeDesiredWanakuCapabilityDeployment(
-            WanakuCapability resource,
-            Context<WanakuCapability> context,
-            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
-                Deployment.class, WanakuCapabilityReconciler.class, WANAKU_CAPABILITY_DEPLOYMENT_FILE);
-
-        return configureCapabilityDeployment(
-                desiredDeployment,
-                resource,
-                capabilitiesSpec,
-                () -> computeWanakuCapabilitiesEnvVars(resource, capabilitiesSpec));
-    }
-
-    public static Deployment makeDesiredCiCCapabilityDeployment(
-            WanakuCapability resource,
-            Context<WanakuCapability> context,
-            WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
-                Deployment.class, WanakuCapabilityReconciler.class, CAMEL_INTEGRATION_CAPABILITY_DEPLOYMENT_FILE);
-
-        return configureCapabilityDeployment(
-                desiredDeployment,
-                resource,
-                capabilitiesSpec,
-                () -> computeCamelIntegrationCapabilitiesEnvVars(resource, capabilitiesSpec));
-    }
-
-    public static Service makeCapabilityInternalService(
-            WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
-        Service service = ReconcilerUtilsInternal.loadYaml(
-                Service.class, WanakuCapabilityReconciler.class, CAPABILITY_INTERNAL_SERVICE_FILE);
-
-        String serviceName = capabilitiesSpec.getName();
-        String ns = resource.getMetadata().getNamespace();
-        String parentName = resource.getMetadata().getName();
-
-        LOG.infof("Creating internal service for capability: %s", serviceName);
-        service.getMetadata().setName(serviceName);
-        service.getMetadata().setNamespace(ns);
-        service.getMetadata().getLabels().put("app", parentName);
-        service.getMetadata().getLabels().put("component", serviceName);
-
-        ServiceSpec serviceSpec2 = service.getSpec();
-        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
-
-        service.addOwnerReference(resource);
-
-        return service;
-    }
-
+    /**
+     * Resolves the auth realm for a WanakuCapability resource.
+     *
+     * @param resource the WanakuCapability custom resource (may be null)
+     * @return the configured realm, or the default "wanaku" realm
+     */
     static String resolveAuthRealm(WanakuCapability resource) {
         if (resource == null || resource.getSpec() == null || resource.getSpec().getAuth() == null) {
             return EnvironmentVariables.DEFAULT_AUTH_REALM;
@@ -576,6 +121,12 @@ public final class OperatorUtil {
         return (realm == null || realm.isBlank()) ? EnvironmentVariables.DEFAULT_AUTH_REALM : realm;
     }
 
+    /**
+     * Resolves the auth realm for a WanakuRouter resource.
+     *
+     * @param resource the WanakuRouter custom resource (may be null)
+     * @return the configured realm, or the default "wanaku" realm
+     */
     static String resolveAuthRealm(WanakuRouter resource) {
         if (resource == null || resource.getSpec() == null || resource.getSpec().getAuth() == null) {
             return EnvironmentVariables.DEFAULT_AUTH_REALM;

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
@@ -1,0 +1,277 @@
+package ai.wanaku.operator.util;
+
+import java.util.List;
+import java.util.Map;
+import org.jboss.logging.Logger;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.ReconcilerUtilsInternal;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import ai.wanaku.operator.wanaku.WanakuRouter;
+import ai.wanaku.operator.wanaku.WanakuRouterReconciler;
+import ai.wanaku.operator.wanaku.WanakuRouterSpec;
+import ai.wanaku.operator.wanaku.WanakuTypes;
+
+/**
+ * Factory for creating Kubernetes resources related to WanakuRouter deployments.
+ *
+ * <p>Handles the creation of router deployments, internal/external services,
+ * ingresses, routes, and persistent volume claims.</p>
+ */
+public final class RouterResourceFactory {
+    private static final Logger LOG = Logger.getLogger(RouterResourceFactory.class);
+
+    public static final String ROUTER_BACKEND_DEPLOYMENT_FILE = "wanaku-router-deployment.yaml";
+    public static final String ROUTER_BACKEND_INTERNAL_SERVICE_FILE = "wanaku-router-service-internal.yaml";
+    public static final String ROUTER_BACKEND_EXTERNAL_SERVICE_FILE = "wanaku-router-service-external.yaml";
+    public static final String ROUTER_INGRESS_FILE = "wanaku-router-ingress.yaml";
+    public static final String SERVICES_VOLUME_PVC_FILE = "services-volume-pvc.yaml";
+    public static final String ROUTER_VOLUME_CLAIM = "router-volume-claim";
+
+    private RouterResourceFactory() {}
+
+    /**
+     * Creates the desired router backend deployment for the given WanakuRouter resource.
+     *
+     * @param resource the WanakuRouter custom resource
+     * @param context the reconciler context
+     * @param host the external host for the router
+     * @return a fully configured Deployment
+     */
+    public static Deployment makeDesiredRouterBackendDeployment(
+            WanakuRouter resource, Context<WanakuRouter> context, String host) {
+        Deployment desiredDeployment = ReconcilerUtilsInternal.loadYaml(
+                Deployment.class, WanakuRouterReconciler.class, ROUTER_BACKEND_DEPLOYMENT_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        desiredDeployment.getMetadata().setName(routerName(deploymentName));
+        desiredDeployment.getMetadata().setNamespace(ns);
+
+        final DeploymentSpec serviceSpec = desiredDeployment.getSpec();
+
+        serviceSpec.getSelector().getMatchLabels().put("app", routerName(deploymentName));
+        serviceSpec.getSelector().getMatchLabels().put("component", "wanaku-router-backend");
+        serviceSpec.getTemplate().getMetadata().getLabels().put("app", routerName(deploymentName));
+        serviceSpec.getTemplate().getMetadata().getLabels().put("component", "wanaku-router-backend");
+
+        setupBackendContainer(resource, serviceSpec, host);
+
+        final Container routerContainer = serviceSpec.getTemplate().getSpec().getContainers().stream()
+                .filter(c -> c.getName().equals("wanaku-mcp-router"))
+                .findFirst()
+                .get();
+
+        // Override image if specified in router spec
+        if (resource.getSpec().getRouter() != null
+                && resource.getSpec().getRouter().getImage() != null
+                && !resource.getSpec().getRouter().getImage().isEmpty()) {
+            routerContainer.setImage(resource.getSpec().getRouter().getImage());
+            LOG.infof(
+                    "Using custom router image: %s",
+                    resource.getSpec().getRouter().getImage());
+        }
+
+        desiredDeployment.addOwnerReference(resource);
+        return desiredDeployment;
+    }
+
+    /**
+     * Creates the internal (ClusterIP) service for the router.
+     *
+     * @param resource the WanakuRouter custom resource
+     * @return a fully configured Service
+     */
+    public static Service makeRouterInternalService(WanakuRouter resource) {
+        Service service = ReconcilerUtilsInternal.loadYaml(
+                Service.class, WanakuRouterReconciler.class, ROUTER_BACKEND_INTERNAL_SERVICE_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating new external service for deployment: %s", deploymentName);
+        service.getMetadata().setName("internal-" + deploymentName);
+        service.getMetadata().setNamespace(ns);
+        service.getMetadata().getLabels().put("app", routerName(deploymentName));
+        service.getMetadata().getLabels().put("component", "wanaku-router-backend");
+        service.getSpec().getSelector().put("app", routerName(deploymentName));
+
+        ServiceSpec serviceSpec = service.getSpec();
+        serviceSpec.setSelector(Map.of("app", routerName(deploymentName), "component", "wanaku-router-backend"));
+
+        service.addOwnerReference(resource);
+
+        return service;
+    }
+
+    /**
+     * Creates an OpenShift Route for external access to the router.
+     *
+     * @param resource the WanakuRouter custom resource
+     * @return a fully configured Route
+     */
+    public static Route makeRouterExternalService(WanakuRouter resource) {
+        Route route = ReconcilerUtilsInternal.loadYaml(
+                Route.class, WanakuRouterReconciler.class, ROUTER_BACKEND_EXTERNAL_SERVICE_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating new external service for deployment: %s", deploymentName);
+        route.getMetadata().setName(deploymentName);
+        route.getMetadata().setNamespace(ns);
+        route.getMetadata().getLabels().put("app", routerName(deploymentName));
+        route.getMetadata().getLabels().put("component", "wanaku-router-backend");
+        route.getSpec().getTo().setName("internal-" + deploymentName);
+
+        route.addOwnerReference(resource);
+
+        return route;
+    }
+
+    /**
+     * Creates a Kubernetes Ingress for external access to the router.
+     *
+     * @param resource the WanakuRouter custom resource
+     * @param host the host for the ingress rule
+     * @return a fully configured Ingress
+     */
+    public static Ingress makeRouterIngress(WanakuRouter resource, String host) {
+        Ingress ingress =
+                ReconcilerUtilsInternal.loadYaml(Ingress.class, WanakuRouterReconciler.class, ROUTER_INGRESS_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating new ingress for deployment: %s", deploymentName);
+        ingress.getMetadata().setName(deploymentName);
+        ingress.getMetadata().setNamespace(ns);
+        ingress.getMetadata().getLabels().put("app", routerName(deploymentName));
+        ingress.getMetadata().getLabels().put("component", "wanaku-router-backend");
+
+        // Set the host and backend service
+        ingress.getSpec().getRules().getFirst().setHost(host);
+        ingress.getSpec()
+                .getRules()
+                .getFirst()
+                .getHttp()
+                .getPaths()
+                .getFirst()
+                .getBackend()
+                .getService()
+                .setName("internal-" + deploymentName);
+
+        ingress.addOwnerReference(resource);
+
+        return ingress;
+    }
+
+    /**
+     * Creates a PersistentVolumeClaim for router storage.
+     *
+     * @param resource the WanakuRouter custom resource
+     * @return a fully configured PersistentVolumeClaim
+     */
+    public static PersistentVolumeClaim makeRouterVolumePVC(WanakuRouter resource) {
+        PersistentVolumeClaim pvc = ReconcilerUtilsInternal.loadYaml(
+                PersistentVolumeClaim.class, WanakuRouterReconciler.class, SERVICES_VOLUME_PVC_FILE);
+
+        String deploymentName = resource.getMetadata().getName();
+        String ns = resource.getMetadata().getNamespace();
+
+        LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
+        pvc.getMetadata().setName(ROUTER_VOLUME_CLAIM);
+        pvc.getMetadata().setNamespace(ns);
+        pvc.getMetadata().getLabels().put("app", routerName(deploymentName));
+        pvc.getMetadata().getLabels().put("component", "wanaku-router-storage");
+
+        pvc.addOwnerReference(resource);
+
+        return pvc;
+    }
+
+    private static void setupBackendContainer(WanakuRouter resource, DeploymentSpec spec, String host) {
+        final List<Container> containers = spec.getTemplate().getSpec().getContainers();
+
+        final Container service = containers.stream()
+                .filter(c -> c.getName().equals("wanaku-mcp-router"))
+                .findFirst()
+                .get();
+
+        final String authServer = resource.getSpec().getAuth().getAuthServer();
+
+        // If a proxy is not defined,
+        String authProxy = resource.getSpec().getAuth().getAuthProxy();
+        if ("auto".equals(authProxy)) {
+            // TODO: needs to support https
+            authProxy = String.format("http://%s", host);
+        } else {
+            if (authProxy == null) {
+                authProxy = authServer;
+            }
+        }
+
+        String realm = OperatorUtil.resolveAuthRealm(resource);
+
+        EnvVar authServerEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_SERVER)
+                .withValue(authServer)
+                .build();
+        EnvVar authProxyEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_PROXY)
+                .withValue(authProxy)
+                .build();
+        EnvVar authRealmEnv = new EnvVarBuilder()
+                .withName(EnvironmentVariables.AUTH_REALM)
+                .withValue(realm)
+                .build();
+
+        List<EnvVar> envVars = new java.util.ArrayList<>();
+        envVars.add(authServerEnv);
+        envVars.add(authProxyEnv);
+        envVars.add(authRealmEnv);
+
+        final WanakuRouterSpec.RouterSpec routerSpec = resource.getSpec().getRouter();
+
+        // Resolve pull policy with fallback chain: component -> global -> default
+        String componentPolicy = routerSpec != null ? routerSpec.getImagePullPolicy() : null;
+        String globalPolicy = resource.getSpec().getImagePullPolicy();
+        String resolvedPolicy = OperatorUtil.resolveImagePullPolicy(componentPolicy, globalPolicy);
+        service.setImagePullPolicy(resolvedPolicy);
+
+        if (routerSpec != null) {
+            // Set a custom image
+            final String image = routerSpec.getImage();
+
+            if (image != null) {
+                service.setImage(image);
+            }
+
+            // Add custom environment variables from router spec if provided
+            if (routerSpec.getEnv() != null && !routerSpec.getEnv().isEmpty()) {
+                for (WanakuTypes.EnvVar env : routerSpec.getEnv()) {
+                    EnvVar customEnvVar = new EnvVarBuilder()
+                            .withName(env.getName())
+                            .withValue(env.getValue())
+                            .build();
+                    envVars.add(customEnvVar);
+                }
+            }
+        }
+
+        service.setEnv(envVars);
+    }
+
+    private static String routerName(String deploymentName) {
+        return deploymentName + "-mcp-router";
+    }
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
@@ -19,15 +19,16 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
-import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.util.CapabilityResourceFactory;
+import ai.wanaku.operator.util.OperatorConstants;
 
+import static ai.wanaku.operator.util.CapabilityResourceFactory.createVolumeClaimName;
+import static ai.wanaku.operator.util.CapabilityResourceFactory.makeCapabilityInternalService;
+import static ai.wanaku.operator.util.CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment;
+import static ai.wanaku.operator.util.CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment;
 import static ai.wanaku.operator.util.Matchers.match;
 import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
-import static ai.wanaku.operator.util.OperatorUtil.createVolumeClaimName;
 import static ai.wanaku.operator.util.OperatorUtil.findCondition;
-import static ai.wanaku.operator.util.OperatorUtil.makeCapabilityInternalService;
-import static ai.wanaku.operator.util.OperatorUtil.makeDesiredCiCCapabilityDeployment;
-import static ai.wanaku.operator.util.OperatorUtil.makeDesiredWanakuCapabilityDeployment;
 import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT_NAMESPACE;
 
@@ -123,7 +124,7 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
             if (capabilitiesSpec.getType() == null) {
                 desiredDeployment = makeDesiredWanakuCapabilityDeployment(resource, context, capabilitiesSpec);
             } else {
-                if ("camel-integration-capability".equals(capabilitiesSpec.getType())) {
+                if (OperatorConstants.CAMEL_INTEGRATION_CAPABILITY_TYPE.equals(capabilitiesSpec.getType())) {
                     desiredDeployment = makeDesiredCiCCapabilityDeployment(resource, context, capabilitiesSpec);
                 } else {
                     LOG.error("Invalid capability type: " + capabilitiesSpec.getType());
@@ -170,7 +171,8 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
 
     private void createCapabilityPVCs(WanakuCapability resource, String namespace, String serviceName) {
         // Create services-volume PVC
-        final PersistentVolumeClaim servicesVolumePVC = OperatorUtil.makeServicesVolumePVC(resource, serviceName);
+        final PersistentVolumeClaim servicesVolumePVC =
+                CapabilityResourceFactory.makeServicesVolumePVC(resource, serviceName);
         PersistentVolumeClaim existingServicesVolume = kubernetesClient
                 .persistentVolumeClaims()
                 .inNamespace(namespace)

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -23,16 +23,17 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
-import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.util.RouterResourceFactory;
 
 import static ai.wanaku.operator.util.Matchers.match;
 import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
 import static ai.wanaku.operator.util.OperatorUtil.findCondition;
-import static ai.wanaku.operator.util.OperatorUtil.makeDesiredRouterBackendDeployment;
-import static ai.wanaku.operator.util.OperatorUtil.makeRouterExternalService;
-import static ai.wanaku.operator.util.OperatorUtil.makeRouterIngress;
-import static ai.wanaku.operator.util.OperatorUtil.makeRouterInternalService;
 import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
+import static ai.wanaku.operator.util.RouterResourceFactory.ROUTER_VOLUME_CLAIM;
+import static ai.wanaku.operator.util.RouterResourceFactory.makeDesiredRouterBackendDeployment;
+import static ai.wanaku.operator.util.RouterResourceFactory.makeRouterExternalService;
+import static ai.wanaku.operator.util.RouterResourceFactory.makeRouterIngress;
+import static ai.wanaku.operator.util.RouterResourceFactory.makeRouterInternalService;
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT_NAMESPACE;
 
 @ControllerConfiguration(informer = @Informer(namespaces = WATCH_CURRENT_NAMESPACE), name = "wanaku-router")
@@ -136,8 +137,8 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
         try {
             existingExternalService =
                     context.getSecondaryResource(Service.class).orElse(null);
-        } catch (Exception e) {
-            LOG.warnf("There is no existing service");
+        } catch (IllegalStateException e) {
+            LOG.warnf(e, "There is no existing service");
             existingExternalService = null;
         }
         if (!match(desiredExternalService, existingExternalService)) {
@@ -173,8 +174,8 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
         Deployment existingDeployment;
         try {
             existingDeployment = context.getSecondaryResource(Deployment.class).orElse(null);
-        } catch (Exception e) {
-            LOG.warnf("There is no existing deployment");
+        } catch (IllegalStateException e) {
+            LOG.warnf(e, "There is no existing deployment");
             existingDeployment = null;
         }
 
@@ -204,7 +205,7 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
                     .withName(desiredRoute.getMetadata().getName())
                     .get();
         } catch (Exception e) {
-            LOG.warnf("There is no existing service");
+            LOG.warnf(e, "There is no existing service");
             existingRoute = null;
         }
         if (!match(desiredRoute, existingRoute)) {
@@ -284,11 +285,11 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
 
     private void createRouterPVCs(WanakuRouter resource, String namespace) {
         // Create services-volume PVC
-        final PersistentVolumeClaim servicesVolumePVC = OperatorUtil.makeRouterVolumePVC(resource);
+        final PersistentVolumeClaim servicesVolumePVC = RouterResourceFactory.makeRouterVolumePVC(resource);
         PersistentVolumeClaim existingServicesVolume = kubernetesClient
                 .persistentVolumeClaims()
                 .inNamespace(namespace)
-                .withName(OperatorUtil.ROUTER_VOLUME_CLAIM)
+                .withName(ROUTER_VOLUME_CLAIM)
                 .get();
 
         if (!match(servicesVolumePVC, existingServicesVolume)) {

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
@@ -49,7 +49,7 @@ class OperatorUtilTest {
 
     @Test
     void createVolumeClaimName() {
-        assertEquals("my-service-volume-claim", OperatorUtil.createVolumeClaimName("my-service"));
+        assertEquals("my-service-volume-claim", CapabilityResourceFactory.createVolumeClaimName("my-service"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Split OperatorUtil (500+ line God Class) into focused factory classes:
  - `RouterResourceFactory` for router K8s resource creation (deployments, services, routes, ingresses, PVCs)
  - `CapabilityResourceFactory` for capability K8s resource creation (deployments, services, PVCs)
  - `EnvironmentVariableHelper` for env var computation with deduplicated common logic
  - `OperatorConstants` for shared constants (capability type strings)
- Slimmed `OperatorUtil` to only shared utilities (conditions, image pull policy, auth realm, router URL)
- Extracted hardcoded `"camel-integration-capability"` string to `OperatorConstants.CAMEL_INTEGRATION_CAPABILITY_TYPE`
- Narrowed broad `catch(Exception)` blocks in `WanakuRouterReconciler` to `catch(IllegalStateException)` and included exception in log calls
- Eliminated env var construction duplication via `buildCommonEnvVars()` template method

Fixes #1088

## Summary by Sourcery

Refactor the operator utilities by extracting router and capability resource creation and environment variable computation into dedicated helper classes, simplifying OperatorUtil and tightening exception handling in router reconciliation.

Enhancements:
- Extract router-related Kubernetes resource creation into RouterResourceFactory.
- Extract capability-related Kubernetes resource creation into CapabilityResourceFactory and centralize shared constants in OperatorConstants.
- Introduce EnvironmentVariableHelper to deduplicate capability environment variable construction logic.
- Simplify OperatorUtil to focus on condition handling, image pull policy resolution, auth realm resolution, and router URL construction.
- Narrow broad exception handling in WanakuRouterReconciler to IllegalStateException and include exception details in logs.

Tests:
- Update OperatorUtil tests to validate volume claim name creation via the new CapabilityResourceFactory.