### PR TITLE
Backport: improve local runner log messages

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -131,6 +131,8 @@ public class LocalRunner {
             return;
         }
 
+        LOG.infof("Open the Wanaku dashboard available at %s", "http://localhost:8080/admin");
+
         for (Map.Entry<String, String> component : components.entrySet()) {
             if (isEnabled(services, component)) {
                 startService(component, grpcPort, profileOpt, executorService, countDownLatch, environment);
@@ -172,7 +174,7 @@ public class LocalRunner {
             ExecutorService executorService,
             CountDownLatch countDownLatch,
             LocalRunnerEnvironment environment) {
-        LOG.infof("Starting Wanaku Service %s on port %d", component.getKey(), grpcPort);
+        LOG.infof("Starting Wanaku Service %s (gRPC port %d)", component.getKey(), grpcPort);
         File componentDir = quarkusAppDir(component.getKey());
 
         String grpcPortOpt = String.format("-Dquarkus.grpc.server.port=%d", grpcPort);


### PR DESCRIPTION
Cherry-picks 0a1658aecee378d0e2862eb008721ad813b81f45 onto 0.1.x.\n\nChanges:\n- Log the dashboard URL after router startup wait\n- Clarify that the service port log refers to the gRPC port

## Summary by Sourcery

Improve local runner logging for the Wanaku CLI.

Enhancements:
- Log the Wanaku dashboard URL after the local router has started.
- Clarify the service startup log message to explicitly reference the gRPC port.