### PR TITLE
Fix #1234: Default to wanaku_body for tools in service expose

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
@@ -195,6 +195,11 @@ public class ServiceExpose extends BaseCommand {
                 if (namespace != null && !namespace.isBlank()) {
                     pw.println("        namespace: \"" + namespace + "\"");
                 }
+                pw.println("        properties:");
+                pw.println("          - name: wanaku_body");
+                pw.println("            type: string");
+                pw.println("            description: The input data for route " + routeId);
+                pw.println("            required: true");
             }
         }
     }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
@@ -48,6 +48,7 @@ class ServiceExposeTest {
         assertTrue(rulesFile.exists());
         String content = Files.readString(rulesFile.toPath());
         assertTrue(content.contains("my-route-1"));
+        assertTrue(content.contains("wanaku_body"), "Tools should include wanaku_body property by default");
     }
 
     @Test
@@ -137,6 +138,7 @@ class ServiceExposeTest {
         assertTrue(content.contains("s3-read"), "Should contain route ID");
         assertTrue(content.contains("uri: \"wanaku://s3-read\""), "Should contain default URI");
         assertTrue(content.contains("mimeType: \"application/octet-stream\""), "Should contain default MIME type");
+        assertFalse(content.contains("wanaku_body"), "Resources should not include wanaku_body property");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `wanaku service expose` now generates a `wanaku_body` property by default when exposing tools, so they have input parameters out of the box
- Added test assertions verifying tools include `wanaku_body` and resources do not

## Test plan

- [x] Existing `ServiceExposeTest` passes (243 tests, 0 failures)
- [x] New assertion in `testExposeGeneratesRules` verifies `wanaku_body` is present for tools
- [x] New assertion in `testExposeGeneratesResourceRules` verifies `wanaku_body` is absent for resources

## Summary by Sourcery

Default wanaku service tool rules to include a wanaku_body input field and add coverage to distinguish tool and resource behavior.

New Features:
- Add a default wanaku_body string property to generated tool rules in wanaku service expose so tools have a required input payload field by default.

Tests:
- Extend ServiceExposeTest to assert wanaku_body is present for tools and absent for resources, ensuring correct rule generation.