### PR TITLE
ci: fix Javadoc unescaped ampersand in ServiceCatalogResource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ make install
 - Java: Follow standard Quarkus conventions, no Records or Lombok unless already present
 - TypeScript: ESLint enforced, Carbon Design System components
 - REST API responses use `WanakuResponse<T>` wrapper: `{"data": ..., "error": ...}`
+- Javadoc: URLs with query parameters must escape `&` (use `{@code ...}` wrapper or `&amp;`) — the Javadoc plugin treats bare `&` as HTML entity references and fails the build
 - Frontend `customFetch` wraps responses again, so actual data is at `result.data.data`
 
 ## Operator

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogResource.java
@@ -2,7 +2,6 @@ package ai.wanaku.backend.api.v1.servicecatalog;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -174,7 +173,7 @@ public class ServiceCatalogResource {
 
     /**
      * Get deployment instructions for a service catalog.
-     * GET /api/v1/service-catalog/instructions?name={name}&model={model}
+     * {@code GET /api/v1/service-catalog/instructions?name={name}&model={model}}
      *
      * @param name the catalog name
      * @param model the deployment model: local, docker, or kubernetes


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/25844138227

### Errors Fixed
- `ServiceCatalogResource.java:177`: Javadoc URL containing `&model` was parsed as a malformed HTML entity reference. Wrapped the URL in `{@code ...}` to prevent HTML parsing.
- Added a note to `CLAUDE.md` Code Style section about escaping `&` in Javadoc URLs.

### Deferred Issues
None.

## Summary by Sourcery

Documentation:
- Document Javadoc URL escaping requirements and recommended patterns in CLAUDE.md code style guidelines.