### PR TITLE
Remove fixed versions from Camel and Forage service template dependencies

### DIFF
--- a/docs/service-catalogs.md
+++ b/docs/service-catalogs.md
@@ -135,9 +135,13 @@ rules:
 Dependencies files (`*.dependencies.txt`) list Maven coordinates for libraries required by the routes. One dependency per line:
 
 ```text
-org.apache.camel:camel-http:4.4.0
-org.apache.camel:camel-jackson:4.4.0
+org.apache.camel:camel-http
+org.apache.camel:camel-jackson
 ```
+
+> [!NOTE]
+> Apache Camel and Forage dependencies do not require a version — they are resolved automatically.
+> All other dependencies must include the version (e.g., `org.apache.activemq:artemis-commons:2.44.0`).
 
 ## CLI Workflow
 

--- a/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
+++ b/services/service-templates/src/main/services/aws-s3-resource/aws-s3/aws-s3.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-aws2-s3:4.18.2
+org.apache.camel:camel-aws2-s3

--- a/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
+++ b/services/service-templates/src/main/services/azure-files-resource/azure-files/azure-files.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-azure-files:4.18.2
+org.apache.camel:camel-azure-files

--- a/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
+++ b/services/service-templates/src/main/services/ftp-resource/ftp/ftp.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ftp:4.18.2
+org.apache.camel:camel-ftp

--- a/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pr-comments-tool/github-pr-comments/github-pr-comments.dependencies.txt
@@ -1,2 +1,2 @@
-org.apache.camel:camel-http:4.18.2
-org.apache.camel:camel-jackson:4.18.2
+org.apache.camel:camel-http
+org.apache.camel:camel-jackson

--- a/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
+++ b/services/service-templates/src/main/services/github-pullrequest-source-tool/github-pullrequest-source/github-pullrequest-source.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-http:4.18.2
+org.apache.camel:camel-http

--- a/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/google-vertexai-sink-tool/google-vertexai-sink/google-vertexai-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-google-vertexai:4.18.2
+org.apache.camel:camel-google-vertexai

--- a/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-comment-tool/jira-add-comment/jira-add-comment.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira

--- a/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-add-issue-tool/jira-add-issue/jira-add-issue.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira

--- a/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
+++ b/services/service-templates/src/main/services/jira-update-issue-tool/jira-update-issue/jira-update-issue.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-jira:4.18.2
+org.apache.camel:camel-jira

--- a/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
+++ b/services/service-templates/src/main/services/jms-tool/jms/jms.dependencies.txt
@@ -1,5 +1,5 @@
-org.apache.camel:camel-jms:4.18.2
-io.kaoto.forage:forage-jms:1.3
-io.kaoto.forage:forage-core-common:1.3
-io.kaoto.forage:forage-jms-artemis:1.3
+org.apache.camel:camel-jms
+io.kaoto.forage:forage-jms
+io.kaoto.forage:forage-core-common
+io.kaoto.forage:forage-jms-artemis
 org.apache.activemq:artemis-commons:2.44.0

--- a/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
+++ b/services/service-templates/src/main/services/kafka-tool/kafka/kafka.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-kafka:4.18.2
+org.apache.camel:camel-kafka

--- a/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/mail-sink-tool/mail-sink/mail-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-mail:4.18.2
+org.apache.camel:camel-mail

--- a/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
+++ b/services/service-templates/src/main/services/rabbitmq-tool/rabbitmq/rabbitmq.dependencies.txt
@@ -1,3 +1,3 @@
-org.apache.camel:camel-spring-rabbitmq:4.18.2
-io.kaoto.forage:forage-core-common:1.3
-io.kaoto.forage:forage-spring-rabbitmq:1.3
+org.apache.camel:camel-spring-rabbitmq
+io.kaoto.forage:forage-core-common
+io.kaoto.forage:forage-spring-rabbitmq

--- a/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
+++ b/services/service-templates/src/main/services/sftp-resource/sftp/sftp.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ftp:4.18.2
+org.apache.camel:camel-ftp

--- a/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
+++ b/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
@@ -1,5 +1,5 @@
 # Maven dependencies for tavily-search
-# One dependency per line in format: groupId:artifactId or groupId:artifactId:version
+# One dependency per line in the format: groupId:artifactId or groupId:artifactId:version
 org.apache.camel:camel-langchain4j-web-search
 io.kaoto.forage:forage-core-common
 io.kaoto.forage:forage-core-ai

--- a/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
+++ b/services/service-templates/src/main/services/tavily-search-tool/tavily-search/tavily-search.dependencies.txt
@@ -1,7 +1,7 @@
 # Maven dependencies for tavily-search
-# One dependency per line in format: groupId:artifactId:version
-org.apache.camel:camel-langchain4j-web-search:4.18.2
-io.kaoto.forage:forage-core-common:1.3
-io.kaoto.forage:forage-core-ai:1.3
-io.kaoto.forage:forage-web-search:1.3
-io.kaoto.forage:forage-web-search-tavily:1.3
+# One dependency per line in format: groupId:artifactId or groupId:artifactId:version
+org.apache.camel:camel-langchain4j-web-search
+io.kaoto.forage:forage-core-common
+io.kaoto.forage:forage-core-ai
+io.kaoto.forage:forage-web-search
+io.kaoto.forage:forage-web-search-tavily

--- a/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/telegram-sink-tool/telegram-sink/telegram-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-telegram:4.18.2
+org.apache.camel:camel-telegram

--- a/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
+++ b/services/service-templates/src/main/services/watson-nlu-sink-tool/watson-nlu-sink/watson-nlu-sink.dependencies.txt
@@ -1,1 +1,1 @@
-org.apache.camel:camel-ibm-watson-language:4.18.2
+org.apache.camel:camel-ibm-watson-language


### PR DESCRIPTION
## Summary

- Remove hardcoded versions from `org.apache.camel` and `io.kaoto.forage` dependencies across all 17 service template `.dependencies.txt` files — these are now resolved automatically by the SDK
- Keep explicit versions for third-party dependencies (e.g., `org.apache.activemq:artemis-commons:2.44.0`)
- Update `docs/service-catalogs.md` with a note clarifying when versions are required

## Test plan

- [ ] Verify service templates deploy correctly without version suffixes
- [ ] Confirm third-party dependencies with explicit versions still resolve

## Summary by Sourcery

Align service template dependency declarations with SDK-managed versions for Camel and Forage libraries.

Enhancements:
- Remove explicit version suffixes from Apache Camel and Forage dependencies across service template dependency files to rely on SDK-managed versions.

Documentation:
- Clarify in service catalog documentation that Camel and Forage dependencies omit versions while other dependencies must specify explicit versions.