### PR TITLE
chore: suppress Infinispan split package warning

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.arc.ignored-split-packages=org.infinispan.commons.jdkspecific
 quarkus.native.resources.includes=service-templates/**
 quarkus.package.jar.type=mutable-jar
 quarkus.banner.enabled=false


### PR DESCRIPTION
## Summary
- Ignore the `org.infinispan.commons.jdkspecific` split package warning caused by overlap between `quarkus-infinispan-embedded` and `infinispan-commons`

## Test plan
- [ ] Verify the WARN from `SplitPackageProcessor` no longer appears during build

## Summary by Sourcery

Build:
- Configure Quarkus to ignore the org.infinispan.commons.jdkspecific split package warning emitted by the build.