### PR TITLE
Refactor ConfigureIbmBob to remove default value for alwaysAllow and update test cases for transport protocol

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureIbmBob.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/configure/ConfigureIbmBob.java
@@ -17,9 +17,8 @@ public class ConfigureIbmBob extends ConfigureMcpClientCommand {
     @CommandLine.Option(
             names = {"--always-allow"},
             description = "Tool names to add to alwaysAllow list",
-            split = ",",
-            defaultValue = "")
-    protected List<String> alwaysAllow = List.of();
+            split = ",")
+    protected List<String> alwaysAllow;
 
     public ConfigureIbmBob() {
         super();
@@ -50,10 +49,10 @@ public class ConfigureIbmBob extends ConfigureMcpClientCommand {
         }
 
         if (alwaysAllow != null && !alwaysAllow.isEmpty()) {
-            entry.set("alwaysAllow", newArrayNode());
+            var arr = entry.putArray("alwaysAllow");
             for (String tool : alwaysAllow) {
                 if (!tool.isBlank()) {
-                    entry.withArray("alwaysAllow").add(tool);
+                    arr.add(tool);
                 }
             }
         }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/configure/ConfigureCommandsTest.java
@@ -18,7 +18,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -120,7 +119,7 @@ class ConfigureCommandsTest {
     void ibmBobConfigureShouldCreateConfigWithDefaults() throws Exception {
         Path configPath = tempDir.resolve(".bob/mcp_settings.json");
         ConfigureIbmBob cmd = new ConfigureIbmBob(configPath);
-        cmd.transport = "http";
+        cmd.transport = "sse";
         cmd.host = "localhost";
         cmd.port = 8080;
 
@@ -131,8 +130,8 @@ class ConfigureCommandsTest {
 
         JsonNode root = MAPPER.readTree(Files.readString(configPath));
         JsonNode wanaku = root.path("mcpServers").path("wanaku");
-        assertEquals("http://localhost:8080/mcp", wanaku.path("url").asText());
-        assertNull(wanaku.path("headers").get("Authorization"));
+        assertEquals("http://localhost:8080/mcp/sse/", wanaku.path("url").asText());
+        assertTrue(wanaku.path("headers").isMissingNode());
         assertTrue(wanaku.path("alwaysAllow").isMissingNode()
                 || wanaku.path("alwaysAllow").isEmpty());
 
@@ -194,6 +193,10 @@ class ConfigureCommandsTest {
         JsonNode root = MAPPER.readTree(Files.readString(configPath));
         JsonNode existing = root.path("mcpServers").path("remote-server");
         assertEquals("https://old-server.com/mcp", existing.path("url").asText());
+        assertEquals(
+                "Bearer old-token",
+                existing.path("headers").path("Authorization").asText());
+        assertEquals("tool1", existing.path("alwaysAllow").get(0).asText());
         JsonNode wanaku = root.path("mcpServers").path("wanaku");
         assertEquals("http://localhost:8080/mcp/sse/", wanaku.path("url").asText());
     }


### PR DESCRIPTION
Related to the review : https://github.com/wanaku-ai/wanaku/pull/1233#pullrequestreview-4402728136

and

`ServiceTemplateInstantiate` has been adjusted due to Spotless lint.

## Summary by Sourcery

Refine IBM Bob MCP configuration behavior and its tests while applying formatting updates to a service command.

Bug Fixes:
- Ensure IBM Bob configuration does not create an alwaysAllow list when no tools are provided.
- Adjust IBM Bob configuration tests to validate SSE transport URLs and header handling.

Enhancements:
- Remove the default empty value from the --always-allow option in ConfigureIbmBob so the field can be omitted when unused.
- Simplify alwaysAllow array creation when populating the MCP server entry.
- Update ServiceTemplateInstantiate option descriptions to comply with formatting and linting requirements.

Tests:
- Update ConfigureIbmBob tests to expect SSE-based MCP URLs, missing headers when no auth is configured, and preservation of existing server configuration fields.