### PR TITLE
feat(cli): add --property and --properties-from to service template instantiate Closes #1239

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -3,8 +3,14 @@ package ai.wanaku.cli.main.commands.service;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
@@ -31,9 +37,21 @@ public class ServiceTemplateInstantiate extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--properties"},
-            description = "Comma-separated key=value pairs (e.g., endpoint.url=http://example.com,api.key=secret)",
+            description = "Comma-separated key=value pairs (e.g., endpoint.url=http://example.com,api.key=secret). Deprecated: prefer --property or --properties-from",
             arity = "0..1")
     private String properties;
+
+    @CommandLine.Option(
+            names = {"--property"},
+            description = "A single key=value property; may be repeated (e.g., --property kafka.brokers=localhost:9092 --property kafka.topic=ai.requests)",
+            arity = "1")
+    private List<String> property = new ArrayList<>();
+
+    @CommandLine.Option(
+            names = {"--properties-from"},
+            description = "Load properties from a Java .properties file",
+            arity = "0..1")
+    private File propertiesFrom;
 
     @CommandLine.Option(
             names = {"--service-name"},
@@ -47,23 +65,52 @@ public class ServiceTemplateInstantiate extends BaseCommand {
             arity = "0..1")
     private String serviceSystem;
 
-    @Override
-    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
-
-        // Parse properties
+    private Map<String, String> resolveProperties(WanakuPrinter printer) throws IOException {
         Map<String, String> propsMap = new HashMap<>();
+
+        // 1. Legacy --properties (comma-separated), lowest precedence
         if (properties != null && !properties.isBlank()) {
-            String[] pairs = properties.split(",");
-            for (String pair : pairs) {
+            for (String pair : properties.split(",")) {
                 String[] kv = pair.split("=", 2);
                 if (kv.length == 2) {
                     propsMap.put(kv[0].trim(), kv[1].trim());
                 } else {
                     printer.printErrorMessage(String.format("Invalid property format: '%s'%n", pair));
-                    return EXIT_ERROR;
+                    return null;
                 }
             }
+        }
+
+        // 2. --properties-from <file>, overrides --properties
+        if (propertiesFrom != null) {
+            Properties p = new Properties();
+            try (FileInputStream fis = new FileInputStream(propertiesFrom)) {
+                p.load(fis);
+            }
+            p.forEach((k, v) -> propsMap.put((String) k, (String) v));
+        }
+
+        // 3. --property key=value (repeatable), highest precedence
+        for (String pair : property) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2) {
+                propsMap.put(kv[0].trim(), kv[1].trim());
+            } else {
+                printer.printErrorMessage(String.format("Invalid property format: '%s'%n", pair));
+                return null;
+            }
+        }
+
+        return propsMap;
+    }
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+
+        Map<String, String> propsMap = resolveProperties(printer);
+        if (propsMap == null) {
+            return EXIT_ERROR;
         }
 
         printer.printInfoMessage(

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -93,7 +93,7 @@ public class ServiceTemplateInstantiate extends BaseCommand {
 
         // 3. --property key=value (repeatable), highest precedence
         for (String pair : property) {
-            pair = pair.trim()
+            pair = pair.trim();
             String[] kv = pair.split("=", 2);
             if (kv.length == 2) {
                 propsMap.put(kv[0].trim(), kv[1].trim());

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -71,6 +71,7 @@ public class ServiceTemplateInstantiate extends BaseCommand {
         // 1. Legacy --properties (comma-separated), lowest precedence
         if (properties != null && !properties.isBlank()) {
             for (String pair : properties.split(",")) {
+                pair = pair.trim();
                 String[] kv = pair.split("=", 2);
                 if (kv.length == 2) {
                     propsMap.put(kv[0].trim(), kv[1].trim());
@@ -92,6 +93,7 @@ public class ServiceTemplateInstantiate extends BaseCommand {
 
         // 3. --property key=value (repeatable), highest precedence
         for (String pair : property) {
+            pair = pair.trim()
             String[] kv = pair.split("=", 2);
             if (kv.length == 2) {
                 propsMap.put(kv[0].trim(), kv[1].trim());


### PR DESCRIPTION
## Summary

Adds two new ergonomic property input options to `wanaku service template instantiate`, 
as requested in #1239.

## Changes

- `--property key=value` — repeatable flag for individual key-value pairs
- `--properties-from <file>` — loads properties from a standard Java `.properties` file
- Legacy `--properties` (comma-separated) is retained for backwards compatibility and 
  marked as deprecated in its description

## Precedence

Properties are resolved in this order (later overrides earlier):
1. `--properties` (lowest)
2. `--properties-from`
3. `--property` (highest)

## Example usage

```sh
# Repeatable flags
wanaku service template instantiate --name my-template \
  --property kafka.brokers=localhost:9092 \
  --property kafka.topic=ai.requests

# From file
wanaku service template instantiate --name my-template \
  --properties-from my-template.properties
```

Closes #1239

## Summary by Sourcery

Add new CLI options for providing template instantiation properties with clear precedence while preserving the legacy flag for backwards compatibility.

New Features:
- Introduce a repeatable --property option to pass individual key=value properties to service template instantiation.
- Add a --properties-from option to load properties from a Java .properties file during service template instantiation.

Enhancements:
- Define a unified property resolution flow that applies precedence across legacy comma-separated properties, file-based properties, and repeated single properties.
- Mark the legacy --properties option as deprecated in its description while keeping it functional.