### PR TITLE
feat: add Watson NLU sink tool with configuration and routing

### DIFF
--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.watson-nlu-sink=watson-nlu-sink/watson-nlu-sink.dependencies.txt
+catalog.description=Analyze text using IBM Watson Natural Language Understanding
+catalog.name=watson-nlu-sink-tool
+catalog.properties.watson-nlu-sink=watson-nlu-sink/service.properties
+catalog.routes.watson-nlu-sink=watson-nlu-sink/watson-nlu-sink.camel.yaml
+catalog.rules.watson-nlu-sink=watson-nlu-sink/watson-nlu-sink.rules.yaml
+catalog.services=watson-nlu-sink

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/service.properties
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/service.properties
@@ -1,0 +1,10 @@
+tool.description=Analyze text using IBM Watson Natural Language Understanding for sentiment, entities, keywords, and other NLU features
+watson.nlu.api.key={{watson.nlu.api.key}}
+watson.nlu.service.url={{watson.nlu.service.url}}
+watson.nlu.operation=analyzeText
+watson.nlu.analyze.sentiment=true
+watson.nlu.analyze.entities=true
+watson.nlu.analyze.keywords=true
+watson.nlu.analyze.emotion=false
+watson.nlu.analyze.concepts=false
+watson.nlu.analyze.categories=false

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.camel.yaml
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.camel.yaml
@@ -1,0 +1,18 @@
+- route:
+    id: watson-nlu-analyze
+    description: Analyze text using IBM Watson Natural Language Understanding
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: ibm-watson-language:wanaku
+            parameters:
+              apiKey: "RAW({{watson.nlu.api.key}})"
+              serviceUrl: "{{watson.nlu.service.url}}"
+              operation: "{{watson.nlu.operation}}"
+              analyzeSentiment: "{{watson.nlu.analyze.sentiment}}"
+              analyzeEntities: "{{watson.nlu.analyze.entities}}"
+              analyzeKeywords: "{{watson.nlu.analyze.keywords}}"
+              analyzeEmotion: "{{watson.nlu.analyze.emotion}}"
+              analyzeConcepts: "{{watson.nlu.analyze.concepts}}"
+              analyzeCategories: "{{watson.nlu.analyze.categories}}"

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-ibm-watson-language:4.18.2

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.rules.yaml
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+  - watson-nlu-analyze:
+      route:
+        id: "watson-nlu-analyze"
+      description: "{{tool.description}}"
+      properties:
+      - name: wanaku_body
+        type: string
+        description: The text to analyze for sentiment, entities, keywords, and other NLU features
+        required: true


### PR DESCRIPTION
Closes: #1071

## Summary by Sourcery

Add a new IBM Watson NLU sink tool service template for text analysis routing and configuration.

New Features:
- Introduce a Watson NLU analysis Camel route that posts text to the IBM Watson NLU /v1/analyze API with predefined features.
- Expose an MCP tool definition for invoking Watson NLU analysis with a required text body parameter.
- Register the watson-nlu-sink-tool in the service templates catalog with associated routes, rules, properties, and dependencies configuration.