### PR TITLE
Fix #1217: add Camel Integration Capability support to start local

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -31,6 +31,18 @@ public class StartLocal extends StartBase {
             arity = "1")
     protected List<File> localDists;
 
+    @CommandLine.Option(
+            names = {"--camel-routes"},
+            description =
+                    "Path to Apache Camel routes YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/routes.camel.yaml)")
+    protected String camelRoutes;
+
+    @CommandLine.Option(
+            names = {"--camel-rules"},
+            description =
+                    "Path to route exposure rules YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/rules.yaml)")
+    protected String camelRules;
+
     @Override
     protected void startWanaku() {
         List<String> services;
@@ -46,6 +58,14 @@ public class StartLocal extends StartBase {
             for (File dist : localDists) {
                 environment.withLocalDist(dist);
             }
+        }
+
+        if (camelRoutes != null) {
+            environment.withCamelRoutes(camelRoutes);
+        }
+
+        if (camelRules != null) {
+            environment.withCamelRules(camelRules);
         }
 
         LocalRunner localRunner = new LocalRunner(config, environment);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -78,14 +79,15 @@ public class StartLocal extends StartBase {
             defaultValue = "true")
     protected boolean failFast;
 
+    private static final String CAMEL_INTEGRATION = "camel-integration";
+
     @Override
     protected void startWanaku() {
         List<String> services;
         if (exclusive != null && exclusive.services != null) {
-            services = exclusive.services;
-
+            services = new ArrayList<>(exclusive.services);
         } else {
-            services = config.defaultServices();
+            services = new ArrayList<>(config.defaultServices());
         }
 
         LocalRunner.LocalRunnerEnvironment environment = new LocalRunner.LocalRunnerEnvironment();
@@ -96,6 +98,9 @@ public class StartLocal extends StartBase {
         }
 
         if (cicSourceConfig != null) {
+            if (!services.contains(CAMEL_INTEGRATION)) {
+                services.add(CAMEL_INTEGRATION);
+            }
             if (cicSourceConfig.camelRoutesConfig != null) {
                 environment.withCamelRoutes(cicSourceConfig.camelRoutesConfig.camelRoutes);
                 environment.withCamelRules(cicSourceConfig.camelRoutesConfig.camelRules);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -31,33 +31,46 @@ public class StartLocal extends StartBase {
             arity = "1")
     protected List<File> localDists;
 
-    @CommandLine.Option(
-            names = {"--camel-routes"},
-            description =
-                    "Path to Apache Camel routes YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/routes.camel.yaml)")
-    protected String camelRoutes;
+    static class CamelRoutesConfig {
+        @CommandLine.Option(
+                names = {"--camel-routes"},
+                required = true,
+                description =
+                        "Path to Apache Camel routes YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/routes.camel.yaml)")
+        String camelRoutes;
 
-    @CommandLine.Option(
-            names = {"--camel-rules"},
-            description =
-                    "Path to route exposure rules YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/rules.yaml)")
-    protected String camelRules;
+        @CommandLine.Option(
+                names = {"--camel-rules"},
+                required = true,
+                description =
+                        "Path to route exposure rules YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/rules.yaml)")
+        String camelRules;
+    }
 
-    @CommandLine.Option(
-            names = {"--service-catalog"},
-            description =
-                    "Name of the service catalog to use for the Camel Integration Capability. Mutually exclusive with --camel-routes and --camel-rules.")
-    protected String serviceCatalog;
+    @CommandLine.ArgGroup(exclusive = false)
+    protected CamelRoutesConfig camelRoutesConfig;
 
-    @CommandLine.Option(
-            names = {"--service-catalog-system"},
-            description = "The system name within the service catalog to use (e.g., ftp)")
-    protected String serviceCatalogSystem;
+    static class ServiceCatalogConfig {
+        @CommandLine.Option(
+                names = {"--service-catalog"},
+                required = true,
+                description = "Name of the service catalog to use for the Camel Integration Capability")
+        String serviceCatalog;
+
+        @CommandLine.Option(
+                names = {"--service-catalog-system"},
+                required = true,
+                description = "The system name within the service catalog to use (e.g., ftp)")
+        String serviceCatalogSystem;
+    }
+
+    @CommandLine.ArgGroup(exclusive = false)
+    protected ServiceCatalogConfig serviceCatalogConfig;
 
     @CommandLine.Option(
             names = {"--fail-fast"},
             description = "Fail fast if route loading fails in the Camel Integration Capability",
-            defaultValue = "false")
+            defaultValue = "true")
     protected boolean failFast;
 
     @Override
@@ -77,20 +90,14 @@ public class StartLocal extends StartBase {
             }
         }
 
-        if (camelRoutes != null) {
-            environment.withCamelRoutes(camelRoutes);
+        if (camelRoutesConfig != null) {
+            environment.withCamelRoutes(camelRoutesConfig.camelRoutes);
+            environment.withCamelRules(camelRoutesConfig.camelRules);
         }
 
-        if (camelRules != null) {
-            environment.withCamelRules(camelRules);
-        }
-
-        if (serviceCatalog != null) {
-            environment.withServiceCatalog(serviceCatalog);
-        }
-
-        if (serviceCatalogSystem != null) {
-            environment.withServiceCatalogSystem(serviceCatalogSystem);
+        if (serviceCatalogConfig != null) {
+            environment.withServiceCatalog(serviceCatalogConfig.serviceCatalog);
+            environment.withServiceCatalogSystem(serviceCatalogConfig.serviceCatalogSystem);
         }
 
         environment.withFailFast(failFast);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -43,6 +43,23 @@ public class StartLocal extends StartBase {
                     "Path to route exposure rules YAML file for the Camel Integration Capability. Supports file:// scheme (e.g., file:///path/to/rules.yaml)")
     protected String camelRules;
 
+    @CommandLine.Option(
+            names = {"--service-catalog"},
+            description =
+                    "Name of the service catalog to use for the Camel Integration Capability. Mutually exclusive with --camel-routes and --camel-rules.")
+    protected String serviceCatalog;
+
+    @CommandLine.Option(
+            names = {"--service-catalog-system"},
+            description = "The system name within the service catalog to use (e.g., ftp)")
+    protected String serviceCatalogSystem;
+
+    @CommandLine.Option(
+            names = {"--fail-fast"},
+            description = "Fail fast if route loading fails in the Camel Integration Capability",
+            defaultValue = "false")
+    protected boolean failFast;
+
     @Override
     protected void startWanaku() {
         List<String> services;
@@ -67,6 +84,16 @@ public class StartLocal extends StartBase {
         if (camelRules != null) {
             environment.withCamelRules(camelRules);
         }
+
+        if (serviceCatalog != null) {
+            environment.withServiceCatalog(serviceCatalog);
+        }
+
+        if (serviceCatalogSystem != null) {
+            environment.withServiceCatalogSystem(serviceCatalogSystem);
+        }
+
+        environment.withFailFast(failFast);
 
         LocalRunner localRunner = new LocalRunner(config, environment);
         try {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -47,9 +47,6 @@ public class StartLocal extends StartBase {
         String camelRules;
     }
 
-    @CommandLine.ArgGroup(exclusive = false)
-    protected CamelRoutesConfig camelRoutesConfig;
-
     static class ServiceCatalogConfig {
         @CommandLine.Option(
                 names = {"--service-catalog"},
@@ -64,8 +61,16 @@ public class StartLocal extends StartBase {
         String serviceCatalogSystem;
     }
 
-    @CommandLine.ArgGroup(exclusive = false)
-    protected ServiceCatalogConfig serviceCatalogConfig;
+    static class CicSourceConfig {
+        @CommandLine.ArgGroup(exclusive = false)
+        CamelRoutesConfig camelRoutesConfig;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        ServiceCatalogConfig serviceCatalogConfig;
+    }
+
+    @CommandLine.ArgGroup(exclusive = true)
+    protected CicSourceConfig cicSourceConfig;
 
     @CommandLine.Option(
             names = {"--fail-fast"},
@@ -90,14 +95,16 @@ public class StartLocal extends StartBase {
             }
         }
 
-        if (camelRoutesConfig != null) {
-            environment.withCamelRoutes(camelRoutesConfig.camelRoutes);
-            environment.withCamelRules(camelRoutesConfig.camelRules);
-        }
+        if (cicSourceConfig != null) {
+            if (cicSourceConfig.camelRoutesConfig != null) {
+                environment.withCamelRoutes(cicSourceConfig.camelRoutesConfig.camelRoutes);
+                environment.withCamelRules(cicSourceConfig.camelRoutesConfig.camelRules);
+            }
 
-        if (serviceCatalogConfig != null) {
-            environment.withServiceCatalog(serviceCatalogConfig.serviceCatalog);
-            environment.withServiceCatalogSystem(serviceCatalogConfig.serviceCatalogSystem);
+            if (cicSourceConfig.serviceCatalogConfig != null) {
+                environment.withServiceCatalog(cicSourceConfig.serviceCatalogConfig.serviceCatalog);
+                environment.withServiceCatalogSystem(cicSourceConfig.serviceCatalogConfig.serviceCatalogSystem);
+            }
         }
 
         environment.withFailFast(failFast);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -69,6 +69,4 @@ public interface WanakuCliConfig extends WanakuConfig {
 
     @WithDefault("local")
     String localProfile();
-
-    Map<String, String> componentVersions();
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -69,4 +69,6 @@ public interface WanakuCliConfig extends WanakuConfig {
 
     @WithDefault("local")
     String localProfile();
+
+    Map<String, String> componentVersions();
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -6,6 +6,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +28,7 @@ import ai.wanaku.core.util.VersionHelper;
 public class LocalRunner {
     private static final Logger LOG = Logger.getLogger(LocalRunner.class);
     private static final String QUARKUS_APP = "quarkus-app";
+    private static final String STANDALONE_JAR = "app.jar";
     private static final URI DEFAULT_ROUTER_READINESS_URI = URI.create("http://localhost:8080/q/health/ready");
     private static final Duration ROUTER_READINESS_POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration ROUTER_READINESS_REQUEST_TIMEOUT = Duration.ofSeconds(2);
@@ -36,6 +40,8 @@ public class LocalRunner {
     public static class LocalRunnerEnvironment {
         private final Map<String, String> servicesOptions = new HashMap<>();
         private final List<File> localDists = new ArrayList<>();
+        private String camelRoutes;
+        private String camelRules;
 
         public LocalRunnerEnvironment() {
             withAuthMode("none");
@@ -49,6 +55,24 @@ public class LocalRunner {
         public LocalRunnerEnvironment withLocalDist(File localDist) {
             this.localDists.add(localDist);
             return this;
+        }
+
+        public LocalRunnerEnvironment withCamelRoutes(String camelRoutes) {
+            this.camelRoutes = camelRoutes;
+            return this;
+        }
+
+        public LocalRunnerEnvironment withCamelRules(String camelRules) {
+            this.camelRules = camelRules;
+            return this;
+        }
+
+        public String camelRoutes() {
+            return camelRoutes;
+        }
+
+        public String camelRules() {
+            return camelRules;
         }
 
         public List<File> localDists() {
@@ -108,6 +132,10 @@ public class LocalRunner {
 
         for (Map.Entry<String, String> component : components.entrySet()) {
             if (isEnabled(services, component)) {
+                if (!isQuarkusComponent(component.getKey())) {
+                    LOG.infof("Skipping re-augmentation for non-Quarkus component %s", component.getKey());
+                    continue;
+                }
                 reaugmentComponent(component.getKey(), "-Dquarkus.oidc-client.enabled=false");
             }
         }
@@ -222,7 +250,7 @@ public class LocalRunner {
         });
     }
 
-    private static void startService(
+    private void startService(
             Map.Entry<String, String> component,
             int grpcPort,
             String profileOpt,
@@ -230,8 +258,22 @@ public class LocalRunner {
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
         LOG.infof("Starting Wanaku Service %s on port %d", component.getKey(), grpcPort);
-        File componentDir = quarkusAppDir(component.getKey());
 
+        if (isQuarkusComponent(component.getKey())) {
+            startQuarkusService(component.getKey(), grpcPort, profileOpt, executorService, countDownLatch, environment);
+        } else {
+            startStandaloneService(component.getKey(), grpcPort, executorService, countDownLatch, environment);
+        }
+    }
+
+    private static void startQuarkusService(
+            String componentName,
+            int grpcPort,
+            String profileOpt,
+            ExecutorService executorService,
+            CountDownLatch countDownLatch,
+            LocalRunnerEnvironment environment) {
+        File componentDir = quarkusAppDir(componentName);
         String grpcPortOpt = String.format("-Dquarkus.grpc.server.port=%d", grpcPort);
 
         executorService.submit(() -> {
@@ -245,7 +287,49 @@ public class LocalRunner {
                         "-jar",
                         "quarkus-run.jar");
             } catch (Exception e) {
-                LOG.errorf("Failed to start Wanaku Service %s", component.getKey(), e);
+                LOG.errorf("Failed to start Wanaku Service %s", componentName, e);
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
+    }
+
+    private static void startStandaloneService(
+            String componentName,
+            int grpcPort,
+            ExecutorService executorService,
+            CountDownLatch countDownLatch,
+            LocalRunnerEnvironment environment) {
+        File componentDir = new File(RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
+
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-jar");
+        command.add(STANDALONE_JAR);
+        command.add("--registration-url");
+        command.add("http://localhost:8080");
+        command.add("--registration-announce-address");
+        command.add("localhost");
+        command.add("--grpc-port");
+        command.add(String.valueOf(grpcPort));
+        command.add("--name");
+        command.add(componentName);
+
+        if (environment.camelRoutes() != null) {
+            command.add("--routes-ref");
+            command.add(environment.camelRoutes());
+        }
+
+        if (environment.camelRules() != null) {
+            command.add("--rules-ref");
+            command.add(environment.camelRules());
+        }
+
+        executorService.submit(() -> {
+            try {
+                ProcessRunner.run(componentDir, environment.serviceOptions(), command.toArray(new String[0]));
+            } catch (Exception e) {
+                LOG.errorf("Failed to start Wanaku Service %s", componentName, e);
             } finally {
                 countDownLatch.countDown();
             }
@@ -267,22 +351,30 @@ public class LocalRunner {
         String baseName = extractArtifactBaseName(urlFormat);
         File localMatch = findLocalDist(baseName);
 
-        File zipFile;
+        File downloadedFile;
         if (localMatch != null) {
             LOG.debugf("Using local distribution %s for %s", localMatch, componentName);
-            zipFile = localMatch;
+            downloadedFile = localMatch;
         } else {
-            String downloadUrl = getDownloadURL(urlFormat);
+            String downloadUrl = getDownloadURL(componentName, urlFormat);
             File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
 
             LOG.infof("Downloading %s", componentName);
             LOG.debugf("Download URL: %s", downloadUrl);
-            zipFile = Downloader.downloadFile(downloadUrl, destinationDir);
+            downloadedFile = Downloader.downloadFile(downloadUrl, destinationDir);
         }
 
-        String extractDir = componentName + File.separator + QUARKUS_APP;
-        LOG.infof("Deploying %s", componentName);
-        ZipHelper.unzip(zipFile, RuntimeConstants.WANAKU_LOCAL_DIR, extractDir);
+        if (isJarArtifact(urlFormat)) {
+            Path componentDir = Path.of(RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
+            Files.createDirectories(componentDir);
+            Files.copy(
+                    downloadedFile.toPath(), componentDir.resolve(STANDALONE_JAR), StandardCopyOption.REPLACE_EXISTING);
+            LOG.infof("Installed %s as standalone JAR", componentName);
+        } else {
+            String extractDir = componentName + File.separator + QUARKUS_APP;
+            LOG.infof("Deploying %s", componentName);
+            ZipHelper.unzip(downloadedFile, RuntimeConstants.WANAKU_LOCAL_DIR, extractDir);
+        }
     }
 
     static String extractArtifactBaseName(String urlFormat) {
@@ -303,15 +395,25 @@ public class LocalRunner {
         return null;
     }
 
-    private String getDownloadURL(String urlFormat) {
+    private String getDownloadURL(String componentName, String urlFormat) {
+        String version = config.componentVersions().getOrDefault(componentName, VersionHelper.VERSION);
         String tag;
-        if (VersionHelper.VERSION.contains("SNAPSHOT")) {
+        if (version.contains("SNAPSHOT")) {
             tag = config.earlyAccessTag();
         } else {
-            tag = String.format("v%s", VersionHelper.VERSION);
+            tag = String.format("v%s", version);
         }
 
-        return String.format(urlFormat, tag, VersionHelper.VERSION);
+        return String.format(urlFormat, tag, version);
+    }
+
+    private static boolean isJarArtifact(String urlFormat) {
+        return urlFormat.endsWith(".jar");
+    }
+
+    private static boolean isQuarkusComponent(String componentName) {
+        File quarkusRunJar = new File(quarkusAppDir(componentName), "quarkus-run.jar");
+        return quarkusRunJar.exists();
     }
 
     private static File quarkusAppDir(String componentName) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -399,7 +399,7 @@ public class LocalRunner {
             LOG.debugf("Using local distribution %s for %s", localMatch, componentName);
             downloadedFile = localMatch;
         } else {
-            String downloadUrl = getDownloadURL(componentName, urlFormat);
+            String downloadUrl = getDownloadURL(urlFormat);
             File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
 
             LOG.infof("Downloading %s", componentName);
@@ -438,16 +438,15 @@ public class LocalRunner {
         return null;
     }
 
-    private String getDownloadURL(String componentName, String urlFormat) {
-        String version = config.componentVersions().getOrDefault(componentName, VersionHelper.VERSION);
+    private String getDownloadURL(String urlFormat) {
         String tag;
-        if (version.contains("SNAPSHOT")) {
+        if (VersionHelper.VERSION.contains("SNAPSHOT")) {
             tag = config.earlyAccessTag();
         } else {
-            tag = String.format("v%s", version);
+            tag = String.format("v%s", VersionHelper.VERSION);
         }
 
-        return String.format(urlFormat, tag, version);
+        return String.format(urlFormat, tag, VersionHelper.VERSION);
     }
 
     private static boolean isJarArtifact(String urlFormat) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -42,6 +42,9 @@ public class LocalRunner {
         private final List<File> localDists = new ArrayList<>();
         private String camelRoutes;
         private String camelRules;
+        private String serviceCatalog;
+        private String serviceCatalogSystem;
+        private boolean failFast;
 
         public LocalRunnerEnvironment() {
             withAuthMode("none");
@@ -73,6 +76,33 @@ public class LocalRunner {
 
         public String camelRules() {
             return camelRules;
+        }
+
+        public LocalRunnerEnvironment withServiceCatalog(String serviceCatalog) {
+            this.serviceCatalog = serviceCatalog;
+            return this;
+        }
+
+        public LocalRunnerEnvironment withServiceCatalogSystem(String serviceCatalogSystem) {
+            this.serviceCatalogSystem = serviceCatalogSystem;
+            return this;
+        }
+
+        public LocalRunnerEnvironment withFailFast(boolean failFast) {
+            this.failFast = failFast;
+            return this;
+        }
+
+        public String serviceCatalog() {
+            return serviceCatalog;
+        }
+
+        public String serviceCatalogSystem() {
+            return serviceCatalogSystem;
+        }
+
+        public boolean failFast() {
+            return failFast;
         }
 
         public List<File> localDists() {
@@ -315,14 +345,27 @@ public class LocalRunner {
         command.add("--name");
         command.add(componentName);
 
-        if (environment.camelRoutes() != null) {
-            command.add("--routes-ref");
-            command.add(environment.camelRoutes());
+        if (environment.serviceCatalog() != null) {
+            command.add("--service-catalog");
+            command.add(environment.serviceCatalog());
+            if (environment.serviceCatalogSystem() != null) {
+                command.add("--service-catalog-system");
+                command.add(environment.serviceCatalogSystem());
+            }
+        } else {
+            if (environment.camelRoutes() != null) {
+                command.add("--routes-ref");
+                command.add(environment.camelRoutes());
+            }
+
+            if (environment.camelRules() != null) {
+                command.add("--rules-ref");
+                command.add(environment.camelRules());
+            }
         }
 
-        if (environment.camelRules() != null) {
-            command.add("--rules-ref");
-            command.add(environment.camelRules());
+        if (environment.failFast()) {
+            command.add("--fail-fast");
         }
 
         executorService.submit(() -> {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -407,7 +407,7 @@ public class LocalRunner {
             downloadedFile = Downloader.downloadFile(downloadUrl, destinationDir);
         }
 
-        if (isJarArtifact(urlFormat)) {
+        if (isJarArtifact(downloadedFile.getName())) {
             Path componentDir = Path.of(RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
             Files.createDirectories(componentDir);
             Files.copy(
@@ -449,8 +449,8 @@ public class LocalRunner {
         return String.format(urlFormat, tag, VersionHelper.VERSION);
     }
 
-    private static boolean isJarArtifact(String urlFormat) {
-        return urlFormat.endsWith(".jar");
+    private static boolean isJarArtifact(String fileName) {
+        return fileName.endsWith(".jar");
     }
 
     private static boolean isQuarkusComponent(String componentName) {

--- a/apps/wanaku-cli/src/main/resources/application.properties
+++ b/apps/wanaku-cli/src/main/resources/application.properties
@@ -9,7 +9,7 @@ wanaku.cli.components.service-exec=https://github.com/wanaku-ai/wanaku/releases/
 wanaku.cli.components.service-http=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-http-%s.zip
 wanaku.cli.components.service-tavily=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-tavily-%s.zip
 wanaku.cli.components.camel-integration=https://github.com/wanaku-ai/camel-integration-capability/releases/download/%s/camel-integration-capability-main-%s-jar-with-dependencies.jar
-wanaku.cli.component-versions.camel-integration=0.1.1
+wanaku.cli.component-versions.camel-integration=0.2.0-SNAPSHOT
 wanaku.cli.default-services=provider-file,service-http
 
 # Authentication Configuration

--- a/apps/wanaku-cli/src/main/resources/application.properties
+++ b/apps/wanaku-cli/src/main/resources/application.properties
@@ -9,7 +9,6 @@ wanaku.cli.components.service-exec=https://github.com/wanaku-ai/wanaku/releases/
 wanaku.cli.components.service-http=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-http-%s.zip
 wanaku.cli.components.service-tavily=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-tavily-%s.zip
 wanaku.cli.components.camel-integration=https://github.com/wanaku-ai/camel-integration-capability/releases/download/%s/camel-integration-capability-main-%s-jar-with-dependencies.jar
-wanaku.cli.component-versions.camel-integration=0.2.0-SNAPSHOT
 wanaku.cli.default-services=provider-file,service-http
 
 # Authentication Configuration

--- a/apps/wanaku-cli/src/main/resources/application.properties
+++ b/apps/wanaku-cli/src/main/resources/application.properties
@@ -8,6 +8,8 @@ wanaku.cli.components.wanaku-router-backend=https://github.com/wanaku-ai/wanaku/
 wanaku.cli.components.service-exec=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-exec-%s.zip
 wanaku.cli.components.service-http=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-http-%s.zip
 wanaku.cli.components.service-tavily=https://github.com/wanaku-ai/wanaku/releases/download/%s/wanaku-tool-service-tavily-%s.zip
+wanaku.cli.components.camel-integration=https://github.com/wanaku-ai/camel-integration-capability/releases/download/%s/camel-integration-capability-main-%s-jar-with-dependencies.jar
+wanaku.cli.component-versions.camel-integration=0.1.1
 wanaku.cli.default-services=provider-file,service-http
 
 # Authentication Configuration

--- a/docs/testing-wanaku-start-local.md
+++ b/docs/testing-wanaku-start-local.md
@@ -14,3 +14,33 @@ java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local
 ```
 
 Then, access <http://localhost:8080/admin>. Wanaku should be available at that address. No authentication should be required.
+
+## Testing with the Camel Integration Capability
+
+Build the [Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability) JAR, then
+use `--local-dist` to supply it alongside the wanaku distributions.
+
+**With route files:**
+
+```shell
+version=$(cat core/core-util/target/classes/version.txt)
+java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
+  --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip \
+  --local-dist apps/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${version}.zip \
+  --local-dist /path/to/camel-integration-capability-main-0.2.0-SNAPSHOT-jar-with-dependencies.jar \
+  --camel-routes file:///path/to/routes.camel.yaml \
+  --camel-rules file:///path/to/rules.yaml
+```
+
+**With a service catalog:**
+
+```shell
+version=$(cat core/core-util/target/classes/version.txt)
+java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
+  --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip \
+  --local-dist /path/to/camel-integration-capability-main-0.2.0-SNAPSHOT-jar-with-dependencies.jar \
+  --service-catalog my-catalog \
+  --service-catalog-system ftp
+```
+
+The `camel-integration` service is automatically added when any CIC option is provided.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -301,6 +301,40 @@ If that is successful, open your browser at <http://localhost:8080>, and you sho
 > [!NOTE]
 > You can use the command line to enable more services by using the `--services` option. Use the `--help` to see the details.
 
+#### Running with the Camel Integration Capability
+
+The [Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability) (CIC) lets you
+expose Apache Camel routes as MCP tools. You can supply routes in two ways: from local YAML files or from a
+service catalog.
+
+**Using Camel route files:**
+
+```shell
+wanaku start local \
+  --camel-routes file:///path/to/routes.camel.yaml \
+  --camel-rules file:///path/to/rules.yaml
+```
+
+`--camel-routes` and `--camel-rules` must both be provided when using route files.
+
+**Using a service catalog:**
+
+```shell
+wanaku start local \
+  --service-catalog my-catalog \
+  --service-catalog-system ftp
+```
+
+`--service-catalog` and `--service-catalog-system` must both be provided when using service catalogs.
+
+> [!NOTE]
+> The two modes are mutually exclusive — you can use route files **or** a service catalog, but not both at the same time.
+
+The `--fail-fast` flag (enabled by default) causes the CIC to fail immediately if route loading encounters an
+error. Disable it with `--fail-fast=false` if you want the service to start regardless.
+
+When any CIC option is provided, the `camel-integration` service is automatically added to the launch list.
+
 ### Installing and Running Wanaku on OpenShift or Kubernetes Using the Wanaku Operator
 
 The Wanaku Operator simplifies the deployment and management of Wanaku instances on Kubernetes and OpenShift clusters.


### PR DESCRIPTION
## Summary

- Adds `camel-integration` as a component in `wanaku start local`, enabling the Camel Integration Capability (CIC) to be launched alongside the router
- Handles CIC's standalone fat JAR distribution (vs Quarkus ZIP) with automatic detection and appropriate deploy/augment/run behavior
- Supports per-component version overrides since CIC is versioned independently from Wanaku
- Adds `--camel-routes` and `--camel-rules` CLI options to pass route configuration to CIC
- Adds `--service-catalog` and `--service-catalog-system` options for service catalog mode
- Adds `--fail-fast` option for CIC route loading behavior
- Bumps CIC to 0.2.0-SNAPSHOT (`--client-id` now optional per wanaku-ai/camel-integration-capability#103)

**Related:** wanaku-ai/camel-integration-capability#108 (defaults for `--registration-url` and `--registration-announce-address`)

## Key Design Decisions

- **JAR vs ZIP detection**: Uses the download URL suffix (`.jar` vs `.zip`) to decide whether to unzip or copy directly
- **Quarkus detection**: Checks for `quarkus-run.jar` existence after deploy to determine re-augment and startup behavior
- **No-auth mode**: Does not pass `--client-id` — the CIC 0.2.0 makes it optional, so no OAuth2 flow is attempted when omitted
- **Service catalog vs routes mode**: When `--service-catalog` is set, the CIC uses catalog-based configuration instead of `--routes-ref`/`--rules-ref`
- **Opt-in only**: CIC is not added to `default-services` — users must explicitly request it via `--services camel-integration`

## Test plan

- [ ] `wanaku start local --list-services` shows `camel-integration`
- [ ] `wanaku start local --services camel-integration --camel-routes file:///path/to/routes.yaml --camel-rules file:///path/to/rules.yaml` starts CIC and registers with router
- [ ] `wanaku start local --services camel-integration --service-catalog ftp-resource --service-catalog-system ftp --fail-fast` starts CIC in service catalog mode
- [ ] Existing `--services service-http` flow remains unaffected
- [ ] `mvn verify` passes

## Summary by Sourcery

Add support for running the Camel Integration Capability as a standalone component via `wanaku start local`, including standalone JAR handling and integration into the local runner.

New Features:
- Enable the `camel-integration` component to be launched with `wanaku start local` alongside existing services.
- Add CLI options to configure the Camel Integration Capability via route files (`--camel-routes`, `--camel-rules`) or a service catalog (`--service-catalog`, `--service-catalog-system`).
- Introduce a `--fail-fast` option to control Camel Integration Capability behavior on route loading errors.

Enhancements:
- Extend the local runner to handle both Quarkus-based components and standalone JAR components, skipping Quarkus re-augmentation for non-Quarkus services.
- Automatically include the `camel-integration` service in the launch set whenever Camel Integration CLI options are provided.
- Support downloading Camel Integration as a fat JAR artifact and installing it into the local runtime directory.

Build:
- Register the `camel-integration` component download URL in the CLI application configuration.

Documentation:
- Document how to run `wanaku start local` with the Camel Integration Capability using route files or a service catalog, including the `--fail-fast` behavior.
- Add testing instructions for running `wanaku start local` together with a locally built Camel Integration Capability JAR.