### PR TITLE
LLM chat with LangChain4j

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -7,10 +7,10 @@ import {
   TextArea,
   Tile
 } from "@carbon/react"
-import {Send, Stop} from "@carbon/icons-react"
+import {Send} from "@carbon/icons-react"
 import {LlmConfig} from "./config"
-import {McpClient} from "./mcp"
 import {LLMChatMessage} from "./LLMChatMessage"
+import {getUrl} from "../../custom-fetch"
 
 
 interface ChatMessage {
@@ -36,9 +36,7 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
   const [systemPrompt, setSystemPrompt] = useState("You are an assistant that can use tools.")
   const [userPrompt, setUserPrompt] = useState("")
   const [displayMessages, setDisplayMessages] = useState<DisplayMessage[]>([])
-  const [isRunning, setIsRunning] = useState(false)
   
-  const stopRunning = useRef(false)
   const chatMessages = useRef<ChatMessage[]>([])
   
   function clear() {
@@ -50,42 +48,8 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
     
     const messages: DisplayMessage[] = [...displayMessages]
     
-    const tools = config.tools.map(tool => {
-      return {
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description || "No description provided.",
-          parameters: tool.inputSchema || {}
-        }
-      }
-    })
-    
-    async function chat(): Promise<Response> {
-      return fetch(window.location.origin + "/api/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          baseUrl: config.baseUrl,
-          apiKey: config.apiKey,
-          chatParams: {
-            model: config.llmModel,
-            messages: chatMessages.current,
-            tools,
-            ...(config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {})
-          }
-        })
-      })
-    }
-    
     function isFirstMessage() {
       return chatMessages.current.length === 0
-    }
-    
-    function isToolAvailable(tool: string): boolean {
-      return config.tools.map(tool => tool.name).includes(tool)
     }
     
     function displayMessage(message: DisplayMessage) {
@@ -93,84 +57,33 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
       setDisplayMessages([...messages])
     }
     
-    let mcpClient = new McpClient()
-    
-    if (isFirstMessage()) {
-      chatMessages.current.push({ role: "system", content: systemPrompt })
-      displayMessage({ role: "system", content: systemPrompt })
-    }
-    chatMessages.current.push({ role: "user", content: userPrompt })
-    displayMessage({ role: "user", content: userPrompt })
-    
-    setIsRunning(true)
-    
     try {
-      while (!stopRunning.current) {
-        const response = await chat()
-        if (response.status != 200) {
-          displayMessage({ role: "error", content: "Error: " + response.status})
-          break
-        }
-        
-        const data = await response.json()
-        if (data?.choices[0]?.message?.content) {
-          const messageContent = data.choices[0].message.content
-          chatMessages.current.push({
-            role: data.choices[0].message.role,
-            content: messageContent
-          })
-          displayMessage({
-            role: data.choices[0].message.role,
-            content: messageContent
-          })
-        }
-        if (data?.choices[0]?.finish_reason === "stop") {
-          console.log("Stopping conversation from server side")
-          break
-        }
-        if (data?.choices[0]?.finish_reason === "tool_calls") {
-          chatMessages.current.push({
-            role: data.choices[0].message.role,
-            tool_calls: data.choices[0].message.tool_calls
-          })
-          displayMessage({
-            role: data.choices[0].message.role,
-            content: "tool_calls"
-          })
-          for (const toolCall of data.choices[0].message.tool_calls) {
-            if (isToolAvailable(toolCall.function.name)) {
-              const toolArgs = JSON.parse(toolCall.function.arguments || "{}")
-              displayMessage({
-                role: "tool-request",
-                content: toolCall.function.name + "(" + JSON.stringify(toolArgs) + ")"
-              })
-              const toolResult = await mcpClient.callTool(
-                toolCall.function.name,
-                toolArgs
-              )
-              const toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
-              chatMessages.current.push({
-                name: toolCall.function.name,
-                content: toolResultText,
-                role: "tool",
-                tool_call_id: toolCall.id
-              })
-              displayMessage({
-                content: toolResultText,
-                role: "tool-response"
-              })
-            }
-          }
-        }
+      const response = await fetch(getUrl("/api/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          llm: config.llm,
+          model: config.llmModel,
+          apiKey: config.apiKey,
+          systemPrompt: isFirstMessage() ? systemPrompt : null,
+          userPrompt: userPrompt,
+          chatHistory: chatMessages.current,
+          selectedTools: config.tools.map(tool => tool.name),
+          chatParams: config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {}
+        })
+      })
+      if (response.ok) {
+        const responseText = await response.text()
+        chatMessages.current.push({ role: "user", content: userPrompt })
+        chatMessages.current.push({ role: "assistant", content: responseText })
+        displayMessage({ role: "assistant", content: responseText })
+      } else {
+        displayMessage({ role: "error", content: "Error: " + response.status })
       }
     } catch (error) {
       console.error("Error during conversation:", error)
-    } finally {
-      if (mcpClient) {
-        await mcpClient.close()
-      }
-      stopRunning.current = false
-      setIsRunning(false)
     }
   }
   
