### PR TITLE
chore: enable formatted changelog in JReleaser

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -39,6 +39,7 @@ release:
       enabled: true
     skipTag: true
     changelog:
+      formatted: ALWAYS
       contentTemplate: src/jreleaser/changelog.tpl
 
 distributions:


### PR DESCRIPTION
## Summary

- Add `formatted: ALWAYS` to the JReleaser changelog configuration so the `contentTemplate` (`src/jreleaser/changelog.tpl`) is actually used when generating release notes.

## Test plan

- [ ] Verify JReleaser dry-run produces release notes using the template

## Summary by Sourcery

Build:
- Configure JReleaser changelog to always use the formatted mode with the specified content template.