### PR TITLE
[UI] Optional prompt modal fields in own tabs

### DIFF
--- a/apps/ui/admin/src/App.scss
+++ b/apps/ui/admin/src/App.scss
@@ -28,3 +28,8 @@ li {
   height: 460px;
   overflow-y: auto;
 }
+
+#prompts-tab-panel-wrapper {
+  height: 460px;
+  overflow-y: auto;
+}

--- a/apps/ui/admin/src/Pages/Prompts/PromptsModal.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsModal.tsx
@@ -1,0 +1,117 @@
+import React, {useState} from "react"
+import {PromptReference} from "../../models"
+import {Modal, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, TextArea, TextInput} from "@carbon/react"
+import {NamespaceSelect} from "../Namespaces/NamespaceSelect"
+
+
+interface PromptModalProps {
+  onSubmit: (newPrompt: PromptReference) => void
+  onRequestClose: () => void
+}
+
+export const PromptModal: React.FC<PromptModalProps> = ({ onSubmit, onRequestClose }) => {
+  
+  const [promptName, setPromptName] = useState("")
+  const [description, setDescription] = useState("")
+  const [messagesJson, setMessagesJson] = useState("")
+  const [argumentsJson, setArgumentsJson] = useState("")
+  const [toolReferences, setToolReferences] = useState("")
+  const [selectedNamespace, setSelectedNamespace] = useState("")
+  
+  const handleSubmit = () => {
+    try {
+      const messages = messagesJson ? JSON.parse(messagesJson) : []
+      const args = argumentsJson ? JSON.parse(argumentsJson) : []
+      const toolRefs = toolReferences ? toolReferences.split(',').map(t => t.trim()) : []
+      
+      onSubmit({
+        name: promptName,
+        description,
+        messages,
+        arguments: args,
+        toolReferences: toolRefs,
+        namespace: selectedNamespace
+      })
+    } catch (error) {
+      console.error("Invalid JSON in prompt data:", error)
+    }
+  }
+  
+  return (
+    <Modal
+      open={true}
+      modalHeading="Add a Prompt"
+      primaryButtonText="Add"
+      secondaryButtonText="Cancel"
+      onRequestSubmit={handleSubmit}
+      onRequestClose={onRequestClose}
+    >
+      <Tabs>
+        <TabList>
+          <Tab>Overview</Tab>
+          <Tab>Arguments</Tab>
+          <Tab>Tools</Tab>
+        </TabList>
+        <div id="prompts-tab-panel-wrapper">
+          <TabPanels>
+            <TabPanel id="prompts-tab-panel">
+              <Stack gap={5}>
+                <TextInput
+                  id="prompt-name"
+                  labelText="Prompt Name"
+                  placeholder="e.g. code-reviewer"
+                  value={promptName}
+                  onChange={(event) => setPromptName(event.target.value)}
+                />
+                <TextInput
+                  id="prompt-description"
+                  labelText="Description"
+                  placeholder="e.g. A prompt for reviewing code"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                />
+                <TextArea
+                  id="messages-json"
+                  labelText="Messages (JSON)"
+                  placeholder='Examples:
+        Text: {"role": "user", "content": {"type": "text", "text": "Review {{code}}"}}
+        Image: {"role": "user", "content": {"type": "image", "data": "base64...", "mimeType": "image/png"}}
+        Audio: {"role": "user", "content": {"type": "audio", "data": "base64...", "mimeType": "audio/wav"}}
+        Resource: {"role": "user", "content": {"type": "resource", "resource": {"location": "file:///path", "description": "File content", "mimeType": "text/plain"}}}'
+                  rows={6}
+                  value={messagesJson}
+                  onChange={(event) => setMessagesJson(event.target.value)}
+                />
+                <NamespaceSelect
+                  id="namespace"
+                  labelText="Select a Namespace"
+                  value={selectedNamespace}
+                  onChange={namespace => setSelectedNamespace(namespace.id!)}
+                />
+              </Stack>
+            </TabPanel>
+            <TabPanel>
+              <TextArea
+                id="arguments-json"
+                labelText="Arguments (JSON, optional)"
+                placeholder='e.g. [{"name": "code", "description": "The code to review", "required": true}]'
+                rows={16}
+                value={argumentsJson}
+                onChange={(event) => setArgumentsJson(event.target.value)}
+              />
+            </TabPanel>
+            <TabPanel>
+              <TextInput
+                id="tool-references"
+                labelText="Tool References (comma-separated, optional)"
+                placeholder="e.g. code-analyzer, linter"
+                value={toolReferences}
+                onChange={(event) => setToolReferences(event.target.value)}
+              />
+            </TabPanel>
+          </TabPanels>
+        </div>
+      </Tabs>
+    </Modal>
+  )
+}

