### PR TITLE
feat: add Kafka tool service template with request/reply correlation

### DIFF
--- a/docs/service-templates.md
+++ b/docs/service-templates.md
@@ -233,6 +233,23 @@ A template for creating an ActiveMQ 6 (Artemis) tool service. This template incl
 
 This template is ideal for quickly connecting Wanaku to an ActiveMQ instance without manually writing routes or configuring properties.
 
+### `kafka-tool`
+
+A template for creating a Kafka-backed MCP tool with manual request/reply correlation. This template includes:
+
+- A request route that sends a message to the request topic
+- A response route that consumes the response topic and forwards replies into a shared reply queue
+- Parameterized brokers, request topic, response topic, reply timeout, and reply consumer group settings
+
+**Parameters:**
+- `kafka.brokers`: Kafka bootstrap servers, for example `localhost:9092`
+- `kafka.request.topic`: Topic used for outbound requests
+- `kafka.response.topic`: Topic used for correlated replies
+- `kafka.reply.timeout-ms`: How long to wait for a reply before failing, in milliseconds
+- `kafka.response.group-id`: Consumer group used for the reply listener
+
+The request route sets a `wanakuCorrelationId` header from the Camel exchange id, and the response route uses that same header to match the reply to the original request.
+
 ## Best Practices
 
 ### When to Use Templates

--- a/services/service-templates/src/main/services/kafka-tool/index.properties
+++ b/services/service-templates/src/main/services/kafka-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.kafka=kafka/kafka.dependencies.txt
+catalog.description=Send and receive correlated messages via Apache Kafka
+catalog.name=kafka-tool
+catalog.properties.kafka=kafka/service.properties
+catalog.routes.kafka=kafka/kafka.camel.yaml
+catalog.rules.kafka=kafka/kafka.rules.yaml
+catalog.services=kafka

--- a/services/service-templates/src/main/services/kafka-tool/kafka/kafka.camel.yaml
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/kafka.camel.yaml
@@ -1,0 +1,77 @@
+- route:
+    id: kafka-request-reply
+    description: Send a Kafka request and wait for the correlated reply
+    from:
+      uri: direct:wanaku
+      steps:
+        - setExchangePattern:
+            pattern: InOut
+        - setHeader:
+            name: wanakuCorrelationId
+            expression:
+              simple:
+                expression: "${exchangeId}"
+        - log:
+            message: "Sending Kafka request with correlation id ${header.wanakuCorrelationId}"
+        - to:
+            uri: kafka:{{kafka.request.topic}}
+            parameters:
+              brokers: "{{kafka.brokers}}"
+        - pollEnrich:
+            timeout: "{{kafka.reply.timeout-ms}}"
+            expression:
+              simple:
+                expression: "seda:kafka-replies"
+        - choice:
+            when:
+              - simple: "${header.wanakuKafkaReplyReceived} != 'true'"
+                steps:
+                  - log:
+                      message: "Kafka reply timed out after {{kafka.reply.timeout-ms}} ms for correlation id ${header.wanakuCorrelationId}"
+                  - throwException:
+                      exceptionType: java.util.concurrent.TimeoutException
+                      message: "Kafka reply timed out after {{kafka.reply.timeout-ms}} ms for correlation id ${header.wanakuCorrelationId}"
+              - simple: "${exchangeProperty.wanakuCorrelationId} != ${header.wanakuReplyCorrelationId}"
+                steps:
+                  - log:
+                      message: "Kafka reply correlation mismatch for ${exchangeProperty.wanakuCorrelationId}: received ${header.wanakuReplyCorrelationId}"
+                  - throwException:
+                      exceptionType: java.lang.IllegalStateException
+                      message: "Kafka reply correlation mismatch for ${exchangeProperty.wanakuCorrelationId}"
+            otherwise:
+              steps:
+                - log:
+                    message: "Received Kafka reply for ${header.wanakuCorrelationId}: ${body}"
+
+- route:
+    id: kafka-response-reply
+    description: Correlate Kafka replies back to the waiting request
+    from:
+      uri: kafka:{{kafka.response.topic}}
+      parameters:
+        brokers: "{{kafka.brokers}}"
+        groupId: "{{kafka.response.group-id}}"
+        autoOffsetReset: latest
+      steps:
+        - filter:
+            simple: "${header.wanakuCorrelationId} != null"
+            steps:
+              - log:
+                  message: "Routing Kafka reply for ${header.wanakuCorrelationId}"
+              - setHeader:
+                  name: wanakuReplyCorrelationId
+                  expression:
+                    simple:
+                      expression: "${header.wanakuCorrelationId}"
+              - setHeader:
+                  name: wanakuKafkaReplyReceived
+                  expression:
+                    simple:
+                      expression: "true"
+              - to:
+                  uri: seda:kafka-replies
+        - filter:
+            simple: "${header.wanakuCorrelationId} == null"
+            steps:
+              - log:
+                  message: "Dropping Kafka reply without correlation id: ${body}"

--- a/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-kafka:4.18.2

--- a/services/service-templates/src/main/services/kafka-tool/kafka/kafka.rules.yaml
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/kafka.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - send-message-to-kafka:
+        route:
+          id: "kafka-request-reply"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The message to send to Kafka
+            required: true

--- a/services/service-templates/src/main/services/kafka-tool/kafka/service.properties
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/service.properties
@@ -1,0 +1,6 @@
+tool.description=Send a message to Kafka and wait for the correlated reply
+kafka.brokers={{kafka.brokers}}
+kafka.request.topic={{kafka.request.topic}}
+kafka.response.topic={{kafka.response.topic}}
+kafka.reply.timeout-ms={{kafka.reply.timeout-ms}}
+kafka.response.group-id={{kafka.response.group-id}}


### PR DESCRIPTION
Closes: #1072

## Summary by Sourcery

Add a Kafka-based tool service template that supports request/reply messaging with manual correlation headers.

New Features:
- Introduce a Kafka MCP tool template with configurable brokers, request topic, and response topic for correlated messaging.
- Expose an MCP tool for sending a message to Kafka and waiting for the correlated reply via a predefined Camel route.

Documentation:
- Document the new kafka-tool service template and its configuration parameters in the service templates guide.