### PR TITLE
chore: add JUnit HTML test reports to CI workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -97,6 +97,17 @@ jobs:
           -Dquarkus.container-image.tag=${{ github.ref_name }}-${{ steps.arch.outputs.arch }} \
           -Dquarkus.jib.platforms=linux/arm64/v8 \
           -Pdist
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: '**/target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore
 
 
   createManifests:

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -66,6 +66,17 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build with Maven
       run: mvn -B --no-transfer-progress install --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: '**/target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore
     - name: Test Archetypes
       if: runner.os != 'Windows'
       run: bash tests/archetype-tests/test-archetypes.sh

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,6 +20,7 @@
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.5.5</maven-surefire-report-plugin.version>
         <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-plugin-plugin.version>3.8.1</maven-plugin-plugin.version>
@@ -218,6 +219,11 @@
                             <phase>test</phase>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>${maven-surefire-report-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>${quarkus.platform.group-id}</groupId>


### PR DESCRIPTION
## Summary
- Add `maven-surefire-report-plugin` (3.5.5) to `parent/pom.xml` pluginManagement
- Generate HTML test reports (`surefire-report:report-only` + `failsafe-report-only`) in both PR and main-build workflows
- Archive reports as downloadable GitHub Actions artifacts (`test-reports-<os>`, 14-day retention)
- Reports are generated even when tests fail (`if: always()`)

## Test plan
- [ ] Verify PR workflow uploads `test-reports-*` artifacts with HTML files
- [ ] Verify main-build workflow produces the same artifacts
- [ ] Confirm reports are generated on test failure (not just success)