### PR TITLE
ci: fix Javadoc errors in REST resource comments

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -69,7 +69,7 @@ public class DataStoresResource {
     /**
      * List all data stores, optionally filtered by label expression.
      * GET /api/v1/data-store
-     * GET /api/v1/data-store?labelFilter={expression}
+     * {@code GET /api/v1/data-store?labelFilter={expression}}
      *
      * @param labelFilter optional label expression to filter data stores
      * @return response with list of data stores

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -44,7 +44,7 @@ public class ServiceCatalogResource {
     /**
      * List all service catalog entries, optionally filtered by search term.
      * GET /api/v1/service-catalog/list
-     * GET /api/v1/service-catalog/list?search={term}
+     * {@code GET /api/v1/service-catalog/list?search={term}}
      *
      * @param search optional search term
      * @return response with list of catalog summaries
@@ -81,7 +81,7 @@ public class ServiceCatalogResource {
 
     /**
      * Get a specific service catalog by name with system details.
-     * GET /api/v1/service-catalog/get?name={name}
+     * {@code GET /api/v1/service-catalog/get?name={name}}
      *
      * @param name the catalog name
      * @return response with catalog detail including system information
@@ -123,7 +123,7 @@ public class ServiceCatalogResource {
 
     /**
      * Download a service catalog by name, returning the raw DataStore with Base64-encoded ZIP data.
-     * GET /api/v1/service-catalog/download?name={name}
+     * {@code GET /api/v1/service-catalog/download?name={name}}
      *
      * @param name the catalog name
      * @return response with the DataStore containing the Base64-encoded ZIP
@@ -162,7 +162,7 @@ public class ServiceCatalogResource {
 
     /**
      * Remove a service catalog by name.
-     * DELETE /api/v1/service-catalog/remove?name={name}
+     * {@code DELETE /api/v1/service-catalog/remove?name={name}}
      *
      * @param name the catalog name to remove
      * @return HTTP 200 if removed, 404 if not found
@@ -186,7 +186,7 @@ public class ServiceCatalogResource {
 
     /**
      * Get deployment instructions for a service catalog.
-     * GET /api/v1/service-catalog/instructions?name={name}&model={model}
+     * {@code GET /api/v1/service-catalog/instructions?name={name}&model={model}}
      *
      * @param name the catalog name
      * @param model the deployment model: local, docker, or kubernetes

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -1077,6 +1077,13 @@
           }
         }
       }
+    },
+    "securitySchemes" : {
+      "SecurityScheme" : {
+        "type" : "openIdConnect",
+        "openIdConnectUrl" : "http://localhost:8543/realms/wanaku/.well-known/openid-configuration",
+        "description" : "Authentication"
+      }
     }
   },
   "paths" : {

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -720,6 +720,11 @@ components:
           $ref: "#/components/schemas/WanakuError"
         data:
           $ref: "#/components/schemas/ToolReference"
+  securitySchemes:
+    SecurityScheme:
+      type: openIdConnect
+      openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
+      description: Authentication
 paths:
   /api/v1/capabilities:
     get:


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/25725622656

### Errors Fixed
- **Javadoc generation failure** in `wanaku-router-backend`: URL patterns with curly braces (`{name}`, `{model}`) and ampersands (`&`) in Javadoc comments were interpreted as malformed inline tags and HTML entities, causing `maven-javadoc-plugin` to fail with "semicolon missing" error.
- Wrapped all URL patterns in `{@code ...}` across `ServiceCatalogResource.java` (5 occurrences) and `DataStoresResource.java` (1 occurrence).
- Included auto-regenerated `openapi.json`/`openapi.yaml` from full reactor build.

### Deferred Issues
None.

## Summary by Sourcery

Fix documentation issues in REST resources and refresh the generated OpenAPI specifications.

Documentation:
- Wrap REST endpoint URL examples in Javadoc comments with {@code} to avoid Javadoc parsing errors.
- Update OpenAPI YAML/JSON specs to include the security scheme configuration for OpenID Connect authentication.