### PR TITLE
Fix NPE in local runner when optional CLI options are null

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -28,7 +28,9 @@ public class LocalRunner {
         public LocalRunnerEnvironment() {}
 
         public LocalRunnerEnvironment withServiceOption(String key, String value) {
-            servicesOptions.put(key, value);
+            if (value != null) {
+                servicesOptions.put(key, value);
+            }
             return this;
         }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -69,9 +69,12 @@ public class AuthConfigSource implements ConfigSource {
         if (noauthProperties == null) {
             Map<String, String> props = new HashMap<>();
             props.put("quarkus.oidc.enabled", "false");
+            props.put("quarkus.oidc.tenant-enabled", "false");
             props.put("quarkus.oidc.discovery-enabled", "false");
+            props.put("quarkus.oidc.mcp.tenant-enabled", "false");
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
             for (int i = 1; i <= MAX_NAMESPACES; i++) {
+                props.put("quarkus.oidc.ns-%d.tenant-enabled".formatted(i), "false");
                 props.put("quarkus.oidc.ns-%d.discovery-enabled".formatted(i), "false");
             }
             props.put("quarkus.oidc-proxy.enabled", "false");

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -63,9 +63,12 @@ class AuthConfigSourceTest {
         Map<String, String> props = configSource.getProperties();
         assertNotNull(props);
         assertEquals("false", props.get("quarkus.oidc.enabled"));
+        assertEquals("false", props.get("quarkus.oidc.tenant-enabled"));
         assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", props.get("quarkus.oidc.mcp.tenant-enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
         for (int i = 1; i <= 10; i++) {
+            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".tenant-enabled"));
             assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
         }
         assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
@@ -83,9 +86,13 @@ class AuthConfigSourceTest {
     void getValue_returnsNoAuthValue_whenAuthSetToNone() {
         System.setProperty(AUTH_PROPERTY, "none");
         assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.tenant-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.mcp.tenant-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-1.tenant-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-1.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-10.tenant-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-10.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
         assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));


### PR DESCRIPTION
## Summary
- `wanaku start local` crashes when `--capabilities-client-secret` is not provided because `withServiceOption()` stored null values in the environment map, and `ProcessBuilder.environment().putAll()` rejects nulls with a `NullPointerException`
- After fixing the NPE, the router backend still fails to start in noauth mode because `AuthConfigSource` disabled discovery on named OIDC tenants (`mcp`, `ns-*`) without disabling the tenants themselves, causing `Either 'jwks-path' or 'introspection-path' must be set`
- Now `withServiceOption()` skips null values, and `AuthConfigSource` sets `tenant-enabled=false` on all named tenants in noauth mode

## Test plan
- [ ] Run `wanaku start local` without `--capabilities-client-secret` and verify it starts successfully
- [ ] Run `wanaku start local --capabilities-client-secret <secret>` and verify the secret is passed through
- [ ] Verify `AuthConfigSourceTest` passes (71 tests pass)