### PR TITLE
chore: remove duplicate kubectl logs references in usage docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3477,7 +3477,6 @@ This section provides solutions to common issues you may encounter while using W
 
    ```shell
    kubectl logs <pod-name>
-   kubectl logs <pod-name>
    ```
 
 3. Verify ConfigMaps and Secrets are properly mounted:
@@ -3578,7 +3577,7 @@ Check logs in these locations:
 
 - **Router backend:** Look for `wanaku-router-backend.log` or check container logs
 - **Capability services:** Check individual service log files
-- **Kubernetes:** `kubectl logs <pod-name>` or `kubectl logs <pod-name>`
+- **Kubernetes:** `kubectl logs <pod-name>`
 
 ### Getting Help
 


### PR DESCRIPTION
## Summary

- Removes duplicate `kubectl logs <pod-name>` line in the troubleshooting section
- Removes redundant `or kubectl logs` in the log locations reference

Both duplicates were introduced in #1287 when `oc` commands were replaced with `kubectl`.

## Summary by Sourcery

Documentation:
- Remove repeated kubectl logs command examples from troubleshooting and log locations sections in the usage guide.