### PR TITLE
Add Claude Code configure command

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/Configure.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/Configure.java
@@ -8,7 +8,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "configure",
         description = "Configure popular MCP clients to connect to Wanaku",
-        subcommands = {ConfigureClaude.class, ConfigureCursor.class})
+        subcommands = {ConfigureClaude.class, ConfigureClaudeCode.class, ConfigureCursor.class})
 public class Configure extends BaseCommand {
 
     @Override

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
@@ -31,7 +31,8 @@ public class ConfigureClaudeCode extends BaseCommand {
     }
 
     private String sseEndpoint() {
-        String normalizedHost = normalizeHost(host);
+        String configuredHost = host == null ? DEFAULT_HOST : host;
+        String normalizedHost = normalizeHost(configuredHost);
         return normalizedHost + "/mcp/sse";
     }
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
@@ -15,13 +15,14 @@ public class ConfigureClaudeCode extends BaseCommand {
             names = {"--host"},
             description = "Wanaku host URL",
             defaultValue = DEFAULT_HOST)
-    String host = DEFAULT_HOST;
+    String host;
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
         try {
+            String endpoint = sseEndpoint();
             printer.printInfoMessage("Run this command to register Wanaku with Claude Code:");
-            printer.printInfoMessage("claude mcp add wanaku --transport sse " + sseEndpoint());
+            printer.printInfoMessage("claude mcp add wanaku --transport sse " + endpoint);
             return EXIT_OK;
         } catch (IllegalArgumentException e) {
             printer.printErrorMessage(e.getMessage());

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
@@ -1,0 +1,53 @@
+package ai.wanaku.cli.main.commands.configure;
+
+import java.net.URI;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "claude-code", description = "Print a Claude Code command to connect to Wanaku")
+public class ConfigureClaudeCode extends BaseCommand {
+
+    private static final String DEFAULT_HOST = "http://localhost:8080";
+
+    @CommandLine.Option(
+            names = {"--host"},
+            description = "Wanaku host URL",
+            defaultValue = DEFAULT_HOST)
+    String host = DEFAULT_HOST;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try {
+            printer.printInfoMessage("Run this command to register Wanaku with Claude Code:");
+            printer.printInfoMessage("claude mcp add wanaku --transport sse " + sseEndpoint());
+            return EXIT_OK;
+        } catch (IllegalArgumentException e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private String sseEndpoint() {
+        String normalizedHost = normalizeHost(host);
+        return normalizedHost + "/mcp/sse";
+    }
+
+    private String normalizeHost(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Wanaku host URL must not be blank");
+        }
+
+        URI uri = URI.create(value.trim());
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            throw new IllegalArgumentException("Wanaku host URL must include a scheme and host");
+        }
+
+        String normalized = uri.toString();
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class ConfigureCommandsTest {
@@ -131,5 +132,41 @@ class ConfigureCommandsTest {
         assertEquals(EXIT_ERROR, result);
         assertFalse(Files.exists(configPath));
         verify(printer).printErrorMessage("Unsupported transport 'stdio'. Supported transports: sse, http");
+    }
+
+    @Test
+    void claudeCodeConfigureShouldPrintAddCommandWithDefaultHost() throws Exception {
+        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
+
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer).printInfoMessage("Run this command to register Wanaku with Claude Code:");
+        verify(printer)
+                .printInfoMessage("claude mcp add wanaku --transport sse http://localhost:8080/mcp/sse");
+    }
+
+    @Test
+    void claudeCodeConfigureShouldPrintAddCommandWithCustomHost() throws Exception {
+        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
+        cmd.host = "https://wanaku.example.com/";
+
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer)
+                .printInfoMessage("claude mcp add wanaku --transport sse https://wanaku.example.com/mcp/sse");
+    }
+
+    @Test
+    void claudeCodeConfigureShouldRejectHostWithoutScheme() throws Exception {
+        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
+        cmd.host = "wanaku.example.com";
+
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_ERROR, result);
+        verify(printer).printErrorMessage("Wanaku host URL must include a scheme and host");
+        verify(printer, never()).printInfoMessage("claude mcp add wanaku --transport sse http://wanaku.example.com/mcp/sse");
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
@@ -167,6 +167,6 @@ class ConfigureCommandsTest {
 
         assertEquals(EXIT_ERROR, result);
         verify(printer).printErrorMessage("Wanaku host URL must include a scheme and host");
-        verify(printer, never()).printInfoMessage("claude mcp add wanaku --transport sse http://wanaku.example.com/mcp/sse");
+        verify(printer, never()).printInfoMessage(anyString());
     }
 }


### PR DESCRIPTION
## Summary
- add a `configure claude-code` subcommand for Claude Code setup
- print the expected `claude mcp add wanaku --transport sse ...` command
- support a configurable Wanaku host URL and normalize trailing slashes
- add focused tests for default host, custom host, and invalid host handling

Closes #1225

## Verification
- `git diff --check`

Note: this local environment does not have a Java runtime installed, so `./mvnw -pl apps/wanaku-cli -Dtest=ConfigureCommandsTest test` could not run locally here.

## Summary by Sourcery

Add a new CLI subcommand to help users configure Claude Code to connect to Wanaku, including host validation and SSE endpoint generation.

New Features:
- Introduce a `configure claude-code` subcommand that prints the Claude MCP add command for Wanaku with an SSE transport.

Enhancements:
- Allow configuring a custom Wanaku host URL with normalization of trailing slashes and validation of scheme and host components.

Tests:
- Add unit tests covering default host behavior, custom host handling, and invalid host URL rejection for the Claude Code configure command.