### PR TITLE
Fix #1193: disable service catalog tests on Windows

### DIFF
--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceDeployTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceDeployTest.java
@@ -7,9 +7,12 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
 class ServiceDeployTest {
 
     @TempDir

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
@@ -9,11 +9,14 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
 class ServiceExposeTest {
 
     @TempDir

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
@@ -9,11 +9,14 @@ import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
 class ServiceInitTest {
 
     @TempDir


### PR DESCRIPTION
## Summary
- Disable `ServiceDeployTest`, `ServiceExposeTest`, and `ServiceInitTest` on Windows via `@DisabledOnOs(OS.WINDOWS)`
- Each annotation references #1193 in the `disabledReason`

## Test plan
- [ ] Verify tests are skipped on Windows CI runner
- [ ] Verify tests still run on Linux and macOS

## Summary by Sourcery

Tests:
- Mark ServiceDeployTest, ServiceExposeTest, and ServiceInitTest as disabled on Windows using JUnit OS conditions.