### PR TITLE
chore: update Forage dependencies from 1.3-SNAPSHOT to 1.3

### DIFF
--- a/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
+++ b/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
@@ -1,5 +1,5 @@
 org.apache.camel:camel-jms:4.18.2
-io.kaoto.forage:forage-jms:1.3-SNAPSHOT
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-jms-artemis:1.3-SNAPSHOT
+io.kaoto.forage:forage-jms:1.3
+io.kaoto.forage:forage-core-common:1.3
+io.kaoto.forage:forage-jms-artemis:1.3
 org.apache.activemq:artemis-commons:2.44.0

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
@@ -1,3 +1,3 @@
 org.apache.camel:camel-spring-rabbitmq:4.18.2
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-spring-rabbitmq:1.3-SNAPSHOT
+io.kaoto.forage:forage-core-common:1.3
+io.kaoto.forage:forage-spring-rabbitmq:1.3

--- a/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
+++ b/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
@@ -1,7 +1,7 @@
 # Maven dependencies for tavily-search
 # One dependency per line in format: groupId:artifactId:version
 org.apache.camel:camel-langchain4j-web-search:4.18.2
-io.kaoto.forage:forage-core-common:1.3-SNAPSHOT
-io.kaoto.forage:forage-core-ai:1.3-SNAPSHOT
-io.kaoto.forage:forage-web-search:1.3-SNAPSHOT
-io.kaoto.forage:forage-web-search-tavily:1.3-SNAPSHOT
+io.kaoto.forage:forage-core-common:1.3
+io.kaoto.forage:forage-core-ai:1.3
+io.kaoto.forage:forage-web-search:1.3
+io.kaoto.forage:forage-web-search-tavily:1.3


### PR DESCRIPTION
## Summary
- Update Forage dependency versions from `1.3-SNAPSHOT` to `1.3` in service catalogs: jms-tool, rabbitmq-tool, and tavily-search-tool

## Test plan
- [ ] Verify service catalogs resolve dependencies correctly with Forage 1.3

## Summary by Sourcery

Build:
- Bump Forage dependency versions from 1.3-SNAPSHOT to 1.3 across jms-tool, rabbitmq-tool, and tavily-search-tool service catalogs.