### PR TITLE
Add a sample user to wanaku realm in keycloak config

### DIFF
--- a/deploy/auth/wanaku-config.json
+++ b/deploy/auth/wanaku-config.json
@@ -486,6 +486,34 @@
       ],
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "id": "c8f9e2a1-3b4d-4c5e-8f7a-9d6e5b4c3a2b",
+      "username": "wuser",
+      "firstName": "Wanaku",
+      "lastName": "User",
+      "email": "wuser@localhost.local",
+      "emailVerified": true,
+      "enabled": true,
+      "createdTimestamp": 1748188800000,
+      "totp": false,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "wpasswd",
+          "temporary": false
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-wanaku"
+      ],
+      "clientRoles": {
+        "wanaku-mcp-router": []
+      },
+      "notBefore": 0,
+      "groups": []
     }
   ],
   "scopeMappings": [

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "8543:8080"
     volumes:
+    # there is sample wuser/wpasswd
       - ../auth/wanaku-config.json:/opt/keycloak/data/import/realm-export.json:ro,Z
     healthcheck:
       test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/8080' || exit 1"]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,7 +71,7 @@ wanaku services create tool --name kafka
 Alternatively, if you don't have the CLI installed locally, you can obtain it using Maven:
 
 ```shell
-mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-tool-service-archetype \ 
+mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-tool-service-archetype \
   -DarchetypeVersion=0.0.8 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.tool.kafka -DartifactId=wanaku-tool-service-kafka \
   -Dname=Kafka -Dwanaku-version=0.0.8 -Dwanaku-capability-type=camel
 ```
@@ -184,8 +184,8 @@ For custom containers, please make sure you set the following properties
 You can do that in the `pom.xml` file:
 
 ```xml
-<project> 
-    <!-- lots of stuff --> 
+<project>
+    <!-- lots of stuff -->
     <properties>
         <quarkus.container-image.registry>quay.io</quarkus.container-image.registry>
         <quarkus.container-image.group>my-group</quarkus.container-image.group>
@@ -274,6 +274,8 @@ export WANAKU_KEYCLOAK_HOST=localhost:8543
 cd deploy/auth
 ./configure-auth.sh
 ```
+
+In `wanaku-config.json` there is a sample user wuser/wpasswd.
 
 Then, take note of the newly generated client secret and use that for the capabilities services.
 


### PR DESCRIPTION
## Summary by Sourcery

Document and wire up a sample user in the Wanaku Keycloak realm configuration for local development.

Enhancements:
- Annotate the Keycloak service in docker-compose with a comment about the bundled sample user credentials.

Documentation:
- Add documentation for the sample Keycloak user credentials in the contributing guide.