@@ -183,20 +96,8 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
             size="lg"
             renderIcon={Send}
             iconDescription="Send"
-            disabled={isRunning}
             onClick={runPrompt}>
             Send
-          </Button>
-          <Button
-            kind="ghost"
-            size="lg"
-            renderIcon={Stop}
-            iconDescription="Stop"
-            disabled={!isRunning}
-            onClick={() => {
-              stopRunning.current = true
-            }}>
-            Stop
           </Button>
           <Button
             kind="ghost"

--- a/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
@@ -1,26 +1,40 @@
-import React from "react"
+import React, {useEffect, useState} from "react"
 import {ComboBox} from "@carbon/react"
-import {LlmConfig} from "./config"
+import {getUrl} from "../../custom-fetch"
 
 
 interface LLMModelComboBoxProps {
-  config?: LlmConfig
+  llm?: string
+  value?: string
   labelText?: string
   onChange: (llmModel: string) => void
 }
 
-export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ config, onChange, labelText }) => {
+export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ llm, value, onChange, labelText }) => {
   
-  const llmModelSuggestions = {
-    "https://api.openai.com": ["gpt-4o", "gpt-4o-mini", "o3-mini", "o1", "o1-mini"],
-    "https://api.mistral.ai": ["mistral-small-latest"],
-    "https://generativelanguage.googleapis.com/v1beta/openai/": ["gemini-3.1-pro", "gemini-2.5-pro"],
-    "https://api.anthropic.com": ["claude-4.7-opus", "claude-4.6-opus"]
-  }
+  const [modelCatalog, setModelCatalog] = useState({})
+  
+  
+  useEffect(() => {
+    (async () => {
+      const response = await fetch(getUrl("/api/v1/chat/llms"))
+      if (response.ok) {
+        const llms: string[] = await response.json()
+        const modelCatalog = {}
+        for (const llm of llms) {
+          const response = await fetch(getUrl(`/api/v1/chat/${llm}/models`))
+          if (response.ok) {
+            const models: string[] = await response.json()
+            modelCatalog[llm] = models
+          }
+        }
+        setModelCatalog(modelCatalog)
+      }
+    })()
+  }, [setModelCatalog])
   
   function createItems(): string[] {
-    const baseUrl = config?.baseUrl || undefined
-    return (baseUrl && llmModelSuggestions[baseUrl]) ? llmModelSuggestions[baseUrl] : []
+    return (llm && modelCatalog[llm]) ? modelCatalog[llm] : []
   }
   
   return (
@@ -29,7 +43,7 @@ export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ config, onCh
       titleText={labelText}
       items={createItems()}
       allowCustomValue
-      selectedItem={config?.llmModel}
+      selectedItem={value}
       onChange={(event) => {
         setTimeout(() => {
           const llmModel = event.selectedItem || event.inputValue || ""

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSelect.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSelect.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from "react"
 import {getUrl} from "../../custom-fetch.ts"
 
 
-interface BaseUrlSelectProps {
+interface LLMSelectProps {
   id?: string
   labelText?: string
   helperText?: string
@@ -11,27 +11,27 @@ interface BaseUrlSelectProps {
   onChange: (baseUrl: string) => void
 }
 
-export const BaseUrlSelect : React.FC<BaseUrlSelectProps> = ({ id, labelText, helperText, value, onChange }) => {
+export const LLMSelect : React.FC<LLMSelectProps> = ({ id, labelText, helperText, value, onChange }) => {
   
-  const [baseUrls, setBaseUrls] = useState<string[]>([])
+  const [llms, setLlms] = useState<string[]>([])
   const [isLoading, setLoading] = useState(true)
   
   useEffect(() => {
     (async () => {
-      const response = await fetch(getUrl("/api/v1/chat/allowlist"))
+      const response = await fetch(getUrl("/api/v1/chat/llms"))
       if (response.ok) {
         const data: string[] = await response.json()
-        setBaseUrls(data)
+        setLlms(data)
         setLoading(false)
         if (data.length > 0) {
           onChange(selectedValue(data)!)
         }
       }
     })()
-  }, [setBaseUrls, setLoading])
+  }, [setLlms, setLoading])
   
-  function selectedValue(urls: string[]): string | undefined {
-    return value || (urls.length > 0 ? urls[0] : undefined)
+  function selectedValue(llms: string[]): string | undefined {
+    return value || (llms.length > 0 ? llms[0] : undefined)
   }
   
   if (isLoading) {
@@ -39,21 +39,21 @@ export const BaseUrlSelect : React.FC<BaseUrlSelectProps> = ({ id, labelText, he
   } else {
     return (
       <Select
-        id={id || "baseUrl"}
+        id={id || "llm"}
         labelText={labelText}
         helperText={helperText}
-        value={selectedValue(baseUrls)}
+        value={selectedValue(llms)}
         onChange={(event) => {
-          const baseUrl = event.target.value
-          onChange(baseUrl)
+          const llm = event.target.value
+          onChange(llm)
         }}
       >
-        {baseUrls.map((url: string) => (
+        {llms.map((name: string) => (
           <SelectItem
-            id={url}
-            key={url}
-            text={url}
-            value={url}
+            id={name}
+            key={name}
+            text={name}
+            value={name}
           />
         ))}
       </Select>

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -11,7 +11,7 @@ import {
   LlmConfig,
   STORE_IN_LOCAL_STORAGE
 } from "./config.ts"
-import {BaseUrlSelect} from "./BaseUrlSelect"
+import {LLMSelect} from "./LLMSelect"
 import {LLMModelComboBox} from "./LLMModelComboBox"
 
 
@@ -23,6 +23,7 @@ interface LLMSetupProps {
 export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
+  const [selectedLlm, setSelectedLlm] = useState(config.llm || "")
   
   function applyConfigChange(config: LlmConfig) {
     if (isStoredInLocalStorage) {
@@ -50,17 +51,19 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
           }}
           id="enabledLocalStorage"
         />
-        <BaseUrlSelect
+        <LLMSelect
           id="base-url"
-          labelText="LLM API Base URL"
-          value={config.baseUrl || ""}
-          onChange={(baseUrl: string) => {
-            applyConfigChange({ ...config, baseUrl })
+          labelText="LLM API"
+          value={selectedLlm}
+          onChange={(llm: string) => {
+            setSelectedLlm(llm)
+            applyConfigChange({ ...config, llm })
           }}
         />
         <LLMModelComboBox
           labelText="LLM Model"
-          config={config}
+          llm={selectedLlm}
+          value={config.llmModel}
           onChange={(llmModel) => {
             applyConfigChange({ ...config, llmModel })
           }}

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -2,7 +2,7 @@ import {ToolReference} from "../../models"
 
 
 export interface LlmConfig {
-  baseUrl?: string | null
+  llm?: string | null
   llmModel?: string
   apiKey?: string
   extraLlmParams?: string
@@ -11,7 +11,7 @@ export interface LlmConfig {
 
 export function defaultLlmConfig(): LlmConfig {
   return {
-    baseUrl: "https://api.mistral.ai",
+    llm: "Mistral",
     llmModel: "mistral-small-latest",
     extraLlmParams: '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}',
     tools: []

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -29,6 +29,36 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mistral-ai</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-anthropic</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-google-ai-gemini</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-query</artifactId>
         </dependency>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/CustomLlmParameters.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/CustomLlmParameters.java
@@ -1,0 +1,33 @@
+package ai.wanaku.backend.api.v1.chat;
+
+import jakarta.json.JsonObject;
+
+import java.util.Map;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+
+public class CustomLlmParameters {
+
+    private static final String MAX_TOKENS = "max_tokens";
+    private static final String TEMPERATURE = "temperature";
+    private static final String TOOL_CHOICE = "tool_choice";
+
+    private static final Map<String, ToolChoice> toolChoices = Map.of(
+            "auto", ToolChoice.AUTO,
+            "required", ToolChoice.REQUIRED,
+            "none", ToolChoice.NONE);
+
+    public static ChatRequestParameters fromJson(JsonObject json) {
+        var builder = ChatRequestParameters.builder();
+        if (json.containsKey(MAX_TOKENS)) {
+            builder.maxOutputTokens(json.getInt(MAX_TOKENS));
+        }
+        if (json.containsKey(TEMPERATURE)) {
+            builder.temperature(json.getJsonNumber(TEMPERATURE).doubleValue());
+        }
+        if (json.containsKey(TOOL_CHOICE)) {
+            builder.toolChoice(toolChoices.get(json.getString(TOOL_CHOICE)));
+        }
+        return builder.build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
@@ -3,88 +3,185 @@ package ai.wanaku.backend.api.v1.chat;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 
-import java.io.IOException;
 import java.io.StringReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.mcp.McpToolProvider;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicChatModelName;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.model.mistralai.MistralAiChatModel;
+import dev.langchain4j.model.mistralai.MistralAiChatModelName;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModelName;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.UserMessage;
 
+import static dev.langchain4j.data.message.AiMessage.aiMessage;
+import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static jakarta.ws.rs.core.Response.Status.OK;
-import static jakarta.ws.rs.core.Response.Status.TOO_MANY_REQUESTS;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 @ApplicationScoped
 @Path("/api/v1/chat")
 public class LlmChatResource {
     private static final Logger LOG = Logger.getLogger(LlmChatResource.class);
 
+    private static final String MISTRAL = "Mistral";
+    private static final String OPEN_AI = "OpenAi";
+    private static final String GEMINI = "Gemini";
+    private static final String ANTHROPIC = "Anthropic";
+    private static final String OLLAMA = "Ollama";
+
     @ConfigProperty(name = "wanaku.chat.allowlist")
     List<String> allowlist;
 
     @GET
-    @Path("/allowlist")
+    @Path("/llms")
     @Produces(APPLICATION_JSON)
-    public List<String> getBaseUrls() {
-        return allowlist;
+    public List<String> getAllowedLlms() {
+        Stream<String> supportedLlms = Stream.of(MISTRAL, OPEN_AI, GEMINI, ANTHROPIC, OLLAMA);
+        return supportedLlms.filter(llm -> allowlist.contains(llm)).toList();
+    }
+
+    @GET
+    @Path("/{llm}/models")
+    @Produces(APPLICATION_JSON)
+    public List<String> getModels(@PathParam("llm") String llm) {
+        return switch (llm) {
+            case MISTRAL ->
+                Arrays.stream(MistralAiChatModelName.values())
+                        .map(MistralAiChatModelName::toString)
+                        .toList();
+            case OPEN_AI ->
+                Arrays.stream(OpenAiChatModelName.values())
+                        .map(OpenAiChatModelName::toString)
+                        .toList();
+            case GEMINI -> List.of("gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite");
+            case OLLAMA -> List.of();
+            case ANTHROPIC ->
+                Arrays.stream(AnthropicChatModelName.values())
+                        .map(AnthropicChatModelName::toString)
+                        .toList();
+            default -> throw new WebApplicationException("%s is not supported".formatted(llm), NOT_FOUND);
+        };
     }
 
     @POST
     @Path("/completions")
     @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
     public String codeCompletions(String data) {
         JsonObject json = Json.createReader(new StringReader(data)).readObject();
-        String baseUrl = json.getString("baseUrl");
+        String llm = json.getString("llm");
+        String modelName = json.getString("model");
         String apiKey = json.getString("apiKey", null);
-        JsonObject llmParams = json.getJsonObject("chatParams");
+        String systemPrompt = json.getString("systemPrompt", null);
+        String userPrompt = json.getString("userPrompt");
+        List<String> selectedTools = json.getJsonArray("selectedTools").getValuesAs(JsonString.class).stream()
+                .map(JsonString::getString)
+                .toList();
+        List<JsonObject> chatHistory = json.getJsonArray("chatHistory").getValuesAs(JsonObject.class);
+        JsonObject customLlmParameters = json.getJsonObject("chatParams");
 
-        if (!allowlist.contains(baseUrl)) {
-            throw new WebApplicationException("Base URL: %s is not allowed".formatted(baseUrl), BAD_REQUEST);
+        if (!allowlist.contains(llm)) {
+            throw new WebApplicationException("%s is not allowed".formatted(llm), BAD_REQUEST);
         }
-        try (var client = HttpClient.newHttpClient()) {
-            String url = baseUrl + "/v1/chat/completions";
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(new URI(url))
-                    .POST(BodyPublishers.ofString(llmParams.toString()))
-                    .header("Content-Type", APPLICATION_JSON);
 
-            if (apiKey != null && !apiKey.isEmpty()) {
-                requestBuilder.header("Authorization", "Bearer " + apiKey);
-            }
-            HttpRequest request = requestBuilder.build();
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+        McpTransport transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost:8080/public/mcp")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
 
-            if (response.statusCode() != OK.getStatusCode()) {
-                LOG.errorf("HTTP Response Error: %s", response.body());
+        try (McpClient mcpClient =
+                DefaultMcpClient.builder().transport(transport).build()) {
 
-                if (response.statusCode() == TOO_MANY_REQUESTS.getStatusCode()) {
-                    throw new WebApplicationException(TOO_MANY_REQUESTS);
+            McpToolProvider toolProvider = McpToolProvider.builder()
+                    .mcpClients(mcpClient)
+                    .filterToolNames(selectedTools)
+                    .build();
+
+            ChatModel model = buildModel(llm, modelName, apiKey);
+
+            ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+            for (JsonObject jsonMessage : chatHistory) {
+                String role = jsonMessage.getString("role");
+                String content = jsonMessage.getString("content");
+                if (("user".equals(role) || "assistant".equals(role)) && !content.isEmpty()) {
+                    ChatMessage chatMessage =
+                            switch (role) {
+                                case "user" -> userMessage(content);
+                                case "assistant" -> aiMessage(content);
+                                default -> throw new IllegalArgumentException("Unknown role: " + role);
+                            };
+                    chatMemory.add(chatMessage);
                 }
-
-                throw new WebApplicationException(INTERNAL_SERVER_ERROR);
             }
 
-            return response.body();
-        } catch (URISyntaxException ex) {
-            throw new WebApplicationException("Malformed base URL", ex, BAD_REQUEST);
-        } catch (IOException | InterruptedException ex) {
-            throw new WebApplicationException(INTERNAL_SERVER_ERROR);
+            ChatBot bot = AiServices.builder(ChatBot.class)
+                    .chatModel(model)
+                    .chatMemory(chatMemory)
+                    .systemMessage(systemPrompt)
+                    .toolProvider(toolProvider)
+                    .build();
+
+            return customLlmParameters == null || customLlmParameters.isEmpty()
+                    ? bot.chat(userPrompt)
+                    : bot.chat(userPrompt, CustomLlmParameters.fromJson(customLlmParameters));
+        } catch (Exception ex) {
+            LOG.errorf("Error in LLM chat: %s", ex);
+            throw new WebApplicationException(ex, INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private ChatModel buildModel(String llm, String model, String apiKey) {
+        return switch (llm) {
+            case MISTRAL ->
+                MistralAiChatModel.builder().modelName(model).apiKey(apiKey).build();
+            case OPEN_AI ->
+                OpenAiChatModel.builder().modelName(model).apiKey(apiKey).build();
+            case GEMINI ->
+                GoogleAiGeminiChatModel.builder()
+                        .modelName(model)
+                        .apiKey(apiKey)
+                        .build();
+            case ANTHROPIC ->
+                AnthropicChatModel.builder().modelName(model).apiKey(apiKey).build();
+            case OLLAMA -> OllamaChatModel.builder().modelName(model).build();
+            default -> throw new IllegalArgumentException("Unsupported LLM: " + llm);
+        };
+    }
+
+    private interface ChatBot {
+
+        String chat(@UserMessage String userMessage);
+
+        String chat(@UserMessage String userMessage, ChatRequestParameters params);
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -208,7 +208,7 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
                         localReference,
                         toolManager,
                         ns,
-                        (args, ignored) -> mcpBridge.executeTool(forwardClient, args, reference));
+                        (args, ignored) -> mcpBridge.executeTool(forwardClient.address(), args, reference));
 
                 reservedNames.add(localName);
                 locallyRegisteredTools.add(localReference);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/McpBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/McpBridge.java
@@ -22,7 +22,7 @@ public interface McpBridge {
     List<RemoteToolReference> listTools(ForwardClient forwardClient) throws ServiceUnavailableException;
 
     Uni<ToolResponse> executeTool(
-            ForwardClient forwardClient, ToolManager.ToolArguments toolArguments, CallableReference toolReference);
+            String address, ToolManager.ToolArguments toolArguments, CallableReference toolReference);
 
     List<ResourceReference> listResources(ForwardClient forwardClient) throws ServiceUnavailableException;
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
@@ -26,6 +26,7 @@ import ai.wanaku.capabilities.sdk.api.types.InputSchema;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.RemoteToolReference;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.McpReadResourceResult;
@@ -66,19 +67,19 @@ public class DefaultMcpBridge implements McpBridge {
 
     @Override
     public Uni<ToolResponse> executeTool(
-            ForwardClient forwardClient, ToolManager.ToolArguments toolArguments, CallableReference toolReference) {
+            String address, ToolManager.ToolArguments toolArguments, CallableReference toolReference) {
         return Uni.createFrom()
-                .item(() -> doExecuteTool(forwardClient, toolArguments, toolReference))
+                .item(() -> doExecuteTool(address, toolArguments, toolReference))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor());
     }
 
     private ToolResponse doExecuteTool(
-            ForwardClient forwardClient, ToolManager.ToolArguments toolArguments, CallableReference toolReference) {
+            String address, ToolManager.ToolArguments toolArguments, CallableReference toolReference) {
         LOG.infof(
                 "Calling tool on behalf of connection %s",
                 toolArguments.connection().id());
 
-        ReentrantLock lock = locks.computeIfAbsent(forwardClient.address(), k -> new ReentrantLock());
+        ReentrantLock lock = locks.computeIfAbsent(address, k -> new ReentrantLock());
         try {
             lock.lock();
             ToolExecutionRequest request = ToolExecutionRequest.builder()
@@ -86,12 +87,14 @@ public class DefaultMcpBridge implements McpBridge {
                     .arguments(serializeArguments(toolArguments.args()))
                     .build();
 
-            ToolExecutionResult result = forwardClient.client().executeTool(request);
-            if (result.isError()) {
-                return ToolResponse.error(result.resultText());
-            }
+            try (var mcpClient = ClientUtil.createClient(address)) {
+                ToolExecutionResult result = mcpClient.executeTool(request);
+                if (result.isError()) {
+                    return ToolResponse.error(result.resultText());
+                }
 
-            return ToolResponse.success(result.resultText());
+                return ToolResponse.success(result.resultText());
+            }
         } catch (Exception e) {
             LOG.errorf(
                     e,

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -18,7 +18,7 @@ wanaku.router.health-check.max-concurrent=10
 wanaku.bridge.grpc.transport.deadline-seconds=10
 
 # Chat LLM proxy allowlist
-wanaku.chat.allowlist=http://localhost:11434,https://api.openai.com,https://api.mistral.ai,https://generativelanguage.googleapis.com/v1beta/openai/,https://api.anthropic.com
+wanaku.chat.allowlist=Ollama,OpenAi,Mistral,Gemini,Anthropic
 
 # Wanaku internal NS
 quarkus.mcp.server.wanaku-internal.sse.root-path=/wanaku-internal/mcp


### PR DESCRIPTION
I've moved the LLM chat logic from UI to backend and implemented in in LangChain4j. I believe this brings more control and options in the future.

What is implemented:
- the chat is completely handled by _LangChain4j_. Only final answer is returned to the UI.
- LLM selection now displays names instead of URLs
- LLM allowlist is now an intersection between supported and allowed LLMs
- bugfix included - `DefaultMcpBridge` was storing already closed MCPClient that wasn't able to execute any tools
- The Stop button was removed because the UI method now awaits for the whole answer, so there is no purpose for it anymore.

What is not implemented:
- it's still possible to call public MCP tools only. I hope this opens the way to integration with Keycloak.

Any comments are welcome. 

@orpiske I have tested it with a tool call and with chat memory. Everythiong seems ok for me, but please test it before merging as these are big changes and I might have forgotten something or introduced a new bug. Thank you!

## Summary by Sourcery

Move LLM chat handling from the UI to the backend using LangChain4j with support for multiple providers and MCP tools.

New Features:
- Add backend LangChain4j-based chat endpoint that orchestrates LLM calls, tool usage via MCP, and short-term chat memory.
- Expose APIs to list allowed LLM providers and their models for dynamic UI configuration.

Bug Fixes:
- Fix MCP tool execution by creating a fresh MCP client per call instead of reusing a closed client instance.

Enhancements:
- Update UI LLM chat flow to call the backend chat endpoint and render only the final assistant response, removing client-side tool orchestration and streaming control.
- Replace URL-based LLM selection with named providers and dynamically populated model lists based on backend-reported capabilities.
- Introduce configuration mapping and helpers to pass custom LLM parameters such as max tokens, temperature, and tool choice from the UI to the backend.

Build:
- Add LangChain4j dependencies for Mistral, OpenAI, Anthropic, Google Gemini, and Ollama in the backend module.