### PR TITLE
chore: support releasing from branches instead of main

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -14,12 +14,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout Wanaku Capabilities SDK Main Project
+      - name: Determine SDK ref
+        id: sdk-ref
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+            echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "ref=main" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout Wanaku Capabilities SDK
         uses: actions/checkout@v6
         with:
           repository: wanaku-ai/wanaku-capabilities-java-sdk
           persist-credentials: false
-          ref: main
+          ref: ${{ steps.sdk-ref.outputs.ref }}
           path: wanaku-capabilities-java-sdk
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -27,7 +36,7 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-      - name: Build Wanaku Capabilities SDK Main Project
+      - name: Build Wanaku Capabilities SDK
         run: mvn --no-transfer-progress -DskipTests clean install
         working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
       - name: Checkout

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,6 +15,7 @@ on:
         - main
         - release-prep
         - ci-**
+        - '[0-9]*.[0-9]*.x'
     tags:
       - wanaku-*
     paths-ignore:
@@ -57,14 +58,23 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Checkout Wanaku Capabilities SDK Main Project
+    - name: Determine SDK ref
+      id: sdk-ref
+      run: |
+        BRANCH="${GITHUB_REF_NAME}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
+    - name: Checkout Wanaku Capabilities SDK
       uses: actions/checkout@v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
-        ref: main
+        ref: ${{ steps.sdk-ref.outputs.ref }}
         path: wanaku-capabilities-java-sdk
-    - name: Build Wanaku Capabilities SDK Main Project
+    - name: Build Wanaku Capabilities SDK
       run: mvn --no-transfer-progress -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
     - name: Set arch

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - '[0-9]*.[0-9]*.x'
     paths-ignore:
       - .github/**
       - docs/**
@@ -47,12 +48,22 @@ jobs:
       fail-fast: true
 
     steps:
-    - name: Checkout Wanaku Capabilities SDK Main Project
+    - name: Determine SDK ref
+      id: sdk-ref
+      shell: bash
+      run: |
+        BRANCH="${{ github.base_ref }}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
+    - name: Checkout Wanaku Capabilities SDK
       uses: actions/checkout@v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
-        ref: main
+        ref: ${{ steps.sdk-ref.outputs.ref }}
         path: wanaku-capabilities-java-sdk
     - name: Set up JDK 21
       uses: actions/setup-java@v5
@@ -60,7 +71,7 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Build Wanaku Capabilities SDK Main Project
+    - name: Build Wanaku Capabilities SDK
       run: mvn --no-transfer-progress -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
     - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       nextDevelopmentVersion:
         description: 'The next development version'
         required: true
+      releaseBranch:
+        description: 'The release branch (e.g., 0.1.x)'
+        required: true
 
 jobs:
   perform-release:
@@ -24,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.releaseBranch }}
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -54,7 +58,7 @@ jobs:
           mvn --no-transfer-progress -PcommitFiles scm:checkin
           git tag -d wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
           git tag wanaku-${{ github.event.inputs.currentDevelopmentVersion }} HEAD~2
-          git push origin wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
+          git push origin HEAD:${{ github.event.inputs.releaseBranch }} wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
           mvn --no-transfer-progress -Pdist release:perform
 
       # Warm up javadoc.io caches

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -2,19 +2,34 @@
 
 ## Automated Release Process
 
-Start by setting the versions.
+Releases are cut from release branches following the `X.Y.x` naming convention (e.g., `0.1.x`, `0.2.x`).
+
+### Create the release branch (first release of a minor version only)
 
 ```shell
+git checkout main
+git checkout -b 0.2.x
+git push origin 0.2.x
+```
+
+### Set the versions
+
+```shell
+export RELEASE_BRANCH=0.2.x
 export PREVIOUS_VERSION=0.1.0
-export CURRENT_DEVELOPMENT_VERSION=0.1.1
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+export CURRENT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.2.1
 ```
 
-Trigger a release build:
+### Trigger the release
 
 ```shell
-gh workflow run release -f previousDevelopmentVersion=${PREVIOUS_VERSION} -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
+gh workflow run release -r ${RELEASE_BRANCH} -f releaseBranch=${RELEASE_BRANCH} -f previousDevelopmentVersion=${PREVIOUS_VERSION} -f currentDevelopmentVersion=${CURRENT_DEVELOPMENT_VERSION} -f nextDevelopmentVersion=${NEXT_DEVELOPMENT_VERSION}
 ```
+
+> [!NOTE]
+> The `-r` flag tells GitHub to run the workflow from the release branch. The `releaseBranch` input tells the
+> workflow which branch to check out and push version bump commits to.
 
 The release build can take up to 30 minutes to complete. This will:
 
@@ -63,12 +78,14 @@ gpg --list-public-keys --keyid-format LONG
 
 ## Before start
 
-Repeat this for every machine to be used for the release.
+Repeat this for every machine to be used for the release. Make sure you are on the release branch.
 
 ```shell
+export RELEASE_BRANCH=0.2.x
+git checkout ${RELEASE_BRANCH}
 export PREVIOUS_VERSION=0.1.0
-export CURRENT_DEVELOPMENT_VERSION=0.1.1
-export NEXT_DEVELOPMENT_VERSION=0.2.0
+export CURRENT_DEVELOPMENT_VERSION=0.2.0
+export NEXT_DEVELOPMENT_VERSION=0.2.1
 ```
 
 > [!NOTE]
@@ -135,10 +152,10 @@ Recreate the release tag by marking tagging at exactly two commits before HEAD (
 git tag wanaku-${CURRENT_DEVELOPMENT_VERSION} HEAD~2
 ```
 
-Push the code to the repository:
+Push the version bump commits to the release branch and the tag:
 
 ```shell
-git push upstream wanaku-${CURRENT_DEVELOPMENT_VERSION}
+git push upstream HEAD:${RELEASE_BRANCH} wanaku-${CURRENT_DEVELOPMENT_VERSION}
 ```
 
 Now continue with the release:


### PR DESCRIPTION
## Summary

- Add `releaseBranch` input to `release.yml` so releases are cut from `X.Y.x` branches instead of `main`
- Add release branch triggers (`[0-9]*.[0-9]*.x`) to `main-build.yml` and `pr-builds.yml`
- Add SDK branch-matching logic to all CI workflows (tries matching branch on `wanaku-capabilities-java-sdk`, falls back to `main`)
- Update `docs/release-guide.md` with branch-based release instructions

## Test plan

- [ ] Create a test release branch (e.g. `0.1.x`) and verify `main-build.yml` triggers on push
- [ ] Open a PR targeting the release branch and verify `pr-builds.yml` runs
- [ ] Dry-run the release workflow with `releaseBranch` input
- [ ] Verify `release-artifacts.yml` still works unchanged (tag-based checkout)

## Summary by Sourcery

Update release workflows and documentation to support cutting releases from versioned release branches instead of main, while aligning CI builds with matching SDK branches.

Enhancements:
- Allow the release workflow to run against a specified release branch and push version bump commits back to that branch alongside tags.
- Add branch-based triggering for CI builds on versioned release branches in main-build and PR workflows.
- Make CI workflows dynamically select the matching wanaku-capabilities-java-sdk branch when available, falling back to main otherwise.

CI:
- Extend PR and main build workflows to run on X.Y.x release branches and to use a branch-aware checkout of the wanaku-capabilities-java-sdk repository.

Documentation:
- Document a branch-based release flow using X.Y.x release branches and updated workflow invocation examples in the release guide.