### PR TITLE
Improve error message when instantiating a non-existing service template

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -83,10 +83,20 @@ public class ServiceTemplateInstantiate extends BaseCommand {
                     String.format("Service catalog created successfully from template '%s'%n", name));
         } catch (WebApplicationException ex) {
             Response response = ex.getResponse();
+            if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+                handleNotFoundTemplate(printer, name);
+                return EXIT_ERROR;
+            }
             commonResponseErrorHandler(response);
             return EXIT_ERROR;
         }
 
         return EXIT_OK;
+    }
+
+    private void handleNotFoundTemplate(WanakuPrinter printer, String templateName) {
+        printer.printErrorMessage(String.format(
+                "Error: template '%s' does not exist. Use 'wanaku service template list' to see available templates.%n",
+                templateName));
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ResponseHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ResponseHelper.java
@@ -23,7 +23,13 @@ public final class ResponseHelper {
                 // Ignore if we can't read the body
             }
 
-            if (response.getStatus() == Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
+            if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+                message = String.format(
+                        "The requested resource was not found: %s%s%n",
+                        response.getStatusInfo().getReasonPhrase(),
+                        responseBody.isEmpty() ? "" : "\nDetails: " + responseBody);
+                printer.printErrorMessage(message);
+            } else if (response.getStatus() == Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
                 message = String.format(
                         "The server was unable to handle the request: %s%s%n",
                         response.getStatusInfo().getReasonPhrase(),

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/NotFoundExceptionMapper.java
@@ -63,3 +63,6 @@ class PromptNotFoundExceptionMapper extends NotFoundExceptionMapper<PromptNotFou
 
 @Provider
 class DataStoreResourceNotFoundExceptionMapper extends NotFoundExceptionMapper<DataStoreResourceNotFoundException> {}
+
+@Provider
+class ServiceTemplateNotFoundExceptionMapper extends NotFoundExceptionMapper<ServiceTemplateNotFoundException> {}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceTemplateNotFoundException.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/ServiceTemplateNotFoundException.java
@@ -1,0 +1,12 @@
+package ai.wanaku.backend.api.v1.exceptions;
+
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Exception thrown when a requested service template does not exist.
+ */
+public class ServiceTemplateNotFoundException extends WanakuException {
+    public ServiceTemplateNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/WanakuExceptionMapper.java
@@ -50,7 +50,8 @@ public class WanakuExceptionMapper implements ExceptionMapper<WanakuException> {
                 || e instanceof ServiceNotFoundException
                 || e instanceof ConfigurationNotFoundException
                 || e instanceof NamespaceNotFoundException
-                || e instanceof DataStoreResourceNotFoundException) {
+                || e instanceof DataStoreResourceNotFoundException
+                || e instanceof ServiceTemplateNotFoundException) {
             status = 404;
         } else if (e instanceof EntityAlreadyExistsException) {
             status = 409;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -20,6 +20,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import org.jboss.logging.Logger;
+import ai.wanaku.backend.api.v1.exceptions.ServiceTemplateNotFoundException;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
@@ -181,7 +182,7 @@ public class ServiceTemplateBean {
 
         DataStore template = get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: %s".formatted(name));
+            throw new ServiceTemplateNotFoundException("Service template not found: %s".formatted(name));
         }
 
         ServiceCatalogIndex index = parseIndex(template);
@@ -246,7 +247,7 @@ public class ServiceTemplateBean {
 
         DataStore template = get(templateName);
         if (template == null) {
-            throw new WanakuException("Service template not found: %s".formatted(templateName));
+            throw new ServiceTemplateNotFoundException("Service template not found: %s".formatted(templateName));
         }
 
         ServiceCatalogIndex index = parseIndex(template);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateResource.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
+import ai.wanaku.backend.api.v1.exceptions.ServiceTemplateNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.DataStoreResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
@@ -104,7 +105,7 @@ public class ServiceTemplateResource {
 
         DataStore template = serviceTemplateBean.get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: %s".formatted(name));
+            throw new ServiceTemplateNotFoundException("Service template not found: %s".formatted(name));
         }
 
         ServiceCatalogIndex index = serviceTemplateBean.parseIndex(template);
@@ -147,7 +148,7 @@ public class ServiceTemplateResource {
 
         DataStore template = serviceTemplateBean.get(name);
         if (template == null) {
-            throw new WanakuException("Service template not found: %s".formatted(name));
+            throw new ServiceTemplateNotFoundException("Service template not found: %s".formatted(name));
         }
 
         return new WanakuResponse<>(template);


### PR DESCRIPTION
Closes: #1238

## Summary by Sourcery

Improve handling of non-existing service templates by returning clearer 404 errors from the backend and surfacing more user-friendly messages in the CLI when a template is not found.

Bug Fixes:
- Return a specific ServiceTemplateNotFoundException instead of a generic WanakuException when a requested service template does not exist, ensuring it maps correctly to HTTP 404 responses.
- Handle HTTP 404 responses from the CLI service template instantiation command with a targeted error message that guides users to list available templates.
- Enhance common HTTP error handling to provide clearer messaging for 404 Not Found responses, including optional response body details.

Enhancements:
- Introduce a dedicated ServiceTemplateNotFoundException type and corresponding JAX-RS exception mapper for cleaner separation of not-found error cases.