### PR TITLE
feat: add vertex-ai-sink tool with configuration and routing

### DIFF
--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.camel.yaml
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.camel.yaml
@@ -1,0 +1,15 @@
+- route:
+    id: google-vertexai-generate
+    description: Generate content using Google Vertex AI
+    from:
+      uri: direct:wanaku
+      steps:
+        - to:
+            uri: "google-vertexai:{{google.vertexai.project.id}}:{{google.vertexai.location}}:{{google.vertexai.model.id}}"
+            parameters:
+              operation: "{{google.vertexai.operation}}"
+              temperature: "{{google.vertexai.temperature}}"
+              maxOutputTokens: "{{google.vertexai.max.output.tokens}}"
+              topP: "{{google.vertexai.top.p}}"
+              topK: "{{google.vertexai.top.k}}"
+              serviceAccountKey: "{{google.vertexai.service.account.key}}"

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-google-vertexai:4.18.2

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.rules.yaml
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+  - google-vertexai-generate:
+      route:
+        id: "google-vertexai-generate"
+      description: "{{tool.description}}"
+      properties:
+      - name: wanaku_body
+        type: string
+        description: The prompt text to send to Google Vertex AI for content generation
+        required: true

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/service.properties
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/service.properties
@@ -1,0 +1,10 @@
+tool.description=Generate content using Google Vertex AI models such as Gemini, Claude, and Llama
+google.vertexai.project.id={{google.vertexai.project.id}}
+google.vertexai.location={{google.vertexai.location}}
+google.vertexai.model.id={{google.vertexai.model.id}}
+google.vertexai.operation=generateText
+google.vertexai.temperature=0.7
+google.vertexai.max.output.tokens=1024
+google.vertexai.top.p=0.95
+google.vertexai.top.k=40
+google.vertexai.service.account.key=

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.google-vertexai-sink=google-vertexai-sink/google-vertexai-sink.dependencies.txt
+catalog.description=Generate content using Google Vertex AI
+catalog.name=google-vertexai-sink-tool
+catalog.properties.google-vertexai-sink=google-vertexai-sink/service.properties
+catalog.routes.google-vertexai-sink=google-vertexai-sink/google-vertexai-sink.camel.yaml
+catalog.rules.google-vertexai-sink=google-vertexai-sink/google-vertexai-sink.rules.yaml
+catalog.services=google-vertexai-sink


### PR DESCRIPTION
Closes: #1070

## Summary by Sourcery

Add a configurable service template and MCP tool for invoking Google Vertex AI text generation models via Camel routing.

New Features:
- Introduce a vertex-ai-sink tool that exposes a route for invoking Google Vertex AI models for text generation.
- Add MCP tool routing rules to accept a prompt input and forward it to the Vertex AI invocation route.
- Provide service configuration and catalog metadata for Vertex AI project, location, model, and generation parameters.