### PR TITLE
[UI] Enhancement: resource parameters editing

### DIFF
--- a/apps/ui/admin/src/App.scss
+++ b/apps/ui/admin/src/App.scss
@@ -23,3 +23,8 @@ ol {
 li {
   margin-bottom: 5px;
 }
+
+#resource-tab-panel-wrapper {
+  height: 460px;
+  overflow-y: auto;
+}

--- a/apps/ui/admin/src/Pages/Resources/ParametersTable.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ParametersTable.tsx
@@ -1,53 +1,118 @@
-import {FunctionComponent} from "react";
+import {FunctionComponent, useState} from "react";
 import {
-    Button,
-    DataTable,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableHeader,
-    TableRow,
-    TableToolbar,
-    TableToolbarContent,
-    TextInput
+  Button,
+  DataTable,
+  DataTableRow,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TextInput
 } from "@carbon/react";
-import {Add, TrashCan} from "@carbon/icons-react";
+import {Add, Close, Edit, Save, TrashCan} from "@carbon/icons-react";
 import {Param} from "../../models";
+
+
+interface ParameterDraft {
+  parameterName: string
+  parameterValue: string
+}
+
+interface ParameterEntry extends Param {
+  updateDraft?: ParameterDraft
+}
 
 interface ParametersTableProps {
   parameters: Param[]
-  onAdd: () => void
-  onSetName: (index: number, name: string) => void
-  onSetValue: (index: number, value: string) => void
-  onDelete: (index: number) => void
+  onUpdate: (parameters: Param[]) => void
+  onInlineEditorOpen?: () => void
+  onInlineEditorClose?: () => void
 }
 
 export const ParametersTable: FunctionComponent<ParametersTableProps> = ({
-  parameters,
-  onDelete,
-  onAdd,
-  onSetName,
-  onSetValue,
+  parameters, onUpdate, onInlineEditorOpen, onInlineEditorClose
 }) => {
 
+  const [entries, setEntries] = useState<ParameterEntry[]>(parameters)
+  
   const headers = [
     {key: "name", header: "Name"},
     {key: "value", header: "Value"},
     {key: "actions", header: "Actions"}
   ]
-
-  function parametersAsRows() {
-    return parameters.map((parameter: Param, index: number) => ({
-        id: parameter.name || `parameter-${index}`,
-        name: parameter.name,
-        value: parameter.value ,
-    }))
+  
+  function addParameter() {
+    setEntries([...entries, { updateDraft: { parameterName: "", parameterValue: "" } }])
+    if (onInlineEditorOpen) {
+      onInlineEditorOpen()
+    }
+  }
+  
+  function updateParameterDraft(i: number, key: "parameterName" | "parameterValue", value: string) {
+    const newEntries = structuredClone(entries)
+    const entry = newEntries[i]
+    if (entry.updateDraft) {
+      entry.updateDraft[key] = value
+      setEntries(newEntries)
+    }
+  }
+  
+  function editParameter(i: number) {
+    const newEntries = structuredClone(entries)
+    if (!newEntries.some(entry => entry.updateDraft) && onInlineEditorOpen) {
+      onInlineEditorOpen()
+    }
+    const entry = newEntries[i]
+    entry.updateDraft = { parameterName: entry.name!, parameterValue: entry.value! }
+    setEntries(newEntries)
+  }
+  
+  function mergeParameterDraft(i: number) {
+    const newEntries = structuredClone(entries)
+    const entry = newEntries[i]
+    if (entry.updateDraft) {
+      entry.name = entry.updateDraft.parameterName
+      entry.value = entry.updateDraft.parameterValue
+      entry.updateDraft = undefined
+    }
+    setEntries(newEntries)
+    onUpdate(newEntries)
+    if (newEntries.every(entry => !entry.updateDraft) && onInlineEditorClose) {
+      onInlineEditorClose()
+    }
+  }
+  
+  function clearParameterDraft(i: number) {
+    const newEntries = structuredClone(entries)
+    const entry = newEntries[i]
+    if (entry.name) {
+      // underlying parameter exists, only remove the draft
+      newEntries[i].updateDraft = undefined
+    } else {
+      // no underlying parameter, remove the whole entry
+      newEntries.splice(i, 1)
+    }
+    setEntries(newEntries)
+    if (newEntries.every(entry => !entry.updateDraft) && onInlineEditorClose) {
+      onInlineEditorClose()
+    }
+  }
+  
+  function removeParameter(i: number) {
+    const newEntries = structuredClone(entries)
+    newEntries.splice(i, 1)
+    setEntries(newEntries)
   }
 
   return (
-    <DataTable headers={headers} rows={parametersAsRows()}>
+    <DataTable headers={headers}
+      rows={entries.map((_, i: number) => ({ id: `parameter-${i}` }))}>
       {({
         headers,
         rows,
@@ -55,70 +120,134 @@ export const ParametersTable: FunctionComponent<ParametersTableProps> = ({
         getHeaderProps,
         getRowProps,
         getToolbarProps,
-      }) => (
-        <TableContainer>
-          <TableToolbar {...getToolbarProps()}>
-            <TableToolbarContent>
-              <Button renderIcon={Add} onClick={onAdd}>New Parameter</Button>
-            </TableToolbarContent>
-          </TableToolbar>
-          <Table {...getTableProps()}>
-            <TableHead>
-              <TableRow>
-                {headers.map((header) => (
-                  <TableHeader {...getHeaderProps({header})}>
-                    {header.header}
-                  </TableHeader>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map((row, i) => {
-                const parameter = parameters[i]
-                const alreadyFilled = parameter && parameter.name
-                return (
-                  <TableRow {...getRowProps({row})}>
-                    <TableCell>
-                      {alreadyFilled ? (
-                        // if the name is already filled, just display it
-                        parameter.name
-                      ) : (
-                        <TextInput
-                            id={"parameter-" + i + "-name"}
-                            labelText="Parameter name"
-                            placeholder="Parameter name"
-                            onChange={(event) => onSetName(i, event.target.value)}
-                        />
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      {alreadyFilled ? (
-                        // if the value is already filled, just display it
-                        parameter.value
-                      ) : (
-                        <TextInput
-                            id={"parameter-" + i + "-value"}
-                            labelText="Parameter value"
-                            placeholder="Parameter value"
-                            onChange={(event) => onSetValue(i, event.target.value)}
-                        />
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Button kind="ghost"
-                              renderIcon={TrashCan}
-                              iconDescription="Delete"
-                              hasIconOnly
-                              onClick={() => onDelete(i)}
-                      />
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
+      }) => {
+        
+        function createEmptyTableState() {
+          return (
+            <TableRow>
+              <TableCell colSpan={headers.length}>
+                <Stack gap={6} style={{
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: '4rem 0',
+                  color: 'var(--cds-text-secondary)'
+                }}>
+                  <div style={{ textAlign: 'center' }}>
+                    <h4 style={{ marginBottom: '0.5rem', color: 'var(--cds-text-primary)' }}>
+                      No parameters
+                    </h4>
+                    <p>You can add resource parameters here.</p>
+                  </div>
+                </Stack>
+              </TableCell>
+            </TableRow>
+          )
+        }
+        
+        function createParameterRow(row: DataTableRow<any[]>, i: number) {
+          const entry = entries[i]
+          return (
+            <TableRow {...getRowProps({row})}>
+              <TableCell>{entry.name}</TableCell>
+              <TableCell>{entry.value}</TableCell>
+              <TableCell>
+                <Button
+                  kind="ghost"
+                  renderIcon={Edit}
+                  iconDescription="Edit"
+                  hasIconOnly
+                  onClick={() => editParameter(i)}
+                />
+                <Button
+                  kind="ghost"
+                  renderIcon={TrashCan}
+                  iconDescription="Delete"
+                  hasIconOnly
+                  onClick={() => removeParameter(i)}
+                />
+              </TableCell>
+            </TableRow>
+          )
+        }
+        
+        function createParameterDraftRow(row: DataTableRow<any[]>, i: number) {
+          const entry = entries[i]
+          const draft = entry.updateDraft!
+          return (
+            <TableRow {...getRowProps({row})}>
+              <TableCell>
+                <TextInput
+                  id={"parameter-" + i + "-name"}
+                  labelText=""
+                  placeholder="Parameter name"
+                  value={draft.parameterName}
+                  onChange={(event) => {
+                    const name = event.target.value
+                    updateParameterDraft(i, "parameterName", name)
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <TextInput
+                  id={"parameter-" + i + "-value"}
+                  labelText=""
+                  placeholder="Parameter value"
+                  value={draft.parameterValue}
+                  onChange={(event) => {
+                    const value = event.target.value
+                    updateParameterDraft(i, "parameterValue", value)
+                  }}
+                />
+              </TableCell>
+              <TableCell>
+                <Button
+                  kind="ghost"
+                  renderIcon={Save}
+                  hasIconOnly
+                  iconDescription="Save changes"
+                  onClick={() => mergeParameterDraft(i)}
+                />
+                <Button
+                  kind="ghost"
+                  renderIcon={Close}
+                  hasIconOnly
+                  iconDescription="Cancel changes"
+                  onClick={() => clearParameterDraft(i)}
+                />
+              </TableCell>
+            </TableRow>
+          )
+        }
+        
+        return (
+          <TableContainer>
+            <TableToolbar {...getToolbarProps()}>
+              <TableToolbarContent>
+                <Button renderIcon={Add} kind="ghost" onClick={addParameter}>Add parameter</Button>
+              </TableToolbarContent>
+            </TableToolbar>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map((header) => (
+                    <TableHeader {...getHeaderProps({header})}>
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.filter((_, i) => entries[i]).map((row, i) => {
+                  const entry = entries[i]
+                  return entry.updateDraft
+                    ? createParameterDraftRow(row, i)
+                    : createParameterRow(row, i)
+                })}
+                {entries.length == 0 && createEmptyTableState()}
+              </TableBody>
+            </Table>
+          </TableContainer>
+      )}}
     </DataTable>
   )
 }

--- a/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
@@ -25,6 +25,7 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, on
   const [params, setParams] = useState<Param[]>(openedResource?.params || [])
   const [configurationURI, setConfigurationURI] = useState(openedResource?.configurationURI)
   const [secretsURI, setSecretsURI] = useState(openedResource?.secretsURI)
+  const [submitDisable, setSubmitDisabled] = useState(false)
   const { listManagementResources } = useCapabilities()
 
   function handleSubmit() {
@@ -36,7 +37,7 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, on
       type,
       mimeType,
       namespace,
-      params: nonEmptyParameters(),
+      params,
       configurationURI,
       secretsURI
     })
@@ -53,27 +54,12 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, on
     }
   }
 
-  function newParameter() {
-    const temp = [...params]
-    temp.push({name: "", value: ""})
-    setParams(temp)
-  }
-
-  function removeParameter(i: number) {
-    const temp = [...params]
-    temp.splice(i, 1)
-    setParams(temp)
-  }
-
-  function nonEmptyParameters() {
-    return params.filter(parameter => parameter.name !== "")
-  }
-
   return (
     <Modal
       open={true}
       modalHeading={openedResource ? "Edit resource" : "Add a Resource"}
       primaryButtonText={openedResource ? "Save" : "Add"}
+      primaryButtonDisabled={submitDisable}
       secondaryButtonText="Cancel"
       onRequestSubmit={handleSubmit}
       onRequestClose={onCancel}
@@ -84,87 +70,88 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, on
           <Tab>Parameters</Tab>
           <Tab>External</Tab>
         </TabList>
-        <TabPanels>
-          <TabPanel>
-            <TextInput
-              id="resource-name"
-              labelText="Resource Name"
-              placeholder="e.g. example-resource"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-            />
-            <TextInput
-              id="resource-description"
-              labelText="Description"
-              placeholder="e.g. Description of the resource"
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-            />
-            <TextInput
-              id="resource-location"
-              labelText="Location"
-              placeholder="e.g. /path/to/resource"
-              value={location}
-              onChange={(event) => {
-                const location = event.target.value
-                setLocation(location)
-                autoDetectMimeType(location)
-              }}
-            />
-            <TargetTypeSelect
-              value={type}
-              onChange={setType}
-              apiCall={listManagementResources}
-            />
-            <ComboBox
-              id="resource-mime-type"
-              titleText="MIME Type"
-              placeholder="Select or enter MIME type"
-              helperText="Content type of the resource (optional)"
-              items={commonMimeTypes}
-              selectedItem={mimeType}
-              onChange={(event) => {
-                let value = event.selectedItem
-                if (value === null) {
-                  value = undefined
-                }
-                setMimeType(value)
-              }}
-            />
-            <NamespaceSelect
-              id="resource-namespace"
-              labelText="Select a Namespace"
-              helperText="Choose a Namespace from the list"
-              value={namespace}
-              onChange={namespace => setNamespace(namespace.id)}
-            />
-          </TabPanel>
-          <TabPanel>
-            <ParametersTable
-              parameters={params}
-              onAdd={newParameter}
-              onSetName={(i, name) => params[i].name = name}
-              onSetValue={(i, value) => params[i].value = value}
-              onDelete={removeParameter}
-            />
-          </TabPanel>
-          <TabPanel>
-            <TextInput
-              id="resource-configuration-uri"
-              labelText="Configuration URI"
-              placeholder="e.g. file:///config/resource-config.json"
-              value={configurationURI}
-              onChange={(event) => setConfigurationURI(event.target.value)}
-            />
-            <TextInput
-              id="resource-secrets-uri"
-              labelText="Secrets URI"
-              placeholder="e.g. vault://secrets/db-credentials"
-              value={secretsURI}
-              onChange={(event) => setSecretsURI(event.target.value)}
-            />
-          </TabPanel>
-        </TabPanels>
+        <div id="resource-tab-panel-wrapper">
+          <TabPanels>
+            <TabPanel id="resource-tab-panel">
+              <TextInput
+                id="resource-name"
+                labelText="Resource Name"
+                placeholder="e.g. example-resource"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+              <TextInput
+                id="resource-description"
+                labelText="Description"
+                placeholder="e.g. Description of the resource"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+              <TextInput
+                id="resource-location"
+                labelText="Location"
+                placeholder="e.g. /path/to/resource"
+                value={location}
+                onChange={(event) => {
+                  const location = event.target.value
+                  setLocation(location)
+                  autoDetectMimeType(location)
+                }}
+              />
+              <TargetTypeSelect
+                value={type}
+                onChange={setType}
+                apiCall={listManagementResources}
+              />
+              <ComboBox
+                id="resource-mime-type"
+                titleText="MIME Type"
+                placeholder="Select or enter MIME type"
+                helperText="Content type of the resource (optional)"
+                items={commonMimeTypes}
+                selectedItem={mimeType}
+                onChange={(event) => {
+                  let value = event.selectedItem
+                  if (value === null) {
+                    value = undefined
+                  }
+                  setMimeType(value)
+                }}
+              />
+              <NamespaceSelect
+                id="resource-namespace"
+                labelText="Select a Namespace"
+                helperText="Choose a Namespace from the list"
+                value={namespace}
+                onChange={namespace => setNamespace(namespace.id)}
+              />
+            </TabPanel>
+            <TabPanel>
+              <ParametersTable
+                parameters={params}
+                onUpdate={(parameters: Param[]) => setParams(parameters)}
+                onInlineEditorOpen={() => setSubmitDisabled(true)}
+                onInlineEditorClose={() => setSubmitDisabled(false)}
+              />
+            </TabPanel>
+            <TabPanel>
+              <TextInput
+                id="resource-configuration-uri"
+                labelText="Configuration URI"
+                placeholder="e.g. file:///config/resource-config.json"
+                value={configurationURI}
+                onChange={(event) => setConfigurationURI(event.target.value)}
+              />
+              <TextInput
+                id="resource-secrets-uri"
+                labelText="Secrets URI"
+                placeholder="e.g. vault://secrets/db-credentials"
+                value={secretsURI}
+                onChange={(event) => setSecretsURI(event.target.value)}
+              />
+            </TabPanel>
+          </TabPanels>
+        </div>
       </Tabs>
     </Modal>
   )


### PR DESCRIPTION
Enhanced user experience on editing resource parameters. 

A new concept of inline editable data table. Each row (parameter) can be edited separately with explicit save button. Unsaved changes can now be cancelled. While empty, the table now follows Carbon guidelines for an empty state: https://carbondesignsystem.com/patterns/empty-states-pattern/. While only half-way editing, the dialog cannot be submitted to avoid saving unintentional changes.

## Summary by Sourcery

Introduce inline, per-row editing for resource parameters in the resource modal and align the parameters table UX with Carbon empty-state guidance while preventing submission during in-progress edits.

New Features:
- Allow inline editing of individual resource parameters with explicit save and cancel actions in the parameters table.
- Disable resource modal submission while parameter edits are in progress to avoid partial or unsaved changes.
- Display a Carbon-style empty state when no parameters are defined.

Enhancements:
- Refactor parameter handling so the table owns parameter drafts and notifies the modal via a single update callback.
- Constrain the resource modal tab panel height and make it scrollable to improve layout consistency.