### PR TITLE
Removed references from authentication stuff from wanaku start local

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartBase.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartBase.java
@@ -35,11 +35,5 @@ public abstract class StartBase extends BaseCommand {
         protected boolean clean = false;
     }
 
-    @CommandLine.Option(
-            names = {"--capabilities-client-secret"},
-            description = "The secret used by the capabilities in order to register with the router",
-            arity = "0..1")
-    protected String capabilitiesClientSecret;
-
     protected abstract void startWanaku();
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -301,17 +301,6 @@ If that is successful, open your browser at <http://localhost:8080>, and you sho
 > [!NOTE]
 > You can use the command line to enable more services by using the `--services` option. Use the `--help` to see the details.
 
-#### Running with Authentication
-
-If you need authentication for your local instance, first set up Keycloak by following
-[Option 1: Local Setup with Podman](#option-1-local-setup-with-podman) in the
-[Keycloak Setup For Wanaku](#keycloak-setup-for-wanaku) section. Then pass the client secret so that the capabilities
-can authenticate with the router:
-
-```shell
-wanaku start local --capabilities-client-secret=aBqsU3EzUPCHumf9sTK5sanxXkB0yFtv
-```
-
 ### Installing and Running Wanaku on OpenShift or Kubernetes Using the Wanaku Operator
 
 The Wanaku Operator simplifies the deployment and management of Wanaku instances on Kubernetes and OpenShift clusters.


### PR DESCRIPTION
This fixes issue #1247

## Summary by Sourcery

Remove deprecated local authentication configuration from the CLI and its documentation.

Enhancements:
- Remove the deprecated --capabilities-client-secret option from the wanaku start local command.

Documentation:
- Remove documentation for running the local instance with Keycloak-based authentication and the capabilities client secret option.