### PR TITLE
feat: add sql-tool service template

### DIFF
--- a/services/service-templates/src/main/services/sql-tool/index.properties
+++ b/services/service-templates/src/main/services/sql-tool/index.properties
@@ -1,0 +1,6 @@
+catalog.dependencies.sql=sql/sql.dependencies.txt
+catalog.description=Execute SQL queries against a relational database using Apache Camel SQL component
+catalog.name=sql-tool
+catalog.routes.sql=sql/sql.camel.yaml
+catalog.rules.sql=sql/sql.rules.yaml
+catalog.services=sql

--- a/services/service-templates/src/main/services/sql-tool/sql/service.properties
+++ b/services/service-templates/src/main/services/sql-tool/sql/service.properties
@@ -1,0 +1,2 @@
+tool.description=Execute SQL queries against a relational database using camel-sql
+sql.query=SELECT 1

--- a/services/service-templates/src/main/services/sql-tool/sql/sql.camel.yaml
+++ b/services/service-templates/src/main/services/sql-tool/sql/sql.camel.yaml
@@ -1,0 +1,18 @@
+- route:
+    description: Execute SQL queries against a relational database
+        from:
+              uri: direct:wanaku
+                  steps:
+                        - setHeader:
+                                  name: CamelSqlQuery
+                                            expression:
+                                                        simple:
+                                                                      expression: "{{sql.query}}"
+                                                                            - to:
+                                                                                      uri: sql
+                                                                                                parameters:
+                                                                                                            dataSource: "#dataSource"
+                                                                                                                        query: "${header.CamelSqlQuery}"
+                                                                                                                              - marshal:
+                                                                                                                                        json: {}
+                                                                                                                                            id: sql-tool

--- a/services/service-templates/src/main/services/sql-tool/sql/sql.dependencies.txt
+++ b/services/service-templates/src/main/services/sql-tool/sql/sql.dependencies.txt
@@ -1,0 +1,3 @@
+# Maven dependencies for sql-tool
+  # One dependency per line in the format: groupId:artifactId or groupId:artifactId:version
+    org.apache.camel:camel-sql

--- a/services/service-templates/src/main/services/sql-tool/sql/sql.rules.yaml
+++ b/services/service-templates/src/main/services/sql-tool/sql/sql.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+  - sql:
+      route:
+        id: "sql-tool"
+        description: "Execute SQL queries against a relational database using camel-sql"
+      properties:
+      - name: wanaku_body
+        type: string
+        description: The SQL query to execute (e.g. SELECT * FROM users WHERE id = 1)
+        required: true


### PR DESCRIPTION
Closes #1187

Adds a new `sql-tool` service template that enables executing SQL queries against a relational database using the Apache Camel SQL component. Includes Camel route, MCP tool definition, Maven dependencies, and configuration properties.

## Summary by Sourcery

Add a new service template for executing SQL queries via Apache Camel SQL.

New Features:
- Introduce a sql-tool service template for running SQL queries against relational databases via Apache Camel SQL.

Enhancements:
- Define Camel route, MCP tool metadata, and default configuration for the sql-tool service template.