### PR TITLE
[#1004] Make LLM chat base URL allowlist configurable via application properties

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/WanakuRouterConfig.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/WanakuRouterConfig.java
@@ -1,5 +1,6 @@
 package ai.wanaku.backend;
 
+import java.util.List;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 
@@ -21,6 +22,13 @@ public interface WanakuRouterConfig {
 
         @WithDefault("10")
         int maxConcurrent();
+    }
+
+    LlmConfig llm();
+
+    interface LlmConfig {
+
+        List<String> allowlist();
     }
 
     @WithDefault("100000000000")

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
@@ -1,6 +1,7 @@
 package ai.wanaku.backend.api.v1.chat;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.Consumes;
@@ -20,6 +21,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
+import ai.wanaku.backend.WanakuRouterConfig;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -30,19 +32,14 @@ import static jakarta.ws.rs.core.Response.Status.TOO_MANY_REQUESTS;
 @Path("/api/v1/chat")
 public class LlmChatResource {
 
-    /* Allowlist of chat URLs */
-    private final List<String> allowlist = List.of(
-            "http://localhost:11434",
-            "https://api.openai.com",
-            "https://api.mistral.ai",
-            "https://generativelanguage.googleapis.com/v1beta/openai/",
-            "https://api.anthropic.com");
+    @Inject
+    WanakuRouterConfig config;
 
     @GET
     @Path("/allowlist")
     @Produces(APPLICATION_JSON)
     public List<String> getBaseUrls() {
-        return allowlist;
+        return config.llm().allowlist();
     }
 
     @POST
@@ -55,7 +52,7 @@ public class LlmChatResource {
         String apiKey = json.getString("apiKey");
         JsonObject llmParams = json.getJsonObject("chatParams");
 
-        if (!allowlist.contains(baseUrl)) {
+        if (!config.llm().allowlist().contains(baseUrl)) {
             throw new WebApplicationException("Base URL: %s is not allowed".formatted(baseUrl), BAD_REQUEST);
         }
         try (var client = HttpClient.newHttpClient()) {

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -13,6 +13,13 @@ wanaku.router.health-check.enabled=true
 wanaku.router.health-check.interval-seconds=60
 wanaku.router.health-check.max-concurrent=10
 
+# Allowlist of LLM APIs
+wanaku.router.llm.allowlist=http://localhost:11434,\
+    https://api.openai.com,\
+    https://api.mistral.ai,\
+    https://generativelanguage.googleapis.com/v1beta/openai/,\
+    https://api.anthropic.com
+
 wanaku.bridge.grpc.transport.deadline-seconds=10
 
 # Wanaku internal NS

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -177,6 +177,14 @@ These `wanaku.router.health-check.*` properties control the periodic health prob
 | `wanaku.router.health-check.interval-seconds` | `60` - The interval in seconds between health check sweeps.                |
 | `wanaku.router.health-check.max-concurrent`   | `10` - The maximum number of concurrent health check probes.               |
 
+### LLM
+
+Wanaku provides an allowlist for LLM APIs. Only URLs from this list are allowed in the LLM Chat.
+
+| Property                      | Description                                              |
+|-------------------------------|----------------------------------------------------------|
+| `wanaku.router.llm.allowlist` | A comma separated list of LLM API URLs that are allowed. |
+
 ### gRPC Transport
 
 | Property                                        | Description                                                                                                                           |


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1004

## Summary by Sourcery

Make the LLM chat base URL allowlist configurable via application properties instead of being hardcoded.

New Features:
- Introduce configurable LLM allowlist properties exposed through WanakuRouterConfig and application.properties.
- Expose the configured LLM allowlist via the existing /api/v1/chat/allowlist endpoint.

Enhancements:
- Update LlmChatResource to validate LLM base URLs against the configurable allowlist rather than a static in-code list.

Documentation:
- Document the new wanaku.router.llm.allowlist configuration property in the configurations guide.