### PR TITLE
Fix #1223: correct OIDC tenant identifiers from ns-1..ns-10 to ns-0..ns-9

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -71,7 +71,7 @@ public class AuthConfigSource implements ConfigSource {
             props.put("quarkus.oidc.enabled", "false");
             props.put("quarkus.oidc.discovery-enabled", "false");
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
-            for (int i = 1; i <= MAX_NAMESPACES; i++) {
+            for (int i = 0; i < MAX_NAMESPACES; i++) {
                 props.put("quarkus.oidc.ns-%d.discovery-enabled".formatted(i), "false");
             }
             props.put("quarkus.oidc-proxy.enabled", "false");

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -24,6 +24,7 @@ wanaku.chat.allowlist=http://localhost:11434,https://api.openai.com,https://api.
 quarkus.mcp.server.wanaku-internal.sse.root-path=/wanaku-internal/mcp
 
 # Namespaces must be set in build time
+quarkus.mcp.server.ns-0.sse.root-path=/ns-0/mcp
 quarkus.mcp.server.ns-1.sse.root-path=/ns-1/mcp
 quarkus.mcp.server.ns-2.sse.root-path=/ns-2/mcp
 quarkus.mcp.server.ns-3.sse.root-path=/ns-3/mcp
@@ -33,7 +34,6 @@ quarkus.mcp.server.ns-6.sse.root-path=/ns-6/mcp
 quarkus.mcp.server.ns-7.sse.root-path=/ns-7/mcp
 quarkus.mcp.server.ns-8.sse.root-path=/ns-8/mcp
 quarkus.mcp.server.ns-9.sse.root-path=/ns-9/mcp
-quarkus.mcp.server.ns-10.sse.root-path=/ns-10/mcp
 
 # Public NS
 quarkus.mcp.server.public.sse.root-path=/public/mcp
@@ -90,6 +90,14 @@ quarkus.oidc.mcp.resource-metadata.force-https-scheme=false
 
 # Per-namespace OIDC tenant configurations so that each namespace
 # advertises the correct resource metadata URL in WWW-Authenticate headers
+quarkus.oidc.ns-0.resource-metadata.authorization-server=${auth.proxy}/q/oidc
+quarkus.oidc.ns-0.auth-server-url=${auth.server}/realms/${auth.realm}
+quarkus.oidc.ns-0.tenant-paths=/ns-0/*
+quarkus.oidc.ns-0.token.audience=wanaku-mcp-client
+quarkus.oidc.ns-0.resource-metadata.enabled=true
+quarkus.oidc.ns-0.resource-metadata.resource=ns-0/mcp
+quarkus.oidc.ns-0.resource-metadata.force-https-scheme=false
+
 quarkus.oidc.ns-1.resource-metadata.authorization-server=${auth.proxy}/q/oidc
 quarkus.oidc.ns-1.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.ns-1.tenant-paths=/ns-1/*
@@ -162,14 +170,6 @@ quarkus.oidc.ns-9.resource-metadata.enabled=true
 quarkus.oidc.ns-9.resource-metadata.resource=ns-9/mcp
 quarkus.oidc.ns-9.resource-metadata.force-https-scheme=false
 
-quarkus.oidc.ns-10.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-10.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-10.tenant-paths=/ns-10/*
-quarkus.oidc.ns-10.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-10.resource-metadata.enabled=true
-quarkus.oidc.ns-10.resource-metadata.resource=ns-10/mcp
-quarkus.oidc.ns-10.resource-metadata.force-https-scheme=false
-
 quarkus.oidc-proxy.enabled=true
 quarkus.oidc-proxy.root-path=/q/oidc
 # Make sure to use the configurations for the MCP tenant instead of the default ones
@@ -188,7 +188,7 @@ quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/d
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Restricted MCP namespaces
-quarkus.http.auth.permission.mcp-authenticated.paths=/mcp/*, /ns-1/*, /ns-2/*, /ns-3/*, /ns-4/*, /ns-5/*, /ns-6/*, /ns-7/*, /ns-8/*, /ns-9/*, /ns-10/*
+quarkus.http.auth.permission.mcp-authenticated.paths=/mcp/*, /ns-0/*, /ns-1/*, /ns-2/*, /ns-3/*, /ns-4/*, /ns-5/*, /ns-6/*, /ns-7/*, /ns-8/*, /ns-9/*
 quarkus.http.auth.permission.mcp-authenticated.policy=authenticated
 
 # Public APIs and static resources

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -66,7 +66,7 @@ class AuthConfigSourceTest {
         assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
         assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
-        for (int i = 1; i <= 10; i++) {
+        for (int i = 0; i < 10; i++) {
             assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
         }
         assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
@@ -86,8 +86,8 @@ class AuthConfigSourceTest {
         assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-1.discovery-enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-10.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.discovery-enabled"));
         assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 


### PR DESCRIPTION
## Summary
- Replaces wrong OIDC tenant identifier `ns-10` with `ns-0` to match actual namespace range `ns-0` through `ns-9`
- Fixes the MCP server root-path, OIDC tenant configuration block, and auth permission paths
- Updates `AuthConfigSource` loop from `1..10` to `0..9` and corresponding test assertions

## Test plan
- [x] `AuthConfigSourceTest` passes with updated assertions
- [x] Full build passes (`mvn test`)
- [ ] Verify OIDC authentication works for `ns-0` namespace in a deployed environment

## Summary by Sourcery

Align OIDC and MCP namespace configuration with the actual ns-0 through ns-9 range.

Bug Fixes:
- Correct OIDC tenant and MCP server configuration to use namespaces ns-0 through ns-9 instead of ns-1 through ns-10, including auth permission paths and disabled-discovery flags in no-auth mode.

Tests:
- Update AuthConfigSource tests to reflect the ns-0 through ns-9 namespace range and ensure discovery-disabled assertions cover the corrected tenants.