### PR TITLE
ci: fix Javadoc reference to removed Response type

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/datastores/DataStoresResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.List;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/prompts/PromptsResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.List;
 import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.capabilities.sdk.api.exceptions.PromptNotFoundException;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/resources/ResourcesResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.List;
 import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.backend.api.v1.forwards.ForwardsBean;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.List;
 import ai.wanaku.backend.api.v1.common.PayloadValidator;
 import ai.wanaku.backend.api.v1.forwards.ForwardsBean;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResource.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -720,6 +720,17 @@ components:
           $ref: "#/components/schemas/WanakuError"
         data:
           $ref: "#/components/schemas/ToolReference"
+    WanakuResponseVoid:
+      type: object
+      properties:
+        error:
+          $ref: "#/components/schemas/WanakuError"
+        data: {}
+  securitySchemes:
+    SecurityScheme:
+      type: openIdConnect
+      openIdConnectUrl: http://localhost:8543/realms/wanaku/.well-known/openid-configuration
+      description: Authentication
 paths:
   /api/v1/capabilities:
     get:
@@ -871,7 +882,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -888,7 +900,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove By Name
       tags:
       - Data Stores Resource
@@ -961,7 +974,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove By Id
       tags:
       - Data Stores Resource
@@ -1011,7 +1025,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Add Forward
@@ -1036,7 +1051,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -1054,7 +1070,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove Forward
       tags:
       - Forwards Resource
@@ -1088,7 +1105,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Refresh
       tags:
       - Forwards Resource
@@ -1124,7 +1142,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Deregister
       tags:
       - Discovery Resource
@@ -1142,7 +1161,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Ping
       tags:
       - Discovery Resource
@@ -1276,7 +1296,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -1311,7 +1332,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Delete
       tags:
       - Namespaces Resource
@@ -1328,7 +1350,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -1345,7 +1368,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Prompts Resource
@@ -1492,7 +1516,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -1510,7 +1535,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Resources Resource
@@ -1635,7 +1661,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Service Catalog Resource
@@ -1759,7 +1786,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Service Template Resource
@@ -1854,7 +1882,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
         "400":
           description: Bad Request
       summary: Update
@@ -1872,7 +1901,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Tools Resource
@@ -1966,7 +1996,8 @@ paths:
           description: OK
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: "#/components/schemas/WanakuResponseVoid"
       summary: Remove
       tags:
       - Toolset Repos Resource

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/DataStoresService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/DataStoresService.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/PromptsService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/PromptsService.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.PromptReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.PromptPayload;

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogService.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
 import java.util.Map;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
@@ -98,8 +97,7 @@ public interface ServiceTemplateService {
     @Path("/properties")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name)
-           ;
+    WanakuResponse<Map<String, Map<String, String>>> getProperties(@QueryParam("name") String name);
 
     /**
      * Instantiate a service template by filling in property values.

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsService.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.ToolPayload;
@@ -112,7 +111,7 @@ public interface ToolsService {
      * Removes a tool capability from the system.
      *
      * @param labelExpression the name of the tool to remove
-     * @return a {@link Response} indicating the result of the removal operation
+     * @return a {@link WanakuResponse} indicating the result of the removal operation
      */
     @DELETE
     WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression);

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsetReposService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ToolsetReposService.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
 import java.util.Map;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
@@ -57,8 +56,7 @@ public interface ToolsetReposService {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo)
-           ;
+    WanakuResponse<Map<String, String>> update(@PathParam("name") String name, Map<String, String> repo);
 
     /**
      * Remove a toolset repository by name.


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/25805757988

### Errors Fixed
- `ToolsService.java:115`: Javadoc `{@link Response}` reference not found — changed to `{@link WanakuResponse}` to match the return type after #1080 migration
- Spotless auto-cleanup: removed unused `WanakuException` imports across service interfaces, fixed line-break formatting in `ServiceTemplateService` and `ToolsetReposService`
- Regenerated `openapi.yaml` to reflect current API state

### Deferred Issues
None

## Summary by Sourcery

Align API contracts and CI by fixing Javadoc references and regenerating OpenAPI specs for void WanakuResponse endpoints.

Bug Fixes:
- Correct Javadoc return type reference in ToolsService to point to WanakuResponse instead of a removed Response type.

Enhancements:
- Introduce a WanakuResponseVoid schema and reuse it across void JSON responses in the OpenAPI specification.
- Clean up service API interfaces formatting to satisfy style and CI checks.