### PR TITLE
chore: stabilize OpenAPI schema generation across auth modes

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -241,6 +241,7 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 %test.quarkus.log.category."org.apache.http".level=INFO
 
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
+quarkus.smallrye-openapi.auto-add-security=false
 mp.openapi.scan.exclude.packages=ai.wanaku.backend.api.v1.oidc
 
 # Quinoa configuration


### PR DESCRIPTION
## Summary

- Disable `quarkus.smallrye-openapi.auto-add-security` to prevent SmallRye OpenAPI from auto-injecting `securitySchemes` based on OIDC config at build time
- This stops the `openapi.json`/`openapi.yaml` files from toggling between having and not having the security block depending on which auth mode (`keycloak` vs `none`) is active during the build

## Test plan

- [ ] Build with `wanaku.http.auth=keycloak` and verify OpenAPI files no longer contain `securitySchemes`
- [ ] Build with `wanaku.http.auth=none` and verify OpenAPI files are identical
- [ ] Verify the frontend (Orval-generated client) still works correctly

## Summary by Sourcery

Build:
- Configure SmallRye OpenAPI to not auto-add security schemes during build so OpenAPI outputs are consistent regardless of auth mode.