### PR TITLE
chore: upgrade graalvm/setup-graalvm from v1.3.4 to v1.5.4

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: graalvm/setup-graalvm@v1.3.4
+      - uses: graalvm/setup-graalvm@v1.5.4
         with:
           java-version: '21'
           distribution: 'graalvm'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
           ref: wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
 
-      - uses: graalvm/setup-graalvm@v1.3.4
+      - uses: graalvm/setup-graalvm@v1.5.4
         with:
           java-version: '21'
           distribution: 'graalvm'


### PR DESCRIPTION
## Summary
- Upgrade `graalvm/setup-graalvm` action from v1.3.4 to v1.5.4 in `release-artifacts.yml` and `early-access.yml`

## Test plan
- [ ] Verify next early-access or release workflow run completes successfully

## Summary by Sourcery

CI:
- Bump graalvm/setup-graalvm action from v1.3.4 to v1.5.4 in early-access and release-artifacts workflows.