### PR TITLE
chore: fix test report artifact naming and aggregate into single report

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -99,13 +99,13 @@ jobs:
           -Pdist
     - name: Generate Test Reports
       if: always()
-      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-reports-${{ matrix.os }}
-        path: '**/target/reports/'
+        path: 'target/reports/'
         retention-days: 14
         if-no-files-found: ignore
 

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -42,7 +42,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         experimental: [false]
         include:
-          - os: [ windows-latest ]
+          - os: windows-latest
             experimental: true
       fail-fast: true
 
@@ -68,13 +68,13 @@ jobs:
       run: mvn -B --no-transfer-progress install --file pom.xml
     - name: Generate Test Reports
       if: always()
-      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-reports-${{ matrix.os }}
-        path: '**/target/reports/'
+        path: 'target/reports/'
         retention-days: 14
         if-no-files-found: ignore
     - name: Test Archetypes


### PR DESCRIPTION
## Summary
- Fix `test-reports-Array` artifact name caused by `os: [ windows-latest ]` array syntax in PR builds matrix
- Aggregate surefire/failsafe reports into a single root-level report instead of per-module reports with redundant site assets (CSS, images, fonts, JS)
- Upload only the root `target/reports/` instead of `**/target/reports/`

## Test plan
- [ ] Verify PR build produces `test-reports-windows-latest` instead of `test-reports-Array`
- [ ] Verify the uploaded artifact contains a single aggregated report
- [ ] Verify report HTML renders correctly with all test results

## Summary by Sourcery

Adjust CI workflows to generate aggregated Maven test reports and correct test report artifact naming.

Build:
- Correct the Windows job matrix configuration in PR builds to fix the computed test report artifact name.
- Enable aggregated Maven Surefire/Failsafe test report generation in PR and main build workflows and upload only the root aggregated report directory.