--- a/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -1,9 +1,9 @@
-import {Modal, Stack, TextArea, TextInput, ToastNotification,} from "@carbon/react";
+import {ToastNotification,} from "@carbon/react";
 import React, {useCallback, useEffect, useState} from "react";
 import {usePrompts} from "../../hooks/api/use-prompts";
 import {PromptReference} from "../../models";
 import {PromptsTable} from "./PromptsTable";
-import {NamespaceSelect} from "../Namespaces/NamespaceSelect.tsx";
+import {PromptModal} from "./PromptsModal"
 
 export const PromptsPage: React.FC = () => {
   const [fetchedData, setFetchedData] = useState<PromptReference[]>([]);
@@ -94,110 +94,12 @@ export const PromptsPage: React.FC = () => {
           />
         )}
         {isAddModalOpen && (
-          <AddPromptModal
+          <PromptModal
             onRequestClose={() => setIsAddModalOpen(false)}
             onSubmit={handleAddPrompt}
           />
         )}
       </div>
     </div>
-  );
-};
-
-interface AddPromptModalProps {
-  onRequestClose: () => void;
-  onSubmit: (newPrompt: PromptReference) => void;
-}
-
-const AddPromptModal: React.FC<AddPromptModalProps> = ({
-  onRequestClose,
-  onSubmit,
-}) => {
-  const [promptName, setPromptName] = useState("");
-  const [description, setDescription] = useState("");
-  const [messagesJson, setMessagesJson] = useState("");
-  const [argumentsJson, setArgumentsJson] = useState("");
-  const [toolReferences, setToolReferences] = useState("");
-  const [selectedNamespace, setSelectedNamespace] = useState("");
-
-  const handleSubmit = () => {
-    try {
-      const messages = messagesJson ? JSON.parse(messagesJson) : [];
-      const args = argumentsJson ? JSON.parse(argumentsJson) : [];
-      const toolRefs = toolReferences ? toolReferences.split(',').map(t => t.trim()) : [];
-
-      onSubmit({
-        name: promptName,
-        description,
-        messages,
-        arguments: args,
-        toolReferences: toolRefs,
-        namespace: selectedNamespace,
-      });
-    } catch (error) {
-      console.error("Invalid JSON in prompt data:", error);
-    }
-  };
-
-  return (
-    <Modal
-      open={true}
-      modalHeading="Add a Prompt"
-      primaryButtonText="Add"
-      secondaryButtonText="Cancel"
-      onRequestClose={onRequestClose}
-      onRequestSubmit={handleSubmit}
-    >
-      <Stack gap={5}>
-        <TextInput
-          id="prompt-name"
-          labelText="Prompt Name"
-          placeholder="e.g. code-reviewer"
-          value={promptName}
-          onChange={(e) => setPromptName(e.target.value)}
-        />
-        <TextInput
-          id="prompt-description"
-          labelText="Description"
-          placeholder="e.g. A prompt for reviewing code"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
-        <TextArea
-          id="messages-json"
-          labelText="Messages (JSON)"
-          placeholder='Examples:
-Text: {"role": "user", "content": {"type": "text", "text": "Review {{code}}"}}
-Image: {"role": "user", "content": {"type": "image", "data": "base64...", "mimeType": "image/png"}}
-Audio: {"role": "user", "content": {"type": "audio", "data": "base64...", "mimeType": "audio/wav"}}
-Resource: {"role": "user", "content": {"type": "resource", "resource": {"location": "file:///path", "description": "File content", "mimeType": "text/plain"}}}'
-          rows={6}
-          value={messagesJson}
-          onChange={(e) => setMessagesJson(e.target.value)}
-        />
-        <TextArea
-          id="arguments-json"
-          labelText="Arguments (JSON, optional)"
-          placeholder='e.g. [{"name": "code", "description": "The code to review", "required": true}]'
-          rows={3}
-          value={argumentsJson}
-          onChange={(e) => setArgumentsJson(e.target.value)}
-        />
-        <TextInput
-          id="tool-references"
-          labelText="Tool References (comma-separated, optional)"
-          placeholder="e.g. code-analyzer, linter"
-          value={toolReferences}
-          onChange={(e) => setToolReferences(e.target.value)}
-        />
-        <NamespaceSelect
-          id="namespace"
-          labelText="Select a Namespace"
-          helperText="Choose a Namespace from the list"
-          value={selectedNamespace}
-          onChange={namespace => setSelectedNamespace(namespace.id!)}
-        />
-      </Stack>
-    </Modal>
   );
 };


### PR DESCRIPTION
I've moved the two optional fields in Prompt Modal into own tabs. They are marked as optional so the user should be able to submit the dialog witout even looking at them.

## Summary by Sourcery

Extract the prompt creation modal into a dedicated component and reorganize its fields into tabbed sections to separate core and optional inputs.

New Features:
- Introduce a reusable PromptModal component for creating prompts with tabbed navigation for different input sections.

Enhancements:
- Move optional prompt arguments and tool reference fields into their own tabs to streamline the primary prompt creation flow.
- Add a scrollable wrapper for the prompt modal tab panels to maintain a consistent modal height.