### PR TITLE
chore: fix get-wanaku.sh Java fallback install

### DIFF
--- a/get-wanaku.sh
+++ b/get-wanaku.sh
@@ -108,6 +108,19 @@ install_wanaku() {
 
     unzip -qo "${TMPDIR}/${ARTIFACT}" -d "$TMPDIR"
 
+    if [ "$PLATFORM" = "java" ]; then
+        install_java
+    else
+        install_native
+    fi
+
+    if ! echo "$PATH" | tr ':' '\n' | grep -Fxq "$INSTALL_DIR"; then
+        warn "$INSTALL_DIR is not in your PATH. Add it with:"
+        warn "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    fi
+}
+
+install_native() {
     local bin_dir
     bin_dir="$(find "$TMPDIR" -type d -name bin | head -1)"
 
@@ -120,11 +133,33 @@ install_wanaku() {
             install -m 750 "${bin_dir}/${f}" "${INSTALL_DIR}/${f}"
         fi
     done
+}
 
-    if ! echo "$PATH" | tr ':' '\n' | grep -Fxq "$INSTALL_DIR"; then
-        warn "$INSTALL_DIR is not in your PATH. Add it with:"
-        warn "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+install_java() {
+    local extract_dir
+    extract_dir="$(find "$TMPDIR" -maxdepth 1 -type d -name "wanaku-cli-*" | head -1)"
+
+    if [ -z "$extract_dir" ] || [ ! -f "${extract_dir}/quarkus-run.jar" ]; then
+        error "Unexpected Java archive layout — quarkus-run.jar not found"
     fi
+
+    local java_home="${INSTALL_DIR}/wanaku-java"
+    rm -rf "$java_home"
+    cp -R "$extract_dir" "$java_home"
+
+    cat > "${INSTALL_DIR}/wanaku" <<'WRAPPER'
+#!/bin/sh
+installDir="$(dirname "$0")/wanaku-java"
+exec java -jar "${installDir}/quarkus-run.jar" "$@"
+WRAPPER
+    chmod 750 "${INSTALL_DIR}/wanaku"
+
+    cat > "${INSTALL_DIR}/wanaku-cli" <<'WRAPPER'
+#!/bin/sh
+installDir="$(dirname "$0")/wanaku-java"
+exec java -jar "${installDir}/quarkus-run.jar" "$@"
+WRAPPER
+    chmod 750 "${INSTALL_DIR}/wanaku-cli"
 }
 
 main() {


### PR DESCRIPTION
## Summary

- The Java archive (`wanaku-cli-<version>.zip`) uses a Quarkus fast-jar layout (`app/`, `lib/`, `quarkus/`, `quarkus-run.jar`) with no `bin/` directory
- This caused the installer to fail with "no bin/ directory found" on platforms without a native binary (e.g. Linux/aarch64)
- Splits installation into `install_native` and `install_java` paths — the Java path copies the fast-jar tree and generates wrapper scripts that invoke `java -jar quarkus-run.jar`

## Test plan

- [ ] Run `get-wanaku.sh` on Linux/aarch64 with Java installed
- [ ] Run `get-wanaku.sh` on a platform with a native binary (macOS ARM, Linux x86_64) to verify no regression
- [ ] Verify `wanaku --version` works after Java fallback install

## Summary by Sourcery

Handle Java fallback installation in get-wanaku.sh when no native binary is available

Enhancements:
- Split installer into native and Java installation paths in get-wanaku.sh.
- Add Java-based installation flow that copies the Quarkus fast-jar layout and generates wrapper scripts for wanaku executables.
- Move PATH presence warning to run after either native or Java installation completes.