### PR TITLE
Add Keycloak Authorization dependency and configuration

### DIFF
--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>quarkus-oidc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-authorization</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.oidc-proxy</groupId>
             <artifactId>quarkus-oidc-proxy</artifactId>
             <version>${quarkus-oidc-proxy.version}</version>

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -52,6 +52,9 @@ wanaku.http.auth=keycloak
 # Auth
 quarkus.oidc.enabled=true
 
+# Keycloak Authorization (disabled by default, enable to enforce resource-based policies)
+quarkus.keycloak.policy-enforcer.enabled=false
+
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
 auth.server=${AUTH_SERVER:http://localhost:8543}
 # Address used by the OIDC proxy -

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -132,6 +132,7 @@ Configuration for the main Wanaku Router Backend (`wanaku-router-backend`), whic
 | `quarkus.oidc-proxy.enabled` | `true` - Enables the OIDC proxy feature, which simplifies OIDC integration. |
 | `quarkus.http.auth.permission.*.paths` | Defines path patterns for different security policies (`permit`, `authenticated`). |
 | `quarkus.http.auth.permission.*.policy` | Assigns a security policy to the corresponding path pattern. |
+| `quarkus.keycloak.policy-enforcer.enabled` | `false` - Disables Keycloak Authorization Services policy enforcement. Set to `true` to enable policy enforcement so that MCP endpoints (e.g., `/mcp`, `/mcp/sse`) can be protected as Authorization Resources in Keycloak, linked to permissions and policies so that JWT access tokens are only issued to users who meet the associated policy. |
 
 #### Running Without Authentication
 


### PR DESCRIPTION
Closes: #521

## Summary by Sourcery

Add support for Keycloak Authorization Services to the wanaku-router-backend and make its policy enforcement configurable.

New Features:
- Introduce Keycloak authorization integration via the Quarkus Keycloak Authorization extension with configurable policy enforcement.

Documentation:
- Document the new Keycloak policy enforcer configuration option and how it can be used to protect MCP endpoints as authorization resources.