### PR TITLE
Enhance logging for Wanaku Router readiness and service startup

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -232,6 +232,8 @@ public class LocalRunner {
             Duration remaining = Duration.ofNanos(remainingNanos);
             if (routerIsReady(minDuration(remaining, ROUTER_READINESS_REQUEST_TIMEOUT))) {
                 LOG.info("Wanaku Router Backend is ready");
+                var dashboardUri = routerReadinessUri.resolve("/admin");
+                LOG.infof("Open the Wanaku dashboard available at %s", dashboardUri);
                 return;
             }
 
@@ -287,7 +289,7 @@ public class LocalRunner {
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
-        LOG.infof("Starting Wanaku Service %s on port %d", component.getKey(), grpcPort);
+        LOG.infof("Starting Wanaku Service %s (gRPC port %d)", component.getKey(), grpcPort);
 
         if (isQuarkusComponent(component.getKey())) {
             startQuarkusService(component.getKey(), grpcPort, profileOpt, executorService, countDownLatch, environment);


### PR DESCRIPTION
Closes: #1281

## Summary by Sourcery

Improve startup logging for the Wanaku Router and services to better communicate readiness and access details.

Enhancements:
- Log the Wanaku dashboard URL when the router backend becomes ready.
- Clarify Wanaku service startup logs by including the gRPC port in a more descriptive format.