### PR TITLE
Fix #1303: expose Mcp-Session-Id header via CORS for Streamable HTTP transport

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -40,6 +40,7 @@ quarkus.mcp.server.public.sse.root-path=/public/mcp
 
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:8080,http://127.0.0.1:8080,http://localhost:5173,http://localhost:6274
+quarkus.http.cors.exposed-headers=Mcp-Session-Id
 
 %dev.quarkus.mcp.server.traffic-logging.enabled=true
 %dev.quarkus.mcp.server.traffic-logging.text-limit=1000000


### PR DESCRIPTION
## Summary

- Add `quarkus.http.cors.exposed-headers=Mcp-Session-Id` to router's `application.properties`

## Problem

Browser-based MCP clients (e.g., MCP Inspector) cannot maintain Streamable HTTP sessions because the `Mcp-Session-Id` response header is not listed in `Access-Control-Expose-Headers`. Browsers block JavaScript from reading custom headers unless explicitly exposed via CORS, so each request creates a new uninitialized session.

This works in `quarkus:dev` mode because Quarkus Dev UI adds a more permissive CORS handler. In production/local mode, only the explicit CORS configuration applies.

## Fix

One line: expose the `Mcp-Session-Id` header so browser-based clients can read and resend it on subsequent requests.

SSE transport, `curl`, and non-browser clients are not affected.

Closes #1303

## Summary by Sourcery

Bug Fixes:
- Allow browser-based MCP clients to read the Mcp-Session-Id header by adding it to the CORS exposed headers configuration.