### PR TITLE
docs: add $HOME/bin PATH configuration instructions to CLI README

### DIFF
--- a/apps/wanaku-cli/README.md
+++ b/apps/wanaku-cli/README.md
@@ -38,6 +38,26 @@ jbang app install wanaku@wanaku-ai/wanaku
 
 Download the latest release from [GitHub releases](https://github.com/wanaku-ai/wanaku/releases) and extract to your PATH.
 
+### PATH Configuration
+
+If you installed the Wanaku CLI using `get-wanaku.sh`, it is placed in `~/bin` (`$HOME/bin`). Many systems do not include `$HOME/bin` in the default `PATH`, so you may need to add it manually to avoid a "command not found" error when running `wanaku`.
+
+To add `$HOME/bin` to your `PATH` for the current session:
+
+```shell
+export PATH="$HOME/bin:$PATH"
+```
+
+To persist this across sessions, add the line above to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
+
+```shell
+echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+> **Note:** If you are using `zsh`, replace `~/.bashrc` with `~/.zshrc`.
+>
+> 
 ## Basic Usage
 
 ```shell


### PR DESCRIPTION
The get-wanaku.sh script installs the CLI to ~/bin ($HOME/bin), but many systems do not include this in the default PATH. This adds a new PATH Configuration section explaining how to add $HOME/bin to PATH. Resolves #1280.

## Summary by Sourcery

Documentation:
- Add a PATH Configuration section explaining how to add $HOME/bin to PATH and persist it across shell sessions for the Wanaku CLI README.