### PR TITLE
[UI] Empty states for the main tables

### DIFF
--- a/apps/ui/admin/src/Pages/EmptyTableState.tsx
+++ b/apps/ui/admin/src/Pages/EmptyTableState.tsx
@@ -1,0 +1,31 @@
+import {Stack, TableCell, TableRow} from "@carbon/react"
+import React from "react"
+
+
+interface TableEmptyStateProps {
+  colSpan: number
+  title: string
+  body: string
+}
+
+export const TableEmptyState: React.FC<TableEmptyStateProps> = ({ colSpan, title, body }) => {
+  return (
+    <TableRow>
+      <TableCell colSpan={colSpan}>
+        <Stack gap={6} style={{
+          alignItems: "left",
+          justifyContent: "left",
+          padding: "4rem 0",
+          color: "var(--cds-text-secondary)"
+        }}>
+          <div style={{ textAlign: "left", paddingLeft: "4rem" }}>
+            <h4 style={{ marginBottom: "0.5rem", color: "var(--cds-text-primary)" }}>
+              {title}
+            </h4>
+            <p>{body}</p>
+          </div>
+        </Stack>
+      </TableCell>
+    </TableRow>
+  )
+}

--- a/apps/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
+++ b/apps/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
@@ -15,6 +15,7 @@ import {Add, Edit, Renew, TrashCan} from "@carbon/icons-react"
 import {ForwardReference} from "../../models"
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import React from "react"
+import {TableEmptyState} from "../EmptyTableState"
 
 interface ForwardsTableProps {
   forwards: ForwardReference[]
@@ -114,6 +115,13 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
                 )
               }
             })}
+            {forwards.length == 0 && (
+              <TableEmptyState
+                colSpan={headers.length + 1}
+                title="Start by adding forwards"
+                body="Click Add Forward to add your data"
+              />
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/apps/ui/admin/src/Pages/Prompts/PromptsTable.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsTable.tsx
@@ -15,6 +15,7 @@ import {
 import {FunctionComponent} from "react";
 import {PromptReference} from "../../models";
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
+import {TableEmptyState} from "../EmptyTableState"
 
 interface PromptsListProps {
   fetchedData: PromptReference[];
@@ -58,10 +59,11 @@ export const PromptsTable: FunctionComponent<PromptsListProps> = ({
       namespace: getNamespacePathById(prompt.namespace),
     }));
   }
-
+  
   return (
     <DataTable headers={headers} rows={promptsToRows()}>
-      {({headers, rows, getTableProps, getHeaderProps, getRowProps}) => (
+      {({headers, rows, getTableProps, getHeaderProps, getRowProps}) => {
+        return (
           <TableContainer>
             <TableToolbar>
               <TableToolbarContent>
@@ -111,10 +113,17 @@ export const PromptsTable: FunctionComponent<PromptsListProps> = ({
                     </TableRow>
                   );
                 })}
+                {fetchedData.length == 0 && (
+                  <TableEmptyState
+                    colSpan={headers.length}
+                    title="Start by adding prompts"
+                    body="Click Add Prompt to add your data"
+                  />
+                )}
               </TableBody>
             </Table>
           </TableContainer>
-      )}
+      )}}
     </DataTable>
   );
 };

--- a/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -19,6 +19,7 @@ import {Add, Edit, TrashCan} from "@carbon/icons-react"
 import {Param, ResourceReference} from "../../models"
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import {useResources} from "../../hooks/api/use-resources"
+import {TableEmptyState} from "../EmptyTableState"
 
 
 export interface RefreshHandle {
@@ -200,6 +201,13 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, o
                     )
                   }
                 })}
+                {resources.length == 0 && (
+                  <TableEmptyState
+                    colSpan={headers.length + 1}
+                    title="Start by adding resources"
+                    body="Click Add Resource to add your data"
+                  />
+                )}
               </TableBody>
             </Table>
           </TableContainer>

--- a/apps/ui/admin/src/Pages/Targets/TargetsTable.tsx
+++ b/apps/ui/admin/src/Pages/Targets/TargetsTable.tsx
@@ -1,6 +1,7 @@
 import {DataTable, Table, TableBody, TableCell, TableContainer, TableHead, TableHeader, TableRow,} from "@carbon/react";
 import React from "react";
 import {ServiceTargetState} from "./ServiceTargetState";
+import {TableEmptyState} from "../EmptyTableState"
 
 interface TargetsTableProps {
   targets: ServiceTargetState[];
@@ -58,6 +59,13 @@ export const TargetsTable: React.FC<TargetsTableProps> = ({
                   </TableRow>
                 );
               })}
+              {targets.length == 0 && (
+                <TableEmptyState
+                  colSpan={headers.length}
+                  title=""
+                  body=""
+                />
+              )}
             </TableBody>
           </Table>
         </TableContainer>

--- a/apps/ui/admin/src/Pages/Tools/ToolsTable.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ToolsTable.tsx
@@ -19,6 +19,7 @@ import React, {FunctionComponent, useState} from "react";
 import {ToolReference} from "../../models";
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import {InputSchemaModal} from "./InputSchemaModal";
+import {TableEmptyState} from "../EmptyTableState"
 
 interface ToolListProps {
   fetchedData: ToolReference[];
@@ -180,6 +181,13 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
                       )
                     }
                   })}
+                  {fetchedData.length == 0 && (
+                    <TableEmptyState
+                      colSpan={headers.length + 1}
+                      title="Start by adding tools"
+                      body="Click Add Tool to add your data, or import the toolset from a remote server"
+                    />
+                  )}
                 </TableBody>
               </Table>
             </TableContainer>


### PR DESCRIPTION
Empty table state according to Carbon patterns:
https://carbondesignsystem.com/patterns/empty-states-pattern/

Implemented as a reusable component.

Capabilities/Targets doesn't have any text since there is currently no Add/Edit feature for these.

NamespaceTable doesn't have it since there will be always at least _public_ and _default_ namespaces.

## Summary by Sourcery

Add reusable empty state component for main admin tables when no data is available.

New Features:
- Introduce a shared TableEmptyState component for rendering empty table content following Carbon empty state patterns.
- Display contextual empty state messaging in Prompts, Forwards, Resources, Targets, and Tools tables when they have no rows.

Enhancements:
- Standardize empty table presentation across multiple admin pages for a more consistent user experience.