### PR TITLE
feat: SFTP resource configuration and dependencies

### DIFF
--- a/services/service-templates/src/main/services/sftp-resource/index.properties
+++ b/services/service-templates/src/main/services/sftp-resource/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.sftp=sftp/sftp.dependencies.txt
+catalog.description=Read files from SFTP servers
+catalog.name=sftp-resource
+catalog.properties.sftp=sftp/service.properties
+catalog.routes.sftp=sftp/sftp.camel.yaml
+catalog.rules.sftp=sftp/sftp.rules.yaml
+catalog.services=sftp

--- a/services/service-templates/src/main/services/sftp-resource/sftp/service.properties
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/service.properties
@@ -1,0 +1,13 @@
+resource.description=Read files from SFTP servers
+sftp.host={{sftp.host}}
+sftp.port={{sftp.port}}
+sftp.username={{sftp.username}}
+sftp.authMethod=password
+sftp.password={{sftp.password}}
+sftp.privateKeyFile={{sftp.privateKeyFile}}
+sftp.directory={{sftp.directory}}
+sftp.knownHostsFile={{sftp.knownHostsFile}}
+sftp.strictHostKeyChecking=true
+sftp.disconnect=true
+sftp.soTimeout=10000
+sftp.timeout=30000

--- a/services/service-templates/src/main/services/sftp-resource/sftp/sftp.camel.yaml
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/sftp.camel.yaml
@@ -1,0 +1,48 @@
+- route:
+    id: sftp-read
+    description: Read files from SFTP servers
+    autoStartup: false
+    from:
+      uri: direct:wanaku
+      steps:
+        - choice:
+            when:
+              - simple: "${header.wanaku_resource_uri} != null"
+                steps:
+                  - setHeader:
+                      name: CamelFileName
+                      expression:
+                        simple:
+                          expression: "${header.wanaku_resource_uri}"
+            otherwise:
+              steps:
+                  - log: "No wanaku_resource_uri header provided; using body as filename"
+                  - setHeader:
+                      name: CamelFileName
+                      expression:
+                        simple:
+                          expression: "${body}"
+        - choice:
+            when:
+              - simple: "{{sftp.authMethod}} == 'key'"
+                steps:
+                  - to:
+                      uri: sftp:{{sftp.username}}@{{sftp.host}}:{{sftp.port}}/{{sftp.directory}}
+                      parameters:
+                        privateKeyFile: "{{sftp.privateKeyFile}}"
+                        knownHostsFile: "{{sftp.knownHostsFile}}"
+                        strictHostKeyChecking: "{{sftp.strictHostKeyChecking}}"
+                        disconnect: "{{sftp.disconnect}}"
+                        soTimeout: "{{sftp.soTimeout}}"
+                        timeout: "{{sftp.timeout}}"
+            otherwise:
+              steps:
+                  - to:
+                      uri: sftp:{{sftp.username}}@{{sftp.host}}:{{sftp.port}}/{{sftp.directory}}
+                      parameters:
+                        password: "{{sftp.password}}"
+                        knownHostsFile: "{{sftp.knownHostsFile}}"
+                        strictHostKeyChecking: "{{sftp.strictHostKeyChecking}}"
+                        disconnect: "{{sftp.disconnect}}"
+                        soTimeout: "{{sftp.soTimeout}}"
+                        timeout: "{{sftp.timeout}}"

--- a/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-ftp:4.18.2

--- a/services/service-templates/src/main/services/sftp-resource/sftp/sftp.rules.yaml
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/sftp.rules.yaml
@@ -1,0 +1,8 @@
+mcp:
+  resources:
+    - sftp-read:
+        route:
+          id: "sftp-read"
+        description: "{{resource.description}}"
+        uri: "direct:wanaku"
+        mimeType: "application/octet-stream"


### PR DESCRIPTION
Closes: #1067

## Summary by Sourcery

Add a new SFTP resource template for reading files from SFTP servers and wiring it into the service catalog.

New Features:
- Introduce an SFTP Camel route for reading files from configurable SFTP servers via a wanaku endpoint.
- Register a new SFTP resource in the MCP rules with associated metadata for binary file handling.
- Add service template configuration and catalog entries for the SFTP resource, including connection properties and dependencies placeholder.