### PR TITLE
docs: update PATH configuration instructions in CLI and usage guides

### DIFF
--- a/apps/wanaku-cli/README.md
+++ b/apps/wanaku-cli/README.md
@@ -37,25 +37,10 @@ jbang app install wanaku@wanaku-ai/wanaku
 ### Via Binary Download
 
 Download the latest release from [GitHub releases](https://github.com/wanaku-ai/wanaku/releases) and extract to your PATH.
-
 ### PATH Configuration
 
-If you installed the Wanaku CLI using `get-wanaku.sh`, it is placed in `~/bin` (`$HOME/bin`). Many systems do not include `$HOME/bin` in the default `PATH`, so you may need to add it manually to avoid a "command not found" error when running `wanaku`.
+If you installed via `get-wanaku.sh`, the CLI is placed in `$HOME/bin` which may not be on your default `PATH`. See [PATH Configuration](../../docs/usage.md#path-configuration) in the usage guide for setup instructions.
 
-To add `$HOME/bin` to your `PATH` for the current session:
-
-```shell
-export PATH="$HOME/bin:$PATH"
-```
-
-To persist this across sessions, add the line above to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
-
-```shell
-echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-```
-
-> **Note:** If you are using `zsh`, replace `~/.bashrc` with `~/.zshrc`.
 >
 > 
 ## Basic Usage

--- a/docs/building.md
+++ b/docs/building.md
@@ -72,6 +72,8 @@ make cli-native
 make install
 ```
 
+See [PATH Configuration](usage.md#path-configuration) if `$HOME/bin` is not on your default `PATH`.
+
 ## Building with the containers
 
 ```shell

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,16 +93,7 @@ Kubernetes/OpenShift deployment is recommended for production but not required.
 
 ### How do I install the Wanaku CLI?
 
-There are two main options:
-
-**Via JBang (recommended):**
-
-```shell
-jbang app install wanaku@wanaku-ai/wanaku
-```
-
-**Via binary download:**
-Download the latest release from [GitHub releases](https://github.com/wanaku-ai/wanaku/releases) and extract to your PATH.
+See the [Installing the CLI](usage.md#installing-the-command-line-interface-cli) section in the usage guide for all installation methods and PATH configuration.
 
 ## Usage and Configuration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -272,6 +272,34 @@ executing `wanaku`.
 > It requires access to the internet, in case of using a proxy, please ensure that the proxy is configured for your system.
 > If Wanaku JBang is not working with your current configuration, please look to [Proxy configuration in JBang documentation](https://www.jbang.dev/documentation/jbang/latest/configuration.html#proxy-configuration).
 
+### PATH Configuration
+
+If you installed the Wanaku CLI using `get-wanaku.sh` or the native build (`make install`), it is placed in `$HOME/bin`. Many systems do not include `$HOME/bin` in the default `PATH`, so you may need to add it manually to avoid a "command not found" error when running `wanaku`.
+
+To add `$HOME/bin` to your `PATH` for the current session:
+
+```shell
+export PATH="$HOME/bin:$PATH"
+```
+
+To persist this across sessions, add the line above to your shell configuration file:
+
+```shell
+echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+> **Note:** If you are using `zsh`, replace `~/.bashrc` with `~/.zshrc`.
+
+> [!TIP]
+> The `get-wanaku.sh` script auto-detects your OS and architecture, downloads the latest release, verifies the checksum, and installs to `$HOME/bin`. You can override the install directory with `WANAKU_INSTALL_DIR=/usr/local/bin`.
+
+Verify the installation:
+
+```shell
+wanaku --version
+```
+
 ## Installing and Running the Router
 
 There are three ways to run the router. They work similarly, with the distinction that some of them may come with more


### PR DESCRIPTION
Closes: #1297

## Summary by Sourcery

Document PATH configuration for CLI installs and centralize installation guidance across usage, CLI README, FAQ, and building docs.

Documentation:
- Add a dedicated PATH configuration section to the usage guide, including instructions for adding $HOME/bin to PATH and verifying the CLI installation.
- Simplify the CLI README by linking to the shared PATH configuration section instead of duplicating instructions.
- Update the FAQ to point to the usage guide for CLI installation methods and PATH setup.
- Reference the PATH configuration section from the building guide when installing the native CLI to $HOME/bin.