### PR TITLE
fix: add trailing slash to MCP server URL in usage documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3012,7 +3012,7 @@ If your Wanaku server is exposing streamable HTTP instead of SSE, use `--transpo
 {
   "mcpServers": {
     "wanaku": {
-      "url": "http://localhost:8080/mcp/sse"
+      "url": "http://localhost:8080/mcp/sse/"
     }
   }
 }


### PR DESCRIPTION
related: https://github.com/wanaku-ai/wanaku/pull/1231#discussion_r3332735787

## Summary by Sourcery

Documentation:
- Adjust usage documentation to show the MCP server URL with a trailing slash in the JSON configuration example.