### PR TITLE
[UI] LLM model suggestions based on base URL

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
@@ -1,0 +1,52 @@
+import React, {RefObject, useImperativeHandle, useState} from "react"
+import {ComboBox} from "@carbon/react"
+
+
+export interface LLMChangeHandle {
+  llmBaseUrlChanged: (baseUrl: string) => void
+}
+
+interface LLMModelComboBoxProps {
+  value?: string
+  labelText?: string
+  onChange: (llmModel: string) => void
+  ref?: RefObject<LLMChangeHandle>
+}
+
+export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ value, onChange, labelText, ref }) => {
+  
+  const [modelSuggestions, setModelSuggestions] = useState<string[]>([])
+  
+  const llmModelSuggestions = {
+    "https://api.openai.com": ["gpt-4o", "gpt-4o-mini", "o3-mini", "o1", "o1-mini"],
+    "https://api.mistral.ai": ["mistral-small-latest"],
+    "https://generativelanguage.googleapis.com/v1beta/openai/": ["gemini-3.1-pro", "gemini-2.5-pro"],
+    "https://api.anthropic.com": ["claude-4.7-opus", "claude-4.6-opus"]
+  }
+  
+  useImperativeHandle(ref, (): LLMChangeHandle => ({
+    llmBaseUrlChanged(baseUrl: string) {
+      setModelSuggestions(createItems(baseUrl))
+    }
+  }), [])
+
+  function createItems(baseUrl: string) {
+    return llmModelSuggestions[baseUrl] || []
+  }
+  
+  return (
+    <ComboBox
+      id="llm-model"
+      titleText={labelText}
+      items={modelSuggestions}
+      allowCustomValue
+      value={value}
+      onChange={(event) => {
+        const llmModel = event.selectedItem || event.inputValue || ""
+        onChange(llmModel)
+      }}
+    />
+    
+  )
+
+}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -1,9 +1,8 @@
-import React, {useState} from "react"
+import React, {useRef, useState} from "react"
 import {
   Form,
   PasswordInput, Stack,
   TextArea,
-  TextInput,
   Toggle
 } from "@carbon/react"
 import {
@@ -13,6 +12,7 @@ import {
   STORE_IN_LOCAL_STORAGE
 } from "./config.ts"
 import {BaseUrlSelect} from "./BaseUrlSelect"
+import {LLMChangeHandle, LLMModelComboBox} from "./LLMModelComboBox"
 
 
 interface LLMSetupProps {
@@ -23,6 +23,7 @@ interface LLMSetupProps {
 export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
+  const llmModelComboBoxRef = useRef<LLMChangeHandle>({ llmBaseUrlChanged: () => {} })
   
   function applyConfigChange(config: LlmConfig) {
     if (isStoredInLocalStorage) {
@@ -56,15 +57,14 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
           value={config.baseUrl || ""}
           onChange={(baseUrl: string) => {
             applyConfigChange({ ...config, baseUrl })
+            llmModelComboBoxRef.current.llmBaseUrlChanged(baseUrl)
           }}
         />
-        <TextInput
-          id="llm-model"
+        <LLMModelComboBox
           labelText="LLM Model"
-          placeholder="Type LLM model here..."
           value={config.llmModel}
-          onChange={(event) => {
-            const llmModel = event.target.value
+          ref={llmModelComboBoxRef}
+          onChange={(llmModel) => {
             applyConfigChange({ ...config, llmModel })
           }}
         />


### PR DESCRIPTION
An enhancement for LLM setup. LLM model values are now suggested in a combo box and the suggestion changes based on the Base URL (e.g. https://api.openai.com suggests only models from OpenAI). Because models are many and updated a lot, there is still a possibility to enter it manually.

## Summary by Sourcery

Introduce a model suggestion combo box in the LLM setup that updates options based on the selected base URL while still allowing manual model entry.

New Features:
- Add an LLM model combo box component that suggests models according to the configured base URL and supports custom values.

Enhancements:
- Wire the LLM setup form to notify the model combo box when the base URL changes so model suggestions stay in sync.