### PR TITLE
Local deployment instructions should not include --client-id when auth  is disabled

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBean.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
@@ -27,20 +28,42 @@ public class DeploymentInstructionsBean {
     private static final String TYPE_NATIVE = "native";
     private static final String TEMPLATES_PATH = "templates/deployment/";
 
+    private static final String AUTH_NONE = "none";
+
+    static final String TEMPLATE_LOCAL_CIC = "local-cic";
+    static final String TEMPLATE_LOCAL_NATIVE = "local-native";
+    static final String TEMPLATE_DOCKER_CIC = "docker-cic";
+    static final String TEMPLATE_DOCKER_NATIVE = "docker-native";
+    static final String TEMPLATE_KUBERNETES_HEADER = "kubernetes-header";
+    static final String TEMPLATE_KUBERNETES_CAPABILITY_CIC = "kubernetes-capability-cic";
+    static final String TEMPLATE_KUBERNETES_CAPABILITY_NATIVE = "kubernetes-capability-native";
+
+    private static final Map<String, String> AUTH_OPTIONS = Map.of(
+            TEMPLATE_LOCAL_CIC, "--client-id wanaku-service \\\n  ",
+            TEMPLATE_DOCKER_CIC,
+                    "-e TOKEN_ENDPOINT=<token-endpoint> \\\n  -e CLIENT_ID=wanaku-service \\\n  -e CLIENT_SECRET=<client-secret> \\\n  ",
+            TEMPLATE_DOCKER_NATIVE,
+                    "-e AUTH_SERVER=<auth-server> \\\n  -e QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET=<client-secret> \\\n  ",
+            TEMPLATE_KUBERNETES_HEADER,
+                    "auth:\n    authServer: <auth-server-address>\n    authProxy: \"auto\"\n    secrets:\n      oidcCredentialsSecret: <credentials-secret>\n  ");
+
     @Inject
     ServiceCatalogBean serviceCatalogBean;
+
+    @ConfigProperty(name = "wanaku.http.auth", defaultValue = "keycloak")
+    String httpAuth;
 
     private final Map<String, String> templates = new HashMap<>();
 
     @PostConstruct
     void loadTemplates() {
-        templates.put("local-cic", loadTemplate("local-cic.tpl"));
-        templates.put("local-native", loadTemplate("local-native.tpl"));
-        templates.put("docker-cic", loadTemplate("docker-cic.tpl"));
-        templates.put("docker-native", loadTemplate("docker-native.tpl"));
-        templates.put("kubernetes-header", loadTemplate("kubernetes-header.tpl"));
-        templates.put("kubernetes-capability-cic", loadTemplate("kubernetes-capability-cic.tpl"));
-        templates.put("kubernetes-capability-native", loadTemplate("kubernetes-capability-native.tpl"));
+        templates.put(TEMPLATE_LOCAL_CIC, loadTemplate("local-cic.tpl"));
+        templates.put(TEMPLATE_LOCAL_NATIVE, loadTemplate("local-native.tpl"));
+        templates.put(TEMPLATE_DOCKER_CIC, loadTemplate("docker-cic.tpl"));
+        templates.put(TEMPLATE_DOCKER_NATIVE, loadTemplate("docker-native.tpl"));
+        templates.put(TEMPLATE_KUBERNETES_HEADER, loadTemplate("kubernetes-header.tpl"));
+        templates.put(TEMPLATE_KUBERNETES_CAPABILITY_CIC, loadTemplate("kubernetes-capability-cic.tpl"));
+        templates.put(TEMPLATE_KUBERNETES_CAPABILITY_NATIVE, loadTemplate("kubernetes-capability-native.tpl"));
     }
 
     private String loadTemplate(String fileName) {
@@ -55,11 +78,25 @@ public class DeploymentInstructionsBean {
         }
     }
 
+    private boolean isNoAuth() {
+        return AUTH_NONE.equalsIgnoreCase(httpAuth);
+    }
+
+    private void addIfAuthEnabled(List<PlaceholderDefinition> placeholders, PlaceholderDefinition... defs) {
+        if (!isNoAuth()) {
+            for (PlaceholderDefinition def : defs) {
+                placeholders.add(def);
+            }
+        }
+    }
+
     private String renderTemplate(String templateKey, String catalogName, String systemName) {
+        String authOptions = isNoAuth() ? "" : AUTH_OPTIONS.getOrDefault(templateKey, "");
         return templates
                 .get(templateKey)
                 .replace("{{catalogName}}", catalogName)
-                .replace("{{systemName}}", systemName);
+                .replace("{{systemName}}", systemName)
+                .replace("{{authOptions}}", authOptions);
     }
 
     public DeploymentInstructions generateInstructions(String catalogName, String deploymentModel)
@@ -79,11 +116,13 @@ public class DeploymentInstructionsBean {
 
         switch (deploymentModel) {
             case "local":
-                systems = generatePerSystemInstructions(index, catalogType, "local-cic", "local-native", "shell");
+                systems = generatePerSystemInstructions(
+                        index, catalogType, TEMPLATE_LOCAL_CIC, TEMPLATE_LOCAL_NATIVE, "shell");
                 placeholders = getLocalPlaceholders(catalogType);
                 break;
             case "docker":
-                systems = generatePerSystemInstructions(index, catalogType, "docker-cic", "docker-native", "shell");
+                systems = generatePerSystemInstructions(
+                        index, catalogType, TEMPLATE_DOCKER_CIC, TEMPLATE_DOCKER_NATIVE, "shell");
                 placeholders = getDockerPlaceholders(catalogType);
                 break;
             case "kubernetes":
@@ -121,10 +160,11 @@ public class DeploymentInstructionsBean {
 
     private List<SystemInstruction> generateKubernetesInstructions(ServiceCatalogIndex index, String catalogType) {
         StringBuilder sb = new StringBuilder();
-        sb.append(renderTemplate("kubernetes-header", index.getName(), ""));
+        sb.append(renderTemplate(TEMPLATE_KUBERNETES_HEADER, index.getName(), ""));
 
-        String capabilityTemplate =
-                TYPE_CIC.equals(catalogType) ? "kubernetes-capability-cic" : "kubernetes-capability-native";
+        String capabilityTemplate = TYPE_CIC.equals(catalogType)
+                ? TEMPLATE_KUBERNETES_CAPABILITY_CIC
+                : TEMPLATE_KUBERNETES_CAPABILITY_NATIVE;
 
         for (String system : index.getServiceNames()) {
             sb.append("\n");
@@ -162,40 +202,45 @@ public class DeploymentInstructionsBean {
                     "URL of the Wanaku router (use host.docker.internal for local router)",
                     "http://host.docker.internal:8080",
                     "url"));
-            placeholders.add(new PlaceholderDefinition(
-                    "token-endpoint",
-                    "Token Endpoint",
-                    "OAuth2 token endpoint URL for authentication",
-                    "http://host.docker.internal:8080",
-                    "url"));
-            placeholders.add(new PlaceholderDefinition(
-                    "client-secret", "Client Secret", "OIDC client secret for service authentication", ""));
+            addIfAuthEnabled(
+                    placeholders,
+                    new PlaceholderDefinition(
+                            "token-endpoint",
+                            "Token Endpoint",
+                            "OAuth2 token endpoint URL for authentication",
+                            "http://host.docker.internal:8080",
+                            "url"),
+                    new PlaceholderDefinition(
+                            "client-secret", "Client Secret", "OIDC client secret for service authentication", ""));
         } else {
-            placeholders.add(new PlaceholderDefinition(
-                    "auth-server", "Auth Server", "Address of the authentication server", "http://", "url"));
+            addIfAuthEnabled(
+                    placeholders,
+                    new PlaceholderDefinition(
+                            "auth-server", "Auth Server", "Address of the authentication server", "http://", "url"),
+                    new PlaceholderDefinition("client-secret", "Client Secret", "OIDC client credentials secret", ""));
             placeholders.add(new PlaceholderDefinition(
                     "registration-url",
                     "Registration URL",
                     "URL of the Wanaku router (use host.docker.internal for local router)",
                     "http://host.docker.internal:8080/",
                     "url"));
-            placeholders.add(
-                    new PlaceholderDefinition("client-secret", "Client Secret", "OIDC client credentials secret", ""));
         }
         return placeholders;
     }
 
     private List<PlaceholderDefinition> getKubernetesPlaceholders() {
         List<PlaceholderDefinition> placeholders = new ArrayList<>();
-        placeholders.add(new PlaceholderDefinition(
-                "auth-server-address",
-                "Auth Server Address",
-                "Address of the authentication server (e.g., Keycloak URL)",
-                "http://",
-                "url"));
-        placeholders.add(new PlaceholderDefinition(
-                "credentials-secret", "Credentials Secret",
-                "OIDC credentials secret (create with 'wanaku credentials' command)", ""));
+        addIfAuthEnabled(
+                placeholders,
+                new PlaceholderDefinition(
+                        "auth-server-address",
+                        "Auth Server Address",
+                        "Address of the authentication server (e.g., Keycloak URL)",
+                        "http://",
+                        "url"),
+                new PlaceholderDefinition(
+                        "credentials-secret", "Credentials Secret",
+                        "OIDC credentials secret (create with 'wanaku credentials' command)", ""));
         placeholders.add(new PlaceholderDefinition(
                 "router-name", "Router Name", "Name of the WanakuRouter CR (find with 'oc get wanakurouter')", ""));
         return placeholders;

--- a/apps/wanaku-router-backend/src/main/resources/templates/deployment/docker-cic.tpl
+++ b/apps/wanaku-router-backend/src/main/resources/templates/deployment/docker-cic.tpl
@@ -5,8 +5,5 @@ docker run -d \
   -e SERVICE_NAME={{systemName}} \
   -e SERVICE_CATALOG={{catalogName}} \
   -e SERVICE_CATALOG_SYSTEM={{systemName}} \
-  -e TOKEN_ENDPOINT=<token-endpoint> \
-  -e CLIENT_ID=wanaku-service \
-  -e CLIENT_SECRET=<client-secret> \
-  -p 9190:9190 \
+  {{authOptions}}-p 9190:9190 \
   quay.io/wanaku/camel-integration-capability:latest

--- a/apps/wanaku-router-backend/src/main/resources/templates/deployment/docker-native.tpl
+++ b/apps/wanaku-router-backend/src/main/resources/templates/deployment/docker-native.tpl
@@ -1,6 +1,4 @@
 docker run -d \
-  -e AUTH_SERVER=<auth-server> \
-  -e WANAKU_SERVICE_REGISTRATION_URI=<registration-url> \
-  -e QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET=<client-secret> \
+  {{authOptions}}-e WANAKU_SERVICE_REGISTRATION_URI=<registration-url> \
   -p 9000:9000 \
   quay.io/wanaku/wanaku-tool-service-{{systemName}}:latest

--- a/apps/wanaku-router-backend/src/main/resources/templates/deployment/kubernetes-header.tpl
+++ b/apps/wanaku-router-backend/src/main/resources/templates/deployment/kubernetes-header.tpl
@@ -3,10 +3,5 @@ kind: WanakuCapability
 metadata:
   name: wanaku-dev-{{catalogName}}-capability
 spec:
-  auth:
-    authServer: <auth-server-address>
-    authProxy: "auto"
-  secrets:
-    oidcCredentialsSecret: <credentials-secret>
-  routerRef: <router-name>
+  {{authOptions}}routerRef: <router-name>
   capabilities:

--- a/apps/wanaku-router-backend/src/main/resources/templates/deployment/local-cic.tpl
+++ b/apps/wanaku-router-backend/src/main/resources/templates/deployment/local-cic.tpl
@@ -5,5 +5,4 @@ java -jar camel-integration-capability-main-*-jar-with-dependencies.jar \
   --name {{systemName}} \
   --service-catalog {{catalogName}} \
   --service-catalog-system {{systemName}} \
-  --client-id wanaku-service \
-  --fail-fast
+  {{authOptions}}--fail-fast

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/DeploymentInstructionsBeanTest.java
@@ -1,0 +1,208 @@
+package ai.wanaku.backend.api.v1.servicecatalog;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.Base64;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.services.api.DeploymentInstructions;
+import ai.wanaku.core.services.api.ServiceCatalogIndex;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeploymentInstructionsBeanTest {
+
+    @Mock
+    ServiceCatalogBean serviceCatalogBean;
+
+    @InjectMocks
+    DeploymentInstructionsBean bean;
+
+    private DataStore testCatalog;
+    private ServiceCatalogIndex testIndex;
+    private static final String KEYCLOAK_CONFIG = "keycloak";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Method loadTemplates = DeploymentInstructionsBean.class.getDeclaredMethod("loadTemplates");
+        loadTemplates.setAccessible(true);
+        loadTemplates.invoke(bean);
+
+        testCatalog = new DataStore();
+        testCatalog.setId("test-id");
+        testCatalog.setName("test-catalog.zip");
+        testCatalog.setData(createTestZipBase64("testcatalog", "A test catalog", "sys1"));
+
+        testIndex = ServiceCatalogIndex.fromBase64(testCatalog.getData());
+    }
+
+    @Test
+    void testLocalInstructionsNoAuth() {
+        bean.httpAuth = "none";
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "local");
+        assertNotNull(instructions);
+        assertEquals(1, instructions.systems().size());
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertFalse(instruction.contains("--client-id"), "Instructions should not contain --client-id when noauth");
+        assertFalse(
+                instruction.contains("wanaku-service"), "Instructions should not contain wanaku-service when noauth");
+        assertTrue(instruction.contains("--fail-fast"), "Instructions should still contain --fail-fast");
+    }
+
+    @Test
+    void testLocalInstructionsWithAuth() {
+        bean.httpAuth = KEYCLOAK_CONFIG;
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "local");
+        assertNotNull(instructions);
+        assertEquals(1, instructions.systems().size());
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertTrue(
+                instruction.contains("--client-id wanaku-service"),
+                "Instructions should contain --client-id when auth is enabled");
+        assertTrue(instruction.contains("--fail-fast"), "Instructions should still contain --fail-fast");
+    }
+
+    @Test
+    void testDockerCicInstructionsNoAuth() {
+        bean.httpAuth = "none";
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "docker");
+        assertNotNull(instructions);
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertFalse(instruction.contains("CLIENT_ID"), "Instructions should not contain CLIENT_ID when noauth");
+        assertFalse(
+                instruction.contains("TOKEN_ENDPOINT"), "Instructions should not contain TOKEN_ENDPOINT when noauth");
+        assertFalse(instruction.contains("CLIENT_SECRET"), "Instructions should not contain CLIENT_SECRET when noauth");
+
+        boolean hasAuthPlaceholders = instructions.placeholders().stream()
+                .anyMatch(p -> "client-secret".equals(p.key()) || "token-endpoint".equals(p.key()));
+        assertFalse(hasAuthPlaceholders, "Should not have auth placeholders when noauth");
+    }
+
+    @Test
+    void testDockerCicInstructionsWithAuth() {
+        bean.httpAuth = KEYCLOAK_CONFIG;
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "docker");
+        assertNotNull(instructions);
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertTrue(
+                instruction.contains("CLIENT_ID=wanaku-service"),
+                "Instructions should contain CLIENT_ID when auth is enabled");
+        assertTrue(
+                instruction.contains("TOKEN_ENDPOINT"),
+                "Instructions should contain TOKEN_ENDPOINT when auth is enabled");
+        assertTrue(
+                instruction.contains("CLIENT_SECRET"),
+                "Instructions should contain CLIENT_SECRET when auth is enabled");
+
+        boolean hasAuthPlaceholders = instructions.placeholders().stream()
+                .anyMatch(p -> "client-secret".equals(p.key()) || "token-endpoint".equals(p.key()));
+        assertTrue(hasAuthPlaceholders, "Should have auth placeholders when auth is enabled");
+    }
+
+    @Test
+    void testKubernetesInstructionsNoAuth() {
+        bean.httpAuth = "none";
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "kubernetes");
+        assertNotNull(instructions);
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertFalse(instruction.contains("auth:"), "Instructions should not contain auth section when noauth");
+        assertFalse(instruction.contains("authServer"), "Instructions should not contain authServer when noauth");
+
+        boolean hasAuthPlaceholders = instructions.placeholders().stream()
+                .anyMatch(p -> "auth-server-address".equals(p.key()) || "credentials-secret".equals(p.key()));
+        assertFalse(hasAuthPlaceholders, "Should not have auth placeholders when noauth");
+    }
+
+    @Test
+    void testKubernetesInstructionsWithAuth() {
+        bean.httpAuth = KEYCLOAK_CONFIG;
+
+        when(serviceCatalogBean.get("testcatalog")).thenReturn(testCatalog);
+        when(serviceCatalogBean.parseIndex(testCatalog)).thenReturn(testIndex);
+
+        DeploymentInstructions instructions = bean.generateInstructions("testcatalog", "kubernetes");
+        assertNotNull(instructions);
+
+        String instruction = instructions.systems().get(0).instruction();
+        assertTrue(instruction.contains("auth:"), "Instructions should contain auth section when auth is enabled");
+        assertTrue(instruction.contains("authServer"), "Instructions should contain authServer when auth is enabled");
+
+        boolean hasAuthPlaceholders = instructions.placeholders().stream()
+                .anyMatch(p -> "auth-server-address".equals(p.key()) || "credentials-secret".equals(p.key()));
+        assertTrue(hasAuthPlaceholders, "Should have auth placeholders when auth is enabled");
+    }
+
+    private String createTestZipBase64(String name, String description, String... systems) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                Properties props = new Properties();
+                props.setProperty("catalog.name", name);
+                props.setProperty("catalog.description", description);
+                props.setProperty("catalog.services", String.join(",", systems));
+
+                for (String sys : systems) {
+                    String routesPath = sys + "/" + sys + ".camel.yaml";
+                    String rulesPath = sys + "/" + sys + ".wanaku-rules.yaml";
+                    props.setProperty("catalog.routes." + sys, routesPath);
+                    props.setProperty("catalog.rules." + sys, rulesPath);
+
+                    zos.putNextEntry(new ZipEntry(routesPath));
+                    zos.write(("# Routes for " + sys).getBytes());
+                    zos.closeEntry();
+
+                    zos.putNextEntry(new ZipEntry(rulesPath));
+                    zos.write(("# Rules for " + sys).getBytes());
+                    zos.closeEntry();
+                }
+
+                zos.putNextEntry(new ZipEntry("index.properties"));
+                ByteArrayOutputStream propsOut = new ByteArrayOutputStream();
+                props.store(propsOut, null);
+                zos.write(propsOut.toByteArray());
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes: #1276

## Summary by Sourcery

Make deployment instructions omit authentication-related flags and sections when HTTP auth is disabled, and keep them when it is enabled, across local, Docker, and Kubernetes deployment templates.

Bug Fixes:
- Ensure local deployment instructions no longer include --client-id or other auth-specific options when authentication is disabled.
- Prevent Docker deployment instructions from including auth-related environment variables and placeholders when authentication is disabled.
- Avoid rendering Kubernetes auth configuration sections and related placeholders when authentication is disabled.

Enhancements:
- Centralize auth configuration handling in DeploymentInstructionsBean with helper methods and template placeholders to conditionally render auth options based on configuration.

Tests:
- Add unit tests for DeploymentInstructionsBean covering auth-enabled and auth-disabled behavior for local, Docker, and Kubernetes deployment instructions.