### PR TITLE
[UI] Returning the Stop button to LLM chat

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -7,23 +7,14 @@ import {
   TextArea,
   Tile
 } from "@carbon/react"
-import {Send} from "@carbon/icons-react"
+import {Send, Stop} from "@carbon/icons-react"
 import {LlmConfig} from "./config"
 import {LLMChatMessage} from "./LLMChatMessage"
 import {getUrl} from "../../custom-fetch"
 
 
 interface ChatMessage {
-  id?: string
-  role: string
-  content?: string
-  name?: string
-  tool_calls?: []
-  tool_call_id?: string
-}
-
-interface DisplayMessage {
-  role: string
+  role: "user" | "assistant" | "error"
   content: string
 }
 
@@ -35,29 +26,27 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
   
   const [systemPrompt, setSystemPrompt] = useState("You are an assistant that can use tools.")
   const [userPrompt, setUserPrompt] = useState("")
-  const [displayMessages, setDisplayMessages] = useState<DisplayMessage[]>([])
+  const [displayedMessages, setDisplayedMessages] = useState<ChatMessage[]>([])
+  const [isRunning, setIsRunning] = useState(false)
   
-  const chatMessages = useRef<ChatMessage[]>([])
+  const chatHistory = useRef<ChatMessage[]>([])
+  const abortController = useRef(new AbortController())
   
   function clear() {
-    chatMessages.current = []
-    setDisplayMessages([])
+    chatHistory.current = []
+    setDisplayedMessages([])
   }
   
-  async function runPrompt() {
-    
-    const messages: DisplayMessage[] = [...displayMessages]
-    
-    function isFirstMessage() {
-      return chatMessages.current.length === 0
-    }
-    
-    function displayMessage(message: DisplayMessage) {
-      messages.push(message)
-      setDisplayMessages([...messages])
-    }
-    
+  function filteredChatHistory() {
+    return chatHistory.current.filter(message => message.role === "user" || message.role === "assistant")
+  }
+  
+  async function runPrompt(signal: AbortSignal) {
     try {
+      const userMessage = { role: "user", content: userPrompt } as const
+      setDisplayedMessages([...chatHistory.current, userMessage])
+      setIsRunning(true)
+      
       const response = await fetch(getUrl("/api/v1/chat/completions"), {
         method: "POST",
         headers: {
@@ -67,23 +56,32 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
           llm: config.llm,
           model: config.llmModel,
           apiKey: config.apiKey,
-          systemPrompt: isFirstMessage() ? systemPrompt : null,
+          systemPrompt: systemPrompt,
           userPrompt: userPrompt,
-          chatHistory: chatMessages.current,
+          chatHistory: filteredChatHistory(),
           selectedTools: config.tools.map(tool => tool.name),
-          chatParams: config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {}
+          extraLlmParams: config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {}
         })
       })
+      if (signal.aborted) {
+        // The chat has been aborted, do not display any response and end immediately
+        return
+      }
       if (response.ok) {
         const responseText = await response.text()
-        chatMessages.current.push({ role: "user", content: userPrompt })
-        chatMessages.current.push({ role: "assistant", content: responseText })
-        displayMessage({ role: "assistant", content: responseText })
+        const aiMessage = { role: "assistant", content: responseText } as const
+        chatHistory.current.push(userMessage)
+        chatHistory.current.push(aiMessage)
+        setDisplayedMessages(chatHistory.current)
       } else {
-        displayMessage({ role: "error", content: "Error: " + response.status })
+        const errorMessage = { role: "error", content: `Error: ${response.status} ${response.statusText}` } as const
+        chatHistory.current.push(errorMessage)
+        setDisplayedMessages(chatHistory.current)
       }
     } catch (error) {
       console.error("Error during conversation:", error)
+    } finally {
+      setIsRunning(false)
     }
   }
   
@@ -96,14 +94,30 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
             size="lg"
             renderIcon={Send}
             iconDescription="Send"
-            onClick={runPrompt}>
+            disabled={isRunning}
+            onClick={() => {
+              runPrompt(abortController.current.signal)
+            }}>
             Send
           </Button>
           <Button
             kind="ghost"
             size="lg"
+            renderIcon={Stop}
+            iconDescription="Stop"
+            disabled={!isRunning}
+            onClick={() => {
+              abortController.current.abort()
+              abortController.current = new AbortController()
+              setIsRunning(false)
+            }}>
+            Stop
+          </Button>
+          <Button
+            kind="ghost"
+            size="lg"
             iconDescription="Clear chat"
-            disabled={displayMessages.length == 0}
+            disabled={displayedMessages.length == 0}
             onClick={clear}>
             Clear
           </Button>
@@ -131,7 +145,7 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
           />
         </Stack>
         <Stack>
-          {displayMessages.map((message, index) => (
+          {displayedMessages.map((message, index) => (
             <LLMChatMessage
               key={index}
               message={message}

--- a/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMModelComboBox.tsx
@@ -12,7 +12,7 @@ interface LLMModelComboBoxProps {
 
 export const LLMModelComboBox: React.FC<LLMModelComboBoxProps> = ({ llm, value, onChange, labelText }) => {
   
-  const [modelCatalog, setModelCatalog] = useState({})
+  const [modelCatalog, setModelCatalog] = useState<{ [llm: string]: string[] }>({})
   
   
   useEffect(() => {

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -23,7 +23,6 @@ interface LLMSetupProps {
 export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
-  const [selectedLlm, setSelectedLlm] = useState(config.llm || "")
   
   function applyConfigChange(config: LlmConfig) {
     if (isStoredInLocalStorage) {
@@ -54,15 +53,14 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
         <LLMSelect
           id="base-url"
           labelText="LLM API"
-          value={selectedLlm}
+          value={config.llm || ""}
           onChange={(llm: string) => {
-            setSelectedLlm(llm)
             applyConfigChange({ ...config, llm })
           }}
         />
         <LLMModelComboBox
           labelText="LLM Model"
-          llm={selectedLlm}
+          llm={config.llm || ""}
           value={config.llmModel}
           onChange={(llmModel) => {
             applyConfigChange({ ...config, llmModel })

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/chat/LlmChatResource.java
@@ -107,7 +107,7 @@ public class LlmChatResource {
                 .map(JsonString::getString)
                 .toList();
         List<JsonObject> chatHistory = json.getJsonArray("chatHistory").getValuesAs(JsonObject.class);
-        JsonObject customLlmParameters = json.getJsonObject("chatParams");
+        JsonObject customLlmParameters = json.getJsonObject("extraLlmParams");
 
         if (!allowlist.contains(llm)) {
             throw new WebApplicationException("%s is not allowed".formatted(llm), BAD_REQUEST);


### PR DESCRIPTION
Followup for: https://github.com/wanaku-ai/wanaku/pull/1251

PR ^ got merged before I was able to upload the changes requested in review :)

- Stop button returned in better version (using native `AbortController` class)
- just one type of messages on the UI 
- displaying user messages

## Summary by Sourcery

Restore and improve the LLM chat UI stop functionality while simplifying message handling and aligning frontend and backend chat parameter naming.

New Features:
- Reintroduce a Stop button to the LLM chat UI that cancels in-flight requests using AbortController.
- Display both user and assistant messages in the LLM chat history with a unified message type.

Enhancements:
- Refine LLM chat history management so only user and assistant messages are sent back to the backend.
- Disable send and stop controls appropriately based on whether a request is in progress.
- Simplify LLM selection state in the setup form to derive directly from the shared config.
- Type the LLM model catalog state more strictly in the model combobox component.
- Rename the chat parameter field from chatParams to extraLlmParams to keep frontend and backend in sync.