### PR TITLE
feat: add GitHub PR comments tool with necessary configurations and dependencies

### DIFF
--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.camel.yaml
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.camel.yaml
@@ -1,0 +1,28 @@
+- route:
+    id: github-pr-comments
+    description: Fetch comments from a GitHub Pull Request
+    from:
+      uri: direct:wanaku
+      steps:
+      - setHeader:
+          name: CamelHttpMethod
+          constant: GET
+      - setHeader:
+          name: CamelHttpUri
+          simple: "{{github.api.url}}/repos/{{github.repo.owner}}/{{github.repo.name}}/pulls/{{github.pr.number}}/comments"
+      - setHeader:
+          name: Authorization
+          simple: "Bearer {{github.auth.token}}"
+      - setHeader:
+          name: Accept
+          constant: "application/vnd.github+json"
+      - setHeader:
+          name: X-GitHub-Api-Version
+          constant: "2022-11-28"
+      - setHeader:
+          name: User-Agent
+          constant: "Wanaku-MCP-Router"
+      - to:
+          uri: http:github-api
+          parameters:
+            httpMethod: GET

--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
@@ -1,0 +1,2 @@
+org.apache.camel:camel-http:4.18.2
+org.apache.camel:camel-jackson:4.18.2

--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.rules.yaml
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.rules.yaml
@@ -1,0 +1,6 @@
+mcp:
+  tools:
+  - github-pr-comments:
+      route:
+        id: "github-pr-comments"
+        description: "{{tool.description}}"

--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/service.properties
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/service.properties
@@ -1,0 +1,6 @@
+tool.description=Fetch comments from a GitHub Pull Request
+github.api.url=https://api.github.com
+github.repo.owner={{github.repo.owner}}
+github.repo.name={{github.repo.name}}
+github.pr.number={{github.pr.number}}
+github.auth.token={{github.auth.token}}

--- a/services/service-templates/src/main/services/github-pr-comments-tool/index.properties
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.github-pr-comments=github-pr-comments/github-pr-comments.dependencies.txt
+catalog.description=Fetch comments from GitHub Pull Requests
+catalog.name=github-pr-comments-tool
+catalog.properties.github-pr-comments=github-pr-comments/service.properties
+catalog.routes.github-pr-comments=github-pr-comments/github-pr-comments.camel.yaml
+catalog.rules.github-pr-comments=github-pr-comments/github-pr-comments.rules.yaml
+catalog.services=github-pr-comments


### PR DESCRIPTION
Closes: #1069

## Summary by Sourcery

Introduce a new service template tool for fetching comments from GitHub pull requests.

New Features:
- Add a Camel route to call the GitHub API and retrieve comments for a specified pull request.
- Register the github-pr-comments tool with MCP rules and catalog metadata for discovery and configuration.

Enhancements:
- Configure service properties to parameterize GitHub API URL, repository details, PR number, and authentication token for the comments-fetching tool.