### PR TITLE
chore: update hardcoded 0.1.1 version references to 0.1.2

### DIFF
--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -76,8 +76,8 @@ This produces `.tar.gz` archives under each module's `target/distributions/` dir
 
 ```bash
 tests/load/run-perf-test.sh \
-  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.1-SNAPSHOT.tar.gz \
-  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.1.1-SNAPSHOT.tar.gz \
+  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.2-SNAPSHOT.tar.gz \
+  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.1.2-SNAPSHOT.tar.gz \
   --suite tools-sse \
   --test-name my-run \
   --test-base-dir /tmp/perf-results

--- a/docs/testing-wanaku-start-local.md
+++ b/docs/testing-wanaku-start-local.md
@@ -9,7 +9,7 @@ mvn -DskipTests -Pdist clean package
 Run the CLI with local distributions:
 
 ```shell
-java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.1-SNAPSHOT.zip --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-0.1.1-SNAPSHOT.zip
+java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.2-SNAPSHOT.zip --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-0.1.2-SNAPSHOT.zip
 ```
 
 Then, access <http://localhost:8080/admin>. Wanaku should be available at that address. No authentication should be required.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2948,8 +2948,8 @@ open http://localhost:8080
 
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-mcp-servers-archetype \ 
-  -DarchetypeVersion=0.1.1 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
-  -Dname=S3 -Dwanaku-version=0.1.1 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=0.1.2 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
+  -Dname=S3 -Dwanaku-version=0.1.2 -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -4,7 +4,7 @@
     "wanaku": {
       "script-ref": "apps/wanaku-jbang/src/main/java/ai/wanaku/jbang/WanakuJBang.java",
       "dependencies": [
-        "ai.wanaku:cli:${wanaku.version:0.1.1}"
+        "ai.wanaku:cli:${wanaku.version:0.1.2}"
       ],
       "description": "Run Wanaku easily with JBang"
     }


### PR DESCRIPTION
## Summary
- Update hardcoded version references from 0.1.1 to 0.1.2 across jbang-catalog.json and documentation files
- Ensures version consistency ahead of the 0.1.2 release

## Test plan
- [ ] Verify jbang-catalog.json default version resolves correctly
- [ ] Review docs for any remaining stale version references

## Summary by Sourcery

Align hardcoded version references with the 0.1.2 release across documentation and tooling metadata.

Documentation:
- Update performance, usage, and local testing guides to reference 0.1.2-SNAPSHOT artifacts and archetype versions instead of 0.1.1.

Chores:
- Refresh jbang-catalog metadata to default to version 0.1.2 instead of 0.1.1 for Wanaku artifacts.