### PR TITLE
Fix #1119: catch OperatorException in router reconciler

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteIngress;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -137,7 +138,7 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
         try {
             existingExternalService =
                     context.getSecondaryResource(Service.class).orElse(null);
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException | OperatorException e) {
             LOG.warnf(e, "There is no existing service");
             existingExternalService = null;
         }
@@ -174,7 +175,7 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
         Deployment existingDeployment;
         try {
             existingDeployment = context.getSecondaryResource(Deployment.class).orElse(null);
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException | OperatorException e) {
             LOG.warnf(e, "There is no existing deployment");
             existingDeployment = null;
         }


### PR DESCRIPTION
## Summary
- The operator refactor (b45d355c3) narrowed `catch (Exception e)` to `catch (IllegalStateException e)` in `WanakuRouterReconciler`
- `NoEventSourceForClassException` extends `OperatorException -> RuntimeException`, not `IllegalStateException`, so it escapes the catch and crashes the reconciler
- Added `OperatorException` to both multi-catch blocks for `Service` and `Deployment` secondary resource lookups

## Test plan
- [ ] Deploy a WanakuRouter CR on a cluster and verify no `NoEventSourceForClassException` crash
- [ ] Verify the reconciler creates services and deployments correctly on first run

## Summary by Sourcery

Handle operator exceptions when looking up router secondary resources to prevent reconciler crashes.

Bug Fixes:
- Catch OperatorException during Service secondary resource lookup to avoid crashing when no event source is configured.
- Catch OperatorException during Deployment secondary resource lookup to avoid crashing when no event source is configured.