### PR TITLE
Refactor service tests to use mocks

### DIFF
--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceDeployTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceDeployTest.java
@@ -3,30 +3,40 @@ package ai.wanaku.cli.main.commands.service;
 import java.io.File;
 import java.io.FileWriter;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Properties;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.WanakuPrinter;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
+@ExtendWith(MockitoExtension.class)
 class ServiceDeployTest {
 
     @TempDir
     Path tempDir;
+
+    @Mock
+    private Terminal terminal;
+
+    @Mock
+    private WanakuPrinter printer;
 
     @Test
     void testDeployFailsWithMissingIndex() throws Exception {
         tempDir.resolve("empty").toFile().mkdirs();
 
         ServiceDeploy cmd = new ServiceDeploy();
-        setField(cmd, "path", tempDir.resolve("empty").toString());
+        setField(cmd, "path", tempDir.resolve("empty").toAbsolutePath().toString());
         setField(cmd, "host", "http://localhost:8080");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 
@@ -36,12 +46,11 @@ class ServiceDeployTest {
         rootDir.mkdirs();
 
         Properties props = new Properties();
-        // Missing catalog.name
         props.setProperty("catalog.description", "test");
         props.setProperty("catalog.services", "sys1");
 
         File indexFile = new File(rootDir, "index.properties");
-        try (FileWriter fw = new FileWriter(indexFile)) {
+        try (FileWriter fw = new FileWriter(indexFile, StandardCharsets.UTF_8)) {
             props.store(fw, null);
         }
 
@@ -49,7 +58,7 @@ class ServiceDeployTest {
         setField(cmd, "path", rootDir.getAbsolutePath());
         setField(cmd, "host", "http://localhost:8080");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 
@@ -66,17 +75,15 @@ class ServiceDeployTest {
         props.setProperty("catalog.rules.sys1", "sys1/sys1.wanaku-rules.yaml");
 
         File indexFile = new File(rootDir, "index.properties");
-        try (FileWriter fw = new FileWriter(indexFile)) {
+        try (FileWriter fw = new FileWriter(indexFile, StandardCharsets.UTF_8)) {
             props.store(fw, null);
         }
-
-        // Do NOT create the route file
 
         ServiceDeploy cmd = new ServiceDeploy();
         setField(cmd, "path", rootDir.getAbsolutePath());
         setField(cmd, "host", "http://localhost:8080");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceExposeTest.java
@@ -4,32 +4,40 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.WanakuPrinter;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
+@ExtendWith(MockitoExtension.class)
 class ServiceExposeTest {
 
     @TempDir
     Path tempDir;
 
+    @Mock
+    private Terminal terminal;
+
+    @Mock
+    private WanakuPrinter printer;
+
     @Test
     void testExposeGeneratesRules() throws Exception {
-        // Set up a service catalog directory
         setupServiceDir("myservice", "sys1");
 
-        // Write a Camel route with an ID
         File routeFile = tempDir.resolve("myservice/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: my-route-1");
             pw.println("    from:");
@@ -37,16 +45,15 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("myservice").toString());
+        setField(cmd, "path", tempDir.resolve("myservice").toAbsolutePath().toString());
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        // Verify rules file was generated
         File rulesFile =
                 tempDir.resolve("myservice/sys1/sys1.wanaku-rules.yaml").toFile();
         assertTrue(rulesFile.exists());
-        String content = Files.readString(rulesFile.toPath());
+        String content = Files.readString(rulesFile.toPath(), StandardCharsets.UTF_8);
         assertTrue(content.contains("my-route-1"));
         assertTrue(content.contains("wanaku_body"), "Tools should include wanaku_body property by default");
     }
@@ -56,7 +63,7 @@ class ServiceExposeTest {
         setupServiceDir("nsservice", "sys1");
 
         File routeFile = tempDir.resolve("nsservice/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: ns-route");
             pw.println("    from:");
@@ -64,25 +71,25 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("nsservice").toString());
+        setField(cmd, "path", tempDir.resolve("nsservice").toAbsolutePath().toString());
         setField(cmd, "namespace", "production");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("nsservice/sys1/sys1.wanaku-rules.yaml"));
+        String content =
+                Files.readString(tempDir.resolve("nsservice/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("production"));
     }
 
     @Test
     void testExposeMissingIndexProperties() throws Exception {
-        // Directory without index.properties
         tempDir.resolve("empty").toFile().mkdirs();
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("empty").toString());
+        setField(cmd, "path", tempDir.resolve("empty").toAbsolutePath().toString());
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 
@@ -91,7 +98,7 @@ class ServiceExposeTest {
         setupServiceDir("multiroute", "sys1");
 
         File routeFile = tempDir.resolve("multiroute/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: route-alpha");
             pw.println("    from:");
@@ -103,12 +110,13 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("multiroute").toString());
+        setField(cmd, "path", tempDir.resolve("multiroute").toAbsolutePath().toString());
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("multiroute/sys1/sys1.wanaku-rules.yaml"));
+        String content =
+                Files.readString(tempDir.resolve("multiroute/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("route-alpha"));
         assertTrue(content.contains("route-beta"));
     }
@@ -118,7 +126,7 @@ class ServiceExposeTest {
         setupServiceDir("resservice", "sys1");
 
         File routeFile = tempDir.resolve("resservice/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: s3-read");
             pw.println("    from:");
@@ -126,13 +134,14 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("resservice").toString());
+        setField(cmd, "path", tempDir.resolve("resservice").toAbsolutePath().toString());
         setField(cmd, "type", "resource");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("resservice/sys1/sys1.wanaku-rules.yaml"));
+        String content =
+                Files.readString(tempDir.resolve("resservice/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("resources:"), "Should contain resources section");
         assertFalse(content.contains("tools:"), "Should not contain tools section");
         assertTrue(content.contains("s3-read"), "Should contain route ID");
@@ -146,7 +155,7 @@ class ServiceExposeTest {
         setupServiceDir("resns", "sys1");
 
         File routeFile = tempDir.resolve("resns/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: ftp-read");
             pw.println("    from:");
@@ -154,14 +163,14 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("resns").toString());
+        setField(cmd, "path", tempDir.resolve("resns").toAbsolutePath().toString());
         setField(cmd, "type", "resource");
         setField(cmd, "namespace", "staging");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("resns/sys1/sys1.wanaku-rules.yaml"));
+        String content = Files.readString(tempDir.resolve("resns/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("resources:"));
         assertTrue(content.contains("staging"));
     }
@@ -171,7 +180,7 @@ class ServiceExposeTest {
         setupServiceDir("rescustom", "sys1");
 
         File routeFile = tempDir.resolve("rescustom/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: blob-read");
             pw.println("    from:");
@@ -179,15 +188,16 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("rescustom").toString());
+        setField(cmd, "path", tempDir.resolve("rescustom").toAbsolutePath().toString());
         setField(cmd, "type", "resource");
         setField(cmd, "uri", "azure://container/blob");
         setField(cmd, "mimeType", "text/plain");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("rescustom/sys1/sys1.wanaku-rules.yaml"));
+        String content =
+                Files.readString(tempDir.resolve("rescustom/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("uri: \"azure://container/blob\""), "Should use custom URI");
         assertTrue(content.contains("mimeType: \"text/plain\""), "Should use custom MIME type");
     }
@@ -197,10 +207,10 @@ class ServiceExposeTest {
         setupServiceDir("invalidtype", "sys1");
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("invalidtype").toString());
+        setField(cmd, "path", tempDir.resolve("invalidtype").toAbsolutePath().toString());
         setField(cmd, "type", "invalid");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 
@@ -209,7 +219,7 @@ class ServiceExposeTest {
         setupServiceDir("stepids", "sys1");
 
         File routeFile = tempDir.resolve("stepids/sys1/sys1.camel.yaml").toFile();
-        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile))) {
+        try (PrintWriter pw = new PrintWriter(new FileWriter(routeFile, StandardCharsets.UTF_8))) {
             pw.println("- route:");
             pw.println("    id: get-employee-information");
             pw.println("    description: Retrieve employee basic information");
@@ -225,12 +235,13 @@ class ServiceExposeTest {
         }
 
         ServiceExpose cmd = new ServiceExpose();
-        setField(cmd, "path", tempDir.resolve("stepids").toString());
+        setField(cmd, "path", tempDir.resolve("stepids").toAbsolutePath().toString());
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
-        String content = Files.readString(tempDir.resolve("stepids/sys1/sys1.wanaku-rules.yaml"));
+        String content =
+                Files.readString(tempDir.resolve("stepids/sys1/sys1.wanaku-rules.yaml"), StandardCharsets.UTF_8);
         assertTrue(content.contains("get-employee-information"), "Should contain route ID");
         assertFalse(content.contains("set-method-header"), "Should not contain step ID");
         assertFalse(content.contains("call-employee-service"), "Should not contain step ID");
@@ -252,13 +263,12 @@ class ServiceExposeTest {
             props.setProperty("catalog.routes." + sys, sys + "/" + sys + ".camel.yaml");
             props.setProperty("catalog.rules." + sys, sys + "/" + sys + ".wanaku-rules.yaml");
 
-            // Create empty route file
             new File(sysDir, sys + ".camel.yaml").createNewFile();
             new File(sysDir, sys + ".wanaku-rules.yaml").createNewFile();
         }
 
         File indexFile = new File(rootDir, "index.properties");
-        try (FileWriter fw = new FileWriter(indexFile)) {
+        try (FileWriter fw = new FileWriter(indexFile, StandardCharsets.UTF_8)) {
             props.store(fw, null);
         }
     }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/service/ServiceInitTest.java
@@ -5,44 +5,37 @@ import java.io.FileInputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Properties;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.WanakuPrinter;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "https://github.com/wanaku-ai/wanaku/issues/1193")
+@ExtendWith(MockitoExtension.class)
 class ServiceInitTest {
 
     @TempDir
     Path tempDir;
 
-    private Path originalDir;
+    @Mock
+    private Terminal terminal;
 
-    @BeforeEach
-    void setUp() {
-        originalDir = Path.of(System.getProperty("user.dir"));
-        // Change working directory for the test (since ServiceInit creates relative dirs)
-        System.setProperty("user.dir", tempDir.toString());
-    }
-
-    @AfterEach
-    void tearDown() {
-        System.setProperty("user.dir", originalDir.toString());
-    }
+    @Mock
+    private WanakuPrinter printer;
 
     @Test
     void testInitCreatesSingleSystem() throws Exception {
         ServiceInit cmd = new ServiceInit();
-        setField(cmd, "name", tempDir.resolve("testservice").toString());
+        setField(cmd, "name", tempDir.resolve("testservice").toAbsolutePath().toString());
         setField(cmd, "services", "sys1");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
         File rootDir = tempDir.resolve("testservice").toFile();
@@ -52,7 +45,6 @@ class ServiceInitTest {
         assertTrue(new File(rootDir, "sys1/sys1.wanaku-rules.yaml").exists(), "Rules file should exist");
         assertTrue(new File(rootDir, "sys1/sys1.dependencies.txt").exists(), "Dependencies file should exist");
 
-        // Verify index.properties content
         Properties props = new Properties();
         try (FileInputStream fis = new FileInputStream(new File(rootDir, "index.properties"))) {
             props.load(fis);
@@ -66,10 +58,10 @@ class ServiceInitTest {
     @Test
     void testInitCreatesMultipleSystems() throws Exception {
         ServiceInit cmd = new ServiceInit();
-        setField(cmd, "name", tempDir.resolve("multiservice").toString());
+        setField(cmd, "name", tempDir.resolve("multiservice").toAbsolutePath().toString());
         setField(cmd, "services", "sys1,sys2,sys3");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(0, result);
 
         File rootDir = tempDir.resolve("multiservice").toFile();
@@ -87,7 +79,6 @@ class ServiceInitTest {
 
     @Test
     void testInitFailsWhenDirectoryExists() throws Exception {
-        // Pre-create the directory
         File existing = tempDir.resolve("existing").toFile();
         existing.mkdirs();
 
@@ -95,17 +86,17 @@ class ServiceInitTest {
         setField(cmd, "name", existing.getAbsolutePath());
         setField(cmd, "services", "sys1");
 
-        Integer result = cmd.call();
+        Integer result = cmd.doCall(terminal, printer);
         assertEquals(1, result);
     }
 
     @Test
     void testInitIndexPropertiesHasCorrectServicesList() throws Exception {
         ServiceInit cmd = new ServiceInit();
-        setField(cmd, "name", tempDir.resolve("proptest").toString());
+        setField(cmd, "name", tempDir.resolve("proptest").toAbsolutePath().toString());
         setField(cmd, "services", "alpha,beta");
 
-        cmd.call();
+        cmd.doCall(terminal, printer);
 
         Properties props = new Properties();
         try (FileInputStream fis =


### PR DESCRIPTION
Closes: #1193 

Benchmark

Measured across 3 runs each, excluding JVM startup (test time only):

| Test Class | Tests | Before (avg) | After (avg) | Improvement |
|------------|-------:|-------------:|------------:|------------:|
| `ServiceDeployTest` | 3 | 0.327 s | 1.055 s | — |
| `ServiceExposeTest` | 9 | 0.301 s | 0.087 s | **3.5x** |
| `ServiceInitTest` | 4 | 0.143 s | 0.033 s | **4.3x** |



` ServiceDeployTest` The after-time is higher because the original tests were calling `cmd.call()` which swallows JLine terminal errors silently. The fixed tests call `doCall()` properly with mocked dependencies. The Mockito self-attach overhead (~0.7s one-time) accounts for most of the difference. On Windows, the original `call()` path was much slower (JLine native probing), so the net effect on Windows is a significant improvement.

My computer is average in terms of configuration, etc.

## Summary by Sourcery

Refactor service CLI command tests to invoke the interactive entrypoint with mocked dependencies and improve cross-platform reliability.

Tests:
- Update ServiceInit, ServiceExpose, and ServiceDeploy tests to use mocked Terminal and WanakuPrinter with doCall instead of call.
- Remove Windows-specific DisabledOnOs test exclusions by avoiding real JLine terminal usage and system directory changes.
- Normalize filesystem interactions in tests by using absolute paths and explicitly using UTF-8 for file I/O to make assertions stable across environments.