### PR TITLE
feat: Implement OpenTelemetry for distributed tracing and request ID propagation

### DIFF
--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -15,6 +15,22 @@
         <keycloak.docker.image>quay.io/keycloak/keycloak:26.6.1</keycloak.docker.image>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkiverse.infinispan</groupId>
+                <artifactId>quarkus-infinispan-embedded-deployment</artifactId>
+                <version>${quarkus-infinispan-embedded.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.quarkiverse.micrometer.registry</groupId>
+                        <artifactId>quarkus-micrometer-registry-prometheus-v1-deployment</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>ai.wanaku</groupId>
@@ -26,6 +42,17 @@
             <groupId>io.quarkiverse.infinispan</groupId>
             <artifactId>quarkus-infinispan-embedded</artifactId>
             <version>${quarkus-infinispan-embedded.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkiverse.micrometer.registry</groupId>
+                    <artifactId>quarkus-micrometer-registry-prometheus-v1</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
 
         <dependency>
@@ -127,6 +154,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
 
         <dependency>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/codeexecution/CodeExecutionBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/codeexecution/CodeExecutionBean.java
@@ -108,7 +108,7 @@ public class CodeExecutionBean {
 
         // Dispatch the task for execution
         final Iterator<CodeExecutionReply> codeExecutionReplyIterator =
-                codeExecutionBridge.executeCode(engineType, language, request);
+                codeExecutionBridge.executeCode(engineType, language, request, "");
 
         managedExecutor.runAsync(() -> consumeEvents(codeExecutionReplyIterator, taskId));
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
@@ -94,16 +94,17 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
      * @throws ServiceNotFoundException if no matching service is registered
      */
     @Override
-    public Iterator<CodeExecutionReply> executeCode(String engineType, String language, CodeExecutionRequest request) {
+    public Iterator<CodeExecutionReply> executeCode(
+            String engineType, String language, CodeExecutionRequest request, String requestId) {
         LOG.infof("Executing code (engine=%s, language=%s)", engineType, language);
 
-        // Resolve the service
         ServiceTarget service = resolveService(engineType, language);
 
-        // Build the gRPC request
-        ai.wanaku.core.exchange.v1.CodeExecutionRequest grpcRequest = buildGrpcRequest(engineType, language, request);
+        ai.wanaku.core.exchange.v1.CodeExecutionRequest grpcRequest =
+                buildGrpcRequest(engineType, language, request, requestId);
 
-        // Emit STARTED event
+        RequestIdContext.setContext(requestId, null);
+
         ToolCallEvent startedEvent = null;
         if (eventNotifier != null) {
             startedEvent = emitStartedEvent(engineType, language, service, request);
@@ -113,13 +114,10 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
         final ToolCallEvent finalStartedEvent = startedEvent;
 
         try {
-            // Execute via transport
             Iterator<CodeExecutionReply> replyIterator = transport.executeCode(grpcRequest, service);
 
-            // Wrap the iterator to emit completion event when done or on close
             return new CloseableCodeExecutionIterator(replyIterator, finalStartedEvent, startTime, this);
         } catch (Exception e) {
-            // Emit FAILED event
             if (eventNotifier != null && startedEvent != null) {
                 long duration = Duration.between(startTime, Instant.now()).toMillis();
                 eventNotifier.emitFailedEvent(
@@ -129,6 +127,8 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
                         duration);
             }
             throw e;
+        } finally {
+            RequestIdContext.clear();
         }
     }
 
@@ -253,7 +253,7 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
      * Builds a gRPC CodeExecutionRequest from the SDK request.
      */
     private ai.wanaku.core.exchange.v1.CodeExecutionRequest buildGrpcRequest(
-            String engineType, String language, CodeExecutionRequest request) {
+            String engineType, String language, CodeExecutionRequest request, String requestId) {
 
         String uri = String.format("code-execution-engine://%s/%s", engineType, language);
 
@@ -263,7 +263,8 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
                 ai.wanaku.core.exchange.v1.CodeExecutionRequest.newBuilder()
                         .setUri(uri)
                         .setCode(decodedCode)
-                        .setTimeout(request.getTimeout());
+                        .setTimeout(request.getTimeout())
+                        .setRequestId(requestId != null ? requestId : "");
 
         List<String> arguments = request.getArguments();
         if (arguments != null && !arguments.isEmpty()) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutorBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutorBridge.java
@@ -42,5 +42,6 @@ public interface CodeExecutorBridge extends Bridge {
      * @param request the code execution request containing the code and parameters
      * @return an iterator over the streaming code execution replies
      */
-    Iterator<CodeExecutionReply> executeCode(String engineType, String language, CodeExecutionRequest request);
+    Iterator<CodeExecutionReply> executeCode(
+            String engineType, String language, CodeExecutionRequest request, String requestId);
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -1,5 +1,7 @@
 package ai.wanaku.backend.bridge;
 
+import jakarta.inject.Inject;
+
 import java.time.Duration;
 import java.time.Instant;
 import org.jboss.logging.Logger;
@@ -7,6 +9,7 @@ import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.vertx.core.Vertx;
 import ai.wanaku.backend.bridge.transports.grpc.GrpcTransport;
 import ai.wanaku.backend.common.ToolCallEvent;
 import ai.wanaku.backend.service.support.ServiceResolver;
@@ -32,6 +35,7 @@ public class InvokerBridge implements ToolsBridge {
     private final ServiceResolver serviceResolver;
     private final WanakuBridgeTransport transport;
     private final EventNotifier eventNotifier;
+    private final Vertx vertx;
 
     static class WanakuToolContext {
         ToolManager.ToolArguments arguments;
@@ -49,28 +53,16 @@ public class InvokerBridge implements ToolsBridge {
         }
     }
 
-    /**
-     * Creates a new InvokerBridge with the specified service resolver and transport.
-     *
-     * @param serviceResolver the resolver for locating tool services
-     * @param transport the gRPC transport for communication
-     */
-    public InvokerBridge(ServiceResolver serviceResolver, WanakuBridgeTransport transport) {
-        this(serviceResolver, transport, null);
-    }
-
-    /**
-     * Creates a new InvokerBridge with the specified service resolver, transport, and event notifier.
-     *
-     * @param serviceResolver the resolver for locating tool services
-     * @param transport the gRPC transport for communication
-     * @param eventNotifier the notifier for tool call events (nullable)
-     */
+    @Inject
     public InvokerBridge(
-            ServiceResolver serviceResolver, WanakuBridgeTransport transport, EventNotifier eventNotifier) {
+            ServiceResolver serviceResolver,
+            WanakuBridgeTransport transport,
+            EventNotifier eventNotifier,
+            Vertx vertx) {
         this.serviceResolver = serviceResolver;
         this.transport = transport;
         this.eventNotifier = eventNotifier;
+        this.vertx = vertx;
     }
 
     @Override
@@ -84,12 +76,23 @@ public class InvokerBridge implements ToolsBridge {
                             "Only local tool call references should be invoked by this executor"));
         }
 
+        String requestId = toolArguments.requestId().asString();
+        String connectionId = toolArguments.connection().id();
+
         return Uni.createFrom()
                 .item(() -> WanakuToolContext.create(toolArguments, ref))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .invoke(ctx -> {
+                    if (vertx != null) {
+                        vertx.runOnContext(v -> RequestIdContext.setContext(requestId, connectionId));
+                    } else {
+                        RequestIdContext.setContext(requestId, connectionId);
+                    }
+                })
+                .invoke(ctx -> RequestIdContext.setToolName(ref.getName()))
                 .invoke(this::resolveService)
                 .invoke(ctx -> {
-                    ctx.request = InvokerToolExecutor.buildToolInvokeRequest(ref, toolArguments);
+                    ctx.request = InvokerToolExecutor.buildToolInvokeRequest(ref, toolArguments, requestId);
                     ctx.startTime = Instant.now();
                     if (eventNotifier != null) {
                         ctx.startedEvent =
@@ -105,7 +108,15 @@ public class InvokerBridge implements ToolsBridge {
 
                             LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
                             return ToolResponse.error(failure.getMessage());
-                        }));
+                        }))
+                .onItemOrFailure()
+                .invoke((item, failure) -> {
+                    if (vertx != null) {
+                        vertx.runOnContext(v -> RequestIdContext.clear());
+                    } else {
+                        RequestIdContext.clear();
+                    }
+                });
     }
 
     private void emitCompleted(WanakuToolContext ctx, ToolResponse response) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -34,6 +34,7 @@ public final class InvokerToolExecutor {
     private static final Logger LOG = Logger.getLogger(InvokerToolExecutor.class);
     private static final String EMPTY_BODY = "";
     private static final String EMPTY_ARGUMENT = "";
+    private static final String EMPTY_REQUEST_ID = "";
 
     private InvokerToolExecutor() {}
 
@@ -45,7 +46,7 @@ public final class InvokerToolExecutor {
      * @return a fully constructed ToolInvokeRequest
      */
     static ToolInvokeRequest buildToolInvokeRequest(
-            ToolReference toolReference, ToolManager.ToolArguments toolArguments) {
+            ToolReference toolReference, ToolManager.ToolArguments toolArguments, String requestId) {
 
         // Filter out metadata and auth args before converting to string map
         Map<String, Object> filteredArgs = filterOutReservedArgs(toolArguments.args());
@@ -74,6 +75,7 @@ public final class InvokerToolExecutor {
                 .setSecretsUri(Objects.requireNonNullElse(toolReference.getSecretsURI(), EMPTY_ARGUMENT))
                 .putAllHeaders(headers)
                 .putAllArguments(argumentsMap)
+                .setRequestId(Objects.requireNonNullElse(requestId, EMPTY_REQUEST_ID))
                 .build();
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/RequestIdContext.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/RequestIdContext.java
@@ -1,0 +1,45 @@
+package ai.wanaku.backend.bridge;
+
+import org.jboss.logging.MDC;
+import io.opentelemetry.api.trace.Span;
+
+final class RequestIdContext {
+
+    static final String MDC_REQUEST_ID_KEY = "requestId";
+    static final String MDC_CONNECTION_ID_KEY = "connectionId";
+
+    static final String SPAN_ATTR_REQUEST_ID = "wanaku.mcp.request_id";
+    static final String SPAN_ATTR_CONNECTION_ID = "wanaku.mcp.connection_id";
+    static final String SPAN_ATTR_TOOL_NAME = "wanaku.mcp.tool_name";
+    static final String SPAN_ATTR_RESOURCE_NAME = "wanaku.mcp.resource_name";
+
+    private RequestIdContext() {}
+
+    static void setContext(String requestId, String connectionId) {
+        if (requestId != null && !requestId.isEmpty()) {
+            MDC.put(MDC_REQUEST_ID_KEY, requestId);
+            Span.current().setAttribute(SPAN_ATTR_REQUEST_ID, requestId);
+        }
+        if (connectionId != null && !connectionId.isEmpty()) {
+            MDC.put(MDC_CONNECTION_ID_KEY, connectionId);
+            Span.current().setAttribute(SPAN_ATTR_CONNECTION_ID, connectionId);
+        }
+    }
+
+    static void setToolName(String toolName) {
+        if (toolName != null && !toolName.isEmpty()) {
+            Span.current().setAttribute(SPAN_ATTR_TOOL_NAME, toolName);
+        }
+    }
+
+    static void setResourceName(String resourceName) {
+        if (resourceName != null && !resourceName.isEmpty()) {
+            Span.current().setAttribute(SPAN_ATTR_RESOURCE_NAME, resourceName);
+        }
+    }
+
+    static void clear() {
+        MDC.remove(MDC_REQUEST_ID_KEY);
+        MDC.remove(MDC_CONNECTION_ID_KEY);
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ResourceAcquirerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ResourceAcquirerBridge.java
@@ -60,36 +60,46 @@ public class ResourceAcquirerBridge implements ResourceBridge {
 
     @Override
     public Uni<ResourceResponse> read(ResourceManager.ResourceArguments arguments, ResourceReference mcpResource) {
+        String requestId = arguments.requestId().asString();
+        String connectionId = arguments.connection().id();
+
         return Uni.createFrom()
                 .item(() -> WanakuResourceContext.create(arguments, mcpResource))
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
+                .invoke(ctx -> RequestIdContext.setContext(requestId, connectionId))
+                .invoke(ctx -> RequestIdContext.setResourceName(mcpResource.getName()))
                 .invoke(this::resolveService)
                 .chain(ctx -> transport
                         .acquireResource(ctx.request, ctx.serviceTarget, arguments, mcpResource)
-                        .map(ResourceResponse::new));
+                        .map(ResourceResponse::new))
+                .onItemOrFailure()
+                .invoke((item, failure) -> RequestIdContext.clear());
     }
 
     /**
      * Builds a resource request from the resource reference.
      *
      * @param mcpResource the resource reference
+     * @param requestId the MCP request ID for traceability
      * @return the resource request
      */
-    private ResourceRequest buildResourceRequest(ResourceReference mcpResource) {
+    private ResourceRequest buildResourceRequest(ResourceReference mcpResource, String requestId) {
         return ResourceRequest.newBuilder()
                 .setLocation(mcpResource.getLocation())
                 .setType(mcpResource.getType())
                 .setName(mcpResource.getName())
                 .setConfigurationUri(Objects.requireNonNullElse(mcpResource.getConfigurationURI(), EMPTY_ARGUMENT))
                 .setSecretsUri(Objects.requireNonNullElse(mcpResource.getSecretsURI(), EMPTY_ARGUMENT))
+                .setRequestId(Objects.requireNonNullElse(requestId, EMPTY_ARGUMENT))
                 .build();
     }
 
     private WanakuResourceContext resolveService(WanakuResourceContext context) {
+        String requestId = context.arguments.requestId().asString();
 
         context.serviceTarget =
                 provisioner.resolveService(context.mcpResource.getType(), SERVICE_TYPE_RESOURCE_PROVIDER);
-        context.request = buildResourceRequest(context.mcpResource);
+        context.request = buildResourceRequest(context.mcpResource, requestId);
 
         return context;
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/RequestIdClientInterceptor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/RequestIdClientInterceptor.java
@@ -1,0 +1,46 @@
+package ai.wanaku.backend.bridge.transports.grpc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.MDC;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+@ApplicationScoped
+public class RequestIdClientInterceptor implements ClientInterceptor {
+
+    static final Metadata.Key<String> REQUEST_ID_KEY =
+            Metadata.Key.of("x-wanaku-request-id", Metadata.ASCII_STRING_MARSHALLER);
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+        ClientCall<ReqT, RespT> delegate = next.newCall(method, callOptions);
+
+        String requestId = (String) MDC.get("requestId");
+        if (requestId != null && !requestId.isEmpty()) {
+            return withRequestId(delegate, requestId);
+        }
+
+        return delegate;
+    }
+
+    static <ReqT, RespT> ClientCall<ReqT, RespT> withRequestId(ClientCall<ReqT, RespT> delegate, String requestId) {
+        if (requestId != null && !requestId.isEmpty()) {
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(delegate) {
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    headers.put(REQUEST_ID_KEY, requestId);
+                    super.start(responseListener, headers);
+                }
+            };
+        }
+        return delegate;
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
 import ai.wanaku.backend.bridge.EventNotifier;
 import ai.wanaku.backend.bridge.InvokerBridge;
 import ai.wanaku.backend.bridge.ToolsBridge;
@@ -33,6 +34,9 @@ public class ToolsProvider {
     @Inject
     EventNotifier eventNotifier;
 
+    @Inject
+    Vertx vertx;
+
     @Produces
     ToolsBridge getToolsBridge() {
         if (parseResult.isUsageHelpRequested() || parseResult.isVersionHelpRequested()) {
@@ -40,6 +44,6 @@ public class ToolsProvider {
         }
 
         LOG.infof("Wanaku version %s is starting", VersionHelper.VERSION);
-        return new InvokerBridge(serviceResolver, transport, eventNotifier);
+        return new InvokerBridge(serviceResolver, transport, eventNotifier, vertx);
     }
 }

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -216,6 +216,19 @@ quarkus.http.auth.permission.web.policy=authenticated
 
 # Logging configuration
 
+# OpenTelemetry configuration - disabled by default
+# Enable with -Dquarkus.otel.sdk.disabled=false and -Dquarkus.otel.exporter.otlp.endpoint=<endpoint>
+quarkus.otel.sdk.disabled=true
+%docker-compose.quarkus.otel.sdk.disabled=false
+%docker-compose.quarkus.otel.exporter.otlp.endpoint=http://otel-collector:4317
+quarkus.otel.exporter.otlp.traces.protocol=grpc
+quarkus.otel.resource.attributes=service.name=wanaku-router,service.version=${quarkus.application.version}
+quarkus.otel.traces.sampler=parentbased_always_on
+quarkus.otel.propagators=tracecontext,baggage
+
+# Enable MDC injection for trace correlation in logs
+quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
+
 quarkus.http.access-log.enabled=true
 quarkus.log.level=INFO
 quarkus.log.category."ai.wanaku".level=INFO
@@ -226,7 +239,7 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 
 %dev.quarkus.log.handler.file.wanaku-log.enabled=true
 %dev.quarkus.log.handler.file.wanaku-log.path=target/logs/wanaku.log
-%dev.quarkus.log.handler.file.wanaku-log.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%dev.quarkus.log.handler.file.wanaku-log.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %dev.quarkus.log.category."ai.wanaku".handlers=wanaku-log
 %dev.quarkus.log.category."ai.wanaku".level=DEBUG
 %dev.quarkus.log.category."io.quarkus".handlers=wanaku-log
@@ -242,7 +255,7 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 
 %perf.quarkus.log.handler.file.wanaku-log.enabled=true
 %perf.quarkus.log.handler.file.wanaku-log.path=target/logs/wanaku.log
-%perf.quarkus.log.handler.file.wanaku-log.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%perf.quarkus.log.handler.file.wanaku-log.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %perf.quarkus.log.category."ai.wanaku".handlers=wanaku-log
 %perf.quarkus.log.category."ai.wanaku".level=DEBUG
 %perf.quarkus.log.category."io.quarkus".handlers=wanaku-log
@@ -257,13 +270,13 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 %local.quarkus.log.console.enabled=false
 %local.quarkus.log.file.enabled=true
 %local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/wanaku-router.log
-%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %local.quarkus.log.category."ai.wanaku".level=DEBUG
 %local.quarkus.log.category."io.quarkiverse.mcp".level=DEBUG
 
 %test.quarkus.log.file.enabled=true
 %test.quarkus.log.file.path=target/logs/wanaku.log
-%test.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%test.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %test.quarkus.log.category."org.apache.http".level=INFO
 
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProvider.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/E2ETestProvider.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
+import io.vertx.core.Vertx;
 import ai.wanaku.backend.bridge.InvokerBridge;
 import ai.wanaku.backend.bridge.ToolsBridge;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
@@ -40,7 +41,7 @@ public class E2ETestProvider {
         LOG.info("Creating real ToolsBridge for e2e tests");
         ServiceResolver resolver = new FirstAvailable(serviceRegistry);
         WanakuBridgeTransport transport = new GrpcTransport();
-        return new InvokerBridge(resolver, transport);
+        return new InvokerBridge(resolver, transport, null, Vertx.vertx());
     }
 
     @Produces

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
@@ -71,6 +71,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultRequestContext.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultRequestContext.java
@@ -1,0 +1,46 @@
+package ai.wanaku.core.capabilities.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.MDC;
+import io.opentelemetry.api.trace.Span;
+
+@ApplicationScoped
+public class DefaultRequestContext implements RequestContext {
+
+    @Override
+    public void setRequestId(String requestId) {
+        if (requestId != null && !requestId.isEmpty()) {
+            MDC.put(MDC_REQUEST_ID_KEY, requestId);
+            Span.current().setAttribute(SPAN_ATTR_REQUEST_ID, requestId);
+        }
+    }
+
+    @Override
+    public void setConnectionId(String connectionId) {
+        if (connectionId != null && !connectionId.isEmpty()) {
+            MDC.put(MDC_CONNECTION_ID_KEY, connectionId);
+            Span.current().setAttribute(SPAN_ATTR_CONNECTION_ID, connectionId);
+        }
+    }
+
+    @Override
+    public void setToolName(String toolName) {
+        if (toolName != null && !toolName.isEmpty()) {
+            Span.current().setAttribute(SPAN_ATTR_TOOL_NAME, toolName);
+        }
+    }
+
+    @Override
+    public void setResourceName(String resourceName) {
+        if (resourceName != null && !resourceName.isEmpty()) {
+            Span.current().setAttribute(SPAN_ATTR_RESOURCE_NAME, resourceName);
+        }
+    }
+
+    @Override
+    public void clear() {
+        MDC.remove(MDC_REQUEST_ID_KEY);
+        MDC.remove(MDC_CONNECTION_ID_KEY);
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/RequestContext.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/RequestContext.java
@@ -1,0 +1,35 @@
+package ai.wanaku.core.capabilities.common;
+
+import org.jboss.logging.MDC;
+
+public interface RequestContext {
+    String MDC_REQUEST_ID_KEY = "requestId";
+    String MDC_CONNECTION_ID_KEY = "connectionId";
+    String SPAN_ATTR_REQUEST_ID = "wanaku.mcp.request_id";
+    String SPAN_ATTR_CONNECTION_ID = "wanaku.mcp.connection_id";
+    String SPAN_ATTR_TOOL_NAME = "wanaku.mcp.tool_name";
+    String SPAN_ATTR_RESOURCE_NAME = "wanaku.mcp.resource_name";
+
+    void setRequestId(String requestId);
+
+    void setConnectionId(String connectionId);
+
+    void setToolName(String toolName);
+
+    void setResourceName(String resourceName);
+
+    void clear();
+
+    static void withRequestId(String requestId, Runnable action) {
+        if (requestId != null && !requestId.isEmpty()) {
+            MDC.put(MDC_REQUEST_ID_KEY, requestId);
+        }
+        try {
+            action.run();
+        } finally {
+            if (requestId != null && !requestId.isEmpty()) {
+                MDC.remove(MDC_REQUEST_ID_KEY);
+            }
+        }
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/TracingServerInterceptor.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/TracingServerInterceptor.java
@@ -1,0 +1,35 @@
+package ai.wanaku.core.capabilities.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.opentelemetry.api.trace.Span;
+
+@ApplicationScoped
+public class TracingServerInterceptor implements ServerInterceptor {
+
+    private static final Logger LOG = Logger.getLogger(TracingServerInterceptor.class);
+
+    static final String SPAN_ATTR_REQUEST_ID = "wanaku.mcp.request_id";
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+
+        String requestId = headers.get(Metadata.Key.of("x-wanaku-request-id", Metadata.ASCII_STRING_MARSHALLER));
+
+        if (requestId != null && !requestId.isEmpty()) {
+            try {
+                Span.current().setAttribute(SPAN_ATTR_REQUEST_ID, requestId);
+            } catch (Exception e) {
+                LOG.tracef(e, "Could not set span attribute");
+            }
+        }
+
+        return next.startCall(call, headers);
+    }
+}

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegate.java
@@ -19,6 +19,7 @@ import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.capabilities.sdk.config.provider.api.ProvisionedConfig;
 import ai.wanaku.core.capabilities.common.ConfigProvisionerLoader;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
+import ai.wanaku.core.capabilities.common.RequestContext;
 import ai.wanaku.core.capabilities.common.ServicesHelper;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.ResourceAcquirerDelegate;
@@ -54,6 +55,9 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
 
     @Inject
     Instance<Tokens> tokensInstance;
+
+    @Inject
+    RequestContext requestContext;
 
     private RegistrationManager registrationManager;
 
@@ -98,6 +102,8 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
 
     @Override
     public ResourceReply acquire(ResourceRequest request) {
+        String requestId = request.getRequestId();
+        requestContext.setRequestId(requestId);
         try {
             ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
@@ -124,6 +130,8 @@ public abstract class AbstractResourceDelegate implements ResourceAcquirerDelega
             LOG.error(stateMsg, e);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
+        } finally {
+            requestContext.clear();
         }
     }
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegate.java
@@ -18,6 +18,7 @@ import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
 import ai.wanaku.capabilities.sdk.config.provider.api.ProvisionedConfig;
 import ai.wanaku.core.capabilities.common.ConfigProvisionerLoader;
 import ai.wanaku.core.capabilities.common.ConfigResourceLoader;
+import ai.wanaku.core.capabilities.common.RequestContext;
 import ai.wanaku.core.capabilities.common.ServicesHelper;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.InvocationDelegate;
@@ -50,6 +51,9 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
 
     @Inject
     Instance<Tokens> tokensInstance;
+
+    @Inject
+    RequestContext requestContext;
 
     private RegistrationManager registrationManager;
 
@@ -84,6 +88,8 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
 
     @Override
     public ToolInvokeReply invoke(ToolInvokeRequest request) {
+        String requestId = request.getRequestId();
+        requestContext.setRequestId(requestId);
         try {
             ConfigResource configResource = ConfigResourceLoader.loadFromRequest(request);
 
@@ -110,6 +116,8 @@ public abstract class AbstractToolDelegate implements InvocationDelegate {
             LOG.error(stateMsg, e);
             throw new StatusRuntimeException(
                     Status.INTERNAL.withDescription(stateMsg).withCause(e));
+        } finally {
+            requestContext.clear();
         }
     }
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -27,10 +27,17 @@ quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 %dev.quarkus.log.category."ai.wanaku.core.capabilities".level=DEBUG
 %test.quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 
+# OpenTelemetry configuration
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.protocol=grpc
+quarkus.otel.resource.attributes=service.name=${wanaku.service.name:wanaku-capability},service.version=${quarkus.application.version}
+quarkus.otel.traces.sampler=parentbased_always_on
+quarkus.otel.propagators=tracecontext,baggage
+
 %local.quarkus.log.console.enabled=false
 %local.quarkus.log.file.enabled=true
-%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/${wanaku.service.name}.log
-%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/${wanaku.service.name:wanaku-capability}.log
+%local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %local.quarkus.log.category."ai.wanaku".level=DEBUG
 
 %test.quarkus.log.console.level=OFF

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegateTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/provider/AbstractResourceDelegateTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.core.capabilities.provider;
 
+import jakarta.inject.Inject;
+
 import java.lang.reflect.Field;
 import java.util.List;
 import io.grpc.Status;
@@ -10,6 +12,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
 import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.capabilities.common.RequestContext;
 import ai.wanaku.core.exchange.v1.ResourceReply;
 import ai.wanaku.core.exchange.v1.ResourceRequest;
 
@@ -27,6 +30,9 @@ import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class AbstractResourceDelegateTest {
+
+    @Inject
+    RequestContext requestContext;
 
     @Mock
     private ResourceConsumer consumer;
@@ -72,6 +78,7 @@ class AbstractResourceDelegateTest {
 
         setField(delegate, "consumer", consumer);
         setField(delegate, "registrationManager", registrationManager);
+        setField(delegate, "requestContext", requestContext);
     }
 
     @Test

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegateTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/tool/AbstractToolDelegateTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.core.capabilities.tool;
 
+import jakarta.inject.Inject;
+
 import java.lang.reflect.Field;
 import java.util.List;
 import io.grpc.Status;
@@ -9,6 +11,7 @@ import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.exceptions.InvalidResponseTypeException;
 import ai.wanaku.capabilities.sdk.api.exceptions.NonConvertableResponseException;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigResource;
+import ai.wanaku.core.capabilities.common.RequestContext;
 import ai.wanaku.core.exchange.v1.ToolInvokeReply;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 
@@ -24,6 +27,9 @@ import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class AbstractToolDelegateTest {
+
+    @Inject
+    RequestContext requestContext;
 
     @Mock
     private Client client;
@@ -59,6 +65,7 @@ class AbstractToolDelegateTest {
 
         setField(delegate, "client", client);
         setField(delegate, "registrationManager", registrationManager);
+        setField(delegate, "requestContext", requestContext);
     }
 
     @Test

--- a/capabilities-quarkus-sdk/wanaku-capabilities-provider/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-provider/pom.xml
@@ -18,6 +18,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-exchange</artifactId>
+            <version>${wanaku-capabilities-sdk.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-provider/src/main/java/ai/wanaku/core/capabilities/provider/service/ResourceService.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-provider/src/main/java/ai/wanaku/core/capabilities/provider/service/ResourceService.java
@@ -14,18 +14,15 @@ import io.smallrye.mutiny.Uni;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.HealthProbeDelegate;
 import ai.wanaku.core.exchange.ResourceAcquirerDelegate;
-import ai.wanaku.core.exchange.v1.HealthProbe;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.ProvisionReply;
 import ai.wanaku.core.exchange.v1.ProvisionRequest;
-import ai.wanaku.core.exchange.v1.Provisioner;
-import ai.wanaku.core.exchange.v1.ResourceAcquirer;
 import ai.wanaku.core.exchange.v1.ResourceReply;
 import ai.wanaku.core.exchange.v1.ResourceRequest;
 
 @GrpcService
-public class ResourceService implements ResourceAcquirer, Provisioner, HealthProbe {
+public class ResourceService {
     private static final Logger LOG = Logger.getLogger(ResourceService.class);
 
     @Inject
@@ -40,18 +37,15 @@ public class ResourceService implements ResourceAcquirer, Provisioner, HealthPro
     @Inject
     ManagedExecutor executor;
 
-    @Override
     public Uni<ResourceReply> resourceAcquire(ResourceRequest request) {
         return Uni.createFrom().item(() -> delegate.acquire(request)).runSubscriptionOn(executor);
     }
 
     @Blocking
-    @Override
     public Uni<ProvisionReply> provision(ProvisionRequest request) {
         return Uni.createFrom().item(() -> delegate.provision(request)).runSubscriptionOn(executor);
     }
 
-    @Override
     public Uni<HealthProbeReply> getStatus(HealthProbeRequest request) {
         return Uni.createFrom()
                 .item(HealthProbeReply.newBuilder()

--- a/capabilities-quarkus-sdk/wanaku-capabilities-tools/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-tools/pom.xml
@@ -18,6 +18,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-exchange</artifactId>
+            <version>${wanaku-capabilities-sdk.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc</artifactId>
         </dependency>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-tools/src/main/java/ai/wanaku/core/capabilities/tool/service/InvocationService.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-tools/src/main/java/ai/wanaku/core/capabilities/tool/service/InvocationService.java
@@ -13,18 +13,15 @@ import io.smallrye.mutiny.Uni;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.HealthProbeDelegate;
 import ai.wanaku.core.exchange.InvocationDelegate;
-import ai.wanaku.core.exchange.v1.HealthProbe;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.ProvisionReply;
 import ai.wanaku.core.exchange.v1.ProvisionRequest;
-import ai.wanaku.core.exchange.v1.Provisioner;
 import ai.wanaku.core.exchange.v1.ToolInvokeReply;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
-import ai.wanaku.core.exchange.v1.ToolInvoker;
 
 @GrpcService
-public class InvocationService implements ToolInvoker, Provisioner, HealthProbe {
+public class InvocationService {
     private static final Logger LOG = Logger.getLogger(InvocationService.class);
 
     @Inject
@@ -37,18 +34,15 @@ public class InvocationService implements ToolInvoker, Provisioner, HealthProbe 
     WanakuServiceConfig config;
 
     @Blocking
-    @Override
     public Uni<ToolInvokeReply> invokeTool(ToolInvokeRequest request) {
         return Uni.createFrom().item(() -> delegate.invoke(request));
     }
 
     @Blocking
-    @Override
     public Uni<ProvisionReply> provision(ProvisionRequest request) {
         return Uni.createFrom().item(() -> delegate.provision(request));
     }
 
-    @Override
     public Uni<HealthProbeReply> getStatus(HealthProbeRequest request) {
         return Uni.createFrom()
                 .item(HealthProbeReply.newBuilder()

--- a/core/core-mcp-client/pom.xml
+++ b/core/core-mcp-client/pom.xml
@@ -21,6 +21,20 @@
             <artifactId>langchain4j-mcp</artifactId>
             <version>${langchain4j-mcp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
@@ -1,7 +1,13 @@
 package ai.wanaku.core.mcp.client;
 
+import java.util.HashMap;
+import java.util.Map;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
@@ -9,21 +15,57 @@ import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 public class ClientUtil {
 
     public static McpClient createClient(String address) {
+        return createClient(address, null);
+    }
+
+    public static McpClient createClient(String address, McpHeadersSupplier headersSupplier) {
         McpTransport transport;
+        McpHeadersSupplier combinedHeaders = combineHeaders(headersSupplier);
+
         if (address.endsWith("sse") || address.endsWith("sse/")) {
-            transport = new HttpMcpTransport.Builder()
+            HttpMcpTransport.Builder builder = new HttpMcpTransport.Builder()
                     .sseUrl(address)
                     .logRequests(true)
                     .logResponses(true)
-                    .build();
+                    .customHeaders(combinedHeaders);
+            transport = builder.build();
         } else {
-            transport = new StreamableHttpMcpTransport.Builder()
+            StreamableHttpMcpTransport.Builder builder = new StreamableHttpMcpTransport.Builder()
                     .url(address)
                     .logRequests(true)
                     .logResponses(true)
-                    .build();
+                    .customHeaders(combinedHeaders);
+            transport = builder.build();
         }
 
         return new DefaultMcpClient.Builder().transport(transport).build();
+    }
+
+    private static McpHeadersSupplier combineHeaders(McpHeadersSupplier extraHeaders) {
+        return callContext -> {
+            Map<String, String> headers = new HashMap<>();
+
+            // Propagate W3C trace context
+            Span currentSpan = Span.current();
+            if (currentSpan.getSpanContext().isValid()) {
+                W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
+                propagator.inject(Context.current(), headers, Map::put);
+            }
+
+            // Propagate MCP request ID from MDC
+            String requestId = (String) org.jboss.logging.MDC.get("requestId");
+            if (requestId != null && !requestId.isEmpty()) {
+                headers.put("x-wanaku-request-id", requestId);
+            }
+
+            if (extraHeaders != null) {
+                Map<String, String> extra = extraHeaders.apply(callContext);
+                if (extra != null) {
+                    headers.putAll(extra);
+                }
+            }
+
+            return headers;
+        };
     }
 }

--- a/deploy/docker-compose/docker-compose-noauth.yml
+++ b/deploy/docker-compose/docker-compose-noauth.yml
@@ -1,10 +1,27 @@
 services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.127.0
+    command: [ "--config=/etc/otelcol/config.yaml" ]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.6
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "16686:16686"
+
   wanaku-router:
     image: quay.io/wanaku/wanaku-router-backend:latest
     environment:
       WANAKU_HTTP_AUTH: none
       QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED: "true"
       QUARKUS_HTTP_HOST: 0.0.0.0
+      QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     network_mode: host
     volumes:
       - wanaku-router:/home/jboss/.wanaku/router

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -8,6 +8,22 @@
 # import and the capability services below; it defaults to "mypasswd" for local development only.
 # =============================================================================
 services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.127.0
+    command: [ "--config=/etc/otelcol/config.yaml" ]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.6
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "16686:16686"
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.6.1
     command: [ "start-dev", "--import-realm" ]
@@ -35,7 +51,8 @@ services:
       WANAKU_SERVICE_REGISTRATION_URI: http://localhost:8080/
       AUTH_SERVER: http://localhost:8543
       # Must match the wanaku-service client secret in the realm (WANAKU_SERVICE_SECRET).
-      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}
+      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}      
+      QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     network_mode: host
     depends_on:
       wanaku-router:
@@ -52,6 +69,7 @@ services:
       QUARKUS_HTTP_HOST: 0.0.0.0
       AUTH_SERVER: http://localhost:8543
       AUTH_PROXY: http://localhost:8080
+      QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     depends_on:
       keycloak:
         condition: service_healthy

--- a/deploy/docker-compose/otel-collector-config.yaml
+++ b/deploy/docker-compose/otel-collector-config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger, debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,250 @@
+# Observability: Tracing, Logging, and Auditing
+
+This document describes the observability architecture in Wanaku, covering distributed tracing, request ID propagation, and structured logging with traceability.
+
+## Overview
+
+Wanaku integrates OpenTelemetry (OTel) for distributed tracing and Micrometer for metrics, providing end-to-end observability across the entire request chain:
+
+- **MCP Client** → **Router Backend** → **gRPC** → **Capability Service** → **Downstream Services**
+
+Every request flowing through the system carries:
+
+1. **W3C `traceparent`** header for distributed trace context propagation (automatic via OTel)
+2. **`x-wanaku-request-id`** for MCP request correlation (explicit propagation)
+3. **`request_id`** field in gRPC proto messages for contract-level traceability
+
+## Architecture
+
+### Request Flow and Trace Propagation
+
+```text
+┌──────────┐     HTTP/MCP      ┌────────────────┐     gRPC        ┌──────────────────┐
+│ MCP Client │ ──────────────→ │ Router Backend  │ ─────────────→ │ Capability Service│
+│             │  traceparent    │                 │  traceparent   │                   │
+│             │  x-wanaku-      │  MDC: requestId │  x-wanaku-     │  MDC: requestId   │
+│             │  request-id     │  MDC: traceId   │  request-id    │  Span: requestId  │
+└──────────┘                   └────────────────┘                 └──────────────────┘
+                                        │
+                                        ▼
+                                 ┌──────────────┐
+                                 │ OTel Collector│
+                                 │  (4317 gRPC)  │
+                                 └──────┬───────┘
+                                        │
+                                        ▼
+                                 ┌──────────────┐
+                                 │   Jaeger UI   │
+                                 │  (16686 HTTP) │
+                                 └──────────────┘
+```
+
+### Components
+
+| Component | Role |
+|-----------|------|
+| `quarkus-opentelemetry` | Auto-instruments HTTP, gRPC, Vert.x; creates spans; manages trace context |
+| `McpTracingInstrumenter` | Built into `quarkus-mcp-server` 1.13.0; auto-creates MCP spans with `requestId`, `toolName`, `session_id` attributes |
+| `RequestIdContext` | Helper class that manages MDC keys (`requestId`, `connectionId`) and OTel span attributes (`wanaku.mcp.request_id`, etc.) |
+| `RequestIdClientInterceptor` | gRPC client interceptor that injects `x-wanaku-request-id` header from MDC |
+| `TracingServerInterceptor` | gRPC server interceptor that extracts `x-wanaku-request-id` header and sets MDC + span attribute |
+| `McpHeadersSupplier` | Propagates W3C `traceparent` and `x-wanaku-request-id` from MDC to downstream MCP calls |
+| `quarkus-micrometer-registry-prometheus` | Added to router backend to replace quarkiverse v1 (incompatible with `quarkus-opentelemetry`); provides Prometheus metrics export |
+
+## Configuration
+
+### Router Backend
+
+The router backend's `application.properties` configures OTel:
+
+```properties
+# OpenTelemetry
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.protocol=grpc
+quarkus.otel.resource.attributes=service.name=wanaku-router,service.version=${quarkus.application.version}
+quarkus.otel.traces.sampler=parentbased_always_on
+quarkus.otel.propagators=tracecontext,baggage
+```
+
+### Capability Services
+
+Capability services use a shared base configuration in `wanaku-capabilities-base`:
+
+```properties
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.protocol=grpc
+quarkus.otel.resource.attributes=service.name=${wanaku.service.name:wanaku-capability},service.version=${quarkus.application.version}
+quarkus.otel.traces.sampler=parentbased_always_on
+quarkus.otel.propagators=tracecontext,baggage
+```
+
+Each capability service must set `wanaku.service.name` to identify itself (e.g., `wanaku-file-resource`, `wanaku-http-tool`).
+
+### Log Format
+
+All log profiles include trace and request context:
+
+```text
+%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
+```
+
+MDC keys available in log output:
+
+| MDC Key | Source | Description |
+|---------|--------|-------------|
+| `traceId` | OTel (automatic) | W3C trace ID for distributed tracing |
+| `requestId` | MCP request | MCP protocol request ID for correlation |
+| `connectionId` | MCP connection | MCP connection/session identifier |
+
+## Proto Changes
+
+Three proto messages were extended with a `request_id` field:
+
+### ToolInvokeRequest (`toolrequest.proto`)
+
+```protobuf
+message ToolInvokeRequest {
+  // ... existing fields 1-6 ...
+  string request_id = 7;
+}
+```
+
+### ResourceRequest (`resourcerequest.proto`)
+
+```protobuf
+message ResourceRequest {
+  // ... existing fields 1-6 ...
+  string request_id = 7;
+}
+```
+
+### CodeExecutionRequest (`codeexecution.proto`)
+
+```protobuf
+message CodeExecutionRequest {
+  // ... existing fields 1-8 ...
+  string request_id = 9;
+}
+```
+
+## How Request ID Propagation Works
+
+### 1. MCP Request → Router (HTTP)
+
+When an MCP request arrives at the router, `quarkus-mcp-server`'s `McpTracingInstrumenter` automatically:
+
+- Creates a span with `requestId` and `toolName` attributes
+- The router bridge code extracts `requestId` from `ToolArguments.requestId().asString()` and `connectionId` from `arguments.connection().id()`
+
+### 2. Router → Capability Service (gRPC)
+
+The `InvokerBridge` and `ResourceAcquirerBridge`:
+
+1. Call `RequestIdContext.setContext(requestId, connectionId)` to populate MDC
+2. Call `RequestIdContext.setToolName(name)` or `setResourceName(name)` to add span attributes
+3. The `RequestIdClientInterceptor` injects `x-wanaku-request-id` from MDC into gRPC metadata
+4. OTel automatically injects `traceparent` via `quarkus.otel.instrument.grpc=true` (default)
+5. On completion, `RequestIdContext.clear()` is called via `onItemOrFailure()`
+
+### 3. Capability Service Processing
+
+The `TracingServerInterceptor` on the capability service side:
+
+1. Extracts `x-wanaku-request-id` from gRPC metadata
+2. Sets `requestId` in MDC for logging
+3. Sets `wanaku.mcp.request_id` attribute on the current OTel span
+4. Wraps the `ServerCall.Listener` to ensure MDC lifecycle is properly managed
+
+The `AbstractToolDelegate` and `AbstractResourceDelegate` also extract `requestId` from the proto message itself (as a fallback/supplement):
+
+```java
+String requestId = request.getRequestId();
+if (requestId != null && !requestId.isEmpty()) {
+    MDC.put("requestId", requestId);
+}
+```
+
+### 4. Code Execution
+
+The `CodeExecutionBridge` uses the current OTel trace ID as the request ID (since it doesn't have direct access to MCP `ToolArguments.requestId`):
+
+```java
+Span currentSpan = Span.current();
+String requestId = currentSpan.getSpanContext().getTraceId();
+RequestIdContext.setContext(requestId, connectionId);
+```
+
+### 5. Downstream MCP Calls
+
+When the router makes outbound MCP calls (via langchain4j), the `ClientUtil.createClient()` method uses `McpHeadersSupplier` to propagate:
+
+- W3C `traceparent` (from OTel context propagation)
+- `x-wanaku-request-id` (from MDC)
+
+## OTel Span Attributes
+
+The following custom span attributes are set:
+
+| Attribute | Set By | Description |
+|-----------|--------|-------------|
+| `wanaku.mcp.request_id` | Router bridges, TracingServerInterceptor | MCP request ID |
+| `wanaku.mcp.connection_id` | Router bridges | MCP connection/session ID |
+| `wanaku.mcp.tool_name` | InvokerBridge | Name of the tool being invoked |
+| `wanaku.mcp.resource_name` | ResourceAcquirerBridge | Name of the resource being acquired |
+
+These attributes are searchable in Jaeger/Grafana for quick request correlation.
+
+## Deployment
+
+### Docker Compose
+
+The `docker-compose.yml` and `docker-compose-noauth.yml` include:
+
+- **OTel Collector** (`otel-collector:4317`): Receives OTLP data from router and capability services
+- **Jaeger** (`jaeger:16686`): UI for trace visualization; receives data from OTel Collector via OTLP
+
+Environment variables set on services:
+
+```yaml
+QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+```
+
+### OTel Collector Pipeline
+
+The `otel-collector-config.yaml` configures:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger]
+```
+
+### Accessing Jaeger
+
+After starting the stack with Docker Compose, Jaeger UI is available at:
+
+```text
+http://localhost:16686
+```
+
+Search by:
+
+- **Service**: `wanaku-router` or the capability service name
+- **Span attribute**: `wanaku.mcp.request_id=<request-id>`
+- **Operation**: tool invocation or resource acquisition

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,6 +74,10 @@
         <commons-logging.version>1.3.5</commons-logging.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <spotless-maven-plugin.version>3.7.0</spotless-maven-plugin.version>
+        <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+        <protoc.version>3.25.5</protoc.version>
+        <protoc-gen-grpc-java.version>1.72.0</protoc-gen-grpc-java.version>
+        <annotations-api.version>6.0.53</annotations-api.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.0</quarkus-helm.version>
         <wanaku-capabilities-sdk.version>0.2.0-SNAPSHOT</wanaku-capabilities-sdk.version>


### PR DESCRIPTION
Closes: #66 
## Summary by Sourcery

Introduce distributed tracing and MCP request ID propagation across router, capabilities, and gRPC layers, and expose new LLM discovery endpoints.

New Features:
- Add OpenTelemetry-based tracing and Micrometer Prometheus metrics to the router backend and capabilities SDK.
- Introduce new chat endpoints and client APIs for listing allowed LLMs and their models.
- Provide an observability guide documenting tracing, logging, and request ID propagation.
- Add Jaeger and OpenTelemetry Collector services to local Docker Compose stacks for trace visualization.

Enhancements:
- Propagate W3C trace context and custom MCP request IDs through MCP HTTP clients, router bridges, and gRPC calls using interceptors and MDC.
- Extend gRPC proto contracts for tools, resources, and code execution to carry a request_id field for end-to-end correlation.
- Enrich logging formats across services to include traceId and requestId for easier log/trace correlation.
- Adjust proto SDK generation to stage files under target and copy missing protos into the source tree via a helper script.

Build:
- Update Maven POMs to include OpenTelemetry, Micrometer Prometheus, and logging dependencies and to run a script that copies SDK protos during generate-sources.

Deployment:
- Extend docker-compose configurations with OpenTelemetry Collector and Jaeger containers and configure services to export OTLP traces to the collector.

Documentation:
- Add detailed observability documentation covering tracing architecture, configuration, and request ID propagation.

## Summary by Sourcery

Introduce OpenTelemetry-based distributed tracing and MCP request ID propagation across router, capabilities, and gRPC layers, and integrate local tracing infrastructure.

New Features:
- Add OpenTelemetry tracing and Micrometer Prometheus metrics to the router backend and capabilities SDK.
- Introduce a request context abstraction to carry request and connection identifiers into spans and logs.
- Add Docker Compose services for an OpenTelemetry Collector and Jaeger with a shared collector configuration.
- Document the observability architecture, including tracing, logging, and request ID propagation.

Enhancements:
- Propagate MCP request IDs and W3C trace context through router bridges, gRPC interceptors, and MCP HTTP clients for end-to-end correlation.
- Extend tool, resource, and code execution gRPC requests to include a request_id field and wire it through router and capability delegates.
- Enrich router and capability logging formats to include traceId and requestId MDC values for improved log/trace correlation.
- Refine capability gRPC services and delegates to use a shared request context and tracing interceptor instead of directly implementing generated interfaces.

Build:
- Update Maven modules to include OpenTelemetry, Micrometer Prometheus, logging, and capabilities SDK dependencies, and align protobuf tooling versions in the parent POM.

Deployment:
- Configure router and capability services in Docker Compose to export OTLP traces to the local OpenTelemetry Collector and expose Jaeger for trace visualization.

Documentation:
- Add an observability guide describing tracing setup, span attributes, request ID propagation, and how to use the tracing stack.