### PR TITLE
[UI] Tools grouped by namespace in LLM Chat

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -79,9 +79,10 @@ export const LLMChatPage: React.FC = () => {
             }}
           />
           <LLMTools
+            selectedNamespace={config.selectedNamespace}
             selectedTools={config.selectedTools}
-            onSelectionChange={(selectedTools) => {
-              applyConfigChange({ ...config, selectedTools })
+            onSelectionChange={(selectedNamespace, selectedTools) => {
+              applyConfigChange({ ...config, selectedNamespace, selectedTools })
             }}
             onError={(msg) => setErrorMessage(msg)}
           />

--- a/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
@@ -6,17 +6,20 @@ import {
 } from "@carbon/react"
 import React, {useEffect, useState} from "react"
 import {useTools} from "../../hooks/api/use-tools"
-import {ToolReference} from "../../models"
 import {getErrorMessage} from "../../utils/error"
+import {Namespace, ToolReference} from "../../models"
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect"
 
 
 interface LLMToolsProps {
+  selectedNamespace: Namespace
   selectedTools: ToolReference[]
-  onSelectionChange: (tools: ToolReference[]) => void
+  onSelectionChange: (namespace: Namespace, tools: ToolReference[]) => void
   onError?: (message: string) => void
 }
 
-export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionChange, onError }) => {
+export const LLMTools: React.FC<LLMToolsProps> = ({
+    selectedNamespace, selectedTools, onSelectionChange, onError }) => {
   
   const [tools, setTools] = useState<ToolReference[]>([])
   const [isLoading, setLoading] = useState(true)
@@ -44,25 +47,45 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
     return response.data.data
   }
   
+  function filteredTools(): ToolReference[] {
+    if (!selectedNamespace) {
+      return tools
+    }
+    if (selectedNamespace.path === "default") {
+      return tools.filter(tool => !tool.namespace || tool.namespace === selectedNamespace.id)
+    }
+    return tools.filter(tool => tool.namespace === selectedNamespace.id)
+  }
+  
   function isAllSelected() {
     const selectedToolNames = selectedTools.map(tool => tool.name)
-    return tools.length > 0 && tools.every((tool) => selectedToolNames.includes(tool.name))
+    return selectedTools.length > 0 && filteredTools().every((tool) => selectedToolNames.includes(tool.name))
   }
   
   function isSomeSelected() {
-    return selectedTools.length > 0 && selectedTools.length < tools.length
+    return selectedTools.length > 0 && selectedTools.length < filteredTools().length
   }
   
   return (
-    <Stack gap={7}>
+    <Stack gap={5}>
       {isLoading &&
         <InlineLoading description="Loading tools..." />
       }
-      {!isLoading && tools.length == 0 &&
+      {!isLoading &&
+        <NamespaceSelect
+          id="namespace"
+          labelText="Select tools"
+          value={selectedNamespace.id}
+          onChange={(namespace: Namespace) => {
+            onSelectionChange(namespace, [])
+          }}
+        />
+      }
+      {!isLoading && filteredTools().length == 0 &&
         <div>No tools available</div>
       }
-      {!isLoading && tools.length > 0 && (
-        <CheckboxGroup legendText="Select tools">
+      {!isLoading && filteredTools().length > 0 && (
+        <CheckboxGroup legendText="">
           <Checkbox
             id="select-all"
             labelText="Select All"
@@ -70,10 +93,10 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
             indeterminate={isSomeSelected()}
             onChange={(_, { checked }) => {
               const selection = checked ? [...tools] : []
-              onSelectionChange(selection)
+              onSelectionChange(selectedNamespace, selection)
             }}
           />
-          {tools.map((tool) => (
+          {filteredTools().map((tool) => (
             <Checkbox
               id={tool.name!}
               key={tool.name}
@@ -84,7 +107,7 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
                 const selection = checked
                   ? [...selectedTools, tool]
                   : selectedTools.filter(item => item.name != tool.name)
-                onSelectionChange(selection)
+                onSelectionChange(selectedNamespace, selection)
               }}
             />
           ))}

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -1,4 +1,4 @@
-import {ToolReference} from "../../models"
+import {Namespace, ToolReference} from "../../models"
 
 export const STORE_IN_LOCAL_STORAGE = "storeInLocalStorage"
 export const LLM_CONFIG = "llmConfig"
@@ -17,9 +17,12 @@ const DEFAULT_GEMINI_MODEL = "gemini-3.5-flash"
 const DEFAULT_MISTRAL_MODEL = "mistral-small-latest"
 const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini"
 
+const DEFAULT_NAMESPACE = { name: "default", path: "default" }
+
 export interface LlmConfig {
   selectedLlm: string
   llms: Record<string, { selectedModel: string, apiKey?: string, extraLlmParams: string } >
+  selectedNamespace: Namespace
   selectedTools: ToolReference[]
   systemPrompt: string
 }
@@ -27,6 +30,7 @@ export interface LlmConfig {
 export function defaultLlmConfig(): LlmConfig {
   return {
     selectedLlm: DEFAULT_LLM,
+    selectedNamespace: DEFAULT_NAMESPACE,
     selectedTools: [],
     llms: {
       [ANTHROPIC]: createSubconfig(DEFAULT_ANTHROPIC_MODEL),
@@ -66,6 +70,7 @@ function parseConfig(json: string): LlmConfig {
   config.llms[OPENAI] ??= createSubconfig(DEFAULT_OPENAI_MODEL)
   config.llms[OPENAI].selectedModel ??= DEFAULT_OPENAI_MODEL
   config.llms[OPENAI].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.selectedNamespace ??= DEFAULT_NAMESPACE
   config.selectedTools ??= []
   config.systemPrompt ??= DEFAULT_SYSTEM_PROMPT
   return config


### PR DESCRIPTION
In LLM Chat, tools are now grouped by namespace. The selected namespace is stored into local storage in order to be synchronized with the selected tools. Changing the namespace resets the tool selection.

## Summary by Sourcery

Group LLM chat tools by namespace and persist the selected namespace and tools in the chat configuration.

New Features:
- Add namespace selection to the LLM chat tools panel and filter available tools by the chosen namespace.
- Persist the selected namespace and tools in the LLM chat configuration, including local storage support.

Enhancements:
- Extend the LLM chat configuration model to track both the selected namespace and selected tools instead of a flat tool list.
- Update the namespace selector component to notify callers when the initial namespace has been loaded.