### PR TITLE
Fix #1079: fix build errors from error handling standardization

### DIFF
--- a/apps/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
+++ b/apps/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
@@ -57,7 +57,7 @@ const ForwardsPage = () => {
     try {
       const response = await addForward(newForward)
       if (response.status !== 200) {
-        const errorData = response.data as { error?: { message?: string } } | null
+        const errorData = response.data as unknown as { error?: { message?: string } } | null
         setErrorMessage(errorData?.error?.message || "Failed to add forward")
       }
     } catch (error) {
@@ -71,7 +71,7 @@ const ForwardsPage = () => {
     try {
       const response = await updateForward(forward)
       if (response.status !== 200) {
-        const errorData = response.data as { error?: { message?: string } } | null
+        const errorData = response.data as unknown as { error?: { message?: string } } | null
         setErrorMessage(errorData?.error?.message || "Failed to update forward")
       }
     } catch (error) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -160,8 +160,7 @@ public class DataStoresResource {
      */
     @Path("/labels")
     @DELETE
-    public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression)
-            {
+    public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression) {
         LOG.debugf("REST: Removing data stores by label expression: %s", labelExpression);
         int removed = dataStoresBean.removeIf(labelExpression);
         return new WanakuResponse<>(removed);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceUnavailableExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceUnavailableExceptionMapper.java
@@ -17,7 +17,8 @@ public class ServiceUnavailableExceptionMapper implements ExceptionMapper<Servic
 
     @APIResponse(
             responseCode = "502",
-            description = "Bad Gateway — a downstream capability service is unreachable or returned an invalid response",
+            description =
+                    "Bad Gateway — a downstream capability service is unreachable or returned an invalid response",
             content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
     @Override
     public Response toResponse(ServiceUnavailableException e) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsResource.java
@@ -5,7 +5,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -16,7 +15,7 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.List;
 import org.jboss.resteasy.reactive.RestResponse;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.core.util.StringHelper;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
@@ -17,7 +17,6 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.capabilities.sdk.api.exceptions.PromptNotFoundException;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.PromptReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.PromptPayload;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -92,8 +92,7 @@ public class ResourcesResource {
      * @return a response containing a list of all resource references
      */
     @GET
-    public WanakuResponse<List<ResourceReference>> list(@QueryParam("labelFilter") String labelFilter)
-            {
+    public WanakuResponse<List<ResourceReference>> list(@QueryParam("labelFilter") String labelFilter) {
         List<ResourceReference> list = resourcesBean.list(labelFilter);
         List<ResourceReference> resourceReferences = forwardsBean.listAllResources();
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -202,8 +202,7 @@ public class ServiceTemplateResource {
      */
     @Path("/properties")
     @GET
-    public WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name)
-            {
+    public WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name) {
         LOG.debugf("REST: Getting properties for template: %s", name);
 
         if (StringHelper.isBlank(name)) {
@@ -223,8 +222,7 @@ public class ServiceTemplateResource {
      */
     @Path("/instantiate")
     @POST
-    public WanakuResponse<DataStore> instantiate(ServiceTemplateService.TemplateInstantiationRequest request)
-            {
+    public WanakuResponse<DataStore> instantiate(ServiceTemplateService.TemplateInstantiationRequest request) {
         LOG.debugf("REST: Instantiating template: %s", request.getTemplateName());
 
         if (StringHelper.isBlank(request.getTemplateName())) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -89,8 +89,7 @@ public class ToolsResource {
      * @return a response containing a list of all tool references
      */
     @GET
-    public WanakuResponse<List<ToolReference>> list(@QueryParam("labelFilter") String labelFilter)
-            {
+    public WanakuResponse<List<ToolReference>> list(@QueryParam("labelFilter") String labelFilter) {
         List<ToolReference> forwardTools = forwardsBean.listAllAsTools(labelFilter);
         List<ToolReference> tools = toolsBean.list(labelFilter);
         List<ToolReference> ret = CollectionsHelper.join(tools, forwardTools);
@@ -154,8 +153,7 @@ public class ToolsResource {
      * @return a {@link Response} indicating the number of the tools removed.
      */
     @DELETE
-    public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression)
-            {
+    public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression) {
 
         int deleteCount = toolsBean.removeIf(labelExpression);
         return new WanakuResponse<>(deleteCount);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
@@ -51,8 +50,7 @@ public class ToolsetReposResource {
 
     @Path("/{name}")
     @PUT
-    public WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo)
-            {
+    public WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo) {
         LOG.debugf("REST: Updating toolset repository: %s", name);
         Map<String, String> result = toolsetReposBean.update(
                 name, repo.get("url"), repo.get("description"), repo.get("icon"), repo.get("branch"));

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResourceTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -155,8 +156,7 @@ class ServiceCatalogResourceTest {
     @Test
     void testRemoveNotFound() throws Exception {
         when(serviceCatalogBean.remove("nonexistent")).thenReturn(0);
-        Response response = resource.remove("nonexistent");
-        assertEquals(404, response.getStatus());
+        assertThrows(DataStoreResourceNotFoundException.class, () -> resource.remove("nonexistent"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error in `ForwardsPage.tsx` where Orval-generated `void` response data couldn't be cast directly to an object type — resolved by casting through `unknown` first
- Fix `ServiceCatalogResourceTest.testRemoveNotFound` to expect `DataStoreResourceNotFoundException` instead of a 404 Response, matching the new exception-based error handling
- Apply auto-formatter cleanup on Resource classes

## Test plan
- [x] Frontend build (`npm run build`) passes
- [x] `ServiceCatalogResourceTest` passes all 13 tests
- [ ] Full `mvn verify` passes (Docker-dependent Keycloak tests excluded — unrelated environment issue)

## Summary by Sourcery

Align error handling and typings across frontend and backend and clean up REST resource formatting.

Bug Fixes:
- Adjust ForwardsPage error response casting to be compatible with Orval-generated void responses.
- Update ServiceCatalogResourceTest.testRemoveNotFound to expect DataStoreResourceNotFoundException instead of a 404 response, matching exception-based error handling.

Enhancements:
- Apply code formatter cleanup to REST resource classes and exception mapper annotations for consistent style.