### PR TITLE
feat: add GitHub pull request source tool with parameterized settings  and API integration

### DIFF
--- a/docs/service-templates.md
+++ b/docs/service-templates.md
@@ -250,6 +250,22 @@ A template for creating a Kafka-backed MCP tool with manual request/reply correl
 
 The request route sets a `wanakuCorrelationId` header from the Camel exchange id, and the response route uses that same header to match the reply to the original request.
 
+### `github-pullrequest-source-tool`
+
+A template for creating a GitHub Pull Request tool service. This template allows agents to fetch pull request information on demand from a specified repository.
+
+**Parameters:**
+- `github.owner`: The GitHub repository owner (e.g., `apache`)
+- `github.repo`: The GitHub repository name (e.g., `camel`)
+- `github.token`: A GitHub Personal Access Token (PAT) for authentication
+
+**Tool Parameters:**
+- `state`: Filter PRs by state (`open`, `closed`, `all`). Default: `open`
+- `head`: Filter by head user or head organization and branch (`user:branch`)
+- `base`: Filter by base branch name
+- `sort`: What to sort results by (`created`, `updated`, `popularity`, `long-running`). Default: `created`
+- `direction`: The direction of the sort (`asc`, `desc`)
+
 ## Best Practices
 
 ### When to Use Templates

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.camel.yaml
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.camel.yaml
@@ -1,0 +1,30 @@
+- route:
+    id: github-pullrequest-source
+    from:
+      uri: direct:wanaku
+    steps:
+      - setHeader:
+          name: CamelHttpPath
+          simple: "/repos/{{github.owner}}/{{github.repo}}/pulls"
+      - setHeader:
+          name: CamelHttpMethod
+          constant: GET
+      - setHeader:
+          name: Authorization
+          simple: "Bearer {{github.token}}"
+      - setHeader:
+          name: Accept
+          constant: "application/vnd.github+json"
+      - setHeader:
+          name: User-Agent
+          constant: "Wanaku"
+      - setHeader:
+          name: X-GitHub-Api-Version
+          constant: "2022-11-28"
+      - setHeader:
+          name: CamelHttpQuery
+          simple: "state=${header.state}&head=${header.head}&base=${header.base}&sort=${header.sort}&direction=${header.direction}"
+      - to:
+          uri: "https://api.github.com"
+      - convertBodyTo:
+          type: "java.lang.String"

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-http:4.18.2

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.rules.yaml
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.rules.yaml
@@ -1,0 +1,27 @@
+mcp:
+  tools:
+    - github-pullrequest-source:
+        route:
+          id: "github-pullrequest-source"
+        description: "Fetch pull request information from a GitHub repository"
+        properties:
+          - name: state
+            type: string
+            description: "Filter PRs by state (open, closed, all). Default: open"
+            required: false
+          - name: head
+            type: string
+            description: "Filter by head user or head organization and branch (user:branch)"
+            required: false
+          - name: base
+            type: string
+            description: "Filter by base branch name"
+            required: false
+          - name: sort
+            type: string
+            description: "What to sort results by (created, updated, popularity, long-running). Default: created"
+            required: false
+          - name: direction
+            type: string
+            description: "The direction of the sort (asc, desc)"
+            required: false

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/service.properties
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/service.properties
@@ -1,0 +1,3 @@
+github.owner={{github.owner}}
+github.repo={{github.repo}}
+github.token={{github.token}}

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/index.properties
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.github-pullrequest-source=github-pullrequest-source/github-pullrequest-source.dependencies.txt
+catalog.description=Fetch pull request information from GitHub
+catalog.name=github-pullrequest-source-tool
+catalog.routes.github-pullrequest-source=github-pullrequest-source/github-pullrequest-source.camel.yaml
+catalog.rules.github-pullrequest-source=github-pullrequest-source/github-pullrequest-source.rules.yaml
+catalog.services=github-pullrequest-source


### PR DESCRIPTION
Closes: #1068

## Summary by Sourcery

Add a new service template that exposes a parameterized MCP tool for fetching GitHub pull request data on demand via the GitHub REST API.

New Features:
- Introduce the github-pullrequest-source-tool service template for retrieving pull request metadata from GitHub with configurable repository and authentication settings.

Enhancements:
- Document the github-pullrequest-source-tool template, including supported parameters and tool inputs, in the service templates guide.