### PR TITLE
chore: fix CLI download URLs in changelog template

### DIFF
--- a/src/jreleaser/changelog.tpl
+++ b/src/jreleaser/changelog.tpl
@@ -6,9 +6,9 @@ The CLI is used to manage and interact with the Wanaku MCP Router.
 
 | Platform | File |
 |---|---|
-| **Linux (x86_64)** | [cli-{{projectVersion}}-linux-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}-linux-x86_64.zip) |
-| **macOS (Apple Silicon)** | [cli-{{projectVersion}}-osx-aarch_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}-osx-aarch_64.zip) |
-| **Java (all platforms)** | [cli-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/cli-{{projectVersion}}.zip) |
+| **Linux (x86_64)** | [wanaku-cli-{{projectVersion}}-linux-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}-linux-x86_64.zip) |
+| **macOS (Apple Silicon)** | [wanaku-cli-{{projectVersion}}-osx-aarch_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}-osx-aarch_64.zip) |
+| **Java (all platforms)** | [wanaku-cli-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}.zip) |
 
 > **Tip:** You can also install via JBang: `jbang app install wanaku@wanaku-ai/wanaku`
 


### PR DESCRIPTION
## Summary
- The changelog template used `cli-` prefix instead of `wanaku-cli-`, producing 404 download links on GitHub releases (e.g. `cli-0.1.2-osx-aarch_64.zip` instead of `wanaku-cli-0.1.2-osx-aarch_64.zip`).
- Fixed all three CLI entries (Linux native, macOS native, Java) to match the actual artifact names in `jreleaser.yml`.

## Test plan
- [ ] Verify rendered URLs match artifacts uploaded to the 0.1.2 release

## Summary by Sourcery

Bug Fixes:
- Correct CLI download URLs in the changelog template so they match the actual release artifact names for Linux, macOS, and Java distributions.