### PR TITLE
Fix #1214: replace Quinoa with frontend-maven-plugin to fix start local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 out
-apps/wanaku-router-backend/.quinoa/
 apps/wanaku-router-backend/application.dev.properties
 
 ### IntelliJ IDEA ###

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -24,6 +24,13 @@ public class StartLocal extends StartBase {
     @Inject
     WanakuCliConfig config;
 
+    @CommandLine.Option(
+            names = {"--local-dist"},
+            description =
+                    "Path to a locally built ZIP distribution (repeatable, overrides download for matching components)",
+            arity = "1")
+    protected List<File> localDists;
+
     @Override
     protected void startWanaku() {
         List<String> services;
@@ -34,9 +41,12 @@ public class StartLocal extends StartBase {
             services = config.defaultServices();
         }
 
-        LocalRunner.LocalRunnerEnvironment environment = new LocalRunner.LocalRunnerEnvironment()
-                .withAuthMode(config.auth().mode())
-                .withServiceOption("QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET", capabilitiesClientSecret);
+        LocalRunner.LocalRunnerEnvironment environment = new LocalRunner.LocalRunnerEnvironment();
+        if (localDists != null) {
+            for (File dist : localDists) {
+                environment.withLocalDist(dist);
+            }
+        }
 
         LocalRunner localRunner = new LocalRunner(config, environment);
         try {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.runner.local;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,22 +20,30 @@ import ai.wanaku.core.util.VersionHelper;
 
 public class LocalRunner {
     private static final Logger LOG = Logger.getLogger(LocalRunner.class);
+    private static final String QUARKUS_APP = "quarkus-app";
     private final WanakuCliConfig config;
     private int activeServices = 0;
 
     public static class LocalRunnerEnvironment {
         private final Map<String, String> servicesOptions = new HashMap<>();
+        private final List<File> localDists = new ArrayList<>();
 
-        public LocalRunnerEnvironment() {}
+        public LocalRunnerEnvironment() {
+            withAuthMode("none");
+        }
 
-        public LocalRunnerEnvironment withServiceOption(String key, String value) {
-            servicesOptions.put(key, value);
+        private LocalRunnerEnvironment withAuthMode(String authMode) {
+            servicesOptions.put("WANAKU_HTTP_AUTH", authMode);
             return this;
         }
 
-        public LocalRunnerEnvironment withAuthMode(String authMode) {
-            servicesOptions.put("WANAKU_HTTP_AUTH", authMode);
+        public LocalRunnerEnvironment withLocalDist(File localDist) {
+            this.localDists.add(localDist);
             return this;
+        }
+
+        public List<File> localDists() {
+            return localDists;
         }
 
         public Map<String, String> serviceOptions() {
@@ -68,13 +77,44 @@ public class LocalRunner {
         Map<String, String> components = config.components();
         deploy(services, components);
 
+        reaugment(services, components);
+
         run(services, components);
+    }
+
+    private void reaugment(List<String> services, Map<String, String> components) {
+        LOG.info("Re-augmenting components for local (no-auth) mode");
+
+        reaugmentComponent(
+                RuntimeConstants.WANAKU_ROUTER_BACKEND,
+                "-Dquarkus.oidc.enabled=false",
+                "-Dquarkus.oidc-proxy.enabled=false");
+
+        for (Map.Entry<String, String> component : components.entrySet()) {
+            if (isEnabled(services, component)) {
+                reaugmentComponent(component.getKey(), "-Dquarkus.oidc-client.enabled=false");
+            }
+        }
+    }
+
+    private static void reaugmentComponent(String componentName, String... buildTimeProperties) {
+        File componentDir = quarkusAppDir(componentName);
+
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-Dquarkus.launch.rebuild=true");
+        command.addAll(List.of(buildTimeProperties));
+        command.add("-jar");
+        command.add("quarkus-run.jar");
+
+        LOG.infof("Re-augmenting %s", componentName);
+        ProcessRunner.run(componentDir, command.toArray(new String[0]));
     }
 
     private void run(List<String> services, Map<String, String> components) {
         ExecutorService executorService = Executors.newCachedThreadPool();
 
-        CountDownLatch countDownLatch = new CountDownLatch(activeServices);
+        CountDownLatch countDownLatch = new CountDownLatch(activeServices + 1);
         int grpcPort = config.initialGrpcPort();
 
         startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, executorService, countDownLatch, environment);
@@ -106,7 +146,7 @@ public class LocalRunner {
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
-        File componentDir = new File(RuntimeConstants.WANAKU_LOCAL_DIR, component);
+        File componentDir = quarkusAppDir(component);
 
         executorService.submit(() -> {
             try {
@@ -126,7 +166,7 @@ public class LocalRunner {
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
         LOG.infof("Starting Wanaku Service %s on port %d", component.getKey(), grpcPort);
-        File componentDir = new File(RuntimeConstants.WANAKU_LOCAL_DIR, component.getKey());
+        File componentDir = quarkusAppDir(component.getKey());
 
         String grpcPortOpt = String.format("-Dquarkus.grpc.server.port=%d", grpcPort);
 
@@ -154,15 +194,42 @@ public class LocalRunner {
     }
 
     private void downloadService(String componentName, String urlFormat) throws IOException {
-        String downloadUrl = getDownloadURL(urlFormat);
+        String baseName = extractArtifactBaseName(urlFormat);
+        File localMatch = findLocalDist(baseName);
 
-        File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
+        File zipFile;
+        if (localMatch != null) {
+            LOG.infof("Using local distribution %s for %s", localMatch, componentName);
+            zipFile = localMatch;
+        } else {
+            String downloadUrl = getDownloadURL(urlFormat);
+            File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
 
-        LOG.infof("Downloading %s at %s", componentName, downloadUrl);
-        File downloadedFile = Downloader.downloadFile(downloadUrl, destinationDir);
+            LOG.infof("Downloading %s at %s", componentName, downloadUrl);
+            zipFile = Downloader.downloadFile(downloadUrl, destinationDir);
+        }
 
-        LOG.infof("Unpacking %s at %s", componentName, destinationDir);
-        ZipHelper.unzip(downloadedFile, RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
+        String extractDir = componentName + File.separator + QUARKUS_APP;
+        LOG.infof("Unpacking %s", componentName);
+        ZipHelper.unzip(zipFile, RuntimeConstants.WANAKU_LOCAL_DIR, extractDir);
+    }
+
+    static String extractArtifactBaseName(String urlFormat) {
+        String filename = urlFormat.substring(urlFormat.lastIndexOf('/') + 1);
+        int placeholder = filename.indexOf("-%s");
+        if (placeholder > 0) {
+            return filename.substring(0, placeholder);
+        }
+        return filename.replace(".zip", "");
+    }
+
+    private File findLocalDist(String baseName) {
+        for (File file : environment.localDists()) {
+            if (file.getName().startsWith(baseName)) {
+                return file;
+            }
+        }
+        return null;
     }
 
     private String getDownloadURL(String urlFormat) {
@@ -174,6 +241,10 @@ public class LocalRunner {
         }
 
         return String.format(urlFormat, tag, VersionHelper.VERSION);
+    }
+
+    private static File quarkusAppDir(String componentName) {
+        return new File(new File(RuntimeConstants.WANAKU_LOCAL_DIR, componentName), QUARKUS_APP);
     }
 
     private static boolean isEnabled(List<String> services, Map.Entry<String, String> component) {

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -112,12 +112,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.quarkiverse.quinoa</groupId>
-            <artifactId>quarkus-quinoa</artifactId>
-            <version>${quarkus-quinoa.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
@@ -219,8 +213,68 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.15.1</version>
+                <configuration>
+                    <workingDirectory>${project.basedir}/../ui/admin</workingDirectory>
+                    <installDirectory>${project.build.directory}/frontend</installDirectory>
+                    <skip>${skipUI}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-node-and-yarn</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v22.18.0</nodeVersion>
+                            <yarnVersion>v1.22.22</yarnVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn-install</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn-build</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>copy-ui-dist</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipUI}</skip>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/resources/admin</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../ui/admin/dist</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-service-templates</id>
                         <phase>generate-resources</phase>

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.native.resources.includes=service-templates/**
+quarkus.package.jar.type=mutable-jar
 quarkus.banner.enabled=false
 quarkus.devservices.enabled=false
 quarkus.console.enabled=false
@@ -194,7 +195,7 @@ quarkus.http.auth.permission.public.paths=/api/v1/*, /api/v2/*, /index.html, /*
 quarkus.http.auth.permission.public.policy=permit
 
 ## Admin UI, which requires authentication for all paths in the web interface
-quarkus.http.auth.permission.web.paths=/admin/*, /admin, /node_modules/*
+quarkus.http.auth.permission.web.paths=/admin/*, /admin
 quarkus.http.auth.permission.web.policy=authenticated
 
 # Logging configuration
@@ -202,7 +203,6 @@ quarkus.http.auth.permission.web.policy=authenticated
 quarkus.http.access-log.enabled=true
 quarkus.log.level=INFO
 quarkus.log.category."ai.wanaku".level=INFO
-quarkus.log.category."io.quarkiverse.quinoa".level=WARN
 quarkus.log.category."io.quarkus.oidc.proxy".level=INFO
 quarkus.log.category."io.quarkiverse.mcp".level=INFO
 
@@ -246,23 +246,3 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
 quarkus.smallrye-openapi.auto-add-security=false
 mp.openapi.scan.exclude.packages=ai.wanaku.backend.api.v1.oidc
-
-# Quinoa configuration
-quarkus.quinoa=true
-quarkus.quinoa.ui-dir=../ui/admin
-quarkus.quinoa.build-dir=dist
-quarkus.quinoa.ui-root-path=/admin
-quarkus.quinoa.enable-spa-routing=true
-quarkus.quinoa.ci=true
-quarkus.quinoa.package-manager=yarn
-quarkus.quinoa.package-manager-install=true
-quarkus.quinoa.package-manager-install.yarn-version=1.22.22
-quarkus.quinoa.package-manager-install.node-version=22.18.0
-quarkus.quinoa.package-manager-install.pnpm-version=10.14.0
-quarkus.quinoa.force-install=true
-quarkus.quinoa.package-manager-command.ci=install
-quarkus.quinoa.package-manager-command.build=run build
-quarkus.quinoa.package-manager-command.build-env.VITE_API_URL=""
-quarkus.quinoa.package-manager-command.dev-env.VITE_API_URL=""
-quarkus.quinoa.package-manager-command.dev=run dev
-quarkus.quinoa.package-manager-command.test=run test

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -63,12 +63,12 @@ class AuthConfigSourceTest {
         Map<String, String> props = configSource.getProperties();
         assertNotNull(props);
         assertEquals("false", props.get("quarkus.oidc.enabled"));
+        assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
         assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
         for (int i = 1; i <= 10; i++) {
             assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
         }
-        assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.mcp-authenticated.policy"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.web.policy"));
@@ -76,18 +76,18 @@ class AuthConfigSourceTest {
 
     @Test
     void getValue_returnsNull_whenAuthNotConfigured() {
-        assertNull(configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertNull(configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 
     @Test
     void getValue_returnsNoAuthValue_whenAuthSetToNone() {
         System.setProperty(AUTH_PROPERTY, "none");
         assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-1.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-10.discovery-enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
         assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 
@@ -111,11 +111,11 @@ class AuthConfigSourceTest {
     @Test
     void isNoAuth_isCaseInsensitive() {
         System.setProperty(AUTH_PROPERTY, "NONE");
-        assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
 
         clearAuthProperties();
         System.setProperty(AUTH_PROPERTY, "None");
-        assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
     }
 
     @Test

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
@@ -7,6 +7,9 @@ public class NoOidcTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("wanaku.http.auth", "none");
+        return Map.of(
+                "wanaku.http.auth", "none",
+                "quarkus.oidc.enabled", "false",
+                "quarkus.oidc-proxy.enabled", "false");
     }
 }

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.qute.strict-rendering=false
+quarkus.package.jar.type=mutable-jar
 
 wanaku.http.auth=keycloak
 

--- a/docs/testing-wanaku-start-local.md
+++ b/docs/testing-wanaku-start-local.md
@@ -1,0 +1,15 @@
+# Testing Wanaku Start Local
+
+Build for distribution:
+
+```shell
+mvn -DskipTests -Pdist clean package
+```
+
+Run the CLI with local distributions:
+
+```shell
+java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.1-SNAPSHOT.zip --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-0.1.1-SNAPSHOT.zip
+```
+
+Then, access <http://localhost:8080/admin>. Wanaku should be available at that address. No authentication should be required.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,7 +54,6 @@
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.13.0</langchain4j.version>
         <langchain4j-mcp.version>1.13.0-beta23</langchain4j-mcp.version>
-        <quarkus-quinoa.version>2.8.1</quarkus-quinoa.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <docker-java.version>3.7.1</docker-java.version>
         <commons-pool2.version>2.13.1</commons-pool2.version>


### PR DESCRIPTION
## Summary

- Replace Quinoa with `frontend-maven-plugin` + `maven-resources-plugin` so admin UI files land in `app/*.jar` instead of `generated-bytecode.jar`, surviving OIDC re-augmentation
- Add `--local-dist` option to `wanaku start local` for testing with locally built distributions
- Simplify `LocalRunner` re-augmentation (no JAR backup/restore needed)
- `AuthConfigSource` now disables OIDC and OidcProxy at build time when `wanaku.http.auth=none`, fixing IDE dev mode
- Add `mutable-jar` packaging and `-DskipUI` support for fast backend-only iteration
- Also addresses #836 (slow builds due to Quinoa)

## Test plan

- [ ] `mvn verify` passes (all 71 router backend tests green)
- [ ] `mvn verify -DskipUI` skips frontend build
- [ ] `mvn -DskipTests -Pdist clean package` then `wanaku start local --local-dist <router.zip> --local-dist <http-tool.zip>` starts successfully with admin UI at `/admin/`
- [ ] Run backend from IDE with `-Dwanaku.http.auth=none` — no OIDC errors, admin UI accessible

## Summary by Sourcery

Replace the Quinoa-based admin UI integration with a frontend-maven-plugin build that packages the UI into mutable JARs and adjust local startup to support re-augmentation and local distribution zips while improving no-auth/OIDC behavior.

New Features:
- Add a --local-dist option to `wanaku start local` to run against locally built ZIP distributions.
- Introduce support for running the admin UI from resources packaged into the application JAR via frontend-maven-plugin and maven-resources-plugin.

Bug Fixes:
- Ensure OIDC and OIDC proxy are disabled at build time when `wanaku.http.auth=none`, fixing IDE and dev-mode no-auth runs.
- Fix local start so the admin UI survives Quarkus re-augmentation and remains available at /admin.

Enhancements:
- Simplify LocalRunner re-augmentation by rebuilding components in-place without JAR backup/restore.
- Standardize local component layout on the `quarkus-app` directory and adjust local runner to execute from there.
- Set Quarkus packaging to mutable-jar for faster backend iteration and local re-augmentation workflows.
- Refine HTTP auth path configuration to avoid granting auth rules to /node_modules and clean up outdated logging settings.

Documentation:
- Add documentation for testing `wanaku start local` with locally built distributions.

Tests:
- Update and extend AuthConfigSource-related tests and test profiles to cover new OIDC disablement behavior in no-auth mode.

Chores:
- Remove Quarkus Quinoa dependency and related configuration from the router backend and parent POM.