### PR TITLE
Add local Quarkus profile for file logging and clean up CLI output

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -62,4 +62,7 @@ public interface WanakuCliConfig extends WanakuConfig {
 
     @WithDefault("5")
     int routerStartWaitSecs();
+
+    @WithDefault("local")
+    String localProfile();
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ZipHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ZipHelper.java
@@ -62,7 +62,7 @@ public class ZipHelper {
             }
         }
 
-        LOG.infof("ZIP file contents extracted successfully to: %s", destination.getAbsolutePath());
+        LOG.debugf("ZIP file contents extracted successfully to: %s", destination.getAbsolutePath());
     }
 
     /**

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -83,7 +83,7 @@ public class LocalRunner {
     }
 
     private void reaugment(List<String> services, Map<String, String> components) {
-        LOG.info("Re-augmenting components for local (no-auth) mode");
+        LOG.info("Preparing components for local mode");
 
         reaugmentComponent(
                 RuntimeConstants.WANAKU_ROUTER_BACKEND,
@@ -103,11 +103,12 @@ public class LocalRunner {
         List<String> command = new ArrayList<>();
         command.add("java");
         command.add("-Dquarkus.launch.rebuild=true");
+        command.add("-Dquarkus.log.level=WARNING");
         command.addAll(List.of(buildTimeProperties));
         command.add("-jar");
         command.add("quarkus-run.jar");
 
-        LOG.infof("Re-augmenting %s", componentName);
+        LOG.debugf("Re-augmenting %s", componentName);
         ProcessRunner.run(componentDir, command.toArray(new String[0]));
     }
 
@@ -117,8 +118,9 @@ public class LocalRunner {
         CountDownLatch countDownLatch = new CountDownLatch(activeServices + 1);
         int grpcPort = config.initialGrpcPort();
 
+        LOG.debug("Starting Wanaku Router Backend");
         startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, executorService, countDownLatch, environment);
-        LOG.infof("Waiting %d seconds for the Wanaku Router Backend to start", config.routerStartWaitSecs());
+        LOG.infof("Waiting %d seconds for the router to start", config.routerStartWaitSecs());
         try {
             Thread.sleep(Duration.ofSeconds(config.routerStartWaitSecs()).toMillis());
         } catch (InterruptedException e) {
@@ -150,7 +152,13 @@ public class LocalRunner {
 
         executorService.submit(() -> {
             try {
-                ProcessRunner.run(componentDir, environment.serviceOptions(), "java", "-jar", "quarkus-run.jar");
+                ProcessRunner.run(
+                        componentDir,
+                        environment.serviceOptions(),
+                        "java",
+                        "-Dquarkus.profile=local",
+                        "-jar",
+                        "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Router Service: %s", e.getMessage(), e);
             } finally {
@@ -173,7 +181,13 @@ public class LocalRunner {
         executorService.submit(() -> {
             try {
                 ProcessRunner.run(
-                        componentDir, environment.serviceOptions(), "java", grpcPortOpt, "-jar", "quarkus-run.jar");
+                        componentDir,
+                        environment.serviceOptions(),
+                        "java",
+                        "-Dquarkus.profile=local",
+                        grpcPortOpt,
+                        "-jar",
+                        "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Service %s", component.getKey(), e);
             } finally {
@@ -199,18 +213,18 @@ public class LocalRunner {
 
         File zipFile;
         if (localMatch != null) {
-            LOG.infof("Using local distribution %s for %s", localMatch, componentName);
+            LOG.debugf("Using local distribution %s for %s", localMatch, componentName);
             zipFile = localMatch;
         } else {
             String downloadUrl = getDownloadURL(urlFormat);
             File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
 
-            LOG.infof("Downloading %s at %s", componentName, downloadUrl);
+            LOG.infof("Downloading %s", componentName);
             zipFile = Downloader.downloadFile(downloadUrl, destinationDir);
         }
 
         String extractDir = componentName + File.separator + QUARKUS_APP;
-        LOG.infof("Unpacking %s", componentName);
+        LOG.infof("Deploying %s", componentName);
         ZipHelper.unzip(zipFile, RuntimeConstants.WANAKU_LOCAL_DIR, extractDir);
     }
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -118,8 +118,10 @@ public class LocalRunner {
         CountDownLatch countDownLatch = new CountDownLatch(activeServices + 1);
         int grpcPort = config.initialGrpcPort();
 
+        String profileOpt = String.format("-Dquarkus.profile=%s", config.localProfile());
+
         LOG.debug("Starting Wanaku Router Backend");
-        startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, executorService, countDownLatch, environment);
+        startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, profileOpt, executorService, countDownLatch, environment);
         LOG.infof("Waiting %d seconds for the router to start", config.routerStartWaitSecs());
         try {
             Thread.sleep(Duration.ofSeconds(config.routerStartWaitSecs()).toMillis());
@@ -131,7 +133,7 @@ public class LocalRunner {
 
         for (Map.Entry<String, String> component : components.entrySet()) {
             if (isEnabled(services, component)) {
-                startService(component, grpcPort, executorService, countDownLatch, environment);
+                startService(component, grpcPort, profileOpt, executorService, countDownLatch, environment);
                 grpcPort++;
             }
         }
@@ -145,6 +147,7 @@ public class LocalRunner {
 
     private static void startRouter(
             String component,
+            String profileOpt,
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
@@ -153,12 +156,7 @@ public class LocalRunner {
         executorService.submit(() -> {
             try {
                 ProcessRunner.run(
-                        componentDir,
-                        environment.serviceOptions(),
-                        "java",
-                        "-Dquarkus.profile=local",
-                        "-jar",
-                        "quarkus-run.jar");
+                        componentDir, environment.serviceOptions(), "java", profileOpt, "-jar", "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Router Service: %s", e.getMessage(), e);
             } finally {
@@ -170,6 +168,7 @@ public class LocalRunner {
     private static void startService(
             Map.Entry<String, String> component,
             int grpcPort,
+            String profileOpt,
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
@@ -184,7 +183,7 @@ public class LocalRunner {
                         componentDir,
                         environment.serviceOptions(),
                         "java",
-                        "-Dquarkus.profile=local",
+                        profileOpt,
                         grpcPortOpt,
                         "-jar",
                         "quarkus-run.jar");
@@ -220,6 +219,7 @@ public class LocalRunner {
             File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
 
             LOG.infof("Downloading %s", componentName);
+            LOG.debugf("Download URL: %s", downloadUrl);
             zipFile = Downloader.downloadFile(downloadUrl, destinationDir);
         }
 

--- a/apps/wanaku-cli/src/main/resources/application.properties
+++ b/apps/wanaku-cli/src/main/resources/application.properties
@@ -24,6 +24,7 @@ quarkus.native.resources.includes=docs/**
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
+quarkus.log.category."ai.wanaku.capabilities.sdk.common.ProcessRunner".level=WARNING
 quarkus.log.category."org.jline".level=ERROR
 %dev.quarkus.log.category."ai.wanaku".level=INFO
 %test.quarkus.log.category."ai.wanaku".level=INFO

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -238,6 +238,13 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 %perf.quarkus.log.category."io.quarkiverse.mcp".handlers=wanaku-log
 %perf.quarkus.log.category."io.quarkiverse.mcp".level=DEBUG
 
+%local.quarkus.log.console.enabled=false
+%local.quarkus.log.file.enabled=true
+%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/wanaku-router.log
+%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%local.quarkus.log.category."ai.wanaku".level=DEBUG
+%local.quarkus.log.category."io.quarkiverse.mcp".level=DEBUG
+
 %test.quarkus.log.file.enabled=true
 %test.quarkus.log.file.path=target/logs/wanaku.log
 %test.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -27,5 +27,11 @@ quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 %dev.quarkus.log.category."ai.wanaku.core.capabilities".level=DEBUG
 %test.quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 
+%local.quarkus.log.console.enabled=false
+%local.quarkus.log.file.enabled=true
+%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/${wanaku.service.name}.log
+%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%local.quarkus.log.category."ai.wanaku".level=DEBUG
+
 %test.quarkus.log.console.level=OFF
 %test.quarkus.log.file.enabled=true


### PR DESCRIPTION
## Summary
- Add `%local` Quarkus profile to router and capabilities that logs to `~/.wanaku/local/logs/` with console disabled
- `wanaku start local` now passes `-Dquarkus.profile=local` when launching services
- Clean up CLI log messages: downgrade verbose/internal messages to DEBUG, suppress SDK ProcessRunner noise, simplify deploy/startup messages
- Suppress re-augment child process INFO logs by setting `quarkus.log.level=WARNING` during rebuild

## Test plan
- [ ] Run `wanaku start local` with `--local-dist` flags and verify clean CLI output
- [ ] Verify `~/.wanaku/local/logs/wanaku-router.log` and per-service log files are created and populated
- [ ] Verify router health check passes at `http://localhost:8080/q/health`
- [ ] Run `mvn verify` — all tests pass

## Summary by Sourcery

Introduce a local Quarkus logging profile for router and capabilities and streamline CLI logging for local runs.

Enhancements:
- Add a `%local` Quarkus profile for the router backend and capabilities that logs to per-service files under `~/.wanaku/local/logs/` with console logging disabled.
- Adjust local runner startup and deployment logging to be less verbose and more user-friendly, including downgrading internal and re-augmentation logs to DEBUG and simplifying message wording.
- Set Quarkus log level to WARNING during re-augmentation to suppress noisy child process INFO logs and quiet the CLI ProcessRunner logs via configuration.