### PR TITLE
feat: add FTP resource configuration and dependencies

### DIFF
--- a/services/service-templates/src/main/services/ftp-resource/ftp/ftp.camel.yaml
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/ftp.camel.yaml
@@ -1,0 +1,16 @@
+- route:
+    id: ftp-read
+    description: Read files from FTP servers
+    autoStartup: false
+    from:
+      uri: direct:wanaku
+      steps:
+      - setHeader:
+          name: CamelFileName
+          expression:
+            simple:
+              expression: "${header.wanaku_resource_uri}"
+      - to:
+          uri: ftp://{{ftp.username}}@{{ftp.host}}:{{ftp.port}}/{{ftp.directory}}
+          parameters:
+            password: "{{ftp.password}}"

--- a/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-ftp:4.18.2

--- a/services/service-templates/src/main/services/ftp-resource/ftp/ftp.rules.yaml
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/ftp.rules.yaml
@@ -1,0 +1,8 @@
+mcp:
+  resources:
+  - ftp-read:
+      route:
+        id: "ftp-read"
+        description: "{{resource.description}}"
+        uri: "wanaku://ftp-read"
+        mimeType: "application/octet-stream"

--- a/services/service-templates/src/main/services/ftp-resource/ftp/service.properties
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/service.properties
@@ -1,0 +1,6 @@
+resource.description=Read files from FTP servers
+ftp.host={{ftp.host}}
+ftp.port={{ftp.port}}
+ftp.username={{ftp.username}}
+ftp.password={{ftp.password}}
+ftp.directory={{ftp.directory}}

--- a/services/service-templates/src/main/services/ftp-resource/index.properties
+++ b/services/service-templates/src/main/services/ftp-resource/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.ftp=ftp/ftp.dependencies.txt
+catalog.description=Read files from FTP servers
+catalog.name=ftp-resource
+catalog.properties.ftp=ftp/service.properties
+catalog.routes.ftp=ftp/ftp.camel.yaml
+catalog.rules.ftp=ftp/ftp.rules.yaml
+catalog.services=ftp


### PR DESCRIPTION
Closes: #1066

## Summary by Sourcery

Add a new FTP resource template for reading files from FTP servers and wiring it into the service catalog.

New Features:
- Introduce an FTP-based resource route for reading files from configured FTP servers.
- Add configuration properties and rule definitions for the FTP resource in the service templates catalog.