### PR TITLE
Fix #1253: align CLI service template list with backend response type

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
@@ -4,13 +4,11 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
+import java.util.Map;
 import org.jline.terminal.Terminal;
-import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
-import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
-import ai.wanaku.core.services.api.ServiceCatalogIndex;
 import ai.wanaku.core.services.api.ServiceTemplateService;
 import picocli.CommandLine;
 
@@ -37,25 +35,16 @@ public class ServiceTemplateList extends BaseCommand {
         ServiceTemplateService service = initService(ServiceTemplateService.class, host);
 
         try {
-            WanakuResponse<List<DataStore>> response = service.list(search);
-            List<DataStore> templates = response.data();
+            WanakuResponse<List<Map<String, Object>>> response = service.list(search);
+            List<Map<String, Object>> templates = response.data();
 
             if (templates == null || templates.isEmpty()) {
                 printer.printInfoMessage("No service templates found%n");
                 return EXIT_OK;
             }
 
-            printer.printInfoMessage("Available service templates:%n");
-            for (DataStore ds : templates) {
-                try {
-                    ServiceCatalogIndex index = ServiceCatalogIndex.fromBase64(ds.getData());
-                    printer.printInfoMessage(String.format("  - %s: %s%n", index.getName(), index.getDescription()));
-                } catch (WanakuException e) {
-                    printer.printWarningMessage(
-                            String.format("  - %s: (failed to parse template details)%n", ds.getName()));
-                }
-            }
-
+            printer.printInfoMessage("Available service templates:");
+            printer.printTable(templates, "name", "description");
         } catch (WebApplicationException ex) {
             Response response = ex.getResponse();
             commonResponseErrorHandler(response);

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceTemplateService.java
@@ -31,14 +31,14 @@ public interface ServiceTemplateService {
     @Path("/list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    WanakuResponse<List<DataStore>> list(@QueryParam("search") String search);
+    WanakuResponse<List<Map<String, Object>>> list(@QueryParam("search") String search);
 
     /**
      * List all service template entries without filtering.
      *
      * @return response with list of all template summaries
      */
-    default WanakuResponse<List<DataStore>> list() {
+    default WanakuResponse<List<Map<String, Object>>> list() {
         return list(null);
     }
 


### PR DESCRIPTION
## Summary

- Fix NullPointerException in `wanaku service template list` CLI command
- Align `ServiceTemplateService.list()` return type with the backend's actual response (`List<Map<String, Object>>` instead of `List<DataStore>`)
- Update CLI to read `name` and `description` directly from the summary maps instead of attempting to decode absent base64 ZIP data

## Test plan

- [ ] Run `wanaku service template list` against a router with templates loaded
- [ ] Verify templates display with name and description
- [ ] Verify `--search` filter works
- [ ] Verify empty list shows "No service templates found"

## Summary by Sourcery

Align the service template listing API and CLI to use the backend’s template summary structure and avoid null/parse errors when listing templates.

Bug Fixes:
- Prevent a NullPointerException when running the `wanaku service template list` CLI command by correctly handling the backend response.

Enhancements:
- Change `ServiceTemplateService.list` to return a list of template summary maps instead of `DataStore` objects to match the backend response.
- Update the CLI service template list output to read and display template name and description directly from the summary data instead of decoding template archives.