### PR TITLE
ci: fix Javadoc reference to removed Response type in ToolsResource

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsResource.java
@@ -149,7 +149,7 @@ public class ToolsResource {
      * Removes all tools from the system that match the label expression
      *
      * @param labelExpression the name of the tool to remove
-     * @return a {@link Response} indicating the number of the tools removed.
+     * @return a {@link WanakuResponse} indicating the number of the tools removed.
      */
     @DELETE
     public WanakuResponse<Integer> removeIf(@QueryParam("labelExpression") String labelExpression) {


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/25810831336

### Errors Fixed
- `ToolsResource.java:152`: Javadoc `{@link Response}` references a type that no longer exists after the WanakuResponse migration (#1080). Updated to `{@link WanakuResponse}`.

### Deferred Issues
None.

## Summary by Sourcery

Bug Fixes:
- Correct Javadoc return type reference in ToolsResource to use WanakuResponse instead of the removed Response type.