### PR TITLE
feat: PlaceholderResolver for dynamic placeholder resolution

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -16,6 +17,7 @@ import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ServiceCatalogIndex;
 import ai.wanaku.core.services.api.ServiceCatalogService;
 import ai.wanaku.core.services.api.ServiceTemplateService;
 import picocli.CommandLine;
@@ -44,6 +46,12 @@ public class ServiceDeploy extends BaseCommand {
             description = "Deploy as a service template instead of a catalog",
             defaultValue = "false")
     private boolean template;
+
+    @CommandLine.Option(
+            names = {"--resolve-versions"},
+            description = "Resolve ${placeholder} versions in dependency files before deploying",
+            defaultValue = "true")
+    private boolean resolveVersions;
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
@@ -113,6 +121,27 @@ public class ServiceDeploy extends BaseCommand {
         } catch (IOException e) {
             printer.printErrorMessage(String.format("Failed to create ZIP archive: %s%n", e.getMessage()));
             return EXIT_ERROR;
+        }
+
+        // Resolve version placeholders in-memory, never on disk.
+        if (resolveVersions) {
+            String versionsPath = props.getProperty("catalog.versions");
+            if (versionsPath != null) {
+                File versionsFile = new File(baseDir, versionsPath);
+                if (versionsFile.exists()) {
+                    try {
+                        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zipBytes);
+                        byte[] resolvedZip = index.resolvePlaceholders(zipBytes);
+                        if (!Arrays.equals(resolvedZip, zipBytes)) {
+                            zipBytes = resolvedZip;
+                        }
+                    } catch (Exception e) {
+                        printer.printErrorMessage(
+                                String.format("Failed to resolve version placeholders: %s%n", e.getMessage()));
+                        return EXIT_ERROR;
+                    }
+                }
+            }
         }
 
         // Base64-encode the ZIP

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInit.java
@@ -89,6 +89,7 @@ public class ServiceInit extends BaseCommand {
         props.setProperty("catalog.name", name);
         props.setProperty("catalog.description", "Service catalog for " + name);
         props.setProperty("catalog.services", services);
+        props.setProperty("catalog.versions", "versions.properties");
 
         for (String system : systems) {
             String systemName = system.trim();
@@ -100,7 +101,6 @@ public class ServiceInit extends BaseCommand {
             props.setProperty(
                     "catalog.dependencies." + systemName, systemName + "/" + systemName + ".dependencies.txt");
 
-            // If --template flag is set, add catalog.properties entry
             if (template) {
                 props.setProperty("catalog.properties." + systemName, systemName + "/service.properties");
             }
@@ -109,6 +109,16 @@ public class ServiceInit extends BaseCommand {
         File indexFile = new File(rootDir, "index.properties");
         try (FileWriter writer = new FileWriter(indexFile)) {
             props.store(writer, "Service Catalog Index - " + name);
+        }
+
+        // Create versions.properties skeleton
+        File versionsFile = new File(rootDir, "versions.properties");
+        try (PrintWriter pw = new PrintWriter(new FileWriter(versionsFile))) {
+            pw.println("# Version placeholders for dependency files");
+            pw.println("# Reference these in *.dependencies.txt as ${name}");
+            pw.println("# Example: camel.version=4.18.2");
+            pw.println("# Add the versions you need here, for example:");
+            pw.println("# camel.version=4.18.2");
         }
     }
 
@@ -146,6 +156,7 @@ public class ServiceInit extends BaseCommand {
         try (PrintWriter pw = new PrintWriter(new FileWriter(depsFile))) {
             pw.println("# Maven dependencies for " + systemName);
             pw.println("# One dependency per line in format: groupId:artifactId:version");
+            pw.println("# Use ${camel.version} to reference versions from versions.properties");
         }
 
         // If --template flag is set, create service.properties skeleton

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServicePackage.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServicePackage.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -12,6 +13,7 @@ import java.util.zip.ZipOutputStream;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ServiceCatalogIndex;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "package", description = "Package a service catalog into a Base64-encoded ZIP")
@@ -29,6 +31,12 @@ public class ServicePackage extends BaseCommand {
             description = "Output file path (defaults to <catalog-name>.b64)",
             arity = "0..1")
     private String output;
+
+    @CommandLine.Option(
+            names = {"--resolve-versions"},
+            description = "Resolve ${placeholder} versions in dependency files before packaging",
+            defaultValue = "true")
+    private boolean resolveVersions;
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
@@ -95,6 +103,28 @@ public class ServicePackage extends BaseCommand {
         } catch (IOException e) {
             printer.printErrorMessage(String.format("Failed to create ZIP archive: %s%n", e.getMessage()));
             return EXIT_ERROR;
+        }
+
+        if (resolveVersions) {
+            String versionsPath = props.getProperty("catalog.versions");
+            if (versionsPath != null) {
+                File versionsFile = new File(baseDir, versionsPath);
+                if (versionsFile.exists()) {
+                    try {
+                        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zipBytes);
+                        byte[] resolvedZip = index.resolvePlaceholders(zipBytes);
+                        if (!Arrays.equals(resolvedZip, zipBytes)) {
+                            zipBytes = resolvedZip;
+                            printer.printInfoMessage(
+                                    String.format("Resolved version placeholders using '%s'%n", versionsPath));
+                        }
+                    } catch (Exception e) {
+                        printer.printErrorMessage(
+                                String.format("Failed to resolve version placeholders: %s%n", e.getMessage()));
+                        return EXIT_ERROR;
+                    }
+                }
+            }
         }
 
         String base64Data = Base64.getEncoder().encodeToString(zipBytes);

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.service;
 import java.io.File;
 import java.io.FileInputStream;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -51,6 +53,7 @@ class ServiceInitTest {
         assertTrue(new File(rootDir, "sys1/sys1.camel.yaml").exists(), "Route file should exist");
         assertTrue(new File(rootDir, "sys1/sys1.wanaku-rules.yaml").exists(), "Rules file should exist");
         assertTrue(new File(rootDir, "sys1/sys1.dependencies.txt").exists(), "Dependencies file should exist");
+        assertTrue(new File(rootDir, "versions.properties").exists(), "versions.properties should exist");
 
         // Verify index.properties content
         Properties props = new Properties();
@@ -61,6 +64,12 @@ class ServiceInitTest {
         assertNotNull(props.getProperty("catalog.services"));
         assertNotNull(props.getProperty("catalog.routes.sys1"));
         assertNotNull(props.getProperty("catalog.rules.sys1"));
+
+        String versionsContent = new String(
+                java.nio.file.Files.readAllBytes(new File(rootDir, "versions.properties").toPath()),
+                StandardCharsets.UTF_8);
+        assertTrue(versionsContent.contains("# camel.version=4.18.2"));
+        assertFalse(versionsContent.contains("\ncamel.version=4.18.2"));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServicePackageTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServicePackageTest.java
@@ -1,0 +1,113 @@
+package ai.wanaku.cli.main.commands.service;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
+class ServicePackageTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testPackageResolvesInMemoryWithoutMutatingSourceFiles() throws Exception {
+        File rootDir = tempDir.resolve("catalog").toFile();
+        assertTrue(rootDir.mkdirs());
+
+        createCatalogSkeleton(rootDir);
+
+        File outputFile = tempDir.resolve("catalog.b64").toFile();
+
+        ServicePackage cmd = new ServicePackage();
+        setField(cmd, "path", rootDir.getAbsolutePath());
+        setField(cmd, "output", outputFile.getAbsolutePath());
+        setField(cmd, "resolveVersions", true);
+
+        Integer result = cmd.call();
+        assertEquals(0, result);
+
+        String depsContent;
+        try (FileInputStream fis = new FileInputStream(new File(rootDir, "sys1/sys1.dependencies.txt"))) {
+            depsContent = new String(fis.readAllBytes());
+        }
+        assertTrue(depsContent.contains("${camel.version}"));
+        assertTrue(outputFile.exists());
+
+        String base64Zip;
+        try (FileInputStream fis = new FileInputStream(outputFile)) {
+            base64Zip = new String(fis.readAllBytes());
+        }
+
+        byte[] resolvedZip = java.util.Base64.getDecoder().decode(base64Zip);
+        String resolvedDeps = extractZipEntry(resolvedZip, "sys1/sys1.dependencies.txt");
+        assertTrue(resolvedDeps.contains("org.apache.camel:camel-jms:4.18.2"));
+        assertFalse(resolvedDeps.contains("${camel.version}"));
+    }
+
+    private void createCatalogSkeleton(File rootDir) throws Exception {
+        Properties props = new Properties();
+        props.setProperty("catalog.name", "catalog");
+        props.setProperty("catalog.description", "test");
+        props.setProperty("catalog.services", "sys1");
+        props.setProperty("catalog.versions", "versions.properties");
+        props.setProperty("catalog.routes.sys1", "sys1/sys1.camel.yaml");
+        props.setProperty("catalog.rules.sys1", "sys1/sys1.wanaku-rules.yaml");
+        props.setProperty("catalog.dependencies.sys1", "sys1/sys1.dependencies.txt");
+
+        try (FileOutputStream fos = new FileOutputStream(new File(rootDir, "index.properties"))) {
+            props.store(fos, null);
+        }
+
+        File systemDir = new File(rootDir, "sys1");
+        assertTrue(systemDir.mkdirs());
+
+        try (FileOutputStream fos = new FileOutputStream(new File(systemDir, "sys1.camel.yaml"))) {
+            fos.write("route".getBytes());
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(new File(systemDir, "sys1.wanaku-rules.yaml"))) {
+            fos.write("rules".getBytes());
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(new File(systemDir, "sys1.dependencies.txt"))) {
+            fos.write("org.apache.camel:camel-jms:${camel.version}".getBytes());
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(new File(rootDir, "versions.properties"))) {
+            fos.write("camel.version=4.18.2".getBytes());
+        }
+    }
+
+    private String extractZipEntry(byte[] zipBytes, String fileName) throws Exception {
+        try (ZipInputStream zis = new ZipInputStream(new java.io.ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (fileName.equals(entry.getName())) {
+                    return new String(zis.readAllBytes());
+                }
+                zis.closeEntry();
+            }
+        }
+        throw new AssertionError("File '" + fileName + "' not found in ZIP");
+    }
+
+    private void setField(Object obj, String fieldName, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
@@ -5,6 +5,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import java.util.Base64;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +107,16 @@ public class ServiceCatalogBean {
         }
 
         // Validate ZIP structure by parsing the index
-        ServiceCatalogIndex.fromBase64(dataStore.getData());
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromBase64(dataStore.getData());
+
+        // Resolve version placeholders in dependency files if a versions file is present
+        if (index.hasVersionsFile()) {
+            byte[] zipBytes = Base64.getDecoder().decode(dataStore.getData());
+            byte[] resolvedZip = index.resolvePlaceholders(zipBytes);
+            if (!Arrays.equals(resolvedZip, zipBytes)) {
+                dataStore.setData(Base64.getEncoder().encodeToString(resolvedZip));
+            }
+        }
 
         // Set catalog label
         Map<String, String> labels = dataStore.getLabels();

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Base64;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
+import ai.wanaku.core.util.PlaceholderResolver;
 import ai.wanaku.core.util.StringHelper;
 
 /**
@@ -120,6 +122,15 @@ public class ServiceTemplateBean {
 
         // Validate ZIP structure by parsing the index
         ServiceCatalogIndex index = ServiceCatalogIndex.fromBase64(dataStore.getData());
+
+        // Resolve version placeholders in dependency files if a versions file is present
+        if (index.hasVersionsFile()) {
+            byte[] zipBytes = Base64.getDecoder().decode(dataStore.getData());
+            byte[] resolvedZip = index.resolvePlaceholders(zipBytes);
+            if (!Arrays.equals(resolvedZip, zipBytes)) {
+                dataStore.setData(Base64.getEncoder().encodeToString(resolvedZip));
+            }
+        }
 
         // Set template label
         Map<String, String> labels = dataStore.getLabels();
@@ -345,6 +356,24 @@ public class ServiceTemplateBean {
                     StringWriter propsWriter = new StringWriter();
                     props.store(propsWriter, null);
                     entries.put(propertiesPath, propsWriter.toString().getBytes());
+                }
+            }
+
+            // Resolve version placeholders in dependency files
+            String versionsPath = index.getVersionsFile();
+            if (versionsPath != null && entries.containsKey(versionsPath)) {
+                Map<String, String> bindings = PlaceholderResolver.loadBindings(new String(entries.get(versionsPath)));
+                if (!bindings.isEmpty()) {
+                    for (String system : index.getServiceNames()) {
+                        String depsPath = index.getDependenciesFile(system);
+                        if (depsPath != null && entries.containsKey(depsPath)) {
+                            String content = new String(entries.get(depsPath));
+                            String resolved = PlaceholderResolver.resolve(content, bindings);
+                            if (!resolved.equals(content)) {
+                                entries.put(depsPath, resolved.getBytes());
+                            }
+                        }
+                    }
                 }
             }
 

--- a/core/core-services-api/pom.xml
+++ b/core/core-services-api/pom.xml
@@ -12,6 +12,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogIndex.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogIndex.java
@@ -3,16 +3,20 @@ package ai.wanaku.core.services.api;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.core.util.PlaceholderResolver;
+import ai.wanaku.core.util.ZipPlaceholderResolver;
 
 /**
  * Parses and validates a service catalog index from a ZIP archive.
@@ -30,7 +34,15 @@ import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
  * <ul>
  *   <li>{@code catalog.icon} - display icon</li>
  *   <li>{@code catalog.dependencies.<system>} - relative path to dependencies file</li>
+ *   <li>{@code catalog.versions} - relative path to a version properties file for
+ *      placeholder resolution in dependency files</li>
  * </ul>
+ * <p>
+ * Dependency files may contain placeholders in the form {@code ${name}}
+ * (e.g. {@code ${camel.version}}). These are resolved at deploy time using
+ * the bindings declared in the version properties file referenced by
+ * {@code catalog.versions}. Placeholders without a matching binding are
+ * left unchanged, so hard-coded versions continue to work.
  */
 public class ServiceCatalogIndex {
 
@@ -43,6 +55,7 @@ public class ServiceCatalogIndex {
     private static final String PROP_RULES_PREFIX = "catalog.rules.";
     private static final String PROP_DEPENDENCIES_PREFIX = "catalog.dependencies.";
     private static final String PROP_PROPERTIES_PREFIX = "catalog.properties.";
+    private static final String PROP_VERSIONS = "catalog.versions";
 
     private final String name;
     private final String icon;
@@ -190,6 +203,15 @@ public class ServiceCatalogIndex {
             }
         }
 
+        // Validate optional catalog.versions file if declared
+        String versionsPath = props.getProperty(PROP_VERSIONS);
+        if (versionsPath != null) {
+            validateZipEntryPath(versionsPath);
+            if (zipEntries != null && !zipEntries.contains(versionsPath)) {
+                throw new WanakuException("Referenced versions file '" + versionsPath + "' not found in ZIP archive");
+            }
+        }
+
         return new ServiceCatalogIndex(name, icon, description, serviceNames, props);
     }
 
@@ -264,6 +286,22 @@ public class ServiceCatalogIndex {
     }
 
     /**
+     * Get the versions properties file path, or null if not set.
+     */
+    public String getVersionsFile() {
+        return properties.getProperty(PROP_VERSIONS);
+    }
+
+    /**
+     * Check if this catalog declares a versions properties file.
+     *
+     * @return true if the catalog.versions property is set
+     */
+    public boolean hasVersionsFile() {
+        return properties.getProperty(PROP_VERSIONS) != null;
+    }
+
+    /**
      * Check if this catalog has any service.properties files declared.
      *
      * @return true if at least one system has a properties file
@@ -275,5 +313,55 @@ public class ServiceCatalogIndex {
             }
         }
         return false;
+    }
+
+    /**
+     * Resolve version placeholders in the content of a ZIP archive.
+     * <p>
+     * If the ZIP contains a versions file (as declared by {@code catalog.versions}
+     * in the index), all dependency files will have their {@code ${name}}
+     * placeholders replaced with the corresponding values from the versions file.
+     * The versions file itself is left unchanged so it can serve as documentation.
+     * </p>
+     *
+     * @param zipBytes the raw ZIP archive bytes
+     * @return a new byte array containing the ZIP with resolved placeholders,
+     *         or the original bytes if no versions file is present
+     * @throws WanakuException if the ZIP cannot be read or parsed
+     */
+    public byte[] resolvePlaceholders(byte[] zipBytes) throws WanakuException {
+        if (!hasVersionsFile()) {
+            return zipBytes;
+        }
+
+        String versionsPath = getVersionsFile();
+        Map<String, String> bindings = null;
+
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (versionsPath.equals(entry.getName())) {
+                    bindings = PlaceholderResolver.loadBindings(new String(zis.readAllBytes(), StandardCharsets.UTF_8));
+                }
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new WanakuException("Failed to read ZIP archive: " + e.getMessage());
+        }
+
+        if (bindings == null || bindings.isEmpty()) {
+            return zipBytes;
+        }
+
+        List<String> dependencyFiles = new ArrayList<>();
+        for (String system : serviceNames) {
+            String depsPath = getDependenciesFile(system);
+            if (depsPath != null) {
+                dependencyFiles.add(depsPath);
+            }
+        }
+
+        return ZipPlaceholderResolver.resolveEntries(zipBytes, dependencyFiles, bindings)
+                .getZipBytes();
     }
 }

--- a/core/core-services-api/src/test/java/ai/wanaku/core/services/api/ServiceCatalogIndexTest.java
+++ b/core/core-services-api/src/test/java/ai/wanaku/core/services/api/ServiceCatalogIndexTest.java
@@ -1,14 +1,17 @@
 package ai.wanaku.core.services.api;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Base64;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,23 +19,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ServiceCatalogIndexTest {
 
+    private final String TEST_SERVICE_NAME = "testservice";
+    private final String TEST_SERVICE_DESC = "A test service";
+    private final String TEST_SYSTEM = "sys1";
+    private final String INDEX_PROPERTIES_PATH = "index.properties";
+
     @Test
-    void testValidIndex() {
-        byte[] zip = createTestZip("testservice", "A test service", "sys1");
+    void testValidIndex() throws Exception {
+        byte[] zip = createTestZip(TEST_SERVICE_NAME, TEST_SERVICE_DESC, TEST_SYSTEM);
         ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
 
-        assertEquals("testservice", index.getName());
-        assertEquals("A test service", index.getDescription());
+        assertEquals(TEST_SERVICE_NAME, index.getName());
+        assertEquals(TEST_SERVICE_DESC, index.getDescription());
         assertEquals(1, index.getServiceNames().size());
-        assertEquals("sys1", index.getServiceNames().get(0));
-        assertEquals("sys1/sys1.camel.yaml", index.getRoutesFile("sys1"));
-        assertEquals("sys1/sys1.wanaku-rules.yaml", index.getRulesFile("sys1"));
-        assertNull(index.getDependenciesFile("sys1"));
+        assertEquals(TEST_SYSTEM, index.getServiceNames().get(0));
+        assertEquals(TEST_SYSTEM + "/" + TEST_SYSTEM + ".camel.yaml", index.getRoutesFile(TEST_SYSTEM));
+        assertEquals(TEST_SYSTEM + "/" + TEST_SYSTEM + ".wanaku-rules.yaml", index.getRulesFile(TEST_SYSTEM));
+        assertNull(index.getDependenciesFile(TEST_SYSTEM));
     }
 
     @Test
-    void testValidIndexWithIcon() {
-        byte[] zip = createTestZipWithIcon("testservice", "icon-test", "A test service", "sys1");
+    void testValidIndexWithIcon() throws Exception {
+        byte[] zip = createTestZipWithIcon(TEST_SERVICE_NAME, "icon-test", TEST_SERVICE_DESC, TEST_SYSTEM);
         ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
 
         assertEquals("icon-test", index.getIcon());
@@ -42,7 +50,7 @@ class ServiceCatalogIndexTest {
     void testMissingIndexProperties() {
         byte[] zip = createZipWithoutIndex();
         WanakuException ex = assertThrows(WanakuException.class, () -> ServiceCatalogIndex.fromZipBytes(zip));
-        assertTrue(ex.getMessage().contains("index.properties"));
+        assertTrue(ex.getMessage().contains(INDEX_PROPERTIES_PATH));
     }
 
     @Test
@@ -103,6 +111,76 @@ class ServiceCatalogIndexTest {
         assertTrue(ex.getMessage().contains("catalog.services"));
     }
 
+    @Test
+    void testVersionsFileReference() throws Exception {
+        byte[] zip = createTestZipWithVersions("vtest", "Versions test", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        assertTrue(index.hasVersionsFile());
+        assertEquals("versions.properties", index.getVersionsFile());
+    }
+
+    @Test
+    void testNoVersionsFileByDefault() throws Exception {
+        byte[] zip = createTestZip("testservice", "A test service", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        assertFalse(index.hasVersionsFile());
+        assertNull(index.getVersionsFile());
+    }
+
+    @Test
+    void testMissingVersionsFileInZip() {
+        byte[] zip = createTestZipWithMissingVersions("test", "desc", "sys1");
+        WanakuException ex = assertThrows(WanakuException.class, () -> ServiceCatalogIndex.fromZipBytes(zip));
+        assertTrue(ex.getMessage().contains("not found in ZIP"));
+    }
+
+    @Test
+    void testResolvePlaceholders() throws Exception {
+        byte[] zip = createTestZipWithVersionsAndDeps("resolve-test", "Resolve test", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        byte[] resolved = index.resolvePlaceholders(zip);
+
+        String depsContent = extractFileFromZip(resolved, "sys1/sys1.dependencies.txt");
+        assertTrue(depsContent.contains("com.example:lib-a:1.0.0"));
+        assertFalse(depsContent.contains("${ver.a}"));
+    }
+
+    @Test
+    void testResolvePlaceholdersNoVersionsFile() throws Exception {
+        byte[] zip = createTestZipWithDeps("no-versions", "No versions test", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        byte[] resolved = index.resolvePlaceholders(zip);
+        // Should return same bytes when no versions file present
+        assertEquals(zip, resolved);
+    }
+
+    @Test
+    void testResolvePlaceholdersPreservesVersionsFile() throws Exception {
+        byte[] zip = createTestZipWithVersionsAndDeps("preserve-test", "Preserve test", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        byte[] resolved = index.resolvePlaceholders(zip);
+
+        String versionsContent = extractFileFromZip(resolved, "versions.properties");
+        assertTrue(versionsContent.contains("ver.a="));
+    }
+
+    @Test
+    void testResolvePlaceholdersLeavesUnresolvedPlaceholders() throws Exception {
+        byte[] zip = createTestZipWithVersionsAndDepsPartial("partial-test", "Partial test", "sys1");
+        ServiceCatalogIndex index = ServiceCatalogIndex.fromZipBytes(zip);
+
+        byte[] resolved = index.resolvePlaceholders(zip);
+
+        String depsContent = extractFileFromZip(resolved, "sys1/sys1.dependencies.txt");
+        assertTrue(depsContent.contains("com.example:lib-a:1.0.0"));
+        assertTrue(depsContent.contains("${unknown.version}"));
+    }
+
     // Helper methods to create test ZIPs
 
     private byte[] createTestZip(String name, String description, String... systems) {
@@ -132,7 +210,7 @@ class ServiceCatalogIndexTest {
                 }
 
                 // Write index.properties
-                zos.putNextEntry(new ZipEntry("index.properties"));
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
                 ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
                 props.store(propsOut, null);
                 zos.write(propsOut.toByteArray());
@@ -169,7 +247,7 @@ class ServiceCatalogIndexTest {
                     zos.closeEntry();
                 }
 
-                zos.putNextEntry(new ZipEntry("index.properties"));
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
                 ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
                 props.store(propsOut, null);
                 zos.write(propsOut.toByteArray());
@@ -208,7 +286,7 @@ class ServiceCatalogIndexTest {
                 props.setProperty("catalog.routes." + system, system + "/" + system + ".camel.yaml");
                 props.setProperty("catalog.rules." + system, system + "/" + system + ".wanaku-rules.yaml");
 
-                zos.putNextEntry(new ZipEntry("index.properties"));
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
                 ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
                 props.store(propsOut, null);
                 zos.write(propsOut.toByteArray());
@@ -239,7 +317,7 @@ class ServiceCatalogIndexTest {
                 props.setProperty("catalog.routes." + system, system + "/" + system + ".camel.yaml");
                 props.setProperty("catalog.rules." + system, system + "/" + system + ".wanaku-rules.yaml");
 
-                zos.putNextEntry(new ZipEntry("index.properties"));
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
                 ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
                 props.store(propsOut, null);
                 zos.write(propsOut.toByteArray());
@@ -265,7 +343,7 @@ class ServiceCatalogIndexTest {
                 props.setProperty("catalog.description", "test");
                 props.setProperty("catalog.services", "");
 
-                zos.putNextEntry(new ZipEntry("index.properties"));
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
                 ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
                 props.store(propsOut, null);
                 zos.write(propsOut.toByteArray());
@@ -275,5 +353,234 @@ class ServiceCatalogIndexTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private byte[] createTestZipWithVersions(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+                props.setProperty("catalog.versions", "versions.properties");
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("versions.properties"));
+                zos.write("ver.a=1.0.0\n".getBytes());
+                zos.closeEntry();
+
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] createTestZipWithVersionsAndDeps(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+                props.setProperty("catalog.versions", "versions.properties");
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    String depsPath = sys + "/" + sys + ".dependencies.txt";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+                    props.setProperty("catalog.dependencies." + sys, depsPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(depsPath));
+                    zos.write(("com.example:lib-a:${ver.a}\n").getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("versions.properties"));
+                zos.write("ver.a=1.0.0\n".getBytes());
+                zos.closeEntry();
+
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] createTestZipWithVersionsAndDepsPartial(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+                props.setProperty("catalog.versions", "versions.properties");
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    String depsPath = sys + "/" + sys + ".dependencies.txt";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+                    props.setProperty("catalog.dependencies." + sys, depsPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(depsPath));
+                    zos.write(("com.example:lib-a:${ver.a}\ncom.example:lib-b:${unknown.version}\n").getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("versions.properties"));
+                zos.write("ver.a=1.0.0\n".getBytes());
+                zos.closeEntry();
+
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] createTestZipWithDeps(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    String depsPath = sys + "/" + sys + ".dependencies.txt";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+                    props.setProperty("catalog.dependencies." + sys, depsPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(depsPath));
+                    zos.write(("com.example:lib-a:${ver.a}\n").getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] createTestZipWithMissingVersions(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+                props.setProperty("catalog.versions", "versions.properties");
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+                }
+
+                // Deliberately NOT adding versions.properties file
+
+                zos.putNextEntry(new ZipEntry(INDEX_PROPERTIES_PATH));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String extractFileFromZip(byte[] zipBytes, String fileName) throws Exception {
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (fileName.equals(entry.getName())) {
+                    return new String(zis.readAllBytes());
+                }
+                zis.closeEntry();
+            }
+        }
+        throw new AssertionError("File '" + fileName + "' not found in ZIP");
     }
 }

--- a/core/core-util/src/main/java/ai/wanaku/core/util/PlaceholderResolver.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/PlaceholderResolver.java
@@ -1,0 +1,114 @@
+package ai.wanaku.core.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Resolves {@code ${placeholder}} variables in text content using a supplied
+ * map of name-to-value bindings.
+ * <p>
+ * Placeholders use the syntax {@code ${name}} where {@code name} is a
+ * dot-separated identifier (e.g. {@code ${camel.version}}). Placeholders that
+ * have no matching binding are left unchanged so that hard-coded or
+ * not-yet-resolved values continue to work.
+ * </p>
+ */
+public final class PlaceholderResolver {
+
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([\\w.-]+)}");
+
+    private PlaceholderResolver() {}
+
+    /**
+     * Resolve placeholders in the given text using the provided bindings.
+     *
+     * @param text     the text containing potential {@code ${name}} placeholders
+     * @param bindings map of placeholder names to replacement values
+     * @return the text with resolved placeholders
+     */
+    public static String resolve(String text, Map<String, String> bindings) {
+        if (text == null || bindings == null || bindings.isEmpty()) {
+            return text;
+        }
+
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(text);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            String value = bindings.get(varName);
+            if (value != null) {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(value));
+            }
+        }
+        matcher.appendTail(result);
+
+        return result.toString();
+    }
+
+    /**
+     * Load version bindings from a properties-format reader.
+     *
+     * @param reader the reader containing properties data
+     * @return map of placeholder names to values
+     * @throws WanakuException if the properties cannot be read
+     */
+    public static Map<String, String> loadBindings(Reader reader) throws WanakuException {
+        Properties props = new Properties();
+        try {
+            props.load(reader);
+        } catch (IOException e) {
+            throw new WanakuException("Failed to read version properties: " + e.getMessage());
+        }
+        return propertiesToMap(props);
+    }
+
+    /**
+     * Load version bindings from a properties-format input stream.
+     *
+     * @param inputStream the input stream containing properties data
+     * @return map of placeholder names to values
+     * @throws WanakuException if the properties cannot be read
+     */
+    public static Map<String, String> loadBindings(InputStream inputStream) throws WanakuException {
+        return loadBindings(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Load version bindings from a properties-format string.
+     *
+     * @param content the string content of a properties file
+     * @return map of placeholder names to values
+     * @throws WanakuException if the properties cannot be read
+     */
+    public static Map<String, String> loadBindings(String content) throws WanakuException {
+        return loadBindings(new StringReader(content));
+    }
+
+    /**
+     * Check whether the given text contains any unresolved placeholders.
+     *
+     * @param text the text to check
+     * @return {@code true} if the text contains at least one {@code ${...}} pattern
+     */
+    public static boolean hasPlaceholders(String text) {
+        if (text == null) {
+            return false;
+        }
+        return PLACEHOLDER_PATTERN.matcher(text).find();
+    }
+
+    private static Map<String, String> propertiesToMap(Properties props) {
+        return Map.copyOf(props.stringPropertyNames().stream()
+                .collect(java.util.stream.Collectors.toMap(name -> name, props::getProperty)));
+    }
+}

--- a/core/core-util/src/main/java/ai/wanaku/core/util/ZipPlaceholderResolver.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/ZipPlaceholderResolver.java
@@ -1,0 +1,117 @@
+package ai.wanaku.core.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Resolves placeholders inside selected files of a ZIP archive without touching
+ * the original source files on disk.
+ */
+public final class ZipPlaceholderResolver {
+
+    private ZipPlaceholderResolver() {}
+
+    /**
+     * Result of resolving placeholders inside a ZIP archive.
+     */
+    public static final class ResolutionResult {
+        private final byte[] zipBytes;
+        private final boolean changed;
+
+        private ResolutionResult(byte[] zipBytes, boolean changed) {
+            this.zipBytes = zipBytes;
+            this.changed = changed;
+        }
+
+        public byte[] getZipBytes() {
+            return zipBytes;
+        }
+
+        public boolean isChanged() {
+            return changed;
+        }
+    }
+
+    /**
+     * Resolve placeholders in the given ZIP entries using the supplied bindings.
+     *
+     * @param zipBytes the original ZIP archive bytes
+     * @param entryNames the ZIP entry names that should be processed
+     * @param bindings placeholder bindings loaded from a versions file
+     * @return the original ZIP bytes when nothing changed, or a rebuilt ZIP otherwise
+     * @throws WanakuException if the ZIP cannot be read or written
+     */
+    public static ResolutionResult resolveEntries(
+            byte[] zipBytes, Collection<String> entryNames, Map<String, String> bindings) throws WanakuException {
+        if (zipBytes == null || entryNames == null || entryNames.isEmpty() || bindings == null || bindings.isEmpty()) {
+            return new ResolutionResult(zipBytes, false);
+        }
+
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                entries.put(entry.getName(), zis.readAllBytes());
+                zis.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new WanakuException("Failed to read ZIP archive: " + e.getMessage());
+        }
+
+        Set<String> selectedEntries = Set.copyOf(entryNames);
+        boolean changed = false;
+        for (String entryName : selectedEntries) {
+            byte[] contentBytes = entries.get(entryName);
+            if (contentBytes == null) {
+                continue;
+            }
+
+            String content = new String(contentBytes, StandardCharsets.UTF_8);
+            String resolved = PlaceholderResolver.resolve(content, bindings);
+            if (!resolved.equals(content)) {
+                entries.put(entryName, resolved.getBytes(StandardCharsets.UTF_8));
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return new ResolutionResult(zipBytes, false);
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue());
+                zos.closeEntry();
+            }
+            return new ResolutionResult(baos.toByteArray(), true);
+        } catch (IOException e) {
+            throw new WanakuException("Failed to write resolved ZIP archive: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolve placeholders in the ZIP entries selected by the given list.
+     *
+     * @param zipBytes the original ZIP archive bytes
+     * @param entryNames the ZIP entry names that should be processed
+     * @param bindings placeholder bindings loaded from a versions file
+     * @return the resolved ZIP bytes
+     * @throws WanakuException if the ZIP cannot be processed
+     */
+    public static byte[] resolveEntriesToBytes(
+            byte[] zipBytes, Collection<String> entryNames, Map<String, String> bindings) throws WanakuException {
+        return resolveEntries(zipBytes, entryNames, bindings).getZipBytes();
+    }
+}

--- a/core/core-util/src/test/java/ai/wanaku/core/util/PlaceholderResolverTest.java
+++ b/core/core-util/src/test/java/ai/wanaku/core/util/PlaceholderResolverTest.java
@@ -1,0 +1,128 @@
+package ai.wanaku.core.util;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlaceholderResolverTest {
+
+    private static final String VER_A = "1.0.0";
+    private static final String VER_B = "2.0.0-SNAPSHOT";
+
+    @Test
+    void testResolveSinglePlaceholder() {
+        String result = PlaceholderResolver.resolve("com.example:lib-a:${ver.a}", Map.of("ver.a", VER_A));
+        assertEquals("com.example:lib-a:1.0.0", result);
+    }
+
+    @Test
+    void testResolveHyphenatedPlaceholder() {
+        String result =
+                PlaceholderResolver.resolve("com.example:lib-a:${camel-version}", Map.of("camel-version", VER_A));
+        assertEquals("com.example:lib-a:1.0.0", result);
+    }
+
+    @Test
+    void testResolveMultiplePlaceholders() {
+        String result = PlaceholderResolver.resolve(
+                "com.example:lib-a:${ver.a}\ncom.example:lib-b:${ver.b}\n", Map.of("ver.a", VER_A, "ver.b", VER_B));
+        assertEquals("com.example:lib-a:1.0.0\ncom.example:lib-b:2.0.0-SNAPSHOT\n", result);
+    }
+
+    @Test
+    void testUnresolvedPlaceholderLeftUnchanged() {
+        String result = PlaceholderResolver.resolve("com.example:lib-a:${unknown.version}", Map.of("ver.a", VER_A));
+        assertEquals("com.example:lib-a:${unknown.version}", result);
+    }
+
+    @Test
+    void testMixedResolvedAndUnresolved() {
+        String result = PlaceholderResolver.resolve(
+                "com.example:lib-a:${ver.a}\ncom.example:lib-b:${unknown.version}", Map.of("ver.a", VER_A));
+        assertEquals("com.example:lib-a:1.0.0\ncom.example:lib-b:${unknown.version}", result);
+    }
+
+    @Test
+    void testNoPlaceholders() {
+        String result = PlaceholderResolver.resolve("com.example:lib-a:1.0.0", Map.of("ver.a", VER_A));
+        assertEquals("com.example:lib-a:1.0.0", result);
+    }
+
+    @Test
+    void testNullText() {
+        assertNull(PlaceholderResolver.resolve(null, Map.of("ver.a", VER_A)));
+    }
+
+    @Test
+    void testNullBindings() {
+        String result = PlaceholderResolver.resolve("${ver.a}", null);
+        assertEquals("${ver.a}", result);
+    }
+
+    @Test
+    void testEmptyBindings() {
+        String result = PlaceholderResolver.resolve("${ver.a}", Map.of());
+        assertEquals("${ver.a}", result);
+    }
+
+    @Test
+    void testHardcodedVersionUnchanged() {
+        String result = PlaceholderResolver.resolve("com.example:lib-a:1.0.0", Map.of("ver.a", "9.9.9"));
+        assertEquals("com.example:lib-a:1.0.0", result);
+    }
+
+    @Test
+    void testHasPlaceholders() {
+        assertTrue(PlaceholderResolver.hasPlaceholders("${ver.a}"));
+        assertTrue(PlaceholderResolver.hasPlaceholders("prefix-${ver.a}-suffix"));
+        assertTrue(PlaceholderResolver.hasPlaceholders("line1\n${ver.a}\nline3"));
+    }
+
+    @Test
+    void testHasNoPlaceholders() {
+        assertFalse(PlaceholderResolver.hasPlaceholders("com.example:lib-a:1.0.0"));
+        assertFalse(PlaceholderResolver.hasPlaceholders(""));
+        assertFalse(PlaceholderResolver.hasPlaceholders(null));
+    }
+
+    @Test
+    void testLoadBindingsFromString() {
+        Map<String, String> bindings = PlaceholderResolver.loadBindings("ver.a=1.0.0\nver.b=2.0.0-SNAPSHOT\n");
+        assertEquals(VER_A, bindings.get("ver.a"));
+        assertEquals(VER_B, bindings.get("ver.b"));
+    }
+
+    @Test
+    void testLoadBindingsWithComments() {
+        Map<String, String> bindings = PlaceholderResolver.loadBindings(
+                "# Version properties\nver.a=1.0.0\n# Another comment\nver.b=2.0.0-SNAPSHOT\n");
+        assertEquals(2, bindings.size());
+        assertEquals(VER_A, bindings.get("ver.a"));
+    }
+
+    @Test
+    void testEndToEndResolveFromProperties() {
+        String versionProps = "ver.a=1.0.0\nver.b=2.0.0-SNAPSHOT\nver.c=3.0.0\n";
+        Map<String, String> bindings = PlaceholderResolver.loadBindings(versionProps);
+
+        String deps = "com.example:lib-a:${ver.a}\n"
+                + "com.example:lib-b:${ver.b}\n"
+                + "com.example:lib-b2:${ver.b}\n"
+                + "com.example:lib-b3:${ver.b}\n"
+                + "com.example:lib-c:${ver.c}\n";
+
+        String result = PlaceholderResolver.resolve(deps, bindings);
+
+        String expected = "com.example:lib-a:1.0.0\n"
+                + "com.example:lib-b:2.0.0-SNAPSHOT\n"
+                + "com.example:lib-b2:2.0.0-SNAPSHOT\n"
+                + "com.example:lib-b3:2.0.0-SNAPSHOT\n"
+                + "com.example:lib-c:3.0.0\n";
+
+        assertEquals(expected, result);
+    }
+}

--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-aws2-s3:4.18.2
+org.apache.camel:camel-aws2-s3:${camel.version}

--- a/services/service-templates/src/main/services/aws-s3-resource/index.properties
+++ b/services/service-templates/src/main/services/aws-s3-resource/index.properties
@@ -5,3 +5,4 @@ catalog.routes.aws-s3=aws-s3/aws-s3.camel.yaml
 catalog.rules.aws-s3=aws-s3/aws-s3.rules.yaml
 catalog.services=aws-s3
 catalog.properties.aws-s3=aws-s3/service.properties
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-azure-files:4.18.2
+org.apache.camel:camel-azure-files:${camel.version}

--- a/services/service-templates/src/main/services/azure-files-resource/index.properties
+++ b/services/service-templates/src/main/services/azure-files-resource/index.properties
@@ -5,3 +5,4 @@ catalog.properties.azure-files=azure-files/service.properties
 catalog.routes.azure-files=azure-files/azure-files.camel.yaml
 catalog.rules.azure-files=azure-files/azure-files.rules.yaml
 catalog.services=azure-files
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ftp:4.18.2
+org.apache.camel:camel-ftp:${camel.version}

--- a/services/service-templates/src/main/services/ftp-resource/index.properties
+++ b/services/service-templates/src/main/services/ftp-resource/index.properties
@@ -5,3 +5,4 @@ catalog.properties.ftp=ftp/service.properties
 catalog.routes.ftp=ftp/ftp.camel.yaml
 catalog.rules.ftp=ftp/ftp.rules.yaml
 catalog.services=ftp
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
@@ -1,2 +1,2 @@
-org.apache.camel:camel-http:4.18.2
-org.apache.camel:camel-jackson:4.18.2
+org.apache.camel:camel-http:${camel.version}
+org.apache.camel:camel-jackson:${camel.version}

--- a/services/service-templates/src/main/services/github-pr-comments-tool/index.properties
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/index.properties
@@ -5,3 +5,4 @@ catalog.properties.github-pr-comments=github-pr-comments/service.properties
 catalog.routes.github-pr-comments=github-pr-comments/github-pr-comments.camel.yaml
 catalog.rules.github-pr-comments=github-pr-comments/github-pr-comments.rules.yaml
 catalog.services=github-pr-comments
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-http:4.18.2
+org.apache.camel:camel-http:${camel.version}

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/index.properties
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=github-pullrequest-source-tool
 catalog.routes.github-pullrequest-source=github-pullrequest-source/github-pullrequest-source.camel.yaml
 catalog.rules.github-pullrequest-source=github-pullrequest-source/github-pullrequest-source.rules.yaml
 catalog.services=github-pullrequest-source
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-google-vertexai:4.18.2
+org.apache.camel:camel-google-vertexai:${camel.version}

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/index.properties
@@ -5,3 +5,4 @@ catalog.properties.google-vertexai-sink=google-vertexai-sink/service.properties
 catalog.routes.google-vertexai-sink=google-vertexai-sink/google-vertexai-sink.camel.yaml
 catalog.rules.google-vertexai-sink=google-vertexai-sink/google-vertexai-sink.rules.yaml
 catalog.services=google-vertexai-sink
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/jira-add-comment-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=jira-add-comment-tool
 catalog.routes.jira-add-comment=jira-add-comment/jira-add-comment.camel.yaml
 catalog.rules.jira-add-comment=jira-add-comment/jira-add-comment.rules.yaml
 catalog.services=jira-add-comment
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira:${camel.version}

--- a/services/service-templates/src/main/services/jira-add-issue-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=jira-add-issue-tool
 catalog.routes.jira-add-issue=jira-add-issue/jira-add-issue.camel.yaml
 catalog.rules.jira-add-issue=jira-add-issue/jira-add-issue.rules.yaml
 catalog.services=jira-add-issue
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira:${camel.version}

--- a/services/service-templates/src/main/services/jira-update-issue-tool/index.properties
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=jira-update-issue-tool
 catalog.routes.jira-update-issue=jira-update-issue/jira-update-issue.camel.yaml
 catalog.rules.jira-update-issue=jira-update-issue/jira-update-issue.rules.yaml
 catalog.services=jira-update-issue
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira:${camel.version}

--- a/services/service-templates/src/main/services/jms-tool/index.properties
+++ b/services/service-templates/src/main/services/jms-tool/index.properties
@@ -5,3 +5,4 @@ catalog.properties.jms=jms/service.properties
 catalog.routes.jms=jms/wanaku-jms-tool.camel.yaml
 catalog.rules.jms=jms/wanaku-jms-tool.rules.yaml
 catalog.services=jms
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
+++ b/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
@@ -1,5 +1,5 @@
-org.apache.camel:camel-jms:4.18.2
-io.kaoto.forage:forage-jms:1.3-SNAPSHOT
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-jms-artemis:1.3-SNAPSHOT
-org.apache.activemq:artemis-commons:2.44.0
+org.apache.camel:camel-jms:${camel.version}
+io.kaoto.forage:forage-jms:${forage.version}
+io.kaoto.forage:forage-core-common:${forage.version}
+io.kaoto.forage:forage-jms-artemis:${forage.version}
+org.apache.activemq:artemis-commons:${artemis.version}

--- a/services/service-templates/src/main/services/kafka-tool/index.properties
+++ b/services/service-templates/src/main/services/kafka-tool/index.properties
@@ -5,3 +5,4 @@ catalog.properties.kafka=kafka/service.properties
 catalog.routes.kafka=kafka/kafka.camel.yaml
 catalog.rules.kafka=kafka/kafka.rules.yaml
 catalog.services=kafka
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-kafka:4.18.2
+org.apache.camel:camel-kafka:${camel.version}

--- a/services/service-templates/src/main/services/mail-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/mail-sink-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=mail-sink-tool
 catalog.routes.mail-sink=mail-sink/mail-sink.camel.yaml
 catalog.rules.mail-sink=mail-sink/mail-sink.rules.yaml
 catalog.services=mail-sink
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-mail:4.18.2
+org.apache.camel:camel-mail:${camel.version}

--- a/services/service-templates/src/main/services/rabbitmq-tool/index.properties
+++ b/services/service-templates/src/main/services/rabbitmq-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=rabbitmq-tool
 catalog.routes.rabbitmq=rabbitmq/rabbitmq.camel.yaml
 catalog.rules.rabbitmq=rabbitmq/rabbitmq.rules.yaml
 catalog.services=rabbitmq
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
@@ -1,3 +1,3 @@
-org.apache.camel:camel-spring-rabbitmq:4.18.2
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-spring-rabbitmq:1.3-SNAPSHOT
+org.apache.camel:camel-spring-rabbitmq:${camel.version}
+io.kaoto.forage:forage-core-common:${forage.version}
+io.kaoto.forage:forage-spring-rabbitmq:${forage.version}

--- a/services/service-templates/src/main/services/sftp-resource/index.properties
+++ b/services/service-templates/src/main/services/sftp-resource/index.properties
@@ -5,3 +5,4 @@ catalog.properties.sftp=sftp/service.properties
 catalog.routes.sftp=sftp/sftp.camel.yaml
 catalog.rules.sftp=sftp/sftp.rules.yaml
 catalog.services=sftp
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ftp:4.18.2
+org.apache.camel:camel-ftp:${camel.version}

--- a/services/service-templates/src/main/services/tavily-search-tool/index.properties
+++ b/services/service-templates/src/main/services/tavily-search-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=tavily-search-tool
 catalog.routes.tavily-search=tavily-search/tavily-search.camel.yaml
 catalog.rules.tavily-search=tavily-search/tavily-search.rules.yaml
 catalog.services=tavily-search
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
+++ b/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
@@ -1,7 +1,7 @@
 # Maven dependencies for tavily-search
 # One dependency per line in format: groupId:artifactId:version
-org.apache.camel:camel-langchain4j-web-search:4.18.2
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-core-ai:1.3-SNAPSHOT
-io.kaoto.forage:forage-web-search:1.3-SNAPSHOT
-io.kaoto.forage:forage-web-search-tavily:1.3-SNAPSHOT
+org.apache.camel:camel-langchain4j-web-search:${camel.version}
+io.kaoto.forage:forage-core-common:${forage.version}
+io.kaoto.forage:forage-core-ai:${forage.version}
+io.kaoto.forage:forage-web-search:${forage.version}
+io.kaoto.forage:forage-web-search-tavily:${forage.version}

--- a/services/service-templates/src/main/services/telegram-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/telegram-sink-tool/index.properties
@@ -4,3 +4,4 @@ catalog.name=telegram-sink-tool
 catalog.routes.telegram-sink=telegram-sink/telegram-sink.camel.yaml
 catalog.rules.telegram-sink=telegram-sink/telegram-sink.rules.yaml
 catalog.services=telegram-sink
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-telegram:4.18.2
+org.apache.camel:camel-telegram:${camel.version}

--- a/services/service-templates/src/main/services/versions.properties
+++ b/services/service-templates/src/main/services/versions.properties
@@ -1,0 +1,3 @@
+camel.version=4.18.2
+forage.version=1.3-SNAPSHOT
+artemis.version=2.44.0

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/index.properties
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/index.properties
@@ -5,3 +5,4 @@ catalog.properties.watson-nlu-sink=watson-nlu-sink/service.properties
 catalog.routes.watson-nlu-sink=watson-nlu-sink/watson-nlu-sink.camel.yaml
 catalog.rules.watson-nlu-sink=watson-nlu-sink/watson-nlu-sink.rules.yaml
 catalog.services=watson-nlu-sink
+catalog.versions=versions.properties

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ibm-watson-language:4.18.2
+org.apache.camel:camel-ibm-watson-language:${camel.version}


### PR DESCRIPTION
Closes: #1143

## Summary by Sourcery

Introduce version placeholder resolution for service catalog dependency files via a shared versions properties file and integrate it across CLI commands, backend deployment, and templates.

New Features:
- Add PlaceholderResolver utility for resolving ${placeholder} variables from properties-based bindings.
- Extend ServiceCatalogIndex to support an optional catalog.versions file and resolve placeholders in dependency files within ZIP archives.
- Add --resolve-versions option to service packaging and deployment CLI commands to substitute dependency placeholders before creating ZIPs.
- Initialize new service catalogs with a versions.properties skeleton and wire existing service templates to use a shared versions.properties file for dependency versions.

Enhancements:
- Validate referenced catalog.versions files in ServiceCatalogIndex and expose helper methods to query their presence and path.
- Resolve dependency placeholders in router backend catalog/template deployment flows when a versions file is present.
- Refactor and extend ServiceCatalogIndex tests to cover versions file handling and placeholder resolution behavior.

Tests:
- Add unit tests for PlaceholderResolver covering resolution, placeholder detection, and bindings loading.
- Add ServiceCatalogIndex tests for versions file discovery, validation, and end-to-end placeholder resolution in dependency files.