### PR TITLE
Fix #1151: Add cancellation handling to gRPC emitters in invokeTool and acquireResource

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransport.java
@@ -228,6 +228,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                                 .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                                 .invokeTool(request);
 
+                        em.onTermination(() -> {
+                            future.cancel(true);
+                            channelManager.closeChannel(channel);
+                        });
+
                         future.addListener(
                                 () -> {
                                     try {
@@ -285,6 +290,11 @@ public class GrpcTransport implements WanakuBridgeTransport {
                         var future = ResourceAcquirerGrpc.newFutureStub(channel)
                                 .withDeadline(Deadline.after(deadlineSeconds, TimeUnit.SECONDS))
                                 .resourceAcquire(request);
+
+                        em.onTermination(() -> {
+                            future.cancel(true);
+                            channelManager.closeChannel(channel);
+                        });
 
                         future.addListener(
                                 () -> {

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcTransportTest.java
@@ -3,21 +3,31 @@ package ai.wanaku.backend.bridge.transports.grpc;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import ai.wanaku.backend.support.MockGrpcCapabilityServer;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
+import ai.wanaku.core.exchange.v1.ResourceRequest;
 import ai.wanaku.core.exchange.v1.RuntimeStatus;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GrpcTransportTest {
 
@@ -98,5 +108,72 @@ class GrpcTransportTest {
                 () -> transport.probeHealthAsync(request, target).await().atMost(Duration.ofSeconds(5)));
 
         assertTrue(thrown.getMessage().contains("did not respond within a reasonable time frame"));
+    }
+
+    @Test
+    void invokeTool_usesNonBlockingStub() {
+        var request = ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+
+        var response = transport.invokeTool(request, target).await().atMost(Duration.ofSeconds(5));
+
+        assertFalse(response.content().isEmpty());
+    }
+
+    @Test
+    void acquireResource_usesNonBlockingStub() {
+        var request = ResourceRequest.newBuilder()
+                .setLocation("test://resource")
+                .setName("test-resource")
+                .build();
+        var mcpResource = new ResourceReference();
+        mcpResource.setMimeType("text/plain");
+
+        var arguments = mock(ResourceManager.ResourceArguments.class);
+        when(arguments.requestUri()).thenReturn(new RequestUri("test://resource"));
+
+        var response = transport
+                .acquireResource(request, target, arguments, mcpResource)
+                .await()
+                .atMost(Duration.ofSeconds(5));
+
+        assertFalse(response.isEmpty());
+    }
+
+    @Test
+    void invokeTool_cancellationCleansUp() {
+        CountDownLatch latch = new CountDownLatch(1);
+        server.setResponseLatch(latch);
+
+        var request = ToolInvokeRequest.newBuilder().setUri("test://tool").build();
+        var subscriber = transport.invokeTool(request, target).subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.cancel();
+        latch.countDown();
+        subscriber.assertNotTerminated();
+    }
+
+    @Test
+    void acquireResource_cancellationCleansUp() {
+        CountDownLatch latch = new CountDownLatch(1);
+        server.setResponseLatch(latch);
+
+        var request = ResourceRequest.newBuilder()
+                .setLocation("test://resource")
+                .setName("test-resource")
+                .build();
+        var mcpResource = new ResourceReference();
+        mcpResource.setMimeType("text/plain");
+
+        var arguments = mock(ResourceManager.ResourceArguments.class);
+        when(arguments.requestUri()).thenReturn(new RequestUri("test://resource"));
+
+        var subscriber = transport
+                .acquireResource(request, target, arguments, mcpResource)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.cancel();
+        latch.countDown();
+        subscriber.assertNotTerminated();
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/MockGrpcCapabilityServer.java
@@ -2,6 +2,7 @@ package ai.wanaku.backend.support;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import org.jboss.logging.Logger;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -32,6 +33,7 @@ public class MockGrpcCapabilityServer {
     private Server server;
     private volatile StatusRuntimeException provisionException;
     private volatile StatusRuntimeException probeHealthException;
+    private volatile CountDownLatch responseLatch;
 
     public MockGrpcCapabilityServer(List<String> responseContent) {
         this.responseContent = responseContent;
@@ -43,6 +45,10 @@ public class MockGrpcCapabilityServer {
 
     public void setProbeHealthException(StatusRuntimeException e) {
         this.probeHealthException = e;
+    }
+
+    public void setResponseLatch(CountDownLatch latch) {
+        this.responseLatch = latch;
     }
 
     /**
@@ -72,10 +78,22 @@ public class MockGrpcCapabilityServer {
         }
     }
 
+    private void awaitLatch() {
+        CountDownLatch latch = responseLatch;
+        if (latch != null) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     private class MockToolInvoker extends ToolInvokerGrpc.ToolInvokerImplBase {
         @Override
         public void invokeTool(ToolInvokeRequest request, StreamObserver<ToolInvokeReply> responseObserver) {
             LOG.infof("Mock tool invoked with uri=%s", request.getUri());
+            awaitLatch();
             ToolInvokeReply reply =
                     ToolInvokeReply.newBuilder().addAllContent(responseContent).build();
             responseObserver.onNext(reply);
@@ -87,6 +105,7 @@ public class MockGrpcCapabilityServer {
         @Override
         public void resourceAcquire(ResourceRequest request, StreamObserver<ResourceReply> responseObserver) {
             LOG.infof("Mock resource acquired with location=%s, name=%s", request.getLocation(), request.getName());
+            awaitLatch();
             ResourceReply reply =
                     ResourceReply.newBuilder().addAllContent(responseContent).build();
             responseObserver.onNext(reply);


### PR DESCRIPTION
## Summary

- Add `em.onTermination()` callbacks to `invokeTool` and `acquireResource` in `GrpcTransport`, matching the pattern already in `provisionAsync` and `probeHealthAsync`
- On downstream cancellation, the gRPC future is cancelled and the channel is closed, preventing resource leaks under load
- Add happy-path and cancellation tests for both methods, plus a configurable delay mechanism in `MockGrpcCapabilityServer`

## Test plan

- [x] `GrpcTransportTest.invokeTool_usesNonBlockingStub` — happy path
- [x] `GrpcTransportTest.acquireResource_usesNonBlockingStub` — happy path
- [x] `GrpcTransportTest.invokeTool_cancellationCleansUp` — cancel before completion
- [x] `GrpcTransportTest.acquireResource_cancellationCleansUp` — cancel before completion
- [x] All 9 GrpcTransportTest tests pass
- [x] Full reactor build succeeds

## Summary by Sourcery

Improve gRPC tool invocation and resource acquisition to handle downstream cancellation without leaking channels or futures.

Bug Fixes:
- Ensure invokeTool cancels the gRPC future and closes the channel when the upstream subscriber terminates or cancels.
- Ensure acquireResource cancels the gRPC future and closes the channel when the upstream subscriber terminates or cancels.

Enhancements:
- Extend the mock gRPC capability server with an optional response latch to control reply timing for tests.

Tests:
- Add happy-path tests for invokeTool and acquireResource using the non-blocking stub.
- Add cancellation cleanup tests for invokeTool and acquireResource that verify behavior when the subscriber cancels before completion.