### PR TITLE
feat: add AWS S3 resource with camel routes, dependencies, and properties

### DIFF
--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.camel.yaml
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.camel.yaml
@@ -1,0 +1,20 @@
+- route:
+    id: s3-read-object
+    description: Read objects from an AWS S3 bucket
+    autoStartup: false
+    from:
+      uri: direct:wanaku
+      steps:
+        - setHeader:
+            name: CamelAwsS3BucketName
+            simple: "{{aws.s3.bucketName}}"
+        - setHeader:
+            name: CamelAwsS3Key
+            simple: "${header.wanaku_resource_uri}"
+        - to:
+            uri: aws2-s3:{{aws.s3.bucketName}}
+            parameters:
+              region: "{{aws.s3.region}}"
+              accessKey: "{{aws.s3.accessKey}}"
+              secretKey: "{{aws.s3.secretKey}}"
+              operation: getObject

--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-aws2-s3:4.18.2

--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.rules.yaml
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.rules.yaml
@@ -1,0 +1,8 @@
+mcp:
+  resources:
+    - s3-read-object:
+        route:
+          id: "s3-read-object"
+        description: "{{resource.description}}"
+        uri: "wanaku://s3-read-object"
+        mimeType: "application/octet-stream"

--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/service.properties
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/service.properties
@@ -1,0 +1,5 @@
+resource.description=Read objects from AWS S3
+aws.s3.bucketName={{aws.s3.bucketName}}
+aws.s3.region={{aws.s3.region}}
+aws.s3.accessKey={{aws.s3.accessKey}}
+aws.s3.secretKey={{aws.s3.secretKey}}

--- a/services/service-templates/src/main/services/aws-s3-resource/index.properties
+++ b/services/service-templates/src/main/services/aws-s3-resource/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.aws-s3=aws-s3/aws-s3.dependencies.txt
+catalog.description=Read objects from AWS S3 buckets
+catalog.name=aws-s3-resource
+catalog.routes.aws-s3=aws-s3/aws-s3.camel.yaml
+catalog.rules.aws-s3=aws-s3/aws-s3.rules.yaml
+catalog.services=aws-s3
+catalog.properties.aws-s3=aws-s3/service.properties


### PR DESCRIPTION
Closes: #1064

## Summary by Sourcery

Add a new AWS S3 service template resource for reading objects from S3 via a Camel route and exposing it as an MCP resource.

New Features:
- Introduce a Camel route configuration to read objects from an AWS S3 bucket using configurable connection properties.
- Register an MCP resource that exposes the S3 read-object route over a wanaku URI.
- Add catalog metadata, properties, and dependency wiring for the new aws-s3-resource service template.