### PR TITLE
chore: clean up LabelHelper and add missing tests

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
@@ -116,7 +116,6 @@ public class ResourcesLabelRemove extends BaseCommand {
                     "resource(s)",
                     labelExpression);
         } catch (WebApplicationException ex) {
-
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;
         }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/LabelHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/LabelHelper.java
@@ -2,7 +2,6 @@ package ai.wanaku.cli.main.support;
 
 import jakarta.ws.rs.WebApplicationException;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +58,6 @@ public final class LabelHelper {
             String identifier) {
 
         Map<String, String> existingLabels = entity.getLabels();
-        if (existingLabels == null) {
-            existingLabels = new HashMap<>();
-        }
 
         int addedCount = 0;
         int updatedCount = 0;
@@ -98,9 +94,6 @@ public final class LabelHelper {
             String identifier) {
 
         Map<String, String> existingLabels = entity.getLabels();
-        if (existingLabels == null) {
-            existingLabels = new HashMap<>();
-        }
 
         int removedCount = 0;
         int notFoundCount = 0;
@@ -136,8 +129,7 @@ public final class LabelHelper {
             Consumer<T> updater,
             java.util.function.Function<T, String> identifierExtractor,
             String entityTypePlural,
-            String labelExpression)
-            throws IOException {
+            String labelExpression) {
 
         List<T> matchingEntities = listResponse.data();
 
@@ -157,9 +149,6 @@ public final class LabelHelper {
         for (T entity : matchingEntities) {
             try {
                 Map<String, String> existingLabels = entity.getLabels();
-                if (existingLabels == null) {
-                    existingLabels = new HashMap<>();
-                }
                 existingLabels.putAll(labelsToAdd);
                 entity.setLabels(existingLabels);
                 updater.accept(entity);
@@ -184,8 +173,7 @@ public final class LabelHelper {
             Consumer<T> updater,
             java.util.function.Function<T, String> identifierExtractor,
             String entityTypePlural,
-            String labelExpression)
-            throws IOException {
+            String labelExpression) {
 
         List<T> matchingEntities = listResponse.data();
 
@@ -205,9 +193,6 @@ public final class LabelHelper {
         for (T entity : matchingEntities) {
             try {
                 Map<String, String> existingLabels = entity.getLabels();
-                if (existingLabels == null) {
-                    existingLabels = new HashMap<>();
-                }
 
                 boolean modified = false;
                 for (String labelKey : labelKeys) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
@@ -2,16 +2,23 @@ package ai.wanaku.cli.main.support;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jline.builtins.ConfigurationPath;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.commands.BaseCommand;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LabelHelperTest {
@@ -25,43 +32,259 @@ class LabelHelperTest {
         printer = new WanakuPrinter(configPath, terminal);
     }
 
-    @Test
-    void parseLabelsReturnsEmptyMapWhenLabelsIsNull() {
-        Map<String, String> result = LabelHelper.parseLabels(null, printer);
+    @Nested
+    class ParseLabelsTests {
 
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+        @Test
+        void returnsEmptyMapWhenLabelsIsNull() {
+            Map<String, String> result = LabelHelper.parseLabels(null, printer);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void returnsEmptyMapWhenLabelsIsEmpty() {
+            Map<String, String> result = LabelHelper.parseLabels(List.of(), printer);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void parsesValidLabels() {
+            Map<String, String> result = LabelHelper.parseLabels(List.of("env=prod", "team=backend"), printer);
+
+            assertEquals(2, result.size());
+            assertEquals("prod", result.get("env"));
+            assertEquals("backend", result.get("team"));
+        }
+
+        @Test
+        void returnsNullForInvalidFormat() {
+            Map<String, String> result = LabelHelper.parseLabels(List.of("no-equals-sign"), printer);
+
+            assertNull(result);
+        }
+
+        @Test
+        void trimsKeysAndValues() {
+            Map<String, String> result = LabelHelper.parseLabels(List.of(" env = prod "), printer);
+
+            assertEquals(1, result.size());
+            assertEquals("prod", result.get("env"));
+        }
     }
 
-    @Test
-    void parseLabelsReturnsEmptyMapWhenLabelsIsEmpty() {
-        Map<String, String> result = LabelHelper.parseLabels(List.of(), printer);
+    @Nested
+    class ValidateLabelExpressionTests {
 
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+        @Test
+        void returnErrorWhenBothProvided() {
+            int result = LabelHelper.validateLabelExpression("id", "expr", "--id", printer);
+            assertEquals(BaseCommand.EXIT_ERROR, result);
+        }
+
+        @Test
+        void returnErrorWhenNeitherProvided() {
+            int result = LabelHelper.validateLabelExpression(null, null, "--id", printer);
+            assertEquals(BaseCommand.EXIT_ERROR, result);
+        }
+
+        @Test
+        void returnOkWhenOnlyIdentifierProvided() {
+            int result = LabelHelper.validateLabelExpression("id", null, "--id", printer);
+            assertEquals(BaseCommand.EXIT_OK, result);
+        }
+
+        @Test
+        void returnOkWhenOnlyExpressionProvided() {
+            int result = LabelHelper.validateLabelExpression(null, "expr", "--id", printer);
+            assertEquals(BaseCommand.EXIT_OK, result);
+        }
     }
 
-    @Test
-    void parseLabelsParsesValidLabels() {
-        Map<String, String> result = LabelHelper.parseLabels(List.of("env=prod", "team=backend"), printer);
+    @Nested
+    class AddLabelsToEntityTests {
 
-        assertEquals(2, result.size());
-        assertEquals("prod", result.get("env"));
-        assertEquals("backend", result.get("team"));
+        @Test
+        void addsNewLabels() {
+            ToolReference tool = createTool("my-tool", new HashMap<>());
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            int result = LabelHelper.addLabelsToEntity(
+                    tool, Map.of("env", "prod"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertNotNull(updated.get());
+            assertEquals("prod", updated.get().getLabels().get("env"));
+        }
+
+        @Test
+        void updatesExistingLabel() {
+            ToolReference tool = createTool("my-tool", new HashMap<>(Map.of("env", "dev")));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            int result = LabelHelper.addLabelsToEntity(
+                    tool, Map.of("env", "prod"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertEquals("prod", updated.get().getLabels().get("env"));
+        }
+
+        @Test
+        void preservesExistingLabels() {
+            ToolReference tool = createTool("my-tool", new HashMap<>(Map.of("tier", "backend")));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            LabelHelper.addLabelsToEntity(tool, Map.of("env", "prod"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals("backend", updated.get().getLabels().get("tier"));
+            assertEquals("prod", updated.get().getLabels().get("env"));
+        }
     }
 
-    @Test
-    void parseLabelsReturnsNullForInvalidFormat() {
-        Map<String, String> result = LabelHelper.parseLabels(List.of("no-equals-sign"), printer);
+    @Nested
+    class RemoveLabelsFromEntityTests {
 
-        assertTrue(result == null || result.isEmpty());
+        @Test
+        void removesExistingLabel() {
+            ToolReference tool = createTool("my-tool", new HashMap<>(Map.of("env", "dev", "tier", "backend")));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            int result =
+                    LabelHelper.removeLabelsFromEntity(tool, List.of("env"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertNotNull(updated.get());
+            assertEquals(1, updated.get().getLabels().size());
+            assertEquals("backend", updated.get().getLabels().get("tier"));
+        }
+
+        @Test
+        void skipsNonexistentLabelWithoutCallingUpdater() {
+            ToolReference tool = createTool("my-tool", new HashMap<>(Map.of("env", "dev")));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            int result = LabelHelper.removeLabelsFromEntity(
+                    tool, List.of("nonexistent"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertNull(updated.get());
+        }
+
+        @Test
+        void removesMultipleLabels() {
+            ToolReference tool =
+                    createTool("my-tool", new HashMap<>(Map.of("env", "dev", "tier", "backend", "team", "core")));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            int result = LabelHelper.removeLabelsFromEntity(
+                    tool, List.of("env", "tier"), printer, updated::set, "tool", "my-tool");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertEquals(1, updated.get().getLabels().size());
+            assertEquals("core", updated.get().getLabels().get("team"));
+        }
     }
 
-    @Test
-    void parseLabelsTrimsKeysAndValues() {
-        Map<String, String> result = LabelHelper.parseLabels(List.of(" env = prod "), printer);
+    @Nested
+    class AddLabelsByExpressionTests {
 
-        assertEquals(1, result.size());
-        assertEquals("prod", result.get("env"));
+        @Test
+        void returnsOkWhenNoMatchingEntities() {
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(List.of());
+
+            int result = LabelHelper.addLabelsByExpression(
+                    response, Map.of("env", "prod"), printer, t -> {}, ToolReference::getName, "tool(s)", "env=dev");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+        }
+
+        @Test
+        void addsLabelsToAllMatchingEntities() {
+            ToolReference tool1 = createTool("tool-1", new HashMap<>());
+            ToolReference tool2 = createTool("tool-2", new HashMap<>());
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(List.of(tool1, tool2));
+
+            int result = LabelHelper.addLabelsByExpression(
+                    response,
+                    Map.of("env", "prod"),
+                    printer,
+                    t -> {},
+                    ToolReference::getName,
+                    "tool(s)",
+                    "tier=backend");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertEquals("prod", tool1.getLabels().get("env"));
+            assertEquals("prod", tool2.getLabels().get("env"));
+        }
+
+        @Test
+        void returnsOkForNullData() {
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(null);
+
+            int result = LabelHelper.addLabelsByExpression(
+                    response, Map.of("env", "prod"), printer, t -> {}, ToolReference::getName, "tool(s)", "env=dev");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+        }
+    }
+
+    @Nested
+    class RemoveLabelsByExpressionTests {
+
+        @Test
+        void returnsOkWhenNoMatchingEntities() {
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(List.of());
+
+            int result = LabelHelper.removeLabelsByExpression(
+                    response, List.of("env"), printer, t -> {}, ToolReference::getName, "tool(s)", "env=dev");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+        }
+
+        @Test
+        void removesLabelsFromMatchingEntities() {
+            ToolReference tool1 = createTool("tool-1", new HashMap<>(Map.of("env", "dev", "tier", "backend")));
+            ToolReference tool2 = createTool("tool-2", new HashMap<>(Map.of("env", "prod")));
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(List.of(tool1, tool2));
+
+            int result = LabelHelper.removeLabelsByExpression(
+                    response, List.of("env"), printer, t -> {}, ToolReference::getName, "tool(s)", "tier=backend");
+
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertTrue(tool1.getLabels().containsKey("tier"));
+            assertEquals(1, tool1.getLabels().size());
+            assertTrue(tool2.getLabels().isEmpty());
+        }
+
+        @Test
+        void skipsUnmodifiedEntities() {
+            ToolReference tool = createTool("tool-1", new HashMap<>(Map.of("env", "dev")));
+            WanakuResponse<List<ToolReference>> response = new WanakuResponse<>(List.of(tool));
+            AtomicReference<ToolReference> updated = new AtomicReference<>();
+
+            LabelHelper.removeLabelsByExpression(
+                    response,
+                    List.of("nonexistent"),
+                    printer,
+                    updated::set,
+                    ToolReference::getName,
+                    "tool(s)",
+                    "env=dev");
+
+            assertNull(updated.get());
+        }
+    }
+
+    private ToolReference createTool(String name, Map<String, String> labels) {
+        ToolReference tool = new ToolReference();
+        tool.setName(name);
+        if (labels != null) {
+            tool.setLabels(labels);
+        }
+        return tool;
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ResponseHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ResponseHelperTest.java
@@ -1,0 +1,38 @@
+package ai.wanaku.cli.main.support;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import ai.wanaku.cli.main.commands.BaseCommand;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ResponseHelperTest {
+
+    @Test
+    void handleNotFoundReturnsErrorForNotFoundStatus() throws IOException {
+        WebApplicationException ex = new WebApplicationException(
+                Response.status(Response.Status.NOT_FOUND).build());
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+
+        int result = ResponseHelper.handleNotFound(ex, "Tool", "my-tool", printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printWarningMessage("Tool 'my-tool' not found: Not Found");
+    }
+
+    @Test
+    void handleNotFoundReturnsErrorForOtherStatus() throws IOException {
+        WebApplicationException ex = new WebApplicationException(
+                Response.status(Response.Status.INTERNAL_SERVER_ERROR).build());
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+
+        int result = ResponseHelper.handleNotFound(ex, "Tool", "my-tool", printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+    }
+}


### PR DESCRIPTION
## Summary
- Remove stray blank line in `ResourcesLabelRemove.java`
- Remove redundant null checks in `LabelHelper` (`LabelsAwareEntity.getLabels()` never returns null)
- Remove unnecessary `throws IOException` from `addLabelsByExpression` and `removeLabelsByExpression`
- Expand `LabelHelperTest` with tests for `addLabelsToEntity`, `removeLabelsFromEntity`, `addLabelsByExpression`, and `removeLabelsByExpression`
- Add `ResponseHelperTest` for `handleNotFound`

## Test plan
- [x] `mvn verify -pl apps/wanaku-cli -am` passes (276 tests, 0 failures)

## Summary by Sourcery

Clean up label handling helpers and expand test coverage for label operations and response error handling.

Enhancements:
- Simplify label helper methods by removing redundant null checks on entity labels and dropping unnecessary checked exceptions from expression-based label operations.

Tests:
- Greatly expand LabelHelper tests to cover parsing, validation, entity-level label add/remove operations, and expression-based labeling workflows.
- Add ResponseHelper tests to verify handleNotFound behavior for not-found and other error statuses.