### PR TITLE
Validate port range before gRPC health probe

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -120,6 +120,13 @@ public class PeriodicHealthCheckService {
             return;
         }
 
+        int port = target.getPort();
+        if (port < 1 || port > 65535) {
+            LOG.warnf("Invalid port %d for capability %s (%s), marking as DOWN", port, target.getServiceName(), id);
+            serviceRegistry.updateHealthStatus(id, HealthStatus.DOWN);
+            return;
+        }
+
         if (inProgress.putIfAbsent(id, Boolean.TRUE) != null) {
             LOG.tracef("Health check already in progress for %s, skipping", id);
             return;


### PR DESCRIPTION
## Summary

- Adds port range validation (1-65535) in `PeriodicHealthCheckService.checkInstanceHealth()` before attempting a gRPC health probe
- Prevents an uncaught `IllegalArgumentException: port out of range` on the gRPC executor thread when a capability is registered with an invalid port
- Services with invalid ports are now marked as DOWN immediately instead of triggering an unhandled exception on a background thread

## Test plan

- [x] All 71 router backend tests pass (`mvn verify`)
- [x] No `port out of range` errors in test logs
- [x] Existing tests for invalid port registration (`testRegisterService_WithPortOutOfRange_AcceptsButMayFailLater`, `testRegisterService_WithNegativePort_AcceptsButMayFailLater`, `testRegisterService_WithZeroPort_AcceptsButMayFailLater`) continue to pass

## Summary by Sourcery

Validate service instance ports before running gRPC health checks to avoid background thread failures and mark invalid instances as unhealthy.

Bug Fixes:
- Prevent uncaught port out-of-range exceptions during gRPC health probing for instances registered with invalid ports.

Enhancements:
- Immediately mark services with invalid ports as DOWN during periodic health checks instead of attempting gRPC probes.