### PR TITLE
chore: move javadoc warm script to project root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Warm javadoc.io caches
         continue-on-error: true
-        run: bash docs/javadoc-warm.sh ${{ github.event.inputs.currentDevelopmentVersion }}
+        run: bash javadoc-warm.sh ${{ github.event.inputs.currentDevelopmentVersion }}

--- a/javadoc-warm.sh
+++ b/javadoc-warm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Warms up javadoc.io caches for all publishable modules in this project.
-# Usage: ./docs/javadoc-warm.sh <version>
+# Usage: ./javadoc-warm.sh <version>
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Move `docs/javadoc-warm.sh` to the project root for easier discoverability
- Update the release workflow and script usage comment to reflect the new path

## Test plan
- [ ] Verify the release workflow references the correct script path
- [ ] Confirm no other references to `docs/javadoc-warm.sh` remain

## Summary by Sourcery

Move the javadoc warm-up script to the project root and update references to its path.

CI:
- Update the release workflow to invoke the javadoc warm-up script from its new location.

Chores:
- Relocate the javadoc warm-up script from the docs directory to the project root and adjust its usage comment accordingly.