### PR TITLE
Fix #1236: Unify CLI launch scripts to support both JAR and native binary

### DIFF
--- a/apps/wanaku-cli/src/main/assembly/assembly-native.xml
+++ b/apps/wanaku-cli/src/main/assembly/assembly-native.xml
@@ -24,5 +24,14 @@
                 <include>LICENSE</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>./bin</outputDirectory>
+            <includes>
+                <include>**/*.*</include>
+                <include>**/wanaku</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/apps/wanaku-cli/src/main/scripts/wanaku
+++ b/apps/wanaku-cli/src/main/scripts/wanaku
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+localDir="$(dirname "$0")"
 
+if [ -x "${localDir}/wanaku-cli" ]; then
+    exec "${localDir}/wanaku-cli" "$@"
+fi
 
-localDir="$(dirname $0)"
 installDir="$(dirname "${localDir}")"
-
 java -jar "${installDir}"/quarkus-run.jar "$@"

--- a/apps/wanaku-cli/src/main/scripts/wanaku.bat
+++ b/apps/wanaku-cli/src/main/scripts/wanaku.bat
@@ -8,5 +8,4 @@ if exist "%~dp0wanaku-cli.exe" (
     exit /b %ERRORLEVEL%
 )
 
-set SDM_HOME=%~dp0\..
-@java -jar quarkus-run.jar %*
+@java -jar "%~dp0..\quarkus-run.jar" %*

--- a/apps/wanaku-cli/src/main/scripts/wanaku.bat
+++ b/apps/wanaku-cli/src/main/scripts/wanaku.bat
@@ -1,9 +1,12 @@
 @echo off
 
-set SDM_HOME=%~dp0\..
-
-@REM Set
 if %OS%=="Windows_NT" @setlocal
 if %OS%=="WINNT" @setlocal
 
+if exist "%~dp0wanaku-cli.exe" (
+    "%~dp0wanaku-cli.exe" %*
+    exit /b %ERRORLEVEL%
+)
+
+set SDM_HOME=%~dp0\..
 @java -jar quarkus-run.jar %*


### PR DESCRIPTION
## Summary

- Modified `wanaku` and `wanaku.bat` launcher scripts to detect and use the `wanaku-cli` native binary when present, falling back to JAR execution otherwise
- Added launcher scripts to the native binary distribution (`assembly-native.xml`) so they ship alongside `wanaku-cli`

Fixes #1236

## Summary by Sourcery

Unify the wanaku CLI launch scripts so they can run either the native wanaku-cli binary or the JAR-based launcher, and include these scripts in the native distribution.

Enhancements:
- Update wanaku CLI launcher scripts to prefer the native wanaku-cli executable when available and fall back to running the JAR otherwise.

Build:
- Include wanaku CLI launcher scripts in the native binary assembly under bin with executable permissions.