### PR TITLE
fix: poll local router readiness before starting services

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -60,6 +60,10 @@ public interface WanakuCliConfig extends WanakuConfig {
     @WithDefault("9000")
     int initialGrpcPort();
 
+    /**
+     * Maximum number of seconds to wait for the local router readiness
+     * endpoint before starting capability services.
+     */
     @WithDefault("5")
     int routerStartWaitSecs();
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -2,6 +2,10 @@ package ai.wanaku.cli.runner.local;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +25,12 @@ import ai.wanaku.core.util.VersionHelper;
 public class LocalRunner {
     private static final Logger LOG = Logger.getLogger(LocalRunner.class);
     private static final String QUARKUS_APP = "quarkus-app";
+    private static final URI DEFAULT_ROUTER_READINESS_URI = URI.create("http://localhost:8080/q/health/ready");
+    private static final Duration ROUTER_READINESS_POLL_INTERVAL = Duration.ofMillis(500);
+    private static final Duration ROUTER_READINESS_REQUEST_TIMEOUT = Duration.ofSeconds(2);
     private final WanakuCliConfig config;
+    private final HttpClient httpClient;
+    private final URI routerReadinessUri;
     private int activeServices = 0;
 
     public static class LocalRunnerEnvironment {
@@ -69,8 +78,15 @@ public class LocalRunner {
     private final LocalRunnerEnvironment environment;
 
     public LocalRunner(WanakuCliConfig config, LocalRunnerEnvironment environment) {
+        this(config, environment, HttpClient.newHttpClient(), DEFAULT_ROUTER_READINESS_URI);
+    }
+
+    LocalRunner(
+            WanakuCliConfig config, LocalRunnerEnvironment environment, HttpClient httpClient, URI routerReadinessUri) {
         this.config = config;
         this.environment = environment;
+        this.httpClient = httpClient;
+        this.routerReadinessUri = routerReadinessUri;
     }
 
     public void start(List<String> services) throws IOException {
@@ -112,7 +128,7 @@ public class LocalRunner {
         ProcessRunner.run(componentDir, command.toArray(new String[0]));
     }
 
-    private void run(List<String> services, Map<String, String> components) {
+    private void run(List<String> services, Map<String, String> components) throws IOException {
         ExecutorService executorService = Executors.newCachedThreadPool();
 
         CountDownLatch countDownLatch = new CountDownLatch(activeServices + 1);
@@ -122,9 +138,10 @@ public class LocalRunner {
 
         LOG.debug("Starting Wanaku Router Backend");
         startRouter(RuntimeConstants.WANAKU_ROUTER_BACKEND, profileOpt, executorService, countDownLatch, environment);
-        LOG.infof("Waiting %d seconds for the router to start", config.routerStartWaitSecs());
+        LOG.infof(
+                "Waiting up to %d seconds for the Wanaku Router Backend to become ready", config.routerStartWaitSecs());
         try {
-            Thread.sleep(Duration.ofSeconds(config.routerStartWaitSecs()).toMillis());
+            waitForRouterReadiness(Duration.ofSeconds(config.routerStartWaitSecs()), ROUTER_READINESS_POLL_INTERVAL);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.warn("Interrupted while waiting for Wanaku Router Backend to start ... Aborting");
@@ -143,6 +160,46 @@ public class LocalRunner {
         } catch (InterruptedException e) {
             LOG.infof("Interrupted while waiting for services to run");
         }
+    }
+
+    void waitForRouterReadiness(Duration timeout, Duration pollInterval) throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+
+        while (System.nanoTime() <= deadline) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0) {
+                break;
+            }
+
+            Duration remaining = Duration.ofNanos(remainingNanos);
+            if (routerIsReady(minDuration(remaining, ROUTER_READINESS_REQUEST_TIMEOUT))) {
+                LOG.info("Wanaku Router Backend is ready");
+                return;
+            }
+
+            Thread.sleep(Math.min(pollInterval.toMillis(), remaining.toMillis()));
+        }
+
+        throw new IOException("Wanaku Router Backend did not become ready within %d seconds at %s"
+                .formatted(timeout.toSeconds(), routerReadinessUri));
+    }
+
+    private boolean routerIsReady(Duration timeout) throws InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(routerReadinessUri)
+                .timeout(timeout)
+                .GET()
+                .build();
+        try {
+            HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+            return response.statusCode() >= 200 && response.statusCode() < 300;
+        } catch (IOException e) {
+            LOG.debugf("Wanaku Router Backend readiness check failed: %s", e.getMessage());
+            return false;
+        }
+    }
+
+    private static Duration minDuration(Duration first, Duration second) {
+        return first.compareTo(second) <= 0 ? first : second;
     }
 
     private static void startRouter(

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import ai.wanaku.cli.main.support.WanakuCliConfig;
 import com.sun.net.httpserver.HttpServer;
 
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class LocalRunnerTest {
@@ -66,5 +68,31 @@ class LocalRunnerTest {
 
         assertThrows(
                 IOException.class, () -> runner.waitForRouterReadiness(Duration.ofMillis(50), Duration.ofMillis(10)));
+    }
+
+    @Test
+    void shouldUseRemainingTimeoutForReadinessRequests() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/q/health/ready", exchange -> {
+            LockSupport.parkNanos(Duration.ofMillis(500).toNanos());
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+        URI readinessUri = URI.create("http://localhost:%d/q/health/ready"
+                .formatted(server.getAddress().getPort()));
+
+        LocalRunner runner = new LocalRunner(
+                mock(WanakuCliConfig.class),
+                new LocalRunner.LocalRunnerEnvironment(),
+                HttpClient.newHttpClient(),
+                readinessUri);
+
+        long startedAt = System.nanoTime();
+        assertThrows(
+                IOException.class, () -> runner.waitForRouterReadiness(Duration.ofMillis(100), Duration.ofMillis(10)));
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+        assertTrue(elapsed.compareTo(Duration.ofSeconds(1)) < 0);
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
@@ -1,0 +1,70 @@
+package ai.wanaku.cli.runner.local;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import ai.wanaku.cli.main.support.WanakuCliConfig;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class LocalRunnerTest {
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldPollRouterReadinessUntilHealthy() throws Exception {
+        AtomicInteger requests = new AtomicInteger();
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/q/health/ready", exchange -> {
+            int status = requests.incrementAndGet() < 3 ? 503 : 200;
+            exchange.sendResponseHeaders(status, -1);
+            exchange.close();
+        });
+        server.start();
+        URI readinessUri = URI.create("http://localhost:%d/q/health/ready"
+                .formatted(server.getAddress().getPort()));
+
+        LocalRunner runner = new LocalRunner(
+                mock(WanakuCliConfig.class),
+                new LocalRunner.LocalRunnerEnvironment(),
+                HttpClient.newHttpClient(),
+                readinessUri);
+
+        assertDoesNotThrow(() -> runner.waitForRouterReadiness(Duration.ofSeconds(2), Duration.ofMillis(10)));
+    }
+
+    @Test
+    void shouldFailWhenRouterDoesNotBecomeReady() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/q/health/ready", exchange -> {
+            exchange.sendResponseHeaders(503, -1);
+            exchange.close();
+        });
+        server.start();
+        URI readinessUri = URI.create("http://localhost:%d/q/health/ready"
+                .formatted(server.getAddress().getPort()));
+
+        LocalRunner runner = new LocalRunner(
+                mock(WanakuCliConfig.class),
+                new LocalRunner.LocalRunnerEnvironment(),
+                HttpClient.newHttpClient(),
+                readinessUri);
+
+        assertThrows(
+                IOException.class, () -> runner.waitForRouterReadiness(Duration.ofMillis(50), Duration.ofMillis(10)));
+    }
+}


### PR DESCRIPTION
Fixes #1221

## Changes
- replace the fixed `wanaku start local` router sleep with polling against `/q/health/ready`
- keep `wanaku.cli.router-start-wait-secs` as the maximum readiness wait
- start capability services as soon as the router reports ready, and fail with a clear timeout if it never does
- add focused tests for eventual readiness and timeout behavior

## Verification
- `.\mvnw.cmd -pl apps/wanaku-cli -am '-Dtest=ai.wanaku.cli.runner.local.LocalRunnerTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- `.\mvnw.cmd -pl apps/wanaku-cli -am -DskipTests compile`
- `git diff --check`

## Summary by Sourcery

Poll the local router readiness endpoint before starting services instead of waiting a fixed delay, enforcing a configurable timeout and covering the behavior with tests.

Bug Fixes:
- Ensure local capability services start only after the router actually reports readiness, avoiding race conditions from a fixed startup sleep.
- Fail fast with a clear error when the local router never becomes ready within the configured wait time.

Enhancements:
- Introduce configurable HTTP-based readiness polling for the local router with a sensible default health endpoint and poll interval.
- Document the router startup wait configuration as a maximum readiness wait rather than a fixed delay.

Tests:
- Add unit tests verifying that readiness polling succeeds once the router becomes healthy and fails when it never does.