### PR TITLE
Align ConfigureClaudeCode with existing configure conventions

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
@@ -25,6 +25,10 @@ public class ConfigureClaudeCode extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        if (host.contains("://") || host.contains(":")) {
+            printer.printErrorMessage("--host expects a bare hostname (e.g., localhost), not a URL or host:port");
+            return EXIT_ERROR;
+        }
         String endpoint = "http://%s:%d/mcp/sse/".formatted(host, port);
         printer.printInfoMessage("Run this command to register Wanaku with Claude Code:");
         printer.printInfoMessage("claude mcp add wanaku --transport sse " + endpoint);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureClaudeCode.java
@@ -1,6 +1,5 @@
 package ai.wanaku.cli.main.commands.configure;
 
-import java.net.URI;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
@@ -9,47 +8,26 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "claude-code", description = "Print a Claude Code command to connect to Wanaku")
 public class ConfigureClaudeCode extends BaseCommand {
 
-    private static final String DEFAULT_HOST = "http://localhost:8080";
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 8080;
 
     @CommandLine.Option(
             names = {"--host"},
-            description = "Wanaku host URL",
+            description = "Wanaku host name",
             defaultValue = DEFAULT_HOST)
-    String host;
+    String host = DEFAULT_HOST;
+
+    @CommandLine.Option(
+            names = {"--port"},
+            description = "Wanaku port",
+            defaultValue = "8080")
+    int port = DEFAULT_PORT;
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
-        try {
-            String endpoint = sseEndpoint();
-            printer.printInfoMessage("Run this command to register Wanaku with Claude Code:");
-            printer.printInfoMessage("claude mcp add wanaku --transport sse " + endpoint);
-            return EXIT_OK;
-        } catch (IllegalArgumentException e) {
-            printer.printErrorMessage(e.getMessage());
-            return EXIT_ERROR;
-        }
-    }
-
-    private String sseEndpoint() {
-        String configuredHost = host == null ? DEFAULT_HOST : host;
-        String normalizedHost = normalizeHost(configuredHost);
-        return normalizedHost + "/mcp/sse";
-    }
-
-    private String normalizeHost(String value) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("Wanaku host URL must not be blank");
-        }
-
-        URI uri = URI.create(value.trim());
-        if (uri.getScheme() == null || uri.getHost() == null) {
-            throw new IllegalArgumentException("Wanaku host URL must include a scheme and host");
-        }
-
-        String normalized = uri.toString();
-        while (normalized.endsWith("/")) {
-            normalized = normalized.substring(0, normalized.length() - 1);
-        }
-        return normalized;
+        String endpoint = "http://%s:%d/mcp/sse/".formatted(host, port);
+        printer.printInfoMessage("Run this command to register Wanaku with Claude Code:");
+        printer.printInfoMessage("claude mcp add wanaku --transport sse " + endpoint);
+        return EXIT_OK;
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class ConfigureCommandsTest {
@@ -148,5 +149,29 @@ class ConfigureCommandsTest {
         assertEquals(EXIT_OK, result);
         verify(printer)
                 .printInfoMessage("claude mcp add wanaku --transport sse http://wanaku.example.com:9090/mcp/sse/");
+    }
+
+    @Test
+    void claudeCodeConfigureShouldRejectHostWithScheme() throws Exception {
+        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
+        cmd.host = "http://example.com";
+
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_ERROR, result);
+        verify(printer).printErrorMessage("--host expects a bare hostname (e.g., localhost), not a URL or host:port");
+        verify(printer, never()).printInfoMessage(anyString());
+    }
+
+    @Test
+    void claudeCodeConfigureShouldRejectHostWithPort() throws Exception {
+        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
+        cmd.host = "example.com:9090";
+
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_ERROR, result);
+        verify(printer).printErrorMessage("--host expects a bare hostname (e.g., localhost), not a URL or host:port");
+        verify(printer, never()).printInfoMessage(anyString());
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class ConfigureCommandsTest {
@@ -135,29 +134,19 @@ class ConfigureCommandsTest {
 
         assertEquals(EXIT_OK, result);
         verify(printer).printInfoMessage("Run this command to register Wanaku with Claude Code:");
-        verify(printer).printInfoMessage("claude mcp add wanaku --transport sse http://localhost:8080/mcp/sse");
+        verify(printer).printInfoMessage("claude mcp add wanaku --transport sse http://localhost:8080/mcp/sse/");
     }
 
     @Test
     void claudeCodeConfigureShouldPrintAddCommandWithCustomHost() throws Exception {
         ConfigureClaudeCode cmd = new ConfigureClaudeCode();
-        cmd.host = "https://wanaku.example.com/";
+        cmd.host = "wanaku.example.com";
+        cmd.port = 9090;
 
         int result = cmd.doCall(terminal, printer);
 
         assertEquals(EXIT_OK, result);
-        verify(printer).printInfoMessage("claude mcp add wanaku --transport sse https://wanaku.example.com/mcp/sse");
-    }
-
-    @Test
-    void claudeCodeConfigureShouldRejectHostWithoutScheme() throws Exception {
-        ConfigureClaudeCode cmd = new ConfigureClaudeCode();
-        cmd.host = "wanaku.example.com";
-
-        int result = cmd.doCall(terminal, printer);
-
-        assertEquals(EXIT_ERROR, result);
-        verify(printer).printErrorMessage("Wanaku host URL must include a scheme and host");
-        verify(printer, never()).printInfoMessage(anyString());
+        verify(printer)
+                .printInfoMessage("claude mcp add wanaku --transport sse http://wanaku.example.com:9090/mcp/sse/");
     }
 }


### PR DESCRIPTION
## Summary
- Align `--host` option to take a bare hostname (matching `ConfigureClaude`/`ConfigureCursor`)
- Add `--port` option for consistency with other configure commands
- Remove dead null check in `sseEndpoint()` (picocli sets defaults)
- Fix SSE endpoint trailing slash to match `ConfigureMcpClientCommand`
- Remove now-unnecessary URL parsing and normalization logic
- Update tests to match new interface

## Test plan
- [x] `ConfigureCommandsTest` passes (6/6 tests)

## Summary by Sourcery

Align the Claude Code configure command with other configure commands and simplify its SSE endpoint handling.

New Features:
- Allow configuring the Claude Code SSE endpoint using separate --host and --port options with sensible defaults.

Bug Fixes:
- Ensure the generated Claude Code SSE endpoint matches the format used by other configure commands, including a trailing slash.

Enhancements:
- Simplify ConfigureClaudeCode by removing URL parsing, normalization, and error handling logic now that host and port are handled explicitly.

Tests:
- Update ConfigureCommandsTest to cover the new host/port interface and the revised SSE endpoint format.