### PR TITLE
(chores) Fix trailing spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ South America.
 
 ## Quick Start
 
-Getting started is a single command. Download the CLI from **[releases page](https://github.com/wanaku-ai/wanaku/releases)**, unpack, 
+Getting started is a single command. Download the CLI from **[releases page](https://github.com/wanaku-ai/wanaku/releases)**, unpack,
 and then just run:
 
 ```shell
@@ -44,10 +44,10 @@ The reference documentation, including the complete installation and configurati
 
 ## Documentation
 
-The **[Wanaku Documentation](https://wanaku.ai/docs/)** website contains additional documentation, covering several of 
-components that are part of the project - some of which are hosted in different repositories (i.e.: such as the 
-[Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability/), 
-the [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/), etc.). 
+The **[Wanaku Documentation](https://wanaku.ai/docs/)** website contains additional documentation, covering several of
+components that are part of the project - some of which are hosted in different repositories (i.e.: such as the
+[Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability/),
+the [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/), etc.).
 
 ## Community
 
@@ -55,7 +55,7 @@ the [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/), etc.
 - [Discussions](https://github.com/wanaku-ai/wanaku/discussions) - Ask questions and share ideas
 - [Examples](https://github.com/wanaku-ai/wanaku-examples) - Example capabilities and integrations
 
-Contributors working on the project may want to refer to the [development version of the documentation](/docs) including 
+Contributors working on the project may want to refer to the [development version of the documentation](/docs) including
 
 - [Pre-release Usage Guide](docs/usage.md) - Pre-release usage guide
 - [Architecture](docs/architecture.md) - System architecture and components


### PR DESCRIPTION
## Summary

- Remove trailing whitespace from README.md (lines 26, 47-50, 58)
- Fixes MD009/no-trailing-spaces markdownlint violations causing lint CI failures across multiple PRs

## Test plan

- [ ] Verify `lint` CI check passes

## Summary by Sourcery

Documentation:
- Remove trailing whitespace from README.md to comply with markdownlint rules.