### PR TITLE
feat: add azure-files resource with camel route and properties

### DIFF
--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.camel.yaml
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.camel.yaml
@@ -1,0 +1,17 @@
+- route:
+    id: azure-files-read
+    description: Read files from Azure Storage file shares
+    autoStartup: false
+    from:
+      uri: direct:wanaku
+      steps:
+      - setHeader:
+          name: CamelFileName
+          expression:
+            simple:
+              expression: "${header.wanaku_resource_uri}"
+      - to:
+          uri: azure-files:{{azure.files.account}}/{{azure.files.share}}
+          parameters:
+            credentialType: SHARED_ACCOUNT_KEY
+            sharedKey: "{{azure.files.sharedKey}}"

--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-azure-files:4.18.2

--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.rules.yaml
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.rules.yaml
@@ -1,0 +1,8 @@
+mcp:
+  resources:
+  - azure-files-read:
+      route:
+        id: "azure-files-read"
+        description: "{{resource.description}}"
+        uri: "wanaku://azure-files-read"
+        mimeType: "application/octet-stream"

--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/service.properties
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/service.properties
@@ -1,0 +1,4 @@
+resource.description=Read files from Azure Storage file shares
+azure.files.account={{azure.files.account}}
+azure.files.share={{azure.files.share}}
+azure.files.sharedKey={{azure.files.sharedKey}}

--- a/services/service-templates/src/main/services/azure-files-resource/index.properties
+++ b/services/service-templates/src/main/services/azure-files-resource/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.azure-files=azure-files/azure-files.dependencies.txt
+catalog.description=Read files from Azure Storage file shares
+catalog.name=azure-files-resource
+catalog.properties.azure-files=azure-files/service.properties
+catalog.routes.azure-files=azure-files/azure-files.camel.yaml
+catalog.rules.azure-files=azure-files/azure-files.rules.yaml
+catalog.services=azure-files


### PR DESCRIPTION
Closes: #1065

## Summary by Sourcery

Add a new Azure Files resource template for reading files from Azure Storage file shares via a Camel route and MCP resource configuration.

New Features:
- Introduce a Camel route for reading files from Azure Storage file shares using Azure Files.
- Add MCP resource and catalog configuration entries for the new Azure Files resource template.
- Define service properties for Azure Files account, share, and shared key configuration.