### PR TITLE
Fix #1265: Defer RuntimeConstants initialization to runtime

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -154,10 +154,10 @@ public class StartLocal extends StartBase {
 
             if (exclusive.exclusiveNonStart.clean) {
                 printer.printWarningMessage("Removing Wanaku cache directory");
-                deleteDirectory(printer, new File(RuntimeConstants.WANAKU_CACHE_DIR));
+                deleteDirectory(printer, new File(RuntimeConstants.wanakuCacheDir()));
 
                 printer.printWarningMessage("Removing Wanaku local instance directory");
-                deleteDirectory(printer, new File(RuntimeConstants.WANAKU_LOCAL_DIR));
+                deleteDirectory(printer, new File(RuntimeConstants.wanakuLocalDir()));
 
                 return EXIT_OK;
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/RuntimeConstants.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/RuntimeConstants.java
@@ -3,14 +3,19 @@ package ai.wanaku.cli.main.support;
 import java.io.File;
 
 public class RuntimeConstants {
-    public static final String WANAKU_HOME_DIR;
-    public static final String WANAKU_CACHE_DIR;
-    public static final String WANAKU_LOCAL_DIR;
     public static final String WANAKU_ROUTER_BACKEND = "wanaku-router-backend";
 
-    static {
-        WANAKU_HOME_DIR = System.getProperty("user.home") + File.separator + ".wanaku";
-        WANAKU_CACHE_DIR = WANAKU_HOME_DIR + File.separator + "cache";
-        WANAKU_LOCAL_DIR = WANAKU_HOME_DIR + File.separator + "local";
+    private RuntimeConstants() {}
+
+    public static String wanakuHomeDir() {
+        return System.getProperty("user.home") + File.separator + ".wanaku";
+    }
+
+    public static String wanakuCacheDir() {
+        return wanakuHomeDir() + File.separator + "cache";
+    }
+
+    public static String wanakuLocalDir() {
+        return wanakuHomeDir() + File.separator + "local";
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -330,7 +330,7 @@ public class LocalRunner {
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
-        File componentDir = new File(RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
+        File componentDir = new File(RuntimeConstants.wanakuLocalDir(), componentName);
 
         List<String> command = new ArrayList<>();
         command.add("java");
@@ -398,7 +398,7 @@ public class LocalRunner {
             downloadedFile = localMatch;
         } else {
             String downloadUrl = getDownloadURL(urlFormat);
-            File destinationDir = new File(RuntimeConstants.WANAKU_CACHE_DIR);
+            File destinationDir = new File(RuntimeConstants.wanakuCacheDir());
 
             LOG.infof("Downloading %s", componentName);
             LOG.debugf("Download URL: %s", downloadUrl);
@@ -406,7 +406,7 @@ public class LocalRunner {
         }
 
         if (isJarArtifact(downloadedFile.getName())) {
-            Path componentDir = Path.of(RuntimeConstants.WANAKU_LOCAL_DIR, componentName);
+            Path componentDir = Path.of(RuntimeConstants.wanakuLocalDir(), componentName);
             Files.createDirectories(componentDir);
             Files.copy(
                     downloadedFile.toPath(), componentDir.resolve(STANDALONE_JAR), StandardCopyOption.REPLACE_EXISTING);
@@ -414,7 +414,7 @@ public class LocalRunner {
         } else {
             String extractDir = componentName + File.separator + QUARKUS_APP;
             LOG.infof("Deploying %s", componentName);
-            ZipHelper.unzip(downloadedFile, RuntimeConstants.WANAKU_LOCAL_DIR, extractDir);
+            ZipHelper.unzip(downloadedFile, RuntimeConstants.wanakuLocalDir(), extractDir);
         }
     }
 
@@ -457,7 +457,7 @@ public class LocalRunner {
     }
 
     private static File quarkusAppDir(String componentName) {
-        return new File(new File(RuntimeConstants.WANAKU_LOCAL_DIR, componentName), QUARKUS_APP);
+        return new File(new File(RuntimeConstants.wanakuLocalDir(), componentName), QUARKUS_APP);
     }
 
     private static boolean isEnabled(List<String> services, Map.Entry<String, String> component) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/RuntimeConstantsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/RuntimeConstantsTest.java
@@ -1,0 +1,35 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RuntimeConstantsTest {
+
+    @Test
+    void wanakuHomeDirUsesCurrentUserHome() {
+        String expected = System.getProperty("user.home") + File.separator + ".wanaku";
+        assertEquals(expected, RuntimeConstants.wanakuHomeDir());
+    }
+
+    @Test
+    void wanakuCacheDirIsUnderHomeDir() {
+        String expected = RuntimeConstants.wanakuHomeDir() + File.separator + "cache";
+        assertEquals(expected, RuntimeConstants.wanakuCacheDir());
+    }
+
+    @Test
+    void wanakuLocalDirIsUnderHomeDir() {
+        String expected = RuntimeConstants.wanakuHomeDir() + File.separator + "local";
+        assertEquals(expected, RuntimeConstants.wanakuLocalDir());
+    }
+
+    @Test
+    void directoriesReflectSystemProperty() {
+        String userHome = System.getProperty("user.home");
+        assertNotNull(userHome);
+        assertEquals(userHome + File.separator + ".wanaku", RuntimeConstants.wanakuHomeDir());
+    }
+}


### PR DESCRIPTION
## Summary

- Replace static fields (`WANAKU_HOME_DIR`, `WANAKU_CACHE_DIR`, `WANAKU_LOCAL_DIR`) with methods (`wanakuHomeDir()`, `wanakuCacheDir()`, `wanakuLocalDir()`) so `System.getProperty("user.home")` is evaluated at runtime instead of being baked into the GraalVM native image at build time
- Update all call sites in `LocalRunner` and `StartLocal`
- Add `RuntimeConstantsTest` to verify the methods resolve against the current user's home directory

## Test plan

- [x] `RuntimeConstantsTest` passes (4 tests)
- [ ] Build native CLI binary on CI and verify `wanaku start local` uses the correct home directory

## Summary by Sourcery

Defer resolution of Wanaku CLI user-dependent directories to runtime instead of using static constants baked into the binary.

Bug Fixes:
- Ensure Wanaku home, cache, and local directories are derived from the current user's home directory at runtime, avoiding incorrect paths in native images.

Tests:
- Add RuntimeConstants tests to verify directories are computed from the current user.home system property.