### PR TITLE
[#1173] LLM model field cannot be edited in Firefox

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -16,7 +16,12 @@ export const LLMChatPage: React.FC = () => {
       <h1 className="title">LLM Chat for testing</h1>
       <Grid fullWidth>
         <Column lg={4}>
-          <LLMSetup config={config} onChange={setConfig} />
+          <LLMSetup
+            config={config}
+            onChange={(config: LlmConfig) => {
+              setConfig({ ...config })}
+            }
+          />
           <LLMTools
             selectedTools={config.tools}
             onSelectionChange={(tools) => {

--- a/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
@@ -1,21 +1,15 @@
-import React, {RefObject, useImperativeHandle, useState} from "react"
+import React from "react"
 import {ComboBox} from "@carbon/react"
+import {LlmConfig} from "./config"
 
-
-export interface LLMChangeHandle {
-  llmBaseUrlChanged: (baseUrl: string) => void
-}
 
 interface LLMModelComboBoxProps {
-  value?: string
+  config?: LlmConfig
   labelText?: string
   onChange: (llmModel: string) => void
-  ref?: RefObject<LLMChangeHandle>
 }
 
-export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ value, onChange, labelText, ref }) => {
-  
-  const [modelSuggestions, setModelSuggestions] = useState<string[]>([])
+export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ config, onChange, labelText }) => {
   
   const llmModelSuggestions = {
     "https://api.openai.com": ["gpt-4o", "gpt-4o-mini", "o3-mini", "o1", "o1-mini"],
@@ -24,29 +18,24 @@ export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ value, onCha
     "https://api.anthropic.com": ["claude-4.7-opus", "claude-4.6-opus"]
   }
   
-  useImperativeHandle(ref, (): LLMChangeHandle => ({
-    llmBaseUrlChanged(baseUrl: string) {
-      setModelSuggestions(createItems(baseUrl))
-    }
-  }), [])
-
-  function createItems(baseUrl: string) {
-    return llmModelSuggestions[baseUrl] || []
+  function createItems(): string[] {
+    const baseUrl = config?.baseUrl || undefined
+    return (baseUrl && llmModelSuggestions[baseUrl]) ? llmModelSuggestions[baseUrl] : []
   }
   
   return (
     <ComboBox
       id="llm-model"
       titleText={labelText}
-      items={modelSuggestions}
+      items={createItems()}
       allowCustomValue
-      value={value}
+      selectedItem={config?.llmModel}
       onChange={(event) => {
-        const llmModel = event.selectedItem || event.inputValue || ""
-        onChange(llmModel)
+        setTimeout(() => {
+          const llmModel = event.selectedItem || event.inputValue || ""
+          onChange(llmModel)
+        }, 0)
       }}
     />
-    
   )
-
 }

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from "react"
+import React, {useState} from "react"
 import {
   Form,
   PasswordInput, Stack,
@@ -12,7 +12,7 @@ import {
   STORE_IN_LOCAL_STORAGE
 } from "./config.ts"
 import {BaseUrlSelect} from "./BaseUrlSelect"
-import {LLMChangeHandle, LLMModelComboBox} from "./LLMModelComboBox"
+import {LLMModelComboBox} from "./LLMModelComboBox"
 
 
 interface LLMSetupProps {
@@ -23,7 +23,6 @@ interface LLMSetupProps {
 export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
-  const llmModelComboBoxRef = useRef<LLMChangeHandle>({ llmBaseUrlChanged: () => {} })
   
   function applyConfigChange(config: LlmConfig) {
     if (isStoredInLocalStorage) {
@@ -57,13 +56,11 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
           value={config.baseUrl || ""}
           onChange={(baseUrl: string) => {
             applyConfigChange({ ...config, baseUrl })
-            llmModelComboBoxRef.current.llmBaseUrlChanged(baseUrl)
           }}
         />
         <LLMModelComboBox
           labelText="LLM Model"
-          value={config.llmModel}
-          ref={llmModelComboBoxRef}
+          config={config}
           onChange={(llmModel) => {
             applyConfigChange({ ...config, llmModel })
           }}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1173

I've removed the _useRef_ hook, since on second look, the same effect could be achieved with more simple approach. Also, it seems React has problem with ComboBox rendering. I had to add setTimeout in the handler in order not to call the value change immidiately. 

I hope it fixes the issue!

## Summary by Sourcery

Simplify LLM model selection wiring in the LLM chat admin page and fix the model ComboBox behavior, particularly in Firefox.

Bug Fixes:
- Resolve LLM model ComboBox value update issues by deferring change handling to avoid React/ComboBox rendering glitches.

Enhancements:
- Replace ref-based imperative updates with a config-driven LLM model ComboBox that derives suggestions from the current base URL.
- Streamline LLM setup configuration flow so model and base URL changes are propagated through a single config object.