### PR TITLE
Add Infinispan Remote persistence module

### DIFF
--- a/core/core-persistence-api/pom.xml
+++ b/core/core-persistence-api/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ai.wanaku</groupId>
+        <artifactId>core</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>core-persistence-api</artifactId>
+    <name>Wanaku :: Core :: Persistence :: API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/DataStoreRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/DataStoreRepository.java
@@ -1,0 +1,9 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+
+public interface DataStoreRepository extends LabelAwareRepository<DataStore, String> {
+
+    List<DataStore> findByName(String name);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ForwardReferenceRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ForwardReferenceRepository.java
@@ -1,0 +1,9 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+
+public interface ForwardReferenceRepository extends WanakuRepository<ForwardReference, String, String> {
+
+    List<ForwardReference> findByName(String name);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/LabelAwareRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/LabelAwareRepository.java
@@ -1,0 +1,12 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+import ai.wanaku.core.persistence.util.LabelExpressionParser;
+
+public interface LabelAwareRepository<A extends LabelsAwareEntity<K>, K> extends WanakuRepository<A, K, K> {
+
+    List<A> findAllFilterByLabelExpression(String labelExpression);
+
+    int removeIf(String labelExpression) throws LabelExpressionParser.LabelExpressionParseException;
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/NamespaceRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/NamespaceRepository.java
@@ -1,0 +1,11 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+
+public interface NamespaceRepository extends LabelAwareRepository<Namespace, String> {
+
+    List<Namespace> findByName(String name);
+
+    List<Namespace> findFirstAvailable(String name);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/PromptReferenceRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/PromptReferenceRepository.java
@@ -1,0 +1,11 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference;
+
+public interface PromptReferenceRepository extends WanakuRepository<PromptReference, String, String> {
+
+    List<PromptReference> findByName(String name);
+
+    List<PromptReference> findByNameAndNamespace(String name, String namespace);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ResourceReferenceRepository.java
@@ -1,0 +1,9 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+
+public interface ResourceReferenceRepository extends LabelAwareRepository<ResourceReference, String> {
+
+    List<ResourceReference> findByName(String name);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ToolReferenceRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/ToolReferenceRepository.java
@@ -1,0 +1,9 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+
+public interface ToolReferenceRepository extends LabelAwareRepository<ToolReference, String> {
+
+    List<ToolReference> findByName(String name);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/WanakuRepository.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/api/WanakuRepository.java
@@ -1,0 +1,31 @@
+package ai.wanaku.core.persistence.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
+
+public interface WanakuRepository<A extends WanakuEntity<K>, K, C> {
+
+    A persist(A entity);
+
+    List<A> listAll();
+
+    boolean deleteById(C id);
+
+    A findById(C id);
+
+    boolean update(C id, A entity);
+
+    boolean remove(Predicate<A> matching);
+
+    int size();
+
+    int removeByField(String fieldName, Object fieldValue);
+
+    int removeByFields(Map<String, Object> fields);
+
+    int removeAll();
+
+    boolean exists(C key);
+}

--- a/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/util/LabelExpressionParser.java
+++ b/core/core-persistence-api/src/main/java/ai/wanaku/core/persistence/util/LabelExpressionParser.java
@@ -1,0 +1,240 @@
+package ai.wanaku.core.persistence.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+import ai.wanaku.core.util.StringHelper;
+
+public class LabelExpressionParser {
+
+    private List<Token> tokens;
+    private int position;
+
+    public LabelExpressionParser() {}
+
+    public static Predicate<LabelsAwareEntity<?>> parse(String expression) throws LabelExpressionParseException {
+        LabelExpressionParser parser = new LabelExpressionParser();
+        return parser.parseInternal(expression);
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseInternal(String expression) throws LabelExpressionParseException {
+        if (StringHelper.isBlank(expression)) {
+            throw new LabelExpressionParseException("Expression string cannot be null or empty");
+        }
+
+        String sanitized = sanitize(expression);
+        this.tokens = tokenize(sanitized);
+        this.position = 0;
+
+        if (tokens.isEmpty()) {
+            throw new LabelExpressionParseException("No valid tokens found in expression");
+        }
+
+        Predicate<LabelsAwareEntity<?>> result = parseExpression();
+
+        if (position < tokens.size()) {
+            throw new LabelExpressionParseException(
+                    "Unexpected token after expression: %s".formatted(tokens.get(position).value));
+        }
+
+        return result;
+    }
+
+    private String sanitize(String expression) throws LabelExpressionParseException {
+        if (expression.length() > 1000) {
+            throw new LabelExpressionParseException("Expression string too long (max 1000 characters)");
+        }
+
+        Pattern validPattern = Pattern.compile("^[a-zA-Z0-9\\s&|!()=_\\-./]+$");
+        if (!validPattern.matcher(expression).matches()) {
+            throw new LabelExpressionParseException(
+                    "Expression contains invalid characters. Only alphanumeric, operators (&|!=), parentheses, "
+                            + "hyphen, underscore, and dot are allowed");
+        }
+
+        return expression.trim();
+    }
+
+    private List<Token> tokenize(String expression) throws LabelExpressionParseException {
+        List<Token> result = new ArrayList<>();
+        int i = 0;
+
+        while (i < expression.length()) {
+            char c = expression.charAt(i);
+
+            if (Character.isWhitespace(c)) {
+                i++;
+                continue;
+            }
+
+            switch (c) {
+                case '&':
+                    result.add(new Token(TokenType.AND, "&"));
+                    i++;
+                    continue;
+                case '|':
+                    result.add(new Token(TokenType.OR, "|"));
+                    i++;
+                    continue;
+                case '!':
+                    if (i + 1 < expression.length() && expression.charAt(i + 1) == '=') {
+                        result.add(new Token(TokenType.NOT_EQUALS, "!="));
+                        i += 2;
+                    } else {
+                        result.add(new Token(TokenType.NOT, "!"));
+                        i++;
+                    }
+                    continue;
+                case '=':
+                    result.add(new Token(TokenType.EQUALS, "="));
+                    i++;
+                    continue;
+                case '(':
+                    result.add(new Token(TokenType.LPAREN, "("));
+                    i++;
+                    continue;
+                case ')':
+                    result.add(new Token(TokenType.RPAREN, ")"));
+                    i++;
+                    continue;
+            }
+
+            if (Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.') {
+                StringBuilder sb = new StringBuilder();
+                while (i < expression.length()) {
+                    c = expression.charAt(i);
+                    if (Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.' || c == '/') {
+                        sb.append(c);
+                        i++;
+                    } else {
+                        break;
+                    }
+                }
+                result.add(new Token(TokenType.IDENTIFIER, sb.toString()));
+                continue;
+            }
+
+            throw new LabelExpressionParseException("Unexpected character: %s".formatted(c));
+        }
+
+        return result;
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseExpression() throws LabelExpressionParseException {
+        return parseOrExpression();
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseOrExpression() throws LabelExpressionParseException {
+        Predicate<LabelsAwareEntity<?>> left = parseAndExpression();
+
+        while (match(TokenType.OR)) {
+            Predicate<LabelsAwareEntity<?>> right = parseAndExpression();
+            left = left.or(right);
+        }
+
+        return left;
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseAndExpression() throws LabelExpressionParseException {
+        Predicate<LabelsAwareEntity<?>> left = parseNotExpression();
+
+        while (match(TokenType.AND)) {
+            Predicate<LabelsAwareEntity<?>> right = parseNotExpression();
+            left = left.and(right);
+        }
+
+        return left;
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseNotExpression() throws LabelExpressionParseException {
+        if (match(TokenType.NOT)) {
+            Predicate<LabelsAwareEntity<?>> expr = parseNotExpression();
+            return expr.negate();
+        }
+
+        return parsePrimary();
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parsePrimary() throws LabelExpressionParseException {
+        if (match(TokenType.LPAREN)) {
+            Predicate<LabelsAwareEntity<?>> expr = parseExpression();
+            if (!match(TokenType.RPAREN)) {
+                throw new LabelExpressionParseException("Expected ')' after expression");
+            }
+            return expr;
+        }
+
+        return parseComparison();
+    }
+
+    private Predicate<LabelsAwareEntity<?>> parseComparison() throws LabelExpressionParseException {
+        Token key = consume(TokenType.IDENTIFIER, "Expected label key");
+
+        if (match(TokenType.EQUALS)) {
+            Token value = consume(TokenType.IDENTIFIER, "Expected label value after '='");
+            return entity -> value.value.equals(entity.getLabels().get(key.value));
+        } else if (match(TokenType.NOT_EQUALS)) {
+            Token value = consume(TokenType.IDENTIFIER, "Expected label value after '!='");
+            return entity -> !value.value.equals(entity.getLabels().get(key.value));
+        } else {
+            throw new LabelExpressionParseException("Expected '=' or '!=' after label key '%s'".formatted(key.value));
+        }
+    }
+
+    private boolean match(TokenType type) {
+        if (position >= tokens.size()) {
+            return false;
+        }
+        if (tokens.get(position).type == type) {
+            position++;
+            return true;
+        }
+        return false;
+    }
+
+    private Token consume(TokenType type, String errorMessage) throws LabelExpressionParseException {
+        if (position >= tokens.size()) {
+            throw new LabelExpressionParseException(errorMessage + " (end of input)");
+        }
+        Token token = tokens.get(position);
+        if (token.type != type) {
+            throw new LabelExpressionParseException("%s but got '%s'".formatted(errorMessage, token.value));
+        }
+        position++;
+        return token;
+    }
+
+    private enum TokenType {
+        AND,
+        OR,
+        NOT,
+        EQUALS,
+        NOT_EQUALS,
+        LPAREN,
+        RPAREN,
+        IDENTIFIER
+    }
+
+    private static class Token {
+        final TokenType type;
+        final String value;
+
+        Token(TokenType type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return type + "(" + value + ")";
+        }
+    }
+
+    public static class LabelExpressionParseException extends Exception {
+        public LabelExpressionParseException(String message) {
+            super(message);
+        }
+    }
+}

--- a/core/core-persistence-api/src/test/java/ai/wanaku/core/persistence/util/LabelExpressionParserTest.java
+++ b/core/core-persistence-api/src/test/java/ai/wanaku/core/persistence/util/LabelExpressionParserTest.java
@@ -1,0 +1,246 @@
+package ai.wanaku.core.persistence.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LabelExpressionParserTest {
+
+    private static class TestEntity extends LabelsAwareEntity<String> {
+        private String id;
+        private final Map<String, String> labels = new HashMap<>();
+
+        TestEntity(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+    }
+
+    private TestEntity createEntity(String id, String... labelPairs) {
+        TestEntity entity = new TestEntity(id);
+        for (int i = 0; i < labelPairs.length; i += 2) {
+            entity.getLabels().put(labelPairs[i], labelPairs[i + 1]);
+        }
+        return entity;
+    }
+
+    @Test
+    void testSimpleEquality() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("category=weather");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testSimpleNotEquals() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("category!=news");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testAndExpression() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather", "action", "forecast");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("category=weather & action=forecast");
+        assertTrue(predicate.test(entity));
+
+        TestEntity entity2 = createEntity("2", "category", "weather", "action", "current");
+        assertFalse(predicate.test(entity2));
+    }
+
+    @Test
+    void testOrExpression() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("category=weather | category=news");
+        assertTrue(predicate.test(entity));
+
+        TestEntity entity2 = createEntity("2", "category", "news");
+        assertTrue(predicate.test(entity2));
+
+        TestEntity entity3 = createEntity("3", "category", "finance");
+        assertFalse(predicate.test(entity3));
+    }
+
+    @Test
+    void testNotExpression() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("!category=weather");
+        assertFalse(predicate.test(entity));
+
+        TestEntity entity2 = createEntity("2", "category", "news");
+        assertTrue(predicate.test(entity2));
+    }
+
+    @Test
+    void testComplexExpression() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather", "action", "forecast", "version", "1.0");
+        Predicate<LabelsAwareEntity<?>> predicate =
+                LabelExpressionParser.parse("(category=weather | category=news) & version=1.0");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testParenthesizedExpression() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather", "action", "forecast");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("(category=weather & action=forecast)");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testWhitespaceHandling() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("  category = weather  ");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testHyphenInValue() throws Exception {
+        TestEntity entity = createEntity("1", "environment", "production-us");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("environment=production-us");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testUnderscoreInKey() throws Exception {
+        TestEntity entity = createEntity("1", "service_name", "api");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("service_name=api");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testDotInValue() throws Exception {
+        TestEntity entity = createEntity("1", "version", "1.0");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("version=1.0");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testSlashInValue() throws Exception {
+        TestEntity entity = createEntity("1", "path", "a/b/c");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("path=a/b/c");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testNullExpression() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse(null);
+        });
+    }
+
+    @Test
+    void testEmptyExpression() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("");
+        });
+    }
+
+    @Test
+    void testWhitespaceOnlyExpression() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("   ");
+        });
+    }
+
+    @Test
+    void testInvalidCharacters() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("category@weather");
+        });
+    }
+
+    @Test
+    void testUnmatchedParenthesis() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("(category=weather");
+        });
+    }
+
+    @Test
+    void testMissingValue() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("category=");
+        });
+    }
+
+    @Test
+    void testMissingOperator() {
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse("category weather");
+        });
+    }
+
+    @Test
+    void testTooLongExpression() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1001; i++) {
+            sb.append("a");
+        }
+        Assertions.assertThrows(LabelExpressionParser.LabelExpressionParseException.class, () -> {
+            LabelExpressionParser.parse(sb.toString());
+        });
+    }
+
+    @Test
+    void testDoubleNegation() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("!!category=weather");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testMultipleConditions() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather", "action", "forecast", "version", "1.0");
+        Predicate<LabelsAwareEntity<?>> predicate =
+                LabelExpressionParser.parse("category=weather & action=forecast & version=1.0");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testMixedAndOr() throws Exception {
+        TestEntity entity = createEntity("1", "category", "weather", "version", "1.0");
+        Predicate<LabelsAwareEntity<?>> predicate =
+                LabelExpressionParser.parse("category=weather & version=1.0 | category=news");
+        assertTrue(predicate.test(entity));
+    }
+
+    @Test
+    void testOperatorPrecedence() throws Exception {
+        TestEntity weatherV1 = createEntity("1", "category", "weather", "version", "1.0");
+        TestEntity weatherV2 = createEntity("2", "category", "weather", "version", "2.0");
+        TestEntity newsV1 = createEntity("3", "category", "news", "version", "1.0");
+
+        Predicate<LabelsAwareEntity<?>> predicate =
+                LabelExpressionParser.parse("category=weather & version=1.0 | category=news");
+        assertTrue(predicate.test(weatherV1));
+        assertFalse(predicate.test(weatherV2));
+        assertTrue(predicate.test(newsV1));
+    }
+
+    @Test
+    void testEmptyLabels() throws Exception {
+        TestEntity entity = createEntity("1");
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse("category=weather");
+        assertFalse(predicate.test(entity));
+    }
+}

--- a/core/core-persistence-infinispan-remote/pom.xml
+++ b/core/core-persistence-infinispan-remote/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ai.wanaku</groupId>
+        <artifactId>core</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>core-persistence-infinispan-remote</artifactId>
+    <name>Wanaku :: Core :: Persistence :: Infinispan Remote</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-persistence-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-api</artifactId>
+        </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-infinispan-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/AbstractLabelAwareRemoteInfinispanRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/AbstractLabelAwareRemoteInfinispanRepository.java
@@ -1,0 +1,47 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.function.Predicate;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
+import ai.wanaku.core.persistence.api.LabelAwareRepository;
+import ai.wanaku.core.persistence.util.LabelExpressionParser;
+import ai.wanaku.core.util.StringHelper;
+
+public abstract class AbstractLabelAwareRemoteInfinispanRepository<A extends LabelsAwareEntity<K>, K>
+        extends AbstractRemoteInfinispanRepository<A, K> implements LabelAwareRepository<A, K> {
+
+    protected AbstractLabelAwareRemoteInfinispanRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    public List<A> findAllFilterByLabelExpression(String labelExpression) {
+        if (StringHelper.isBlank(labelExpression)) {
+            return listAll();
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Predicate<A> predicate = (Predicate<A>) LabelExpressionParser.parse(labelExpression);
+            RemoteCache<K, A> c = cacheManager.getCache(entityName());
+            return c.values().stream().filter(predicate).toList();
+        } catch (LabelExpressionParser.LabelExpressionParseException e) {
+            throw new WanakuException("Invalid label expression: %s".formatted(labelExpression), e);
+        } catch (Exception e) {
+            throw new WanakuException("Failed to execute label query: %s".formatted(labelExpression), e);
+        }
+    }
+
+    @Override
+    public int removeIf(String labelExpression) throws LabelExpressionParser.LabelExpressionParseException {
+        RemoteCache<K, A> cache = cacheManager.getCache(entityName());
+        @SuppressWarnings("unchecked")
+        Predicate<A> predicate = (Predicate<A>) LabelExpressionParser.parse(labelExpression);
+        List<A> toRemove = cache.values().stream().filter(predicate).toList();
+        int size = toRemove.size();
+        toRemove.forEach(entity -> cache.remove(entity.getId()));
+        return size;
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/AbstractRemoteInfinispanRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/AbstractRemoteInfinispanRepository.java
@@ -1,0 +1,164 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
+import ai.wanaku.core.persistence.api.WanakuRepository;
+
+public abstract class AbstractRemoteInfinispanRepository<A extends WanakuEntity<K>, K>
+        implements WanakuRepository<A, K, K> {
+
+    protected final RemoteCacheManager cacheManager;
+    protected final ReentrantLock lock = new ReentrantLock();
+
+    private static final String DEFAULT_DELETE_TEMPLATE = "DELETE FROM %s r WHERE %s";
+
+    protected AbstractRemoteInfinispanRepository(RemoteCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Override
+    public A persist(A entity) {
+        try {
+            lock.lock();
+            if (entity.getId() == null) {
+                entity.setId(newId());
+            }
+            final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+            cache.put(entity.getId(), entity);
+        } finally {
+            lock.unlock();
+        }
+        return entity;
+    }
+
+    @Override
+    public List<A> listAll() {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        return cache.values().stream().toList();
+    }
+
+    @Override
+    public boolean deleteById(K id) {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        if (id == null) {
+            return false;
+        }
+        return cache.remove(id) != null;
+    }
+
+    @Override
+    public A findById(K id) {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        return (A) cache.get(id);
+    }
+
+    @Override
+    public boolean update(K id, A entity) {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        try {
+            lock.lock();
+            if (cache.put(id, entity) != null) {
+                return true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    public boolean update(K id, Consumer<A> consumer) {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        try {
+            lock.lock();
+            A entity = findById(id);
+            if (entity == null) {
+                entity = newEntity();
+                entity.setId(id);
+            }
+            consumer.accept(entity);
+            if (cache.put(id, entity) != null) {
+                return true;
+            }
+        } finally {
+            lock.unlock();
+        }
+        return false;
+    }
+
+    protected abstract Class<A> entityType();
+
+    protected abstract String entityName();
+
+    protected abstract K newId();
+
+    protected A newEntity() {
+        try {
+            return entityType().getDeclaredConstructor().newInstance();
+        } catch (InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException
+                | NoSuchMethodException e) {
+            throw new WanakuException(e);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean remove(Predicate<A> matching) {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        try {
+            lock.lock();
+            return cache.values().removeIf(matching);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int removeByField(String fieldName, Object fieldValue) {
+        return removeByFields(Map.of(fieldName, fieldValue));
+    }
+
+    @Override
+    public int removeByFields(Map<String, Object> fields) {
+        if (fields == null || fields.isEmpty()) {
+            throw new IllegalArgumentException("Fields map cannot be null or empty");
+        }
+        var cache = cacheManager.getCache(entityName());
+        var whereClause = fields.keySet().stream()
+                .map(field -> "r.%s = :%s".formatted(field, field))
+                .collect(Collectors.joining(" AND "));
+        var queryString = DEFAULT_DELETE_TEMPLATE.formatted(entityType().getCanonicalName(), whereClause);
+        var query = cache.query(queryString);
+        fields.forEach(query::setParameter);
+        return query.executeStatement();
+    }
+
+    @Override
+    public int size() {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        return cache.size();
+    }
+
+    @Override
+    public int removeAll() {
+        final RemoteCache<Object, A> cache = cacheManager.getCache(entityName());
+        int sizeBefore = cache.size();
+        cache.clear();
+        return sizeBefore - cache.size();
+    }
+
+    @Override
+    public boolean exists(K key) {
+        return findById(key) != null;
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteDataStoreRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteDataStoreRepository.java
@@ -1,0 +1,40 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.persistence.api.DataStoreRepository;
+
+public class InfinispanRemoteDataStoreRepository extends AbstractLabelAwareRemoteInfinispanRepository<DataStore, String>
+        implements DataStoreRepository {
+
+    public InfinispanRemoteDataStoreRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected String entityName() {
+        return "datastore";
+    }
+
+    @Override
+    protected Class<DataStore> entityType() {
+        return DataStore.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<DataStore> findByName(String name) {
+        Query<DataStore> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.DataStore d where d.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteForwardReferenceRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteForwardReferenceRepository.java
@@ -1,0 +1,40 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+import ai.wanaku.core.persistence.api.ForwardReferenceRepository;
+
+public class InfinispanRemoteForwardReferenceRepository
+        extends AbstractRemoteInfinispanRepository<ForwardReference, String> implements ForwardReferenceRepository {
+
+    public InfinispanRemoteForwardReferenceRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected String entityName() {
+        return "forward";
+    }
+
+    @Override
+    protected Class<ForwardReference> entityType() {
+        return ForwardReference.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<ForwardReference> findByName(String name) {
+        Query<ForwardReference> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.ForwardReference t where t.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteNamespaceRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteNamespaceRepository.java
@@ -1,0 +1,50 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.core.persistence.api.NamespaceRepository;
+
+public class InfinispanRemoteNamespaceRepository extends AbstractLabelAwareRemoteInfinispanRepository<Namespace, String>
+        implements NamespaceRepository {
+
+    public InfinispanRemoteNamespaceRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected Class<Namespace> entityType() {
+        return Namespace.class;
+    }
+
+    @Override
+    protected String entityName() {
+        return "namespace";
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<Namespace> findByName(String name) {
+        Query<Namespace> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.Namespace t where t.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+
+    @Override
+    public List<Namespace> findFirstAvailable(String name) {
+        final RemoteCache<Object, Namespace> cache = cacheManager.getCache(entityName());
+        Query<Namespace> query = cache.query(
+                "from ai.wanaku.capabilities.sdk.api.types.Namespace t where t.name = :name OR (t.path != '' AND t.name is NULL)");
+        query.setParameter("name", name);
+        return query.maxResults(1).execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePersistenceConfiguration.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePersistenceConfiguration.java
@@ -1,0 +1,50 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import ai.wanaku.core.persistence.api.DataStoreRepository;
+import ai.wanaku.core.persistence.api.ForwardReferenceRepository;
+import ai.wanaku.core.persistence.api.NamespaceRepository;
+import ai.wanaku.core.persistence.api.PromptReferenceRepository;
+import ai.wanaku.core.persistence.api.ResourceReferenceRepository;
+import ai.wanaku.core.persistence.api.ToolReferenceRepository;
+
+@ApplicationScoped
+public class InfinispanRemotePersistenceConfiguration {
+
+    @Inject
+    RemoteCacheManager cacheManager;
+
+    @Produces
+    ResourceReferenceRepository resourceReferenceRepository() {
+        return new InfinispanRemoteResourceReferenceRepository(cacheManager);
+    }
+
+    @Produces
+    ToolReferenceRepository toolReferenceRepository() {
+        return new InfinispanRemoteToolReferenceRepository(cacheManager);
+    }
+
+    @Produces
+    ForwardReferenceRepository forwardReferenceRepository() {
+        return new InfinispanRemoteForwardReferenceRepository(cacheManager);
+    }
+
+    @Produces
+    NamespaceRepository namespaceRepository() {
+        return new InfinispanRemoteNamespaceRepository(cacheManager);
+    }
+
+    @Produces
+    PromptReferenceRepository promptReferenceRepository() {
+        return new InfinispanRemotePromptReferenceRepository(cacheManager);
+    }
+
+    @Produces
+    DataStoreRepository dataStoreRepository() {
+        return new InfinispanRemoteDataStoreRepository(cacheManager);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePromptReferenceRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePromptReferenceRepository.java
@@ -1,0 +1,51 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference;
+import ai.wanaku.core.persistence.api.PromptReferenceRepository;
+
+public class InfinispanRemotePromptReferenceRepository
+        extends AbstractRemoteInfinispanRepository<PromptReference, String> implements PromptReferenceRepository {
+
+    public InfinispanRemotePromptReferenceRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected String entityName() {
+        return "prompt";
+    }
+
+    @Override
+    protected Class<PromptReference> entityType() {
+        return PromptReference.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<PromptReference> findByName(String name) {
+        Query<PromptReference> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.PromptReference p where p.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+
+    @Override
+    public List<PromptReference> findByNameAndNamespace(String name, String namespace) {
+        Query<PromptReference> query = cacheManager
+                .getCache(entityName())
+                .query(
+                        "from ai.wanaku.capabilities.sdk.api.types.PromptReference p where p.name = :name and p.namespace = :namespace");
+        query.setParameter("name", name);
+        query.setParameter("namespace", namespace);
+        return query.execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteResourceReferenceRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteResourceReferenceRepository.java
@@ -1,0 +1,41 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.core.persistence.api.ResourceReferenceRepository;
+
+public class InfinispanRemoteResourceReferenceRepository
+        extends AbstractLabelAwareRemoteInfinispanRepository<ResourceReference, String>
+        implements ResourceReferenceRepository {
+
+    public InfinispanRemoteResourceReferenceRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected String entityName() {
+        return "resource";
+    }
+
+    @Override
+    protected Class<ResourceReference> entityType() {
+        return ResourceReference.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<ResourceReference> findByName(String name) {
+        Query<ResourceReference> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.ResourceReference t where t.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteToolReferenceRepository.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteToolReferenceRepository.java
@@ -1,0 +1,40 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.api.query.Query;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.core.persistence.api.ToolReferenceRepository;
+
+public class InfinispanRemoteToolReferenceRepository
+        extends AbstractLabelAwareRemoteInfinispanRepository<ToolReference, String> implements ToolReferenceRepository {
+
+    public InfinispanRemoteToolReferenceRepository(RemoteCacheManager cacheManager) {
+        super(cacheManager);
+    }
+
+    @Override
+    protected String entityName() {
+        return "tool";
+    }
+
+    @Override
+    protected Class<ToolReference> entityType() {
+        return ToolReference.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<ToolReference> findByName(String name) {
+        Query<ToolReference> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.capabilities.sdk.api.types.ToolReference t where t.name = :name");
+        query.setParameter("name", name);
+        return query.execute().list();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/AudioContentMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/AudioContentMarshaller.java
@@ -1,0 +1,32 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.AudioContent;
+
+public class AudioContentMarshaller implements MessageMarshaller<AudioContent> {
+
+    @Override
+    public String getTypeName() {
+        return AudioContent.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends AudioContent> getJavaClass() {
+        return AudioContent.class;
+    }
+
+    @Override
+    public AudioContent readFrom(ProtoStreamReader reader) throws IOException {
+        AudioContent content = new AudioContent();
+        content.setData(reader.readString("data"));
+        content.setMimeType(reader.readString("mime_type"));
+        return content;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, AudioContent content) throws IOException {
+        writer.writeString("data", content.getData());
+        writer.writeString("mime_type", content.getMimeType());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/DataStoreMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/DataStoreMarshaller.java
@@ -1,0 +1,37 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.HashMap;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+
+public class DataStoreMarshaller implements MessageMarshaller<DataStore> {
+
+    @Override
+    public DataStore readFrom(ProtoStreamReader reader) throws IOException {
+        DataStore dataStore = new DataStore();
+        dataStore.setId(reader.readString("id"));
+        dataStore.setName(reader.readString("name"));
+        dataStore.setData(reader.readString("data"));
+        dataStore.setLabels(reader.readMap("labels", new HashMap<>(), String.class, String.class));
+        return dataStore;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, DataStore dataStore) throws IOException {
+        writer.writeString("id", dataStore.getId());
+        writer.writeString("name", dataStore.getName());
+        writer.writeString("data", dataStore.getData());
+        writer.writeMap("labels", dataStore.getLabels(), String.class, String.class);
+    }
+
+    @Override
+    public Class<? extends DataStore> getJavaClass() {
+        return DataStore.class;
+    }
+
+    @Override
+    public String getTypeName() {
+        return DataStore.class.getCanonicalName();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/EmbeddedResourceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/EmbeddedResourceMarshaller.java
@@ -1,0 +1,31 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.EmbeddedResource;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+
+public class EmbeddedResourceMarshaller implements MessageMarshaller<EmbeddedResource> {
+
+    @Override
+    public String getTypeName() {
+        return EmbeddedResource.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends EmbeddedResource> getJavaClass() {
+        return EmbeddedResource.class;
+    }
+
+    @Override
+    public EmbeddedResource readFrom(ProtoStreamReader reader) throws IOException {
+        EmbeddedResource content = new EmbeddedResource();
+        content.setResource(reader.readObject("resource", ResourceReference.class));
+        return content;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, EmbeddedResource content) throws IOException {
+        writer.writeObject("resource", content.getResource(), ResourceReference.class);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ForwardReferenceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ForwardReferenceMarshaller.java
@@ -1,0 +1,35 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+
+public class ForwardReferenceMarshaller implements MessageMarshaller<ForwardReference> {
+    @Override
+    public String getTypeName() {
+        return ForwardReference.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ForwardReference> getJavaClass() {
+        return ForwardReference.class;
+    }
+
+    @Override
+    public ForwardReference readFrom(ProtoStreamReader reader) throws IOException {
+        ForwardReference ref = new ForwardReference();
+        ref.setId(reader.readString("id"));
+        ref.setName(reader.readString("name"));
+        ref.setAddress(reader.readString("address"));
+        ref.setNamespace(reader.readString("namespace"));
+        return ref;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ForwardReference ref) throws IOException {
+        writer.writeString("id", ref.getId());
+        writer.writeString("name", ref.getName());
+        writer.writeString("address", ref.getAddress());
+        writer.writeString("namespace", ref.getNamespace());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ImageContentMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ImageContentMarshaller.java
@@ -1,0 +1,32 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.ImageContent;
+
+public class ImageContentMarshaller implements MessageMarshaller<ImageContent> {
+
+    @Override
+    public String getTypeName() {
+        return ImageContent.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ImageContent> getJavaClass() {
+        return ImageContent.class;
+    }
+
+    @Override
+    public ImageContent readFrom(ProtoStreamReader reader) throws IOException {
+        ImageContent content = new ImageContent();
+        content.setData(reader.readString("data"));
+        content.setMimeType(reader.readString("mime_type"));
+        return content;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ImageContent content) throws IOException {
+        writer.writeString("data", content.getData());
+        writer.writeString("mime_type", content.getMimeType());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/InputSchemaMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/InputSchemaMarshaller.java
@@ -1,0 +1,36 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+
+public class InputSchemaMarshaller implements MessageMarshaller<InputSchema> {
+    @Override
+    public String getTypeName() {
+        return InputSchema.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends InputSchema> getJavaClass() {
+        return InputSchema.class;
+    }
+
+    @Override
+    public InputSchema readFrom(ProtoStreamReader reader) throws IOException {
+        InputSchema schema = new InputSchema();
+        schema.setType(reader.readString("type"));
+        schema.setProperties(reader.readMap("properties", new HashMap<>(), String.class, Property.class));
+        schema.setRequired(reader.readCollection("required", new ArrayList<>(), String.class));
+        return schema;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, InputSchema schema) throws IOException {
+        writer.writeString("type", schema.getType());
+        writer.writeMap("properties", schema.getProperties(), String.class, Property.class);
+        writer.writeCollection("required", schema.getRequired(), String.class);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/NamespaceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/NamespaceMarshaller.java
@@ -1,0 +1,36 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.HashMap;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+
+public class NamespaceMarshaller implements MessageMarshaller<Namespace> {
+    @Override
+    public Namespace readFrom(ProtoStreamReader reader) throws IOException {
+        Namespace namespace = new Namespace();
+        namespace.setId(reader.readString("id"));
+        namespace.setName(reader.readString("name"));
+        namespace.setPath(reader.readString("path"));
+        namespace.setLabels(reader.readMap("labels", new HashMap<>(), String.class, String.class));
+        return namespace;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, Namespace namespace) throws IOException {
+        writer.writeString("id", namespace.getId());
+        writer.writeString("name", namespace.getName());
+        writer.writeString("path", namespace.getPath());
+        writer.writeMap("labels", namespace.getLabels(), String.class, String.class);
+    }
+
+    @Override
+    public Class<? extends Namespace> getJavaClass() {
+        return Namespace.class;
+    }
+
+    @Override
+    public String getTypeName() {
+        return Namespace.class.getCanonicalName();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ParamMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ParamMarshaller.java
@@ -1,0 +1,31 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+
+public class ParamMarshaller implements MessageMarshaller<ResourceReference.Param> {
+    @Override
+    public String getTypeName() {
+        return ResourceReference.Param.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ResourceReference.Param> getJavaClass() {
+        return ResourceReference.Param.class;
+    }
+
+    @Override
+    public ResourceReference.Param readFrom(ProtoStreamReader reader) throws IOException {
+        ResourceReference.Param ref = new ResourceReference.Param();
+        ref.setName(reader.readString("name"));
+        ref.setValue(reader.readString("value"));
+        return ref;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ResourceReference.Param ref) throws IOException {
+        writer.writeString("name", ref.getName());
+        writer.writeString("value", ref.getValue());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptArgumentMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptArgumentMarshaller.java
@@ -1,0 +1,34 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference.PromptArgument;
+
+public class PromptArgumentMarshaller implements MessageMarshaller<PromptArgument> {
+
+    @Override
+    public PromptArgument readFrom(ProtoStreamReader reader) throws IOException {
+        PromptArgument argument = new PromptArgument();
+        argument.setName(reader.readString("name"));
+        argument.setDescription(reader.readString("description"));
+        argument.setRequired(reader.readBoolean("required"));
+        return argument;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, PromptArgument argument) throws IOException {
+        writer.writeString("name", argument.getName());
+        writer.writeString("description", argument.getDescription());
+        writer.writeBoolean("required", argument.isRequired());
+    }
+
+    @Override
+    public Class<? extends PromptArgument> getJavaClass() {
+        return PromptArgument.class;
+    }
+
+    @Override
+    public String getTypeName() {
+        return "ai.wanaku.capabilities.sdk.api.types.PromptReference.PromptArgument";
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptMessageMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptMessageMarshaller.java
@@ -1,0 +1,45 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import org.infinispan.protostream.WrappedMessage;
+import ai.wanaku.capabilities.sdk.api.types.PromptContent;
+import ai.wanaku.capabilities.sdk.api.types.PromptMessage;
+
+public class PromptMessageMarshaller implements MessageMarshaller<PromptMessage> {
+
+    @Override
+    public String getTypeName() {
+        return "ai.wanaku.capabilities.sdk.api.types.PromptReference.PromptMessage";
+    }
+
+    @Override
+    public Class<? extends PromptMessage> getJavaClass() {
+        return PromptMessage.class;
+    }
+
+    @Override
+    public PromptMessage readFrom(ProtoStreamReader reader) throws IOException {
+        PromptMessage message = new PromptMessage();
+        message.setRole(reader.readString("role"));
+
+        WrappedMessage wrappedContent = reader.readObject("content", WrappedMessage.class);
+        if (wrappedContent != null) {
+            Object content = wrappedContent.getValue();
+            if (content instanceof PromptContent promptContent) {
+                message.setContent(promptContent);
+            }
+        }
+
+        return message;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, PromptMessage message) throws IOException {
+        writer.writeString("role", message.getRole());
+
+        if (message.getContent() != null) {
+            writer.writeObject("content", new WrappedMessage(message.getContent()), WrappedMessage.class);
+        }
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptReferenceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PromptReferenceMarshaller.java
@@ -1,0 +1,47 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.PromptMessage;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference.PromptArgument;
+
+public class PromptReferenceMarshaller implements MessageMarshaller<PromptReference> {
+
+    @Override
+    public String getTypeName() {
+        return PromptReference.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends PromptReference> getJavaClass() {
+        return PromptReference.class;
+    }
+
+    @Override
+    public PromptReference readFrom(ProtoStreamReader reader) throws IOException {
+        PromptReference ref = new PromptReference();
+        ref.setId(reader.readString("id"));
+        ref.setName(reader.readString("name"));
+        ref.setDescription(reader.readString("description"));
+        ref.setMessages(reader.readCollection("messages", new ArrayList<>(), PromptMessage.class));
+        ref.setArguments(reader.readCollection("arguments", new ArrayList<>(), PromptArgument.class));
+        ref.setToolReferences(reader.readCollection("tool_references", new ArrayList<>(), String.class));
+        ref.setNamespace(reader.readString("namespace"));
+        ref.setConfigurationURI(reader.readString("configuration_uri"));
+        return ref;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, PromptReference ref) throws IOException {
+        writer.writeString("id", ref.getId());
+        writer.writeString("name", ref.getName());
+        writer.writeString("description", ref.getDescription());
+        writer.writeCollection("messages", ref.getMessages(), PromptMessage.class);
+        writer.writeCollection("arguments", ref.getArguments(), PromptArgument.class);
+        writer.writeCollection("tool_references", ref.getToolReferences(), String.class);
+        writer.writeString("namespace", ref.getNamespace());
+        writer.writeString("configuration_uri", ref.getConfigurationURI());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PropertyMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/PropertyMarshaller.java
@@ -1,0 +1,37 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+
+public class PropertyMarshaller implements MessageMarshaller<Property> {
+    @Override
+    public String getTypeName() {
+        return Property.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends Property> getJavaClass() {
+        return Property.class;
+    }
+
+    @Override
+    public Property readFrom(ProtoStreamReader reader) throws IOException {
+        Property property = new Property();
+        property.setType(reader.readString("type"));
+        property.setDescription(reader.readString("description"));
+        property.setTarget(reader.readString("target"));
+        property.setScope(reader.readString("scope"));
+        property.setValue(reader.readString("value"));
+        return property;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, Property property) throws IOException {
+        writer.writeString("type", property.getType());
+        writer.writeString("description", property.getDescription());
+        writer.writeString("target", property.getTarget());
+        writer.writeString("scope", property.getScope());
+        writer.writeString("value", property.getValue());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ResourceReferenceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ResourceReferenceMarshaller.java
@@ -1,0 +1,51 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+
+public class ResourceReferenceMarshaller implements MessageMarshaller<ResourceReference> {
+    @Override
+    public String getTypeName() {
+        return ResourceReference.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ResourceReference> getJavaClass() {
+        return ResourceReference.class;
+    }
+
+    @Override
+    public ResourceReference readFrom(ProtoStreamReader reader) throws IOException {
+        ResourceReference ref = new ResourceReference();
+        ref.setId(reader.readString("id"));
+        ref.setLocation(reader.readString("location"));
+        ref.setType(reader.readString("type"));
+        ref.setName(reader.readString("name"));
+        ref.setDescription(reader.readString("description"));
+        ref.setMimeType(reader.readString("mime_type"));
+        ref.setParams(reader.readCollection("params", new ArrayList<>(), ResourceReference.Param.class));
+        ref.setConfigurationURI(reader.readString("configuration_uri"));
+        ref.setSecretsURI(reader.readString("secrets_uri"));
+        ref.setNamespace(reader.readString("namespace"));
+        ref.setLabels(reader.readMap("labels", new HashMap<>(), String.class, String.class));
+        return ref;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ResourceReference ref) throws IOException {
+        writer.writeString("id", ref.getId());
+        writer.writeString("location", ref.getLocation());
+        writer.writeString("type", ref.getType());
+        writer.writeString("name", ref.getName());
+        writer.writeString("description", ref.getDescription());
+        writer.writeString("mime_type", ref.getMimeType());
+        writer.writeCollection("params", ref.getParams(), ResourceReference.Param.class);
+        writer.writeString("configuration_uri", ref.getConfigurationURI());
+        writer.writeString("secrets_uri", ref.getSecretsURI());
+        writer.writeString("namespace", ref.getNamespace());
+        writer.writeMap("labels", ref.getLabels(), String.class, String.class);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/TextContentMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/TextContentMarshaller.java
@@ -1,0 +1,30 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.TextContent;
+
+public class TextContentMarshaller implements MessageMarshaller<TextContent> {
+
+    @Override
+    public String getTypeName() {
+        return TextContent.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends TextContent> getJavaClass() {
+        return TextContent.class;
+    }
+
+    @Override
+    public TextContent readFrom(ProtoStreamReader reader) throws IOException {
+        TextContent content = new TextContent();
+        content.setText(reader.readString("text"));
+        return content;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, TextContent content) throws IOException {
+        writer.writeString("text", content.getText());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ToolReferenceMarshaller.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/marshaller/ToolReferenceMarshaller.java
@@ -1,0 +1,50 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller;
+
+import java.io.IOException;
+import java.util.HashMap;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+
+public class ToolReferenceMarshaller implements MessageMarshaller<ToolReference> {
+
+    @Override
+    public String getTypeName() {
+        return ToolReference.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ToolReference> getJavaClass() {
+        return ToolReference.class;
+    }
+
+    @Override
+    public ToolReference readFrom(ProtoStreamReader reader) throws IOException {
+        ToolReference ref = new ToolReference();
+        ref.setId(reader.readString("id"));
+        ref.setName(reader.readString("name"));
+        ref.setDescription(reader.readString("description"));
+        ref.setUri(reader.readString("uri"));
+        ref.setType(reader.readString("type"));
+        ref.setInputSchema(reader.readObject("input_schema", InputSchema.class));
+        ref.setConfigurationURI(reader.readString("configuration_uri"));
+        ref.setSecretsURI(reader.readString("secrets_uri"));
+        ref.setNamespace(reader.readString("namespace"));
+        ref.setLabels(reader.readMap("labels", new HashMap<>(), String.class, String.class));
+        return ref;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ToolReference ref) throws IOException {
+        writer.writeString("id", ref.getId());
+        writer.writeString("name", ref.getName());
+        writer.writeString("description", ref.getDescription());
+        writer.writeString("uri", ref.getUri());
+        writer.writeString("type", ref.getType());
+        writer.writeObject("input_schema", ref.getInputSchema(), InputSchema.class);
+        writer.writeString("configuration_uri", ref.getConfigurationURI());
+        writer.writeString("secrets_uri", ref.getSecretsURI());
+        writer.writeString("namespace", ref.getNamespace());
+        writer.writeMap("labels", ref.getLabels(), String.class, String.class);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/AbstractWanakuSerializationContextInitializer.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/AbstractWanakuSerializationContextInitializer.java
@@ -1,0 +1,20 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.ResourceUtils;
+import org.infinispan.protostream.SerializationContext;
+
+public abstract class AbstractWanakuSerializationContextInitializer {
+
+    public abstract String getName();
+
+    public String getContent() {
+        return ResourceUtils.getResourceAsString(getClass(), "/proto/" + getName());
+    }
+
+    public void registerSchema(SerializationContext serCtx) {
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    public abstract void registerMarshallers(SerializationContext serCtx);
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ContentSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ContentSchema.java
@@ -1,0 +1,35 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.AudioContentMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.EmbeddedResourceMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.ImageContentMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.TextContentMarshaller;
+
+public class ContentSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    private final ResourceReferenceSchema resourceReferenceSchema = new ResourceReferenceSchema();
+
+    @Override
+    public String getName() {
+        return "content.proto";
+    }
+
+    @Override
+    public void registerSchema(SerializationContext serCtx) {
+        resourceReferenceSchema.registerSchema(serCtx);
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        resourceReferenceSchema.registerMarshallers(serCtx);
+        serCtx.registerMarshaller(new TextContentMarshaller());
+        serCtx.registerMarshaller(new ImageContentMarshaller());
+        serCtx.registerMarshaller(new AudioContentMarshaller());
+        serCtx.registerMarshaller(new EmbeddedResourceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/DataStoreSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/DataStoreSchema.java
@@ -1,0 +1,19 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.DataStoreMarshaller;
+
+public class DataStoreSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "data_store.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new DataStoreMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ForwardReferenceSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ForwardReferenceSchema.java
@@ -1,0 +1,25 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.ForwardReferenceMarshaller;
+
+public class ForwardReferenceSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "forward_reference.proto";
+    }
+
+    @Override
+    public void registerSchema(SerializationContext serCtx) {
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new ForwardReferenceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/InputSchemaSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/InputSchemaSchema.java
@@ -1,0 +1,29 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.InputSchemaMarshaller;
+
+public class InputSchemaSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    private final PropertySchema propertySchema = new PropertySchema();
+
+    @Override
+    public String getName() {
+        return "input_schema.proto";
+    }
+
+    @Override
+    public void registerSchema(SerializationContext serCtx) {
+        propertySchema.registerSchema(serCtx);
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        propertySchema.registerMarshallers(serCtx);
+        serCtx.registerMarshaller(new InputSchemaMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/NamespaceSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/NamespaceSchema.java
@@ -1,0 +1,19 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.NamespaceMarshaller;
+
+public class NamespaceSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "namespace.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new NamespaceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/PromptReferenceSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/PromptReferenceSchema.java
@@ -1,0 +1,33 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.PromptArgumentMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.PromptMessageMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.PromptReferenceMarshaller;
+
+public class PromptReferenceSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    private final ContentSchema contentSchema = new ContentSchema();
+
+    @Override
+    public String getName() {
+        return "prompt_reference.proto";
+    }
+
+    @Override
+    public void registerSchema(SerializationContext serCtx) {
+        contentSchema.registerSchema(serCtx);
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        contentSchema.registerMarshallers(serCtx);
+        serCtx.registerMarshaller(new PromptArgumentMarshaller());
+        serCtx.registerMarshaller(new PromptMessageMarshaller());
+        serCtx.registerMarshaller(new PromptReferenceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/PropertySchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/PropertySchema.java
@@ -1,0 +1,19 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.PropertyMarshaller;
+
+public class PropertySchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "property.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new PropertyMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ResourceReferenceSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ResourceReferenceSchema.java
@@ -1,0 +1,21 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.ParamMarshaller;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.ResourceReferenceMarshaller;
+
+public class ResourceReferenceSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "resource_reference.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new ParamMarshaller());
+        serCtx.registerMarshaller(new ResourceReferenceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ToolReferenceSchema.java
+++ b/core/core-persistence-infinispan-remote/src/main/java/ai/wanaku/core/persistence/infinispan/remote/protostream/schema/ToolReferenceSchema.java
@@ -1,0 +1,29 @@
+package ai.wanaku.core.persistence.infinispan.remote.protostream.schema;
+
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.SerializationContext;
+import org.infinispan.protostream.SerializationContextInitializer;
+import ai.wanaku.core.persistence.infinispan.remote.protostream.marshaller.ToolReferenceMarshaller;
+
+public class ToolReferenceSchema extends AbstractWanakuSerializationContextInitializer
+        implements SerializationContextInitializer {
+
+    private final InputSchemaSchema inputSchema = new InputSchemaSchema();
+
+    @Override
+    public String getName() {
+        return "tool_reference.proto";
+    }
+
+    @Override
+    public void registerSchema(SerializationContext serCtx) {
+        inputSchema.registerSchema(serCtx);
+        serCtx.registerProtoFiles(FileDescriptorSource.fromString(this.getName(), this.getContent()));
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        inputSchema.registerMarshallers(serCtx);
+        serCtx.registerMarshaller(new ToolReferenceMarshaller());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/META-INF/beans.xml
+++ b/core/core-persistence-infinispan-remote/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/core/core-persistence-infinispan-remote/src/main/resources/META-INF/services/org.infinispan.protostream.SerializationContextInitializer
+++ b/core/core-persistence-infinispan-remote/src/main/resources/META-INF/services/org.infinispan.protostream.SerializationContextInitializer
@@ -1,0 +1,9 @@
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.ContentSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.DataStoreSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.ForwardReferenceSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.InputSchemaSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.NamespaceSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.PromptReferenceSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.PropertySchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.ResourceReferenceSchema
+ai.wanaku.core.persistence.infinispan.remote.protostream.schema.ToolReferenceSchema

--- a/core/core-persistence-infinispan-remote/src/main/resources/application.properties
+++ b/core/core-persistence-infinispan-remote/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+%dev.quarkus.infinispan-client.hosts=localhost:11222
+%dev.quarkus.infinispan-client.username=admin
+%dev.quarkus.infinispan-client.password=secret
+
+quarkus.infinispan-client.cache.tool.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.prompt.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.resource.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.datastore.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.namespace.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.forward.configuration-resource=config/indexed-cache.json

--- a/core/core-persistence-infinispan-remote/src/main/resources/config/indexed-cache.json
+++ b/core/core-persistence-infinispan-remote/src/main/resources/config/indexed-cache.json
@@ -1,0 +1,15 @@
+{
+  "distributed-cache": {
+    "mode": "SYNC",
+    "statistics": true,
+    "encoding": {
+      "media-type": "application/x-protostream"
+    },
+    "indexing": {
+      "enabled": true,
+      "storage": "local-heap",
+      "startup-mode": "auto",
+      "indexed-entities": []
+    }
+  }
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/content.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/content.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+import "resource_reference.proto";
+
+// Represents text content in a prompt message.
+message TextContent {
+  string text = 1;
+}
+
+// Represents image content in a prompt message.
+message ImageContent {
+  string data = 1;
+  string mime_type = 2;
+}
+
+// Represents audio content in a prompt message.
+message AudioContent {
+  string data = 1;
+  string mime_type = 2;
+}
+
+// Represents an embedded resource in a prompt message.
+// This allows prompts to reference external resources.
+message EmbeddedResource {
+  ResourceReference resource = 1;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/data_store.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/data_store.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+/**
+ * Protocol buffer definition for DataStore entity.
+ */
+message DataStore {
+  string id = 1;
+  string name = 2;
+  string data = 3;
+  map<string, string> labels = 4;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/forward_reference.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/forward_reference.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package ai.wanaku.capabilities.sdk.api.types;
+
+// Represents a reference to a forward service.
+message ForwardReference {
+  string id = 1;
+  string name = 2;
+  string address = 3;
+  string namespace = 4;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/input_schema.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/input_schema.proto
@@ -1,0 +1,10 @@
+// Represents the input schema for a tool, including type, properties, and required fields.
+syntax = "proto3";
+package ai.wanaku.capabilities.sdk.api.types;
+import "property.proto";
+
+message InputSchema {
+  string type = 1;
+  map<string, Property> properties = 2;
+  repeated string required = 3;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/namespace.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/namespace.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+// This message represents a namespace
+message Namespace {
+  string id = 1;
+  string name = 2;
+  string path = 3;
+  map<string, string> labels = 4;
+  int32 tool_count = 5;
+  int32 resource_count = 6;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/prompt_reference.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/prompt_reference.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+import "content.proto";
+
+// Represents a prompt reference in the MCP protocol.
+// Prompts are reusable templates that can leverage multiple tools and provide
+// example interactions for LLMs.
+message PromptReference {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  repeated PromptMessage messages = 4;
+  repeated PromptArgument arguments = 5;
+  repeated string tool_references = 6;
+  string namespace = 7;
+  string configuration_uri = 8;
+
+  // Represents a message in an MCP prompt.
+  // Each message has a role and content according to the MCP specification.
+  message PromptMessage {
+    string role = 1;
+    PromptContent content = 2;
+  }
+
+  // Represents an argument/parameter for a prompt.
+  message PromptArgument {
+    string name = 1;
+    string description = 2;
+    bool required = 3;
+  }
+}
+
+// Represents content in a prompt message.
+// This is a polymorphic type that can be one of several content types.
+message PromptContent {
+  oneof content {
+    TextContent text_content = 1;
+    ImageContent image_content = 2;
+    AudioContent audio_content = 3;
+    EmbeddedResource embedded_resource = 4;
+  }
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/property.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/property.proto
@@ -1,0 +1,13 @@
+// Represents a single property in the input schema.
+
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+message Property {
+  string type = 1;
+  string description = 2;
+  string target = 3;
+  string scope = 4;
+  string value = 5;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/resource_reference.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/resource_reference.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+// Represents a resource reference, containing details such as location, type, and parameters.
+message ResourceReference {
+  string id = 1;
+  string location = 2;
+  string type = 3;
+  string name = 4;
+  string description = 5;
+  string mime_type = 6;
+  repeated Param params = 7;
+
+  // A nested message representing a parameter of the resource.
+  message Param {
+    string name = 1;
+    string value = 2;
+  }
+  string configuration_uri = 8;
+  string secrets_uri = 9;
+  string namespace = 10;
+  map<string, string> labels = 11;
+}

--- a/core/core-persistence-infinispan-remote/src/main/resources/proto/tool_reference.proto
+++ b/core/core-persistence-infinispan-remote/src/main/resources/proto/tool_reference.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package ai.wanaku.capabilities.sdk.api.types;
+
+import "input_schema.proto";
+
+// This message represents a reference to a tool with various attributes.
+message ToolReference {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  string uri = 4;
+  string type = 5;
+  InputSchema input_schema = 6;
+  string configuration_uri = 7;
+  string secrets_uri = 8;
+  string namespace = 9;
+  map<string, string> labels = 10;
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteDataStoreRepositoryTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteDataStoreRepositoryTest.java
@@ -1,0 +1,149 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.persistence.api.DataStoreRepository;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestProfile(RemoteInfinispanTestProfile.class)
+public class InfinispanRemoteDataStoreRepositoryTest {
+
+    @Inject
+    DataStoreRepository dataStoreRepository;
+
+    private String testId;
+
+    @BeforeAll
+    void setup() {
+        dataStoreRepository.removeAll();
+    }
+
+    @Order(1)
+    @Test
+    void testInsert() {
+        DataStore dataStore = new DataStore();
+        dataStore.setName("test-data");
+        dataStore.setData("Sample test data content");
+
+        final DataStore persisted = dataStoreRepository.persist(dataStore);
+
+        assertNotNull(persisted, "Persisted data store should not be null");
+        assertNotNull(persisted.getId(), "Generated ID should not be null");
+        assertEquals("test-data", persisted.getName(), "Name should match");
+        assertEquals("Sample test data content", persisted.getData(), "Data should match");
+
+        testId = persisted.getId();
+    }
+
+    @Order(2)
+    @Test
+    void testFindById() {
+        assertNotNull(testId, "Test ID should be available from previous test");
+
+        DataStore found = dataStoreRepository.findById(testId);
+
+        assertNotNull(found, "Data store should be found by ID");
+        assertEquals(testId, found.getId(), "ID should match");
+        assertEquals("test-data", found.getName(), "Name should match");
+        assertEquals("Sample test data content", found.getData(), "Data should match");
+    }
+
+    @Order(3)
+    @Test
+    void testFindByName() {
+        List<DataStore> found = dataStoreRepository.findByName("test-data");
+
+        assertNotNull(found, "Result list should not be null");
+        assertFalse(found.isEmpty(), "Should find at least one data store");
+        assertEquals(1, found.size(), "Should find exactly one data store");
+        assertEquals("test-data", found.get(0).getName(), "Name should match");
+    }
+
+    @Order(4)
+    @Test
+    void testListAll() {
+        List<DataStore> all = dataStoreRepository.listAll();
+
+        assertNotNull(all, "Result list should not be null");
+        assertFalse(all.isEmpty(), "Should have at least one data store");
+    }
+
+    @Order(5)
+    @Test
+    void testUpdate() {
+        assertNotNull(testId, "Test ID should be available");
+
+        DataStore dataStore = dataStoreRepository.findById(testId);
+        assertNotNull(dataStore, "Data store should exist");
+
+        dataStore.setData("Updated test data content");
+        boolean updated = dataStoreRepository.update(testId, dataStore);
+
+        assertTrue(updated, "Update should return true");
+
+        DataStore updatedDataStore = dataStoreRepository.findById(testId);
+        assertNotNull(updatedDataStore, "Updated data store should not be null");
+        assertEquals(testId, updatedDataStore.getId(), "ID should remain the same");
+        assertEquals("Updated test data content", updatedDataStore.getData(), "Data should be updated");
+    }
+
+    @Order(6)
+    @Test
+    void testDelete() {
+        assertNotNull(testId, "Test ID should be available");
+
+        boolean deleted = dataStoreRepository.deleteById(testId);
+        assertTrue(deleted, "Delete should return true");
+
+        DataStore found = dataStoreRepository.findById(testId);
+        assertNull(found, "Data store should be deleted");
+    }
+
+    @Order(7)
+    @Test
+    void testFindByNameNotFound() {
+        List<DataStore> found = dataStoreRepository.findByName("non-existent");
+
+        assertNotNull(found, "Result list should not be null");
+        assertTrue(found.isEmpty(), "Should not find any data stores");
+    }
+
+    @Order(8)
+    @Test
+    void testMultipleEntriesWithSameName() {
+        DataStore ds1 = new DataStore();
+        ds1.setName("duplicate-name");
+        ds1.setData("First entry");
+        dataStoreRepository.persist(ds1);
+
+        DataStore ds2 = new DataStore();
+        ds2.setName("duplicate-name");
+        ds2.setData("Second entry");
+        dataStoreRepository.persist(ds2);
+
+        List<DataStore> found = dataStoreRepository.findByName("duplicate-name");
+
+        assertNotNull(found, "Result list should not be null");
+        assertEquals(2, found.size(), "Should find both data stores with the same name");
+
+        dataStoreRepository.removeAll();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteLabelFilteringIntegrationTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteLabelFilteringIntegrationTest.java
@@ -1,0 +1,299 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.core.persistence.api.ToolReferenceRepository;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestProfile(RemoteInfinispanTestProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InfinispanRemoteLabelFilteringIntegrationTest {
+
+    @Inject
+    ToolReferenceRepository toolReferenceRepository;
+
+    @BeforeAll
+    public void setupTestData() {
+        toolReferenceRepository.removeAll();
+
+        createTool(
+                "weather-forecast-1",
+                "Weather Forecast API",
+                "weather",
+                Map.of("category", "weather", "action", "forecast", "version", "1.0"));
+
+        createTool(
+                "weather-current-1",
+                "Current Weather API",
+                "weather",
+                Map.of("category", "weather", "action", "current", "version", "1.0"));
+
+        createTool(
+                "weather-forecast-2",
+                "Advanced Weather Forecast",
+                "weather",
+                Map.of("category", "weather", "action", "forecast", "version", "2.0"));
+
+        createTool(
+                "news-headlines-1",
+                "News Headlines API",
+                "news",
+                Map.of("category", "news", "action", "headlines", "version", "1.0"));
+
+        createTool(
+                "news-search-1",
+                "News Search API",
+                "news",
+                Map.of("category", "news", "action", "search", "version", "1.0"));
+
+        createTool(
+                "finance-stock-1",
+                "Stock Price API",
+                "finance",
+                Map.of("category", "finance", "action", "stock", "version", "1.0"));
+
+        createTool("tool-prod-1", "Production Tool", "misc", Map.of("environment", "production", "status", "stable"));
+
+        createTool("tool-dev-1", "Development Tool", "misc", Map.of("environment", "development", "status", "beta"));
+
+        createTool("old-tool-1", "Deprecated Tool", "misc", Map.of("deprecated", "true", "category", "weather"));
+
+        createTool("no-labels-1", "Tool Without Labels", "misc", Map.of());
+    }
+
+    private void createTool(String id, String name, String type, Map<String, String> labels) {
+        ToolReference tool = new ToolReference();
+        tool.setId(id);
+        tool.setName(name);
+        tool.setDescription("Description for " + name);
+        tool.setUri("https://api.example.com/" + id);
+        tool.setType(type);
+
+        InputSchema inputSchema = new InputSchema();
+        inputSchema.setType("object");
+        Property property = new Property();
+        property.setDescription("Test property");
+        property.setType("string");
+        inputSchema.setProperties(Map.of("param1", property));
+        tool.setInputSchema(inputSchema);
+
+        tool.addLabels(labels);
+
+        toolReferenceRepository.persist(tool);
+    }
+
+    @Test
+    @Order(1)
+    public void testListAllTools() {
+        List<ToolReference> allTools = toolReferenceRepository.listAll();
+        assertEquals(10, allTools.size(), "Should have 10 tools in total");
+    }
+
+    @Test
+    @Order(2)
+    public void testSimpleEquality() {
+        List<ToolReference> weatherTools = toolReferenceRepository.findAllFilterByLabelExpression("category=weather");
+
+        assertEquals(4, weatherTools.size(), "Should find 4 weather tools");
+        assertTrue(weatherTools.stream()
+                .allMatch(t -> t.getLabelValue("category") != null
+                        && t.getLabelValue("category").equals("weather")));
+    }
+
+    @Test
+    @Order(3)
+    public void testAndExpression() {
+        List<ToolReference> forecastTools =
+                toolReferenceRepository.findAllFilterByLabelExpression("category=weather & action=forecast");
+
+        assertEquals(2, forecastTools.size(), "Should find 2 weather forecast tools");
+        assertTrue(forecastTools.stream()
+                .allMatch(t -> t.getLabelValue("category") != null
+                        && t.getLabelValue("category").equals("weather")
+                        && t.getLabelValue("action") != null
+                        && t.getLabelValue("action").equals("forecast")));
+    }
+
+    @Test
+    @Order(4)
+    public void testNotExpression() {
+        List<ToolReference> nonForecastWeather =
+                toolReferenceRepository.findAllFilterByLabelExpression("category=weather & !action=forecast");
+
+        assertEquals(2, nonForecastWeather.size(), "Should find 2 non-forecast weather tools");
+        assertTrue(nonForecastWeather.stream()
+                .allMatch(t -> t.getLabelValue("category") != null
+                        && t.getLabelValue("category").equals("weather")
+                        && (t.getLabelValue("action") == null
+                                || !t.getLabelValue("action").equals("forecast"))));
+    }
+
+    @Test
+    @Order(5)
+    public void testOrExpression() {
+        List<ToolReference> weatherOrNews =
+                toolReferenceRepository.findAllFilterByLabelExpression("category=weather | category=news");
+
+        assertEquals(6, weatherOrNews.size(), "Should find 6 weather or news tools");
+        assertTrue(weatherOrNews.stream().allMatch(t -> {
+            String category = t.getLabelValue("category");
+            return category != null && (category.equals("weather") || category.equals("news"));
+        }));
+    }
+
+    @Test
+    @Order(6)
+    public void testComplexExpression() {
+        List<ToolReference> result = toolReferenceRepository.findAllFilterByLabelExpression(
+                "(category=weather | category=news) & version=1.0");
+
+        assertEquals(4, result.size(), "Should find 4 tools matching complex expression");
+        assertTrue(result.stream().allMatch(t -> {
+            String category = t.getLabelValue("category");
+            String version = t.getLabelValue("version");
+            return category != null
+                    && version != null
+                    && (category.equals("weather") || category.equals("news"))
+                    && version.equals("1.0");
+        }));
+    }
+
+    @Test
+    @Order(7)
+    public void testNotEquals() {
+        List<ToolReference> nonProdTools =
+                toolReferenceRepository.findAllFilterByLabelExpression("environment!=production");
+
+        assertFalse(nonProdTools.isEmpty(), "Should find at least the development tool");
+
+        assertTrue(nonProdTools.stream()
+                .noneMatch(t -> t.getLabelValue("environment") != null
+                        && t.getLabelValue("environment").equals("production")));
+    }
+
+    @Test
+    @Order(8)
+    public void testNegationOfDeprecated() {
+        List<ToolReference> activeWeather =
+                toolReferenceRepository.findAllFilterByLabelExpression("category=weather & !deprecated=true");
+
+        assertEquals(3, activeWeather.size(), "Should find 3 non-deprecated weather tools");
+        assertTrue(activeWeather.stream()
+                .allMatch(t -> t.getLabelValue("category") != null
+                        && t.getLabelValue("category").equals("weather")
+                        && (t.getLabelValue("deprecated") == null
+                                || !t.getLabelValue("deprecated").equals("true"))));
+    }
+
+    @Test
+    @Order(9)
+    public void testVersionFiltering() {
+        List<ToolReference> v2Tools = toolReferenceRepository.findAllFilterByLabelExpression("version=2.0");
+
+        assertEquals(1, v2Tools.size(), "Should find 1 version 2.0 tool");
+        assertEquals("weather-forecast-2", v2Tools.get(0).getId());
+    }
+
+    @Test
+    @Order(10)
+    public void testMultipleAndConditions() {
+        List<ToolReference> specific = toolReferenceRepository.findAllFilterByLabelExpression(
+                "category=weather & action=forecast & version=1.0");
+
+        assertEquals(1, specific.size(), "Should find exactly 1 tool");
+        assertEquals("weather-forecast-1", specific.get(0).getId());
+    }
+
+    @Test
+    @Order(11)
+    public void testComplexNegation() {
+        List<ToolReference> result =
+                toolReferenceRepository.findAllFilterByLabelExpression("environment=production & !deprecated=true");
+
+        assertEquals(1, result.size(), "Should find 1 production non-deprecated tool");
+        assertEquals("tool-prod-1", result.get(0).getId());
+    }
+
+    @Test
+    @Order(12)
+    public void testNullLabelExpression() {
+        List<ToolReference> allTools = toolReferenceRepository.findAllFilterByLabelExpression(null);
+
+        assertEquals(10, allTools.size(), "Null expression should return all tools");
+    }
+
+    @Test
+    @Order(13)
+    public void testEmptyLabelExpression() {
+        List<ToolReference> allTools = toolReferenceRepository.findAllFilterByLabelExpression("");
+
+        assertEquals(10, allTools.size(), "Empty expression should return all tools");
+    }
+
+    @Test
+    @Order(14)
+    public void testNoMatchingTools() {
+        List<ToolReference> result = toolReferenceRepository.findAllFilterByLabelExpression("category=nonexistent");
+
+        assertEquals(0, result.size(), "Should find no tools with non-existent category");
+    }
+
+    @Test
+    @Order(15)
+    public void testInvalidLabelExpression() {
+        assertThrows(
+                Exception.class,
+                () -> toolReferenceRepository.findAllFilterByLabelExpression("invalid syntax without operator"));
+    }
+
+    @Test
+    @Order(16)
+    public void testParenthesesPrecedence() {
+        List<ToolReference> result = toolReferenceRepository.findAllFilterByLabelExpression(
+                "(category=weather | category=news) & version=1.0");
+
+        assertEquals(4, result.size());
+    }
+
+    @Test
+    @Order(17)
+    public void testDoubleNegation() {
+        List<ToolReference> result = toolReferenceRepository.findAllFilterByLabelExpression("!!category=weather");
+
+        assertEquals(4, result.size(), "Double negation should work correctly");
+    }
+
+    @Test
+    @Order(18)
+    public void testStatusFiltering() {
+        List<ToolReference> stableTools = toolReferenceRepository.findAllFilterByLabelExpression("status=stable");
+
+        assertEquals(1, stableTools.size(), "Should find 1 stable tool");
+        assertEquals("tool-prod-1", stableTools.get(0).getId());
+    }
+
+    @AfterAll
+    public void cleanup() {
+        toolReferenceRepository.removeAll();
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteNamespaceRepositoryTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteNamespaceRepositoryTest.java
@@ -1,0 +1,136 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import org.jboss.logging.Logger;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.core.persistence.api.NamespaceRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@QuarkusTest
+@TestProfile(RemoteInfinispanTestProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InfinispanRemoteNamespaceRepositoryTest {
+    private static final Logger LOG = Logger.getLogger(InfinispanRemoteNamespaceRepositoryTest.class);
+
+    @Inject
+    NamespaceRepository namespaceRepository;
+
+    private final int maxNamespaces = 10;
+
+    @BeforeAll
+    void setup() {
+        namespaceRepository.removeAll();
+    }
+
+    @DisplayName("Tests that preloading records create correct records")
+    @Order(1)
+    @Test
+    void testInsert() {
+        for (int i = 0; i < maxNamespaces; i++) {
+            final String namespacePath = String.format("ns-%d", i);
+            Namespace namespace = new Namespace();
+            namespace.setPath(namespacePath);
+            namespace.setName(null);
+
+            final Namespace persisted = namespaceRepository.persist(namespace);
+            Assertions.assertNotNull(persisted);
+            Assertions.assertNull(persisted.getName());
+            Assertions.assertNotNull(persisted.getPath());
+            Assertions.assertNotNull(persisted.getId());
+
+            LOG.infof("Created new namespace path %s", namespacePath);
+        }
+
+        Assertions.assertEquals(maxNamespaces, namespaceRepository.size());
+    }
+
+    @DisplayName("Tests that creating a new records in an empty cache create correct records")
+    @Order(2)
+    @Test
+    void testFindFirstAvailableAfterEmpty() {
+        final String namespaceName = "testFindFirstAvailableAfterEmpty";
+        final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(namespaceName);
+
+        Assertions.assertEquals(1, namespaces.size());
+        Namespace namespace = namespaces.getFirst();
+        Assertions.assertNotNull(namespace);
+
+        Assertions.assertNull(namespace.getName());
+        namespace.setName(namespaceName);
+        final Namespace persisted = namespaceRepository.persist(namespace);
+        Assertions.assertNotNull(persisted);
+        Assertions.assertEquals(namespaceName, persisted.getName());
+    }
+
+    @DisplayName("Tests that creating a new records in an non-empty cache create correct records")
+    @Order(3)
+    @Test
+    void testFindFirstAvailableAfterInsert() {
+        final String namespaceName = "testFindFirstAvailableAfterInsert";
+        final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(namespaceName);
+
+        Assertions.assertEquals(1, namespaces.size());
+        Namespace namespace = namespaces.getFirst();
+        Assertions.assertNotNull(namespace);
+
+        Assertions.assertNull(namespace.getName(), "Should have returned a namespace without name");
+        namespace.setName(namespaceName);
+        final Namespace persisted = namespaceRepository.persist(namespace);
+        Assertions.assertNotNull(persisted);
+        Assertions.assertEquals(namespaceName, persisted.getName());
+    }
+
+    @DisplayName("Tests that records can be found")
+    @Order(4)
+    @Test
+    void testFind() {
+        final String namespaceName1 = "testFindFirstAvailableAfterEmpty";
+        final List<Namespace> firstAfterInsert = namespaceRepository.findByName(namespaceName1);
+        Assertions.assertNotNull(firstAfterInsert);
+        final Namespace first = firstAfterInsert.getFirst();
+        Assertions.assertEquals(namespaceName1, first.getName());
+        Assertions.assertNotNull(first.getPath());
+
+        final String namespaceName2 = "testFindFirstAvailableAfterInsert";
+        final List<Namespace> secondAfterInsert = namespaceRepository.findByName(namespaceName2);
+        Assertions.assertNotNull(secondAfterInsert);
+        final Namespace second = secondAfterInsert.getFirst();
+        Assertions.assertEquals(namespaceName2, second.getName());
+        Assertions.assertNotNull(second.getPath());
+    }
+
+    @DisplayName("Tests that does not exceed the maximum number of records")
+    @Order(5)
+    @Test
+    void testDoesNotExceedMaxNamespaces() {
+        for (int i = 2; i < maxNamespaces; i++) {
+            final String namespaceName = String.format("name-%d", i);
+            final List<Namespace> firstAvailable = namespaceRepository.findFirstAvailable(namespaceName);
+
+            Namespace namespace = firstAvailable.getFirst();
+            namespace.setName(namespaceName);
+
+            final Namespace persisted = namespaceRepository.persist(namespace);
+            Assertions.assertNotNull(persisted);
+            Assertions.assertEquals(namespaceName, persisted.getName());
+        }
+
+        Assertions.assertEquals(10, namespaceRepository.size());
+        final List<Namespace> firstAvailable = namespaceRepository.findFirstAvailable("name-11");
+        Assertions.assertEquals(10, namespaceRepository.size());
+        Assertions.assertEquals(0, firstAvailable.size());
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePromptReferenceRepositoryTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemotePromptReferenceRepositoryTest.java
@@ -1,0 +1,131 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.PromptMessage;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference;
+import ai.wanaku.capabilities.sdk.api.types.PromptReference.PromptArgument;
+import ai.wanaku.capabilities.sdk.api.types.TextContent;
+import ai.wanaku.core.persistence.api.PromptReferenceRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+@TestProfile(RemoteInfinispanTestProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InfinispanRemotePromptReferenceRepositoryTest {
+
+    @Inject
+    PromptReferenceRepository promptReferenceRepository;
+
+    @Test
+    @Order(1)
+    public void insertThree() {
+        for (int i = 1; i < 4; i++) {
+            PromptReference promptReference = new PromptReference();
+            promptReference.setId("id" + i);
+            promptReference.setName("name" + i);
+            promptReference.setDescription("description" + i);
+            promptReference.setNamespace("namespace" + i);
+
+            PromptMessage userMessage = new PromptMessage();
+            userMessage.setRole("user");
+            userMessage.setContent(new TextContent("User message " + i));
+
+            PromptMessage assistantMessage = new PromptMessage();
+            assistantMessage.setRole("assistant");
+            assistantMessage.setContent(new TextContent("Assistant message " + i));
+
+            promptReference.setMessages(List.of(userMessage, assistantMessage));
+
+            PromptArgument argument = new PromptArgument();
+            argument.setName("arg" + i);
+            argument.setDescription("Argument description " + i);
+            argument.setRequired(i % 2 == 0);
+
+            promptReference.setArguments(List.of(argument));
+
+            promptReference.setToolReferences(List.of("tool" + i));
+
+            promptReferenceRepository.persist(promptReference);
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void list() {
+        List<PromptReference> entities = promptReferenceRepository.listAll();
+
+        assertEquals(3, entities.size());
+        final Optional<PromptReference> refOpt =
+                entities.stream().filter(entity -> entity.getId().equals("id1")).findFirst();
+
+        Assertions.assertTrue(refOpt.isPresent());
+        PromptReference name1Entity = refOpt.get();
+        assertEquals("name1", name1Entity.getName());
+        assertEquals("description1", name1Entity.getDescription());
+        assertEquals("namespace1", name1Entity.getNamespace());
+        assertNotNull(name1Entity.getMessages());
+        assertEquals(2, name1Entity.getMessages().size());
+        assertNotNull(name1Entity.getArguments());
+        assertEquals(1, name1Entity.getArguments().size());
+        assertEquals("arg1", name1Entity.getArguments().get(0).getName());
+        assertNotNull(name1Entity.getToolReferences());
+        assertEquals(1, name1Entity.getToolReferences().size());
+        assertEquals("tool1", name1Entity.getToolReferences().get(0));
+    }
+
+    @Test
+    @Order(3)
+    public void find() {
+        PromptReference model = promptReferenceRepository.findById("id1");
+
+        Assertions.assertNotNull(model);
+        assertEquals("name1", model.getName());
+        assertNotNull(model.getMessages());
+        assertEquals(2, model.getMessages().size());
+        assertEquals("user", model.getMessages().get(0).getRole());
+        assertEquals("assistant", model.getMessages().get(1).getRole());
+    }
+
+    @Test
+    @Order(4)
+    public void findByName() {
+        List<PromptReference> prompts = promptReferenceRepository.findByName("name1");
+
+        Assertions.assertNotNull(prompts);
+        assertEquals(1, prompts.size());
+        assertEquals("id1", prompts.get(0).getId());
+    }
+
+    @Test
+    @Order(5)
+    public void findNonExistent() {
+        Assertions.assertNull(promptReferenceRepository.findById("nameNotExists"));
+    }
+
+    @Test
+    @Order(6)
+    public void delete() {
+        int initialSize = promptReferenceRepository.listAll().size();
+
+        promptReferenceRepository.deleteById("id2");
+
+        int finalSize = promptReferenceRepository.listAll().size();
+
+        Assertions.assertTrue(finalSize < initialSize);
+        assertEquals(2, finalSize);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteResourceReferenceRepositoryTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteResourceReferenceRepositoryTest.java
@@ -1,0 +1,101 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import ai.wanaku.core.persistence.api.ResourceReferenceRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestProfile(RemoteInfinispanTestProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InfinispanRemoteResourceReferenceRepositoryTest {
+
+    @Inject
+    ResourceReferenceRepository resourceReferenceRepository;
+
+    @BeforeAll
+    public void setup() {
+        resourceReferenceRepository.removeAll();
+    }
+
+    @Test
+    @Order(1)
+    public void insertThreeFiles() {
+        for (int i = 1; i < 4; i++) {
+            ResourceReference resourceReference = new ResourceReference();
+            resourceReference.setId("id" + i);
+            resourceReference.setDescription("description" + i);
+            resourceReference.setLocation("location" + i);
+            resourceReference.setName("name" + i);
+            resourceReference.setType("type" + i);
+            resourceReference.setMimeType("mimeType" + i);
+
+            ResourceReference.Param param1 = new ResourceReference.Param();
+            param1.setName("param1" + i);
+            param1.setValue("value1" + i);
+            ResourceReference.Param param2 = new ResourceReference.Param();
+            param2.setName("param2" + i);
+            param2.setValue("value2" + i);
+
+            resourceReference.setParams(List.of(param1, param2));
+            resourceReference.setConfigurationURI("file://local");
+            resourceReference.setSecretsURI("file://local");
+            resourceReferenceRepository.persist(resourceReference);
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void list() {
+        List<ResourceReference> entities = resourceReferenceRepository.listAll();
+        assertEquals(3, entities.size());
+        final Optional<ResourceReference> refOpt = entities.stream()
+                .filter(entity -> entity.getName().equals("name1"))
+                .findFirst();
+
+        Assertions.assertTrue(refOpt.isPresent());
+        ResourceReference name1Entity = refOpt.get();
+        assertEquals("name1", name1Entity.getName());
+        assertEquals("type1", name1Entity.getType());
+        assertEquals("location1", name1Entity.getLocation());
+        assertEquals("description1", name1Entity.getDescription());
+        assertEquals("mimeType1", name1Entity.getMimeType());
+    }
+
+    @Test
+    @Order(3)
+    public void find() {
+        ResourceReference model = resourceReferenceRepository.findById("id1");
+        Assertions.assertNotNull(model);
+    }
+
+    @Test
+    @Order(4)
+    public void findNonExistent() {
+        final ResourceReference nameNotExists = resourceReferenceRepository.findById("nameNotExists");
+        Assertions.assertNull(nameNotExists);
+    }
+
+    @Test
+    @Order(5)
+    public void delete() {
+        int initialSize = resourceReferenceRepository.listAll().size();
+        resourceReferenceRepository.deleteById("id2");
+        int finalSize = resourceReferenceRepository.listAll().size();
+        Assertions.assertTrue(finalSize < initialSize);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteToolReferenceRepositoryTest.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/InfinispanRemoteToolReferenceRepositoryTest.java
@@ -1,0 +1,101 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.core.persistence.api.ToolReferenceRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+@TestProfile(RemoteInfinispanTestProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InfinispanRemoteToolReferenceRepositoryTest {
+
+    @Inject
+    ToolReferenceRepository toolReferenceRepository;
+
+    @Test
+    @Order(1)
+    public void insertThree() {
+        for (int i = 1; i < 4; i++) {
+            ToolReference toolReference = new ToolReference();
+            toolReference.setId("id" + i);
+            toolReference.setName("name" + i);
+            toolReference.setUri("uri" + i);
+            toolReference.setDescription("description" + i);
+            toolReference.setType("type" + i);
+
+            InputSchema inputSchema = new InputSchema();
+            inputSchema.setType("type" + i);
+            Property property = new Property();
+            property.setDescription("propertyDescription" + i);
+            property.setType("propertyType" + i);
+            inputSchema.setProperties(Map.of("prop" + i, property));
+            inputSchema.setRequired(List.of("prop" + 1));
+
+            toolReference.setInputSchema(inputSchema);
+
+            toolReferenceRepository.persist(toolReference);
+        }
+    }
+
+    @Test
+    @Order(2)
+    public void list() {
+        List<ToolReference> entities = toolReferenceRepository.listAll();
+
+        assertEquals(3, entities.size());
+        final Optional<ToolReference> refOpt =
+                entities.stream().filter(entity -> entity.getId().equals("id1")).findFirst();
+
+        Assertions.assertTrue(refOpt.isPresent());
+        ToolReference name1Entity = refOpt.get();
+        assertEquals("name1", name1Entity.getName());
+        assertEquals("type1", name1Entity.getType());
+        assertNotNull(name1Entity.getInputSchema());
+        assertEquals("type1", name1Entity.getInputSchema().getType());
+        assertEquals("description1", name1Entity.getDescription());
+    }
+
+    @Test
+    @Order(3)
+    public void find() {
+        ToolReference model = toolReferenceRepository.findById("id1");
+
+        Assertions.assertNotNull(model);
+    }
+
+    @Test
+    @Order(4)
+    public void findNonExistent() {
+        Assertions.assertNull(toolReferenceRepository.findById("nameNotExists"));
+    }
+
+    @Test
+    @Order(5)
+    public void delete() {
+        int initialSize = toolReferenceRepository.listAll().size();
+
+        toolReferenceRepository.deleteById("id2");
+
+        int finalSize = toolReferenceRepository.listAll().size();
+
+        Assertions.assertTrue(finalSize < initialSize);
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/RemoteInfinispanTestProfile.java
+++ b/core/core-persistence-infinispan-remote/src/test/java/ai/wanaku/core/persistence/infinispan/remote/RemoteInfinispanTestProfile.java
@@ -1,0 +1,15 @@
+package ai.wanaku.core.persistence.infinispan.remote;
+
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RemoteInfinispanTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.devservices.enabled", "true",
+                "quarkus.infinispan-client.devservices.enabled", "true",
+                "quarkus.infinispan-client.devservices.image-name", "infinispan/server:16.0");
+    }
+}

--- a/core/core-persistence-infinispan-remote/src/test/resources/application.properties
+++ b/core/core-persistence-infinispan-remote/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+quarkus.devservices.enabled=true
+quarkus.infinispan-client.devservices.enabled=true
+quarkus.infinispan-client.devservices.image-name=infinispan/server:16.0
+
+quarkus.infinispan-client.cache.tool.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.prompt.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.resource.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.datastore.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.namespace.configuration-resource=config/indexed-cache.json
+quarkus.infinispan-client.cache.forward.configuration-resource=config/indexed-cache.json

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,10 @@
 
         <!-- router core -->
         <module>core-mcp-client</module>
+
+        <!-- persistence -->
+        <module>core-persistence-api</module>
+        <module>core-persistence-infinispan-remote</module>
     </modules>
 
 


### PR DESCRIPTION
draft to Closes: #773 
I had done this last week, but forgot to commit

## Summary by Sourcery

Introduce a remote Infinispan-based persistence layer with shared persistence APIs and label-aware querying, including configuration, protostream schemas, and repositories for core entities.

New Features:
- Add core-persistence-api module defining generic Wanaku repositories and label-aware persistence interfaces for core entities such as tools, resources, prompts, namespaces, forward references, and data stores.
- Add core-persistence-infinispan-remote module providing Infinispan Hot Rod–backed implementations of the core persistence repositories and a shared AbstractRemoteInfinispanRepository base.
- Introduce label expression parsing utilities to support flexible label-based filtering and removal across label-aware repositories.
- Configure a dedicated Infinispan RemoteCacheManager client with protostream schemas/marshallers and cache definitions for all persisted entity types.

Enhancements:
- Wire the new persistence modules into the core build by registering core-persistence-api and core-persistence-infinispan-remote as Maven submodules.

Tests:
- Add comprehensive unit and integration tests for label expression parsing and remote Infinispan repositories covering CRUD, querying by name, label-based filtering, and namespace allocation behavior.
- Add a Quarkus test profile and devservices-based configuration to spin up an Infinispan server for repository integration tests.