### PR TITLE
chore: pre-release fixes for 0.1.1

### DIFF
--- a/apps/wanaku-operator/src/main/resources/application.properties
+++ b/apps/wanaku-operator/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.devservices.enabled=false
 # Logging Configuration
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
-quarkus.log.category."ai.wanaku".level=DEBUG
+quarkus.log.category."ai.wanaku".level=INFO
 
 quarkus.operator-sdk.crd.apply=true
 

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -39,8 +39,8 @@ quarkus.mcp.server.public.sse.root-path=/public/mcp
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:8080,http://127.0.0.1:8080,http://localhost:5173,http://localhost:6274
 
-quarkus.mcp.server.traffic-logging.enabled=true
-quarkus.mcp.server.traffic-logging.text-limit=1000000
+%dev.quarkus.mcp.server.traffic-logging.enabled=true
+%dev.quarkus.mcp.server.traffic-logging.text-limit=1000000
 quarkus.mcp.server.server-info.name=Wanaku
 quarkus.mcp.server.client-logging.default-level=debug
 
@@ -65,7 +65,7 @@ quarkus.oidc.client-id=wanaku-mcp-router
 
 # Wanaku uses hybrid, as it is both a web application and a service
 quarkus.oidc.application-type=hybrid
-quarkus.oidc.tls.verification=none
+%dev.quarkus.oidc.tls.verification=none
 # URL path where users can log out from the application (don't change)
 quarkus.oidc.logout.path=/logout
 quarkus.oidc.discovery-enabled=true

--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -76,8 +76,8 @@ This produces `.tar.gz` archives under each module's `target/distributions/` dir
 
 ```bash
 tests/load/run-perf-test.sh \
-  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.0-SNAPSHOT.tar.gz \
-  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.1.0-SNAPSHOT.tar.gz \
+  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.1-SNAPSHOT.tar.gz \
+  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.1.1-SNAPSHOT.tar.gz \
   --suite tools-sse \
   --test-name my-run \
   --test-base-dir /tmp/perf-results

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -5,9 +5,9 @@
 Start by setting the versions. 
 
 ```shell
-export PREVIOUS_VERSION=0.0.9
-export CURRENT_DEVELOPMENT_VERSION=0.1.0
-export NEXT_DEVELOPMENT_VERSION=0.1.1
+export PREVIOUS_VERSION=0.1.0
+export CURRENT_DEVELOPMENT_VERSION=0.1.1
+export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
 Trigger a release build: 
@@ -66,9 +66,9 @@ gpg --list-public-keys --keyid-format LONG
 Repeat this for every machine to be used for the release.
 
 ```shell
-export PREVIOUS_VERSION=0.0.9
-export CURRENT_DEVELOPMENT_VERSION=0.1.0
-export NEXT_DEVELOPMENT_VERSION=0.1.1
+export PREVIOUS_VERSION=0.1.0
+export CURRENT_DEVELOPMENT_VERSION=0.1.1
+export NEXT_DEVELOPMENT_VERSION=0.2.0
 ```
 
 > [!NOTE]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3264,8 +3264,8 @@ open http://localhost:8080
  
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-mcp-servers-archetype \ 
-  -DarchetypeVersion=0.0.8 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
-  -Dname=S3 -Dwanaku-version=0.0.8 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=0.1.1 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
+  -Dname=S3 -Dwanaku-version=0.1.1 -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

- Update stale version references in docs: release-guide (0.0.9→0.1.0), usage (0.0.8→0.1.1), performance-tests (0.1.0-SNAPSHOT→0.1.1-SNAPSHOT)
- Scope `quarkus.oidc.tls.verification=none` to `%dev` profile (was unconditional — disabling TLS verification in production)
- Scope MCP traffic logging to `%dev` profile (was enabled unconditionally with ~1MB text limit)
- Change operator `ai.wanaku` log level from `DEBUG` to `INFO`

## Test plan

- [ ] Verify router starts correctly in dev mode with OIDC and traffic logging
- [ ] Verify router starts correctly in prod mode without traffic logging and with default TLS verification
- [ ] Verify operator starts with INFO-level logging
- [ ] Confirm docs version references match 0.1.1 release

## Summary by Sourcery

Prepare configuration and documentation for the 0.1.1 release, tightening dev vs prod settings for logging and TLS.

Enhancements:
- Restrict MCP traffic logging configuration to the dev profile to avoid excessive logging in production.
- Limit OIDC TLS verification disabling to the dev profile to restore secure defaults in production.
- Align operator logging to use INFO level for the ai.wanaku category.

Documentation:
- Update release guide, usage, and performance testing docs to reference 0.1.1 and the next 0.2.0 development cycle.