### PR TITLE
Fix #844: Replace blocking MCP operations with non-blocking concurrency

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ProvisionerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ProvisionerBridge.java
@@ -1,6 +1,7 @@
 package ai.wanaku.backend.bridge;
 
 import org.jboss.logging.Logger;
+import io.smallrye.mutiny.Uni;
 import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.backend.support.ProvisioningReference;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceNotFoundException;
@@ -27,6 +28,11 @@ public class ProvisionerBridge implements ProvisionBridge {
     @Override
     public ProvisioningReference provision(String name, String configData, String secretsData, ServiceTarget service) {
         return transport.provision(name, configData, secretsData, service);
+    }
+
+    public Uni<ProvisioningReference> provisionAsync(
+            String name, String configData, String secretsData, ServiceTarget service) {
+        return transport.provisionAsync(name, configData, secretsData, service);
     }
 
     /**

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/WanakuBridgeTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/WanakuBridgeTransport.java
@@ -62,7 +62,21 @@ public interface WanakuBridgeTransport {
      * @throws ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException
      *         if the service cannot be reached or returns an error
      */
-    ProvisioningReference provision(String name, String configData, String secretsData, ServiceTarget service);
+    default ProvisioningReference provision(String name, String configData, String secretsData, ServiceTarget service) {
+        return provisionAsync(name, configData, secretsData, service).await().indefinitely();
+    }
+
+    /**
+     * Provisions configuration and secrets to a remote service without blocking on the transport call.
+     *
+     * @param name the name identifier for the configuration and secrets
+     * @param configData the configuration data to provision (may be null or empty)
+     * @param secretsData the secrets data to provision (may be null or empty)
+     * @param service the target service to provision to
+     * @return a Uni that will emit the provisioning reference
+     */
+    Uni<ProvisioningReference> provisionAsync(
+            String name, String configData, String secretsData, ServiceTarget service);
 
     /**
      * Invokes a tool on a remote service.
@@ -135,5 +149,16 @@ public interface WanakuBridgeTransport {
      *         if the service cannot be reached
      * @throws WanakuException if the remote service returns an error
      */
-    HealthProbeReply probeHealth(HealthProbeRequest request, ServiceTarget service);
+    default HealthProbeReply probeHealth(HealthProbeRequest request, ServiceTarget service) {
+        return probeHealthAsync(request, service).await().indefinitely();
+    }
+
+    /**
+     * Probes the health of a remote service without blocking on the transport call.
+     *
+     * @param request the health probe request containing the service identifier
+     * @param service the target service to probe
+     * @return a Uni that will emit the health probe reply
+     */
+    Uni<HealthProbeReply> probeHealthAsync(HealthProbeRequest request, ServiceTarget service);
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -159,11 +159,6 @@ public class GrpcTransport implements WanakuBridgeTransport {
                                 .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                                 .provision(request);
 
-                        em.onTermination(() -> {
-                            future.cancel(true);
-                            channelManager.closeChannel(channel);
-                        });
-
                         future.addListener(
                                 () -> {
                                     try {
@@ -374,11 +369,6 @@ public class GrpcTransport implements WanakuBridgeTransport {
                 var future = HealthProbeGrpc.newFutureStub(channel)
                         .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                         .getStatus(request);
-
-                em.onTermination(() -> {
-                    future.cancel(true);
-                    channelManager.closeChannel(channel);
-                });
 
                 future.addListener(
                         () -> {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -159,6 +159,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                                 .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                                 .provision(request);
 
+                        em.onTermination(() -> {
+                            future.cancel(true);
+                            channelManager.closeChannel(channel);
+                        });
+
                         future.addListener(
                                 () -> {
                                     try {
@@ -369,6 +374,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                 var future = HealthProbeGrpc.newFutureStub(channel)
                         .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                         .getStatus(request);
+
+                em.onTermination(() -> {
+                    future.cancel(true);
+                    channelManager.closeChannel(channel);
+                });
 
                 future.addListener(
                         () -> {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -159,6 +159,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                                 .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                                 .provision(request);
 
+                        em.onTermination(() -> {
+                            future.cancel(true);
+                            channelManager.closeChannel(channel);
+                        });
+
                         future.addListener(
                                 () -> {
                                     try {
@@ -226,7 +231,7 @@ public class GrpcTransport implements WanakuBridgeTransport {
                         future.addListener(
                                 () -> {
                                     try {
-                                        em.complete(future.get());
+                                        em.complete(future.get(deadlineSeconds, TimeUnit.SECONDS));
                                     } catch (StatusRuntimeException e) {
                                         em.fail(mapStatusRuntimeException(e, service));
                                     } catch (ExecutionException e) {
@@ -284,7 +289,7 @@ public class GrpcTransport implements WanakuBridgeTransport {
                         future.addListener(
                                 () -> {
                                     try {
-                                        em.complete(future.get());
+                                        em.complete(future.get(deadlineSeconds, TimeUnit.SECONDS));
                                     } catch (StatusRuntimeException e) {
                                         em.fail(mapStatusRuntimeException(e, service));
                                     } catch (ExecutionException e) {
@@ -369,6 +374,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                 var future = HealthProbeGrpc.newFutureStub(channel)
                         .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                         .getStatus(request);
+
+                em.onTermination(() -> {
+                    future.cancel(true);
+                    channelManager.closeChannel(channel);
+                });
 
                 future.addListener(
                         () -> {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -129,50 +129,72 @@ public class GrpcTransport implements WanakuBridgeTransport {
      * @return a provisioning reference with URIs and properties
      */
     @Override
-    public ProvisioningReference provision(String name, String configData, String secretsData, ServiceTarget service) {
-
+    public Uni<ProvisioningReference> provisionAsync(
+            String name, String configData, String secretsData, ServiceTarget service) {
         LOG.debugf("Provisioning '%s' to service: %s", name, service.toAddress());
         String safeName = Objects.requireNonNullElse(name, "");
 
-        ManagedChannel channel = createChannel(service);
-        try {
-            Configuration cfg = Configuration.newBuilder()
-                    .setType(PayloadType.PAYLOAD_TYPE_BUILTIN)
-                    .setName(safeName)
-                    .setPayload(Objects.requireNonNullElse(configData, ""))
-                    .build();
+        Configuration cfg = Configuration.newBuilder()
+                .setType(PayloadType.PAYLOAD_TYPE_BUILTIN)
+                .setName(safeName)
+                .setPayload(Objects.requireNonNullElse(configData, ""))
+                .build();
 
-            Secret secret = Secret.newBuilder()
-                    .setType(PayloadType.PAYLOAD_TYPE_BUILTIN)
-                    .setName(safeName)
-                    .setPayload(Objects.requireNonNullElse(secretsData, ""))
-                    .build();
+        Secret secret = Secret.newBuilder()
+                .setType(PayloadType.PAYLOAD_TYPE_BUILTIN)
+                .setName(safeName)
+                .setPayload(Objects.requireNonNullElse(secretsData, ""))
+                .build();
 
-            ProvisionRequest request = ProvisionRequest.newBuilder()
-                    .setConfiguration(cfg)
-                    .setSecret(secret)
-                    .build();
+        ProvisionRequest request = ProvisionRequest.newBuilder()
+                .setConfiguration(cfg)
+                .setSecret(secret)
+                .build();
 
-            ProvisionerGrpc.ProvisionerBlockingStub stub = ProvisionerGrpc.newBlockingStub(channel);
-            ProvisionReply reply = stub.withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
-                    .provision(request);
+        return Uni.createFrom()
+                .<ProvisionReply>emitter(em -> {
+                    ManagedChannel channel = createChannel(service);
+                    try {
+                        var future = ProvisionerGrpc.newFutureStub(channel)
+                                .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
+                                .provision(request);
 
-            LOG.debugf(
-                    "Successfully provisioned configuration '%s' (config URI: %s, secret URI: %s)",
-                    name, reply.getConfigurationUri(), reply.getSecretUri());
+                        future.addListener(
+                                () -> {
+                                    try {
+                                        em.complete(future.get());
+                                    } catch (StatusRuntimeException e) {
+                                        em.fail(mapStatusRuntimeException(e, service));
+                                    } catch (ExecutionException e) {
+                                        em.fail(mapStatusRuntimeException(e, service));
+                                    } catch (Exception e) {
+                                        em.fail(e);
+                                    } finally {
+                                        channelManager.closeChannel(channel);
+                                    }
+                                },
+                                Infrastructure.getDefaultExecutor());
+                    } catch (StatusRuntimeException e) {
+                        channelManager.closeChannel(channel);
+                        em.fail(mapStatusRuntimeException(e, service));
+                    } catch (RuntimeException e) {
+                        channelManager.closeChannel(channel);
+                        LOG.errorf(
+                                e, "Failed to provision configuration '%s' to service: %s", name, service.toAddress());
+                        em.fail(new ServiceUnavailableException(
+                                "Service is not available at the address " + service.toAddress(), e));
+                    }
+                })
+                .map(reply -> {
+                    LOG.debugf(
+                            "Successfully provisioned configuration '%s' (config URI: %s, secret URI: %s)",
+                            name, reply.getConfigurationUri(), reply.getSecretUri());
 
-            return new ProvisioningReference(
-                    URI.create(reply.getConfigurationUri()),
-                    URI.create(reply.getSecretUri()),
-                    reply.getPropertiesMap());
-        } catch (StatusRuntimeException e) {
-            throw mapStatusRuntimeException(e, service);
-        } catch (RuntimeException e) {
-            LOG.errorf(e, "Failed to provision configuration '%s' to service: %s", name, service.toAddress());
-            throw new ServiceUnavailableException("Service is not available at the address " + service.toAddress(), e);
-        } finally {
-            channelManager.closeChannel(channel);
-        }
+                    return new ProvisioningReference(
+                            URI.create(reply.getConfigurationUri()),
+                            URI.create(reply.getSecretUri()),
+                            reply.getPropertiesMap());
+                });
     }
 
     /**
@@ -204,7 +226,7 @@ public class GrpcTransport implements WanakuBridgeTransport {
                         future.addListener(
                                 () -> {
                                     try {
-                                        em.complete(future.get(deadlineSeconds, TimeUnit.SECONDS));
+                                        em.complete(future.get());
                                     } catch (StatusRuntimeException e) {
                                         em.fail(mapStatusRuntimeException(e, service));
                                     } catch (ExecutionException e) {
@@ -262,7 +284,7 @@ public class GrpcTransport implements WanakuBridgeTransport {
                         future.addListener(
                                 () -> {
                                     try {
-                                        em.complete(future.get(deadlineSeconds, TimeUnit.SECONDS));
+                                        em.complete(future.get());
                                     } catch (StatusRuntimeException e) {
                                         em.fail(mapStatusRuntimeException(e, service));
                                     } catch (ExecutionException e) {
@@ -338,26 +360,48 @@ public class GrpcTransport implements WanakuBridgeTransport {
      * @throws WanakuException if the remote service returns an error
      */
     @Override
-    public HealthProbeReply probeHealth(HealthProbeRequest request, ServiceTarget service) {
+    public Uni<HealthProbeReply> probeHealthAsync(HealthProbeRequest request, ServiceTarget service) {
         LOG.debugf("Probing health of service: %s", service.toAddress());
 
-        ManagedChannel channel = createChannel(service);
-        try {
-            HealthProbeGrpc.HealthProbeBlockingStub blockingStub = HealthProbeGrpc.newBlockingStub(channel);
-            return blockingStub
-                    .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
-                    .getStatus(request);
-        } catch (StatusRuntimeException e) {
-            throw mapStatusRuntimeException(e, service);
-        } catch (RuntimeException e) {
-            LOG.errorf(e, "Failed to probe health of service: %s", service.toAddress());
-            throw new ServiceUnavailableException("Service is not available at the address " + service.toAddress(), e);
-        } finally {
-            channelManager.closeChannel(channel);
-        }
+        return Uni.createFrom().<HealthProbeReply>emitter(em -> {
+            ManagedChannel channel = createChannel(service);
+            try {
+                var future = HealthProbeGrpc.newFutureStub(channel)
+                        .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
+                        .getStatus(request);
+
+                future.addListener(
+                        () -> {
+                            try {
+                                em.complete(future.get());
+                            } catch (StatusRuntimeException e) {
+                                em.fail(mapStatusRuntimeException(e, service));
+                            } catch (ExecutionException e) {
+                                em.fail(mapStatusRuntimeException(e, service));
+                            } catch (Exception e) {
+                                em.fail(e);
+                            } finally {
+                                channelManager.closeChannel(channel);
+                            }
+                        },
+                        Infrastructure.getDefaultExecutor());
+            } catch (StatusRuntimeException e) {
+                channelManager.closeChannel(channel);
+                em.fail(mapStatusRuntimeException(e, service));
+            } catch (RuntimeException e) {
+                channelManager.closeChannel(channel);
+                LOG.errorf(e, "Failed to probe health of service: %s", service.toAddress());
+                em.fail(new ServiceUnavailableException(
+                        "Service is not available at the address " + service.toAddress(), e));
+            }
+        });
     }
 
     private RuntimeException mapStatusRuntimeException(ExecutionException e, ServiceTarget service) {
+        if (e.getCause() instanceof StatusRuntimeException statusRuntimeException) {
+            return mapStatusRuntimeException(statusRuntimeException, service);
+        }
+
         LOG.errorf(e, "Service %s did not respond within a reasonable time frame", service.getServiceName());
         return new ServiceUnavailableException(
                 String.format("Service %s did not respond within a reasonable time frame", service.getServiceName()),

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
@@ -1,11 +1,11 @@
 package ai.wanaku.backend.health;
 
 import org.jboss.logging.Logger;
+import io.smallrye.mutiny.Uni;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.types.discovery.HealthStatus;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
-import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.RuntimeStatus;
 
@@ -28,24 +28,33 @@ class HealthProbeClient {
      * @return the health status based on the probe result
      */
     HealthStatus probe(ServiceTarget target) {
-        try {
-            HealthProbeRequest request =
-                    HealthProbeRequest.newBuilder().setId(target.getId()).build();
+        return probeAsync(target).await().indefinitely();
+    }
 
-            HealthProbeReply reply = transport.probeHealth(request, target);
-            return mapRuntimeStatus(reply.getStatus());
-        } catch (ServiceUnavailableException e) {
-            if (e.isTransientCondition()) {
-                LOG.warnf("Service is temporarily unavailable at %s: %s", target.toAddress(), e.getMessage());
-                return HealthStatus.PENDING;
-            }
+    Uni<HealthStatus> probeAsync(ServiceTarget target) {
+        HealthProbeRequest request =
+                HealthProbeRequest.newBuilder().setId(target.getId()).build();
 
-            LOG.warnf("Service is not available at %s: %s", target.toAddress(), e.getMessage());
-            return HealthStatus.DOWN;
-        } catch (Exception e) {
-            LOG.warnf(e, "Health probe failed for %s: %s", target.toAddress(), e.getMessage());
-            return HealthStatus.DOWN;
+        return transport
+                .probeHealthAsync(request, target)
+                .map(reply -> mapRuntimeStatus(reply.getStatus()))
+                .onFailure(ServiceUnavailableException.class)
+                .recoverWithItem(e -> handleServiceUnavailable(target, (ServiceUnavailableException) e))
+                .onFailure()
+                .recoverWithItem(e -> {
+                    LOG.warnf(e, "Health probe failed for %s: %s", target.toAddress(), e.getMessage());
+                    return HealthStatus.DOWN;
+                });
+    }
+
+    private HealthStatus handleServiceUnavailable(ServiceTarget target, ServiceUnavailableException e) {
+        if (e.isTransientCondition()) {
+            LOG.warnf("Service is temporarily unavailable at %s: %s", target.toAddress(), e.getMessage());
+            return HealthStatus.PENDING;
         }
+
+        LOG.warnf("Service is not available at %s: %s", target.toAddress(), e.getMessage());
+        return HealthStatus.DOWN;
     }
 
     private static HealthStatus mapRuntimeStatus(RuntimeStatus status) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -73,8 +73,14 @@ public class PeriodicHealthCheckService {
         List<ServiceTarget> entries = serviceRegistry.getEntries();
         LOG.debugf("Health check sweep: checking %d capabilities", entries.size());
 
+        int maxConcurrent = Math.max(0, config.healthCheck().maxConcurrent());
+        int scheduled = 0;
         for (ServiceTarget target : entries) {
+            if (scheduled >= maxConcurrent) {
+                break;
+            }
             managedExecutor.submit(() -> checkInstanceHealth(target));
+            scheduled++;
         }
     }
 
@@ -111,12 +117,26 @@ public class PeriodicHealthCheckService {
             return;
         }
 
+        probeClient
+                .probeAsync(target)
+                .subscribe()
+                .with(
+                        status -> completeHealthCheck(target, id, status),
+                        failure -> failHealthCheck(id, activityRecord, failure));
+    }
+
+    private void completeHealthCheck(ServiceTarget target, String id, HealthStatus status) {
         try {
-            HealthStatus status = probeClient.probe(target);
             LOG.debugf("Health probe result for %s (%s): %s", target.getServiceName(), id, status.asValue());
             serviceRegistry.updateHealthStatus(id, status);
             emitHealthStatusEvent(id, status);
-        } catch (Exception e) {
+        } finally {
+            inProgress.remove(id);
+        }
+    }
+
+    private void failHealthCheck(String id, ActivityRecord activityRecord, Throwable failure) {
+        try {
             if (activityRecord.getHealthStatus() == HealthStatus.PENDING) {
                 final Instant lastSeen = activityRecord.getLastSeen();
                 final Duration between = Duration.between(lastSeen, Instant.now());
@@ -124,18 +144,20 @@ public class PeriodicHealthCheckService {
                 if (between.toMinutes() < ActivityRecord.TIME_TO_LET_GO) {
                     LOG.infof("Recently registered capability %s is in pending health state. ", id);
                 } else {
-                    LOG.warnf(e, "Error during health check for %s", id);
-                    serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
-                    emitHealthStatusEvent(id, HealthStatus.DOWN);
+                    markDown(id, failure);
                 }
             } else {
-                LOG.warnf(e, "Error during health check for %s", id);
-                serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
-                emitHealthStatusEvent(id, HealthStatus.DOWN);
+                markDown(id, failure);
             }
         } finally {
             inProgress.remove(id);
         }
+    }
+
+    private void markDown(String id, Throwable failure) {
+        LOG.warnf(failure, "Error during health check for %s", id);
+        serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
+        emitHealthStatusEvent(id, HealthStatus.DOWN);
     }
 
     private void emitHealthStatusEvent(String id, HealthStatus status) {
@@ -156,11 +178,11 @@ public class PeriodicHealthCheckService {
 
     /**
      * Consumes health check events from the Vert.x EventBus.
-     * Runs on a worker thread since the health probe involves blocking gRPC calls.
+     * Dispatches the health probe asynchronously.
      *
      * @param target the service target to check
      */
-    @ConsumeEvent(value = HEALTH_CHECK_ADDRESS, blocking = true)
+    @ConsumeEvent(HEALTH_CHECK_ADDRESS)
     void onHealthCheckRequested(ServiceTarget target) {
         checkInstanceHealth(target);
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -74,9 +74,17 @@ public class PeriodicHealthCheckService {
         LOG.debugf("Health check sweep: checking %d capabilities", entries.size());
 
         int maxConcurrent = Math.max(0, config.healthCheck().maxConcurrent());
+        int budget = maxConcurrent - inProgress.size();
+        if (budget <= 0) {
+            LOG.debugf(
+                    "Health check sweep: %d checks already in progress (max %d), skipping",
+                    inProgress.size(), maxConcurrent);
+            return;
+        }
+
         int scheduled = 0;
         for (ServiceTarget target : entries) {
-            if (scheduled >= maxConcurrent) {
+            if (scheduled >= budget) {
                 break;
             }
             managedExecutor.submit(() -> checkInstanceHealth(target));

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
@@ -1,0 +1,55 @@
+package ai.wanaku.backend.bridge.transports.grpc;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import ai.wanaku.backend.support.MockGrpcCapabilityServer;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.core.exchange.v1.HealthProbeRequest;
+import ai.wanaku.core.exchange.v1.RuntimeStatus;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GrpcTransportTest {
+
+    private MockGrpcCapabilityServer server;
+    private ServiceTarget target;
+    private GrpcTransport transport;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockGrpcCapabilityServer(List.of("ok"));
+        int port = server.start();
+        target = new ServiceTarget(
+                "test-id", "test-service", "localhost", port, "tool-invoker", "mcp", null, null, null);
+        transport = new GrpcTransport();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop();
+    }
+
+    @Test
+    void provisionAsync_usesNonBlockingStub() {
+        var reference = transport
+                .provisionAsync("test", "config", "secret", target)
+                .await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertEquals("file:///tmp/mock-config", reference.configurationURI().toString());
+        assertEquals("file:///tmp/mock-secret", reference.secretsURI().toString());
+    }
+
+    @Test
+    void probeHealthAsync_usesNonBlockingStub() {
+        var request = HealthProbeRequest.newBuilder().setId(target.getId()).build();
+
+        var reply = transport.probeHealthAsync(request, target).await().atMost(Duration.ofSeconds(5));
+
+        assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
@@ -3,7 +3,11 @@ package ai.wanaku.backend.bridge.transports.grpc;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import ai.wanaku.backend.support.MockGrpcCapabilityServer;
+import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.RuntimeStatus;
@@ -12,6 +16,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GrpcTransportTest {
 
@@ -51,5 +57,46 @@ class GrpcTransportTest {
         var reply = transport.probeHealthAsync(request, target).await().atMost(Duration.ofSeconds(5));
 
         assertEquals(RuntimeStatus.RUNTIME_STATUS_STARTED, reply.getStatus());
+    }
+
+    @Test
+    void provisionAsync_mapsInvalidArgumentError() {
+        server.setProvisionException(
+                new StatusRuntimeException(Status.INVALID_ARGUMENT.withDescription("invalid config")));
+
+        var thrown = assertThrows(WanakuException.class, () -> transport
+                .provisionAsync("test", "config", "secret", target)
+                .await()
+                .atMost(Duration.ofSeconds(5)));
+
+        assertTrue(thrown.getMessage().contains("invalid config"));
+    }
+
+    @Test
+    void probeHealthAsync_mapsUnavailableError() {
+        server.setProbeHealthException(
+                new StatusRuntimeException(Status.UNAVAILABLE.withDescription("service unavailable")));
+
+        var request = HealthProbeRequest.newBuilder().setId(target.getId()).build();
+
+        var thrown = assertThrows(
+                ServiceUnavailableException.class,
+                () -> transport.probeHealthAsync(request, target).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(thrown.getMessage().contains("not available"));
+    }
+
+    @Test
+    void probeHealthAsync_mapsDeadlineExceededError() {
+        server.setProbeHealthException(
+                new StatusRuntimeException(Status.DEADLINE_EXCEEDED.withDescription("deadline exceeded")));
+
+        var request = HealthProbeRequest.newBuilder().setId(target.getId()).build();
+
+        var thrown = assertThrows(
+                ServiceUnavailableException.class,
+                () -> transport.probeHealthAsync(request, target).await().atMost(Duration.ofSeconds(5)));
+
+        assertTrue(thrown.getMessage().contains("did not respond within a reasonable time frame"));
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/HealthProbeClientTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/HealthProbeClientTest.java
@@ -1,5 +1,6 @@
 package ai.wanaku.backend.health;
 
+import io.smallrye.mutiny.Uni;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
 import ai.wanaku.capabilities.sdk.api.types.discovery.HealthStatus;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
@@ -26,13 +27,14 @@ class HealthProbeClientTest {
         HealthProbeReply reply = HealthProbeReply.newBuilder()
                 .setStatus(RuntimeStatus.RUNTIME_STATUS_STARTED)
                 .build();
-        when(transport.probeHealth(any(HealthProbeRequest.class), eq(TARGET))).thenReturn(reply);
+        when(transport.probeHealthAsync(any(HealthProbeRequest.class), eq(TARGET)))
+                .thenReturn(Uni.createFrom().item(reply));
 
         HealthProbeClient client = new HealthProbeClient(transport);
         HealthStatus status = client.probe(TARGET);
 
         assertEquals(HealthStatus.HEALTHY, status);
-        verify(transport).probeHealth(any(HealthProbeRequest.class), eq(TARGET));
+        verify(transport).probeHealthAsync(any(HealthProbeRequest.class), eq(TARGET));
     }
 
     @Test
@@ -41,7 +43,8 @@ class HealthProbeClientTest {
         HealthProbeReply reply = HealthProbeReply.newBuilder()
                 .setStatus(RuntimeStatus.RUNTIME_STATUS_STOPPED)
                 .build();
-        when(transport.probeHealth(any(HealthProbeRequest.class), eq(TARGET))).thenReturn(reply);
+        when(transport.probeHealthAsync(any(HealthProbeRequest.class), eq(TARGET)))
+                .thenReturn(Uni.createFrom().item(reply));
 
         HealthProbeClient client = new HealthProbeClient(transport);
         HealthStatus status = client.probe(TARGET);
@@ -52,8 +55,8 @@ class HealthProbeClientTest {
     @Test
     void probe_returnsDown_whenTransportThrowsException() {
         WanakuBridgeTransport transport = mock(WanakuBridgeTransport.class);
-        when(transport.probeHealth(any(HealthProbeRequest.class), eq(TARGET)))
-                .thenThrow(new RuntimeException("connection refused"));
+        when(transport.probeHealthAsync(any(HealthProbeRequest.class), eq(TARGET)))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("connection refused")));
 
         HealthProbeClient client = new HealthProbeClient(transport);
         HealthStatus status = client.probe(TARGET);

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/health/PeriodicHealthCheckServiceTest.java
@@ -1,8 +1,11 @@
 package ai.wanaku.backend.health;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.microprofile.context.ManagedExecutor;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.MutinyEmitter;
+import ai.wanaku.backend.WanakuRouterConfig;
 import ai.wanaku.backend.common.ServiceTargetEvent;
 import ai.wanaku.backend.core.mcp.providers.ServiceRegistry;
 import ai.wanaku.capabilities.sdk.api.types.discovery.ActivityRecord;
@@ -13,8 +16,10 @@ import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +36,8 @@ class PeriodicHealthCheckServiceTest {
     private HealthProbeClient probeClient;
     private ManagedExecutor managedExecutor;
     private MutinyEmitter<ServiceTargetEvent> eventEmitter;
+    private WanakuRouterConfig config;
+    private WanakuRouterConfig.HealthCheckConfig healthCheckConfig;
 
     @BeforeEach
     void setUp() {
@@ -39,8 +46,11 @@ class PeriodicHealthCheckServiceTest {
         probeClient = mock(HealthProbeClient.class);
         managedExecutor = mock(ManagedExecutor.class);
         eventEmitter = mock(MutinyEmitter.class);
+        config = mock(WanakuRouterConfig.class);
+        healthCheckConfig = mock(WanakuRouterConfig.HealthCheckConfig.class);
 
         // Inject mocks using reflection
+        injectField(healthCheckService, "config", config);
         injectField(healthCheckService, "serviceRegistry", serviceRegistry);
         injectField(healthCheckService, "probeClient", probeClient);
         injectField(healthCheckService, "managedExecutor", managedExecutor);
@@ -53,6 +63,9 @@ class PeriodicHealthCheckServiceTest {
         });
 
         when(eventEmitter.hasRequests()).thenReturn(false);
+        when(config.healthCheck()).thenReturn(healthCheckConfig);
+        when(healthCheckConfig.enabled()).thenReturn(true);
+        when(healthCheckConfig.maxConcurrent()).thenReturn(10);
     }
 
     @Test
@@ -69,7 +82,7 @@ class PeriodicHealthCheckServiceTest {
         healthCheckService.checkInstanceHealth(target);
 
         // Then: the probe should NOT be called
-        verify(probeClient, never()).probe(any());
+        verify(probeClient, never()).probeAsync(any());
         verify(serviceRegistry, never()).updateHealthStatus(any(), any());
     }
 
@@ -82,13 +95,13 @@ class PeriodicHealthCheckServiceTest {
         // And: the capability is active
         ActivityRecord activeRecord = createActiveRecord();
         when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(activeRecord);
-        when(probeClient.probe(target)).thenReturn(HealthStatus.HEALTHY);
+        when(probeClient.probeAsync(target)).thenReturn(Uni.createFrom().item(HealthStatus.HEALTHY));
 
         // When: checkInstanceHealth is called
         healthCheckService.checkInstanceHealth(target);
 
         // Then: the probe should be called
-        verify(probeClient).probe(target);
+        verify(probeClient).probeAsync(target);
         verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.HEALTHY);
     }
 
@@ -105,7 +118,7 @@ class PeriodicHealthCheckServiceTest {
         healthCheckService.checkInstanceHealth(target);
 
         // Then: the probe should NOT be called (no record = skip)
-        verify(probeClient, never()).probe(any());
+        verify(probeClient, never()).probeAsync(any());
         verify(serviceRegistry, never()).updateHealthStatus(any(), any());
     }
 
@@ -120,14 +133,37 @@ class PeriodicHealthCheckServiceTest {
         crashedRecord.setHealthStatus(HealthStatus.HEALTHY);
         crashedRecord.setLastSeen(java.time.Instant.now());
         when(serviceRegistry.getStates(SERVICE_ID)).thenReturn(crashedRecord);
-        when(probeClient.probe(target)).thenThrow(new RuntimeException("Connection refused"));
+        when(probeClient.probeAsync(target))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("Connection refused")));
 
         // When: checkInstanceHealth is called
         healthCheckService.checkInstanceHealth(target);
 
         // Then: the probe should be called and mark as DOWN
-        verify(probeClient).probe(target);
+        verify(probeClient).probeAsync(target);
         verify(serviceRegistry).updateHealthStatus(SERVICE_ID, HealthStatus.DOWN);
+    }
+
+    @Test
+    void sweep_capsScheduledChecksAtConfiguredMaximum() {
+        ServiceTarget first =
+                new ServiceTarget("first", SERVICE_NAME, "localhost", 8080, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget second =
+                new ServiceTarget("second", SERVICE_NAME, "localhost", 8081, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget third =
+                new ServiceTarget("third", SERVICE_NAME, "localhost", 8082, "tool-invoker", "mcp", null, null, null);
+
+        when(healthCheckConfig.maxConcurrent()).thenReturn(2);
+        when(serviceRegistry.getEntries()).thenReturn(List.of(first, second, third));
+        when(serviceRegistry.getStates(any())).thenReturn(createActiveRecord());
+        when(probeClient.probeAsync(any())).thenReturn(Uni.createFrom().item(HealthStatus.HEALTHY));
+
+        healthCheckService.sweep();
+
+        verify(managedExecutor, times(2)).submit(any(Runnable.class));
+        verify(probeClient).probeAsync(eq(first));
+        verify(probeClient).probeAsync(eq(second));
+        verify(probeClient, never()).probeAsync(eq(third));
     }
 
     private ActivityRecord createActiveRecord() {

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jboss.logging.Logger;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import ai.wanaku.core.exchange.v1.HealthProbeGrpc;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
@@ -29,9 +30,19 @@ public class MockGrpcCapabilityServer {
 
     private final List<String> responseContent;
     private Server server;
+    private volatile StatusRuntimeException provisionException;
+    private volatile StatusRuntimeException probeHealthException;
 
     public MockGrpcCapabilityServer(List<String> responseContent) {
         this.responseContent = responseContent;
+    }
+
+    public void setProvisionException(StatusRuntimeException e) {
+        this.provisionException = e;
+    }
+
+    public void setProbeHealthException(StatusRuntimeException e) {
+        this.probeHealthException = e;
     }
 
     /**
@@ -86,6 +97,10 @@ public class MockGrpcCapabilityServer {
     private class MockProvisioner extends ProvisionerGrpc.ProvisionerImplBase {
         @Override
         public void provision(ProvisionRequest request, StreamObserver<ProvisionReply> responseObserver) {
+            if (provisionException != null) {
+                responseObserver.onError(provisionException);
+                return;
+            }
             LOG.info("Mock provisioner called");
             ProvisionReply reply = ProvisionReply.newBuilder()
                     .setConfigurationUri("file:///tmp/mock-config")
@@ -99,6 +114,10 @@ public class MockGrpcCapabilityServer {
     private class MockHealthProbe extends HealthProbeGrpc.HealthProbeImplBase {
         @Override
         public void getStatus(HealthProbeRequest request, StreamObserver<HealthProbeReply> responseObserver) {
+            if (probeHealthException != null) {
+                responseObserver.onError(probeHealthException);
+                return;
+            }
             HealthProbeReply reply = HealthProbeReply.newBuilder()
                     .setStatus(RuntimeStatus.RUNTIME_STATUS_STARTED)
                     .build();


### PR DESCRIPTION
This PR replaces blocking MCP operations with non-blocking concurrency using Mutiny's Uni for reactive programming.

## Changes

### Core Transport Layer
- **WanakuBridgeTransport**: Added async methods (provisionAsync, probeHealthAsync) with default blocking implementations for backward compatibility
- **GrpcTransport**: Implemented async methods using Uni.createFrom().emitter() with gRPC future stubs instead of blocking stubs
- **ProvisionerBridge**: Added provisionAsync method exposing non-blocking provisioning

### Health Check System
- **HealthProbeClient**: Refactored to use reactive patterns with Uni and proper error recovery using onFailure().recoverWithItem()
- **PeriodicHealthCheckService**: Added concurrency limiting (maxConcurrent config) and async health check handling with subscribe().with() pattern

### Tests
- Added GrpcTransportTest to verify async provision and health probe operations
- Updated HealthProbeClientTest and PeriodicHealthCheckServiceTest for async behavior

Fixes #844

## Summary by Sourcery

Replace blocking gRPC-based MCP provisioning and health probing with reactive, non-blocking operations and propagate this through the transport and health-check layers.

New Features:
- Introduce asynchronous provisioning and health probe operations on the core bridge transport interface using Mutiny Uni.
- Expose a non-blocking provisioning method via the ProvisionerBridge for callers that want reactive behavior.

Enhancements:
- Refactor GrpcTransport to use gRPC future stubs and Mutiny Uni for provisioning and health probes, ensuring channels are closed and errors are mapped consistently.
- Update HealthProbeClient and PeriodicHealthCheckService to use reactive health checks, including async probing, improved error handling, and non-blocking Vert.x event consumption.
- Add configurable concurrency limiting for periodic health checks based on maxConcurrent health check configuration.

Tests:
- Add GrpcTransportTest to validate async provision and health probe operations against a mock gRPC server.
- Update HealthProbeClientTest and PeriodicHealthCheckServiceTest to cover the new async behavior and concurrency limiting in health checks.