### PR TITLE
Fix #1084: standardize string handling patterns

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
@@ -56,7 +56,7 @@ public class LlmChatResource {
         JsonObject llmParams = json.getJsonObject("chatParams");
 
         if (!allowlist.contains(baseUrl)) {
-            throw new WebApplicationException("Base URL: " + baseUrl + " is not allowed", BAD_REQUEST);
+            throw new WebApplicationException("Base URL: %s is not allowed".formatted(baseUrl), BAD_REQUEST);
         }
         try (var client = HttpClient.newHttpClient()) {
             String url = baseUrl + "/v1/chat/completions";

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresBean.java
@@ -13,6 +13,7 @@ import ai.wanaku.backend.core.persistence.api.WanakuRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * Bean for managing DataStore entities.
@@ -58,7 +59,7 @@ public class DataStoresBean extends LabelsAwareWanakuEntityBean<DataStore> {
         }
         DataStore existing = dataStoreRepository.findById(dataStore.getId());
         if (existing == null) {
-            throw new WanakuException("Data store not found with ID: " + dataStore.getId());
+            throw new WanakuException("Data store not found with ID: %s".formatted(dataStore.getId()));
         }
         dataStoreRepository.update(dataStore.getId(), dataStore);
     }
@@ -71,7 +72,7 @@ public class DataStoresBean extends LabelsAwareWanakuEntityBean<DataStore> {
      * @throws WanakuException if label expression is invalid
      */
     public List<DataStore> list(String labelFilter) throws WanakuException {
-        if (labelFilter == null || labelFilter.isBlank()) {
+        if (StringHelper.isBlank(labelFilter)) {
             LOG.debug("Listing all data stores");
             return dataStoreRepository.listAll();
         }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -20,6 +20,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundExcept
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * REST API resource for managing DataStore entries.
@@ -83,7 +84,7 @@ public class DataStoresResource {
             LOG.debugf("REST: Getting data stores by name: %s", name);
             List<DataStore> dataStores = dataStoresBean.findByName(name);
             if (dataStores == null || dataStores.isEmpty()) {
-                throw new DataStoreResourceNotFoundException("Data store not found with name: " + name);
+                throw new DataStoreResourceNotFoundException("Data store not found with name: %s".formatted(name));
             }
             return new WanakuResponse<>(dataStores);
         }
@@ -112,7 +113,7 @@ public class DataStoresResource {
         LOG.debugf("REST: Getting data store by ID: %s", id);
         DataStore dataStore = dataStoresBean.findById(id);
         if (dataStore == null) {
-            throw new DataStoreResourceNotFoundException("Data store not found with ID: " + id);
+            throw new DataStoreResourceNotFoundException("Data store not found with ID: %s".formatted(id));
         }
         return new WanakuResponse<>(dataStore);
     }
@@ -147,7 +148,7 @@ public class DataStoresResource {
      */
     @DELETE
     public Response removeByName(@QueryParam("name") String name) throws WanakuException {
-        if (name == null || name.isEmpty()) {
+        if (StringHelper.isEmpty(name)) {
             throw new WanakuException("The 'name' query parameter must be provided");
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardToolHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardToolHelper.java
@@ -3,6 +3,7 @@ package ai.wanaku.backend.api.v1.forwards;
 import java.util.Set;
 import java.util.function.Predicate;
 import ai.wanaku.capabilities.sdk.api.types.RemoteToolReference;
+import ai.wanaku.core.util.StringHelper;
 
 final class ForwardToolHelper {
     private ForwardToolHelper() {}
@@ -53,7 +54,7 @@ final class ForwardToolHelper {
     }
 
     private static String sanitizeToolNameComponent(String input) {
-        if (input == null || input.isBlank()) {
+        if (StringHelper.isBlank(input)) {
             return "remote";
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -165,7 +165,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             ns = namespacesBean.getDefaultNamespace();
         } else {
             if (!namespacesBean.exists(forwardReference.getNamespace())) {
-                throw new WanakuException("Invalid namespace id: " + forwardReference.getNamespace());
+                throw new WanakuException("Invalid namespace id: %s".formatted(forwardReference.getNamespace()));
             }
             ns = namespacesBean.getById(forwardReference.getNamespace());
         }
@@ -281,7 +281,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
                     .map(RemoteToolReference::asToolReference)
                     .collect(Collectors.toList());
         } catch (LabelExpressionParser.LabelExpressionParseException e) {
-            throw new WanakuException("Invalid label expression: " + labelFilter, e);
+            throw new WanakuException("Invalid label expression: %s".formatted(labelFilter), e);
         }
     }
 
@@ -315,7 +315,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
     public void refresh(ForwardReference forwardReferenceHint) {
         List<ForwardReference> references = forwardReferenceRepository.findByName(forwardReferenceHint.getName());
         if (references.isEmpty()) {
-            throw new WanakuException("Forward reference not found: " + forwardReferenceHint.getName());
+            throw new WanakuException("Forward reference not found: %s".formatted(forwardReferenceHint.getName()));
         }
 
         ForwardReference forwardReference = references.getFirst();

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -19,6 +19,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.core.util.StringHelper;
 
 @ApplicationScoped
 @Path("/api/v1/forwards")
@@ -64,15 +65,14 @@ public class ForwardsResource {
                 return new WanakuResponse<>(reference);
             }
         }
-        throw new NotFoundException("Forward not found with name: " + name);
+        throw new NotFoundException("Forward not found with name: %s".formatted(name));
     }
 
     @Path("/{name}")
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("name") String name, ForwardReference resource) throws WanakuException {
-        if (resource != null
-                && (resource.getName() == null || resource.getName().isBlank())) {
+        if (resource != null && StringHelper.isBlank(resource.getName())) {
             resource.setName(name);
         }
         forwardsBean.update(resource);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/internal/InternalManagementToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/management/internal/InternalManagementToolsBean.java
@@ -30,6 +30,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.management.ServerInfo;
 import ai.wanaku.core.services.api.StaleCapabilityInfo;
+import ai.wanaku.core.util.StringHelper;
 import ai.wanaku.core.util.VersionHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -403,7 +404,7 @@ public class InternalManagementToolsBean {
         String id = toRequiredStringArg(args, "id");
         Namespace namespace = namespacesBean.getById(id);
         if (namespace == null) {
-            throw new IllegalArgumentException("Namespace not found: " + id);
+            throw new IllegalArgumentException("Namespace not found: %s".formatted(id));
         }
         return namespace;
     }
@@ -423,7 +424,7 @@ public class InternalManagementToolsBean {
             namespace.setId(id);
         }
         if (!namespacesBean.update(id, namespace)) {
-            throw new IllegalArgumentException("Namespace not found or update refused: " + id);
+            throw new IllegalArgumentException("Namespace not found or update refused: %s".formatted(id));
         }
         return namespacesBean.getById(id);
     }
@@ -454,7 +455,7 @@ public class InternalManagementToolsBean {
         String name = toRequiredStringArg(args, "name");
         ToolReference tool = toolsBean.getByName(name);
         if (tool == null) {
-            throw new IllegalArgumentException("Tool not found: " + name);
+            throw new IllegalArgumentException("Tool not found: %s".formatted(name));
         }
         return tool;
     }
@@ -488,7 +489,7 @@ public class InternalManagementToolsBean {
         String name = toRequiredStringArg(args, "name");
         ResourceReference resource = resourcesBean.getByName(name);
         if (resource == null) {
-            throw new IllegalArgumentException("Resource not found: " + name);
+            throw new IllegalArgumentException("Resource not found: %s".formatted(name));
         }
         return resource;
     }
@@ -573,8 +574,8 @@ public class InternalManagementToolsBean {
 
     private String toRequiredStringArg(Map<String, Object> args, String key) {
         String value = toStringArg(args.get(key));
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(key + " is required");
+        if (StringHelper.isBlank(value)) {
+            throw new IllegalArgumentException("%s is required".formatted(key));
         }
         return value;
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -16,6 +16,7 @@ import org.jboss.logging.Logger;
 import ai.wanaku.backend.WanakuRouterConfig;
 import ai.wanaku.backend.core.persistence.api.NamespaceRepository;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.core.util.StringHelper;
 
 @Singleton
 public class NamespacesBean {
@@ -96,7 +97,7 @@ public class NamespacesBean {
             throw new IllegalArgumentException("Namespace cannot be null");
         }
 
-        if (namespace.getName() != null && namespace.getName().trim().isEmpty()) {
+        if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }
 
@@ -114,7 +115,7 @@ public class NamespacesBean {
     }
 
     public List<Namespace> list(String labelFilter) {
-        if (labelFilter == null || labelFilter.trim().isEmpty()) {
+        if (StringHelper.isBlank(labelFilter)) {
             ensureDefaultNamespace();
             return namespaceRepository.listAll();
         }
@@ -175,7 +176,7 @@ public class NamespacesBean {
     }
 
     public boolean deleteById(String id) {
-        if (id == null || id.trim().isEmpty()) {
+        if (StringHelper.isBlank(id)) {
             return false;
         }
 
@@ -279,7 +280,7 @@ public class NamespacesBean {
     }
 
     private Instant parseEpochInstant(String value) {
-        if (value == null || value.trim().isEmpty()) {
+        if (StringHelper.isBlank(value)) {
             return null;
         }
         try {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesBean.java
@@ -76,7 +76,7 @@ public class ResourcesBean extends AbstractBean<ResourceReference> {
     }
 
     public List<ResourceReference> list(String labelFilter) {
-        if (labelFilter == null || labelFilter.trim().isEmpty()) {
+        if (StringHelper.isBlank(labelFilter)) {
             return resourceReferenceRepository.listAll();
         }
         return resourceReferenceRepository.findAllFilterByLabelExpression(labelFilter);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBean.java
@@ -47,11 +47,11 @@ public class DeploymentInstructionsBean {
         String path = TEMPLATES_PATH + fileName;
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
             if (is == null) {
-                throw new IllegalStateException("Template not found on classpath: " + path);
+                throw new IllegalStateException("Template not found on classpath: %s".formatted(path));
             }
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new IllegalStateException("Failed to load template: " + path, e);
+            throw new IllegalStateException("Failed to load template: %s".formatted(path), e);
         }
     }
 
@@ -68,7 +68,7 @@ public class DeploymentInstructionsBean {
 
         DataStore catalog = serviceCatalogBean.get(catalogName);
         if (catalog == null) {
-            throw new WanakuException("Service catalog not found: " + catalogName);
+            throw new WanakuException("Service catalog not found: %s".formatted(catalogName));
         }
 
         ServiceCatalogIndex index = serviceCatalogBean.parseIndex(catalog);
@@ -92,7 +92,7 @@ public class DeploymentInstructionsBean {
                 break;
             default:
                 throw new WanakuException(
-                        "Unsupported deployment model: " + deploymentModel + ". Use: local, docker, kubernetes");
+                        "Unsupported deployment model: %s. Use: local, docker, kubernetes".formatted(deploymentModel));
         }
 
         return new DeploymentInstructions(catalogName, catalogType, deploymentModel, systems, placeholders);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
@@ -14,6 +14,7 @@ import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * Business logic for service catalog operations.
@@ -53,7 +54,7 @@ public class ServiceCatalogBean {
         List<DataStore> all =
                 dataStoreRepository.findAllFilterByLabelExpression(LABEL_TYPE_KEY + "=" + LABEL_TYPE_VALUE);
 
-        if (search == null || search.isBlank()) {
+        if (StringHelper.isBlank(search)) {
             return all;
         }
 
@@ -96,10 +97,10 @@ public class ServiceCatalogBean {
     public DataStore deploy(DataStore dataStore) throws WanakuException {
         LOG.debugf("Deploying service catalog: %s", dataStore.getName());
 
-        if (dataStore.getName() == null || dataStore.getName().isBlank()) {
+        if (StringHelper.isBlank(dataStore.getName())) {
             throw new WanakuException("Catalog name is required");
         }
-        if (dataStore.getData() == null || dataStore.getData().isBlank()) {
+        if (StringHelper.isBlank(dataStore.getData())) {
             throw new WanakuException("Catalog data (Base64-encoded ZIP) is required");
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -22,6 +22,7 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.core.services.api.DeploymentInstructions;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * REST API resource for service catalog operations.
@@ -90,13 +91,13 @@ public class ServiceCatalogResource {
     public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Getting service catalog: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
         DataStore catalog = serviceCatalogBean.get(name);
         if (catalog == null) {
-            throw new WanakuException("Service catalog not found: " + name);
+            throw new WanakuException("Service catalog not found: %s".formatted(name));
         }
 
         ServiceCatalogIndex index = serviceCatalogBean.parseIndex(catalog);
@@ -133,13 +134,13 @@ public class ServiceCatalogResource {
     public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Downloading service catalog: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
         DataStore catalog = serviceCatalogBean.get(name);
         if (catalog == null) {
-            throw new WanakuException("Service catalog not found: " + name);
+            throw new WanakuException("Service catalog not found: %s".formatted(name));
         }
 
         return new WanakuResponse<>(catalog);
@@ -174,7 +175,7 @@ public class ServiceCatalogResource {
     public Response remove(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Removing service catalog: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
@@ -201,10 +202,10 @@ public class ServiceCatalogResource {
             @QueryParam("name") String name, @QueryParam("model") String model) throws WanakuException {
         LOG.debugf("REST: Getting deployment instructions for catalog '%s' with model '%s'", name, model);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
-        if (model == null || model.isBlank()) {
+        if (StringHelper.isBlank(model)) {
             throw new WanakuException("Query parameter 'model' is required");
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -24,6 +24,7 @@ import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * Business logic for service template operations.
@@ -67,7 +68,7 @@ public class ServiceTemplateBean {
         List<DataStore> all =
                 dataStoreRepository.findAllFilterByLabelExpression(LABEL_TYPE_KEY + "=" + LABEL_TYPE_VALUE);
 
-        if (search == null || search.isBlank()) {
+        if (StringHelper.isBlank(search)) {
             return all;
         }
 
@@ -110,10 +111,10 @@ public class ServiceTemplateBean {
     public DataStore deploy(DataStore dataStore) throws WanakuException {
         LOG.debugf("Deploying service template: %s", dataStore.getName());
 
-        if (dataStore.getName() == null || dataStore.getName().isBlank()) {
+        if (StringHelper.isBlank(dataStore.getName())) {
             throw new WanakuException("Template name is required");
         }
-        if (dataStore.getData() == null || dataStore.getData().isBlank()) {
+        if (StringHelper.isBlank(dataStore.getData())) {
             throw new WanakuException("Template data (Base64-encoded ZIP) is required");
         }
 
@@ -180,7 +181,7 @@ public class ServiceTemplateBean {
 
         DataStore template = get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: " + name);
+            throw new WanakuException("Service template not found: %s".formatted(name));
         }
 
         ServiceCatalogIndex index = parseIndex(template);
@@ -245,7 +246,7 @@ public class ServiceTemplateBean {
 
         DataStore template = get(templateName);
         if (template == null) {
-            throw new WanakuException("Service template not found: " + templateName);
+            throw new WanakuException("Service template not found: %s".formatted(templateName));
         }
 
         ServiceCatalogIndex index = parseIndex(template);
@@ -360,7 +361,7 @@ public class ServiceTemplateBean {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new WanakuException("Failed to build catalog ZIP: " + e.getMessage());
+            throw new WanakuException("Failed to build catalog ZIP: %s".formatted(e.getMessage()));
         }
     }
 
@@ -388,7 +389,7 @@ public class ServiceTemplateBean {
                 zis.closeEntry();
             }
         } catch (IOException e) {
-            throw new WanakuException("Failed to extract ZIP contents: " + e.getMessage());
+            throw new WanakuException("Failed to extract ZIP contents: %s".formatted(e.getMessage()));
         }
         return result;
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -22,6 +22,7 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
 import ai.wanaku.core.services.api.ServiceTemplateService;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * REST API resource for service template operations.
@@ -97,13 +98,13 @@ public class ServiceTemplateResource {
     public WanakuResponse<Map<String, Object>> get(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Getting service template: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
         DataStore template = serviceTemplateBean.get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: " + name);
+            throw new WanakuException("Service template not found: %s".formatted(name));
         }
 
         ServiceCatalogIndex index = serviceTemplateBean.parseIndex(template);
@@ -141,13 +142,13 @@ public class ServiceTemplateResource {
     public WanakuResponse<DataStore> download(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Downloading service template: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
         DataStore template = serviceTemplateBean.get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: " + name);
+            throw new WanakuException("Service template not found: %s".formatted(name));
         }
 
         return new WanakuResponse<>(template);
@@ -182,7 +183,7 @@ public class ServiceTemplateResource {
     public Response remove(@QueryParam("name") String name) throws WanakuException {
         LOG.debugf("REST: Removing service template: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
@@ -208,7 +209,7 @@ public class ServiceTemplateResource {
             throws WanakuException {
         LOG.debugf("REST: Getting properties for template: %s", name);
 
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Query parameter 'name' is required");
         }
 
@@ -231,7 +232,7 @@ public class ServiceTemplateResource {
             throws WanakuException {
         LOG.debugf("REST: Instantiating template: %s", request.getTemplateName());
 
-        if (request.getTemplateName() == null || request.getTemplateName().isBlank()) {
+        if (StringHelper.isBlank(request.getTemplateName())) {
             throw new WanakuException("Template name is required");
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -17,6 +17,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.core.services.api.ToolsetRepoIndex;
+import ai.wanaku.core.util.StringHelper;
 import ai.wanaku.core.util.ToolsetIndexHelper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -89,10 +90,10 @@ public class ToolsetReposBean {
      */
     public Map<String, String> add(String name, String url, String description, String icon, String branch)
             throws WanakuException {
-        if (name == null || name.isBlank()) {
+        if (StringHelper.isBlank(name)) {
             throw new WanakuException("Repository name is required");
         }
-        if (url == null || url.isBlank()) {
+        if (StringHelper.isBlank(url)) {
             throw new WanakuException("Repository URL is required");
         }
 
@@ -100,7 +101,7 @@ public class ToolsetReposBean {
 
         DataStore existing = findByName(name);
         if (existing != null) {
-            throw new WanakuException("Toolset repository already exists: " + name);
+            throw new WanakuException("Toolset repository already exists: %s".formatted(name));
         }
 
         String effectiveBranch = (branch != null && !branch.isBlank()) ? branch : DEFAULT_BRANCH;
@@ -120,7 +121,7 @@ public class ToolsetReposBean {
         try {
             ds.setData(MAPPER.writeValueAsString(metadata));
         } catch (JsonProcessingException e) {
-            throw new WanakuException("Failed to serialize repository metadata: " + e.getMessage());
+            throw new WanakuException("Failed to serialize repository metadata: %s".formatted(e.getMessage()));
         }
 
         Map<String, String> labels = new HashMap<>();
@@ -146,7 +147,7 @@ public class ToolsetReposBean {
             throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: " + name);
+            throw new WanakuException("Toolset repository not found: %s".formatted(name));
         }
 
         if (url != null && !url.isBlank()) {
@@ -170,7 +171,7 @@ public class ToolsetReposBean {
             }
             ds.setData(MAPPER.writeValueAsString(metadata));
         } catch (JsonProcessingException e) {
-            throw new WanakuException("Failed to serialize repository metadata: " + e.getMessage());
+            throw new WanakuException("Failed to serialize repository metadata: %s".formatted(e.getMessage()));
         }
 
         dataStoreRepository.update(ds.getId(), ds);
@@ -203,7 +204,7 @@ public class ToolsetReposBean {
     public Map<String, Object> browse(String name) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: " + name);
+            throw new WanakuException("Toolset repository not found: %s".formatted(name));
         }
 
         String url = resolveBaseUrl(ds);
@@ -238,7 +239,7 @@ public class ToolsetReposBean {
     public List<ToolReference> fetchToolset(String name, String toolsetName) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: " + name);
+            throw new WanakuException("Toolset repository not found: %s".formatted(name));
         }
 
         String baseUrl = resolveBaseUrl(ds);
@@ -248,7 +249,7 @@ public class ToolsetReposBean {
             return ToolsetIndexHelper.loadToolsIndex(URI.create(toolsetUrl).toURL());
         } catch (Exception e) {
             throw new WanakuException(
-                    "Failed to fetch toolset '" + toolsetName + "' from " + toolsetUrl + ": " + e.getMessage());
+                    "Failed to fetch toolset '%s' from %s: %s".formatted(toolsetName, toolsetUrl, e.getMessage()));
         }
     }
 
@@ -277,7 +278,7 @@ public class ToolsetReposBean {
                 throw new WanakuException("URLs pointing to private network ranges are not allowed");
             }
         } catch (IllegalArgumentException e) {
-            throw new WanakuException("Invalid URL: " + e.getMessage());
+            throw new WanakuException("Invalid URL: %s".formatted(e.getMessage()));
         }
     }
 
@@ -306,13 +307,13 @@ public class ToolsetReposBean {
         try {
             Map<String, String> metadata = MAPPER.readValue(ds.getData(), Map.class);
             String url = metadata.get("url");
-            if (url == null || url.isBlank()) {
-                throw new WanakuException("Repository metadata missing URL for: " + ds.getName());
+            if (StringHelper.isBlank(url)) {
+                throw new WanakuException("Repository metadata missing URL for: %s".formatted(ds.getName()));
             }
             String branch = metadata.getOrDefault("branch", DEFAULT_BRANCH);
             return toRawContentUrl(url, branch);
         } catch (JsonProcessingException e) {
-            throw new WanakuException("Failed to parse repository metadata: " + e.getMessage());
+            throw new WanakuException("Failed to parse repository metadata: %s".formatted(e.getMessage()));
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/codeexecution/CodeExecutionResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/codeexecution/CodeExecutionResource.java
@@ -169,7 +169,7 @@ public class CodeExecutionResource {
             LOG.errorf(e, "Error submitting code execution: engine=%s, language=%s", engineType, language);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(new CodeExecutionError(
-                            "INTERNAL_ERROR", "Failed to submit code execution: " + e.getMessage()))
+                            "INTERNAL_ERROR", "Failed to submit code execution: %s".formatted(e.getMessage())))
                     .build();
         }
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
@@ -32,6 +32,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.ServiceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.types.execution.CodeExecutionRequest;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.CodeExecutionReply;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * Bridge implementation for code execution services via gRPC.
@@ -310,7 +311,7 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
      * @throws IllegalArgumentException if the input is not valid base64
      */
     private String decodeBase64Code(String base64Code) {
-        if (base64Code == null || base64Code.isEmpty()) {
+        if (StringHelper.isEmpty(base64Code)) {
             return "";
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -131,7 +131,7 @@ public class InvokerBridge implements ToolsBridge {
                     serviceResolver.resolve(context.toolReference.getType(), SERVICE__TYPE_CODE_EXECUTION_ENGINE);
             if (context.serviceTarget == null) {
                 throw new ServiceNotFoundException(
-                        "There is no host registered for service " + context.toolReference.getType());
+                        "There is no host registered for service %s".formatted(context.toolReference.getType()));
             }
         }
         return context;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -172,8 +172,9 @@ public final class InvokerToolExecutor {
             LOG.fatalf(
                     "Malformed value for key %s: neither a default value nor an argument were provided",
                     entry.getKey());
-            throw new NullPointerException("Malformed value for key " + entry.getKey()
-                    + ": neither a default value nor an argument were provided (null)");
+            throw new NullPointerException(
+                    "Malformed value for key %s: neither a default value nor an argument were provided (null)"
+                            .formatted(entry.getKey()));
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ProvisionerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ProvisionerBridge.java
@@ -41,7 +41,7 @@ public class ProvisionerBridge implements ProvisionBridge {
         LOG.debugf("Resolving service for type '%s' and service type '%s'", type, serviceType);
         ServiceTarget service = serviceResolver.resolve(type, serviceType);
         if (service == null) {
-            throw new ServiceNotFoundException("There is no host registered for service " + type);
+            throw new ServiceNotFoundException("There is no host registered for service %s".formatted(type));
         }
         LOG.debugf("Resolved service: %s", service.toAddress());
         return service;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/PromptExpander.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/PromptExpander.java
@@ -58,7 +58,7 @@ public class PromptExpander {
 
         for (PromptReference.PromptArgument arg : prompt.getArguments()) {
             if (arg.isRequired() && !arguments.containsKey(arg.getName())) {
-                throw new IllegalArgumentException("Required argument '" + arg.getName() + "' is missing");
+                throw new IllegalArgumentException("Required argument '%s' is missing".formatted(arg.getName()));
             }
         }
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import ai.wanaku.core.util.StringHelper;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -222,7 +223,7 @@ public class ToolCallEvent {
      * Redacts sensitive fields in the body.
      */
     private static String redactBody(String body) {
-        if (body == null || body.isEmpty()) {
+        if (StringHelper.isEmpty(body)) {
             return body;
         }
         // Simple redaction for JSON-like structures
@@ -239,7 +240,7 @@ public class ToolCallEvent {
      * Redacts secrets URI.
      */
     private static String redactSecretsURI(String secretsURI) {
-        if (secretsURI == null || secretsURI.isEmpty()) {
+        if (StringHelper.isEmpty(secretsURI)) {
             return secretsURI;
         }
         return REDACTED;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParser.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParser.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * Recursive descent parser for label expression filters.
@@ -60,7 +61,7 @@ public class LabelExpressionParser {
      * @throws LabelExpressionParseException if the expression is invalid
      */
     private Predicate<LabelsAwareEntity<?>> parseInternal(String expression) throws LabelExpressionParseException {
-        if (expression == null || expression.trim().isEmpty()) {
+        if (StringHelper.isBlank(expression)) {
             throw new LabelExpressionParseException("Expression string cannot be null or empty");
         }
 
@@ -77,7 +78,8 @@ public class LabelExpressionParser {
 
         // Ensure all tokens were consumed
         if (position < tokens.size()) {
-            throw new LabelExpressionParseException("Unexpected token after expression: " + tokens.get(position).value);
+            throw new LabelExpressionParseException(
+                    "Unexpected token after expression: %s".formatted(tokens.get(position).value));
         }
 
         return result;
@@ -181,7 +183,7 @@ public class LabelExpressionParser {
                 continue;
             }
 
-            throw new LabelExpressionParseException("Unexpected character: " + c);
+            throw new LabelExpressionParseException("Unexpected character: %s".formatted(c));
         }
 
         return result;
@@ -248,7 +250,7 @@ public class LabelExpressionParser {
             Token value = consume(TokenType.IDENTIFIER, "Expected label value after '!='");
             return entity -> !value.value.equals(entity.getLabels().get(key.value));
         } else {
-            throw new LabelExpressionParseException("Expected '=' or '!=' after label key '" + key.value + "'");
+            throw new LabelExpressionParseException("Expected '=' or '!=' after label key '%s'".formatted(key.value));
         }
     }
 
@@ -271,7 +273,7 @@ public class LabelExpressionParser {
         }
         Token token = tokens.get(position);
         if (token.type != type) {
-            throw new LabelExpressionParseException(errorMessage + " but got '" + token.value + "'");
+            throw new LabelExpressionParseException("%s but got '%s'".formatted(errorMessage, token.value));
         }
         position++;
         return token;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/AbstractLabelAwareInfinispanRepository.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/AbstractLabelAwareInfinispanRepository.java
@@ -10,6 +10,7 @@ import ai.wanaku.backend.core.mcp.util.LabelExpressionParser.LabelExpressionPars
 import ai.wanaku.backend.core.persistence.api.LabelAwareInfinispanRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+import ai.wanaku.core.util.StringHelper;
 
 public abstract class AbstractLabelAwareInfinispanRepository<A extends LabelsAwareEntity<K>, K>
         extends AbstractInfinispanRepository<A, K> implements LabelAwareInfinispanRepository<A, K> {
@@ -20,7 +21,7 @@ public abstract class AbstractLabelAwareInfinispanRepository<A extends LabelsAwa
 
     public List<A> findAllFilterByLabelExpression(String labelExpression) {
         // If no label expression provided, return all entities
-        if (labelExpression == null || labelExpression.trim().isEmpty()) {
+        if (StringHelper.isBlank(labelExpression)) {
             return listAll();
         }
         try {
@@ -32,9 +33,9 @@ public abstract class AbstractLabelAwareInfinispanRepository<A extends LabelsAwa
             return c.values().stream().filter(predicate).toList();
 
         } catch (LabelExpressionParseException e) {
-            throw new WanakuException("Invalid label expression: " + labelExpression, e);
+            throw new WanakuException("Invalid label expression: %s".formatted(labelExpression), e);
         } catch (Exception e) {
-            throw new WanakuException("Failed to execute label query: " + labelExpression, e);
+            throw new WanakuException("Failed to execute label query: %s".formatted(labelExpression), e);
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/CodeExecutionStatusMarshaller.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/CodeExecutionStatusMarshaller.java
@@ -24,7 +24,7 @@ public class CodeExecutionStatusMarshaller implements EnumMarshaller<CodeExecuti
             case 3 -> CodeExecutionStatus.FAILED;
             case 4 -> CodeExecutionStatus.CANCELLED;
             case 5 -> CodeExecutionStatus.TIMEOUT;
-            default -> throw new IllegalArgumentException("Unknown CodeExecutionStatus value: " + enumValue);
+            default -> throw new IllegalArgumentException("Unknown CodeExecutionStatus value: %d".formatted(enumValue));
         };
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/OidcReadinessCheck.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.jboss.logging.Logger;
+import ai.wanaku.core.util.StringHelper;
 
 /**
  * OIDC readiness health check that verifies the OIDC provider is reachable.
@@ -45,7 +46,7 @@ public class OidcReadinessCheck implements HealthCheck {
             return disabledResponse();
         }
 
-        if (authServerUrl == null || authServerUrl.isBlank()) {
+        if (StringHelper.isBlank(authServerUrl)) {
             return configurationErrorResponse();
         }
 
@@ -165,7 +166,7 @@ public class OidcReadinessCheck implements HealthCheck {
                 connection.setRequestMethod("GET");
                 return connection;
             } catch (URISyntaxException e) {
-                throw new IOException("Invalid URL: " + urlString, e);
+                throw new IOException("Invalid URL: %s".formatted(urlString), e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Standardize null/blank string checks to use StringHelper consistently
- Use String.formatted() for exception messages instead of concatenation

Note: toString() patterns and other string handling in SDK types (ToolReference, ResourceReference) are tracked separately in the SDK repo.

Fixes #1084

## Summary by Sourcery

Standardize string validation and exception message formatting across router backend components.

Enhancements:
- Replace ad-hoc null/blank string checks with centralized StringHelper utilities in REST resources, beans, and core utilities.
- Adopt String.formatted(...) for constructing exception and error messages instead of string concatenation throughout the backend.
- Improve consistency of error messages and label expression handling in persistence and label parsing utilities.