### PR TITLE
chore: warm javadoc.io caches after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,9 @@ jobs:
           git tag wanaku-${{ github.event.inputs.currentDevelopmentVersion }} HEAD~2
           git push origin wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
           mvn --no-transfer-progress -Pdist release:perform
+
+      # Warm up javadoc.io caches
+
+      - name: Warm javadoc.io caches
+        continue-on-error: true
+        run: bash docs/javadoc-warm.sh ${{ github.event.inputs.currentDevelopmentVersion }}

--- a/docs/javadoc-warm.sh
+++ b/docs/javadoc-warm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Warms up javadoc.io caches for all publishable modules in this project.
+# Usage: ./docs/javadoc-warm.sh <version>
+
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+find "$PROJECT_ROOT" -name "pom.xml" \
+    -not -path "*/target/*" \
+    -not -path "*/archetype-resources/*" \
+    -not -path "*/tests/*" \
+    | sort | while read -r pom; do
+
+    read -r gid aid pkg < <(python3 - "$pom" <<'PYEOF'
+import xml.etree.ElementTree as ET, sys
+ns = '{http://maven.apache.org/POM/4.0.0}'
+tree = ET.parse(sys.argv[1])
+root = tree.getroot()
+
+aid_el = root.find(ns + 'artifactId')
+aid = aid_el.text if aid_el is not None else ''
+
+pkg_el = root.find(ns + 'packaging')
+pkg = pkg_el.text if pkg_el is not None else 'jar'
+
+gid_el = root.find(ns + 'groupId')
+if gid_el is None:
+    parent = root.find(ns + 'parent')
+    if parent is not None:
+        gid_el = parent.find(ns + 'groupId')
+gid = gid_el.text if gid_el is not None else ''
+
+print(f'{gid} {aid} {pkg}')
+PYEOF
+    )
+
+    if [[ "$pkg" == "pom" || "$pkg" == "maven-archetype" ]]; then
+        continue
+    fi
+
+    url="https://javadoc.io/doc/${gid}/${aid}/${VERSION}"
+    echo "Warming: ${gid}:${aid}:${VERSION} -> ${url}"
+    curl -sf -o /dev/null "$url" || echo "  WARNING: failed for ${aid}"
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Add a `docs/javadoc-warm.sh` script that discovers all publishable (non-pom, non-archetype) modules and hits their javadoc.io URL for the released version to prime the cache
- Add a `continue-on-error` step in the release workflow that runs the script after `release:perform`

## Test plan
- [ ] Verify the script runs locally: `bash docs/javadoc-warm.sh <version>`
- [ ] Confirm the release workflow step is non-blocking (`continue-on-error: true`)

## Summary by Sourcery

Add a post-release step and script to pre-warm javadoc.io caches for all publishable modules for a given release version.

Build:
- Extend the release workflow with a non-blocking step to warm javadoc.io caches using the released version.

Chores:
- Introduce a docs utility script to discover publishable Maven modules and hit their javadoc.io URLs to prime caches.