### PR TITLE
Fix #1314: re-validate toolset repository URLs before fetch to prevent SSRF

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -5,7 +5,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -208,6 +210,7 @@ public class ToolsetReposBean {
         }
 
         String url = resolveBaseUrl(ds);
+        validateFetchTarget(url);
         ToolsetRepoIndex index = ToolsetRepoIndex.fromUrl(url);
 
         Map<String, Object> result = new HashMap<>();
@@ -242,8 +245,10 @@ public class ToolsetReposBean {
             throw new WanakuException("Toolset repository not found: %s".formatted(name));
         }
 
+        validateToolsetName(toolsetName);
         String baseUrl = resolveBaseUrl(ds);
         String toolsetUrl = ToolsetRepoIndex.toolsetUrl(baseUrl, toolsetName);
+        validateFetchTarget(toolsetUrl);
 
         try {
             return ToolsetIndexHelper.loadToolsIndex(URI.create(toolsetUrl).toURL());
@@ -274,7 +279,10 @@ public class ToolsetReposBean {
             if (host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1") || host.equals("0.0.0.0")) {
                 throw new WanakuException("URLs pointing to localhost are not allowed");
             }
-            if (host.startsWith("10.") || host.startsWith("192.168.") || isPrivate172(host)) {
+            if (host.startsWith("10.")
+                    || host.startsWith("192.168.")
+                    || isPrivate172(host)
+                    || host.startsWith("169.254.")) {
                 throw new WanakuException("URLs pointing to private network ranges are not allowed");
             }
         } catch (IllegalArgumentException e) {
@@ -291,6 +299,95 @@ public class ToolsetReposBean {
             return second >= 16 && second <= 31;
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    /**
+     * Validates that a URL is safe for the server to fetch, guarding against SSRF.
+     * <p>
+     * Unlike {@link #validateUrl(String)}, which performs lightweight textual checks at
+     * registration time, this method resolves the host to its actual IP address(es) and rejects
+     * any that fall in loopback, link-local (including the cloud-metadata range
+     * {@code 169.254.0.0/16}), private, multicast, or IPv6 unique-local ranges. It is intended to
+     * be called immediately before each outbound request so that stored URLs — which may have
+     * been crafted to bypass the textual check, or repointed via DNS after registration — are
+     * re-validated against where they actually resolve.
+     *
+     * @param url the fully resolved URL the server is about to fetch
+     * @throws WanakuException if the URL is not safe to fetch
+     */
+    static void validateFetchTarget(String url) throws WanakuException {
+        final URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw new WanakuException("Invalid URL: %s".formatted(e.getMessage()));
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new WanakuException("Only http and https URLs are allowed");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new WanakuException("URL must have a valid host");
+        }
+        // URI#getHost keeps the brackets around IPv6 literals; strip them before resolving.
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+
+        final InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            throw new WanakuException("Unable to resolve host: %s".formatted(host));
+        }
+
+        for (InetAddress address : addresses) {
+            if (isBlockedAddress(address)) {
+                throw new WanakuException(
+                        "URLs resolving to loopback, link-local, or private addresses are not allowed");
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if the address falls in a range that must never be reachable through a
+     * user-supplied URL (SSRF protection).
+     */
+    static boolean isBlockedAddress(InetAddress address) {
+        if (address.isAnyLocalAddress() // 0.0.0.0, ::
+                || address.isLoopbackAddress() // 127.0.0.0/8, ::1
+                || address.isLinkLocalAddress() // 169.254.0.0/16 (cloud metadata), fe80::/10
+                || address.isSiteLocalAddress() // 10/8, 172.16/12, 192.168/16
+                || address.isMulticastAddress()) {
+            return true;
+        }
+
+        byte[] bytes = address.getAddress();
+        // IPv6 unique-local addresses fc00::/7 are not covered by isSiteLocalAddress().
+        if (bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc) {
+            return true;
+        }
+        // IPv4 carrier-grade NAT 100.64.0.0/10 is used by some cloud metadata services.
+        return bytes.length == 4 && (bytes[0] & 0xff) == 100 && (bytes[1] & 0xc0) == 64;
+    }
+
+    /**
+     * Validates a toolset name that is used to build an outbound URL path segment, rejecting any
+     * value that could alter the request path (path traversal / SSRF).
+     *
+     * @param toolsetName the caller-supplied toolset name
+     * @throws WanakuException if the name contains anything other than {@code [A-Za-z0-9._-]}
+     */
+    static void validateToolsetName(String toolsetName) throws WanakuException {
+        if (toolsetName == null
+                || toolsetName.isBlank()
+                || !toolsetName.matches("[A-Za-z0-9._-]+")
+                || toolsetName.contains("..")) {
+            throw new WanakuException("Invalid toolset name: %s".formatted(toolsetName));
         }
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanSsrfTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanSsrfTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.backend.api.v1.toolsetrepos;
+
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the SSRF guards in {@link ToolsetReposBean}. These exercise the static
+ * validation helpers directly so they require neither CDI nor outbound network access — every
+ * blocked case below uses an IP literal or a malformed input, so the host resolution is purely
+ * local.
+ */
+class ToolsetReposBeanSsrfTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "http://127.0.0.1/index.properties",
+                "http://127.0.0.5/index.properties",
+                "https://169.254.169.254/latest/meta-data/", // cloud metadata
+                "http://10.0.0.1/",
+                "http://192.168.1.1/",
+                "http://172.16.0.1/",
+                "http://100.100.100.200/", // carrier-grade NAT metadata
+                "http://[::1]/", // IPv6 loopback literal
+                "http://0.0.0.0/",
+                "ftp://example.com/", // non-http scheme
+                "file:///etc/passwd"
+            })
+    void rejectsUnsafeFetchTargets(String url) {
+        assertThrows(WanakuException.class, () -> ToolsetReposBean.validateFetchTarget(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "../../../etc/passwd",
+                "foo/bar",
+                "foo/../../bar",
+                "name with space",
+                "name?x=1",
+                "name#frag",
+                "name:1234",
+                ".."
+            })
+    void rejectsUnsafeToolsetNames(String name) {
+        assertThrows(WanakuException.class, () -> ToolsetReposBean.validateToolsetName(name));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"my-toolset", "weather_v2", "Search.Tools", "abc123"})
+    void acceptsWellFormedToolsetNames(String name) {
+        assertDoesNotThrow(() -> ToolsetReposBean.validateToolsetName(name));
+    }
+}


### PR DESCRIPTION
Closes #1314

`ToolsetReposBean.validateUrl()` ran only when a repository was registered or updated; `browse()`
and `fetchToolset()` then fetched the stored URL with no re-validation. The textual guard also
missed the `169.254.0.0/16` metadata range and IPv6/encoded hosts, and `fetchToolset()` built the
outbound path from an unsanitized `toolsetName`.

This change:

- adds `validateFetchTarget()`, which resolves the host to its IP address(es) and rejects
  loopback, link-local (incl. the `169.254.0.0/16` cloud-metadata range), private, multicast,
  IPv6 unique-local and carrier-grade-NAT ranges, and calls it before each outbound fetch in
  `browse()` and `fetchToolset()`;
- hardens the registration-time `validateUrl()` with the link-local range; and
- restricts `toolsetName` to a `[A-Za-z0-9._-]` allowlist so it cannot alter the request path.

New `ToolsetReposBeanSsrfTest` covers the blocked address ranges and malformed toolset names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden toolset repository fetching against SSRF by re-validating resolved targets and constraining toolset names before outbound requests.

Bug Fixes:
- Prevent server-side request forgery by blocking toolset repository URLs that resolve to loopback, link-local, private, multicast, IPv6 unique-local, or carrier-grade NAT address ranges at fetch time.
- Disallow registration-time repository URLs in the 169.254.0.0/16 link-local range that were previously missed by textual validation.

Enhancements:
- Validate toolset names against a strict allowlist to prevent path manipulation when constructing toolset fetch URLs.

Tests:
- Add ToolsetReposBeanSsrfTest to cover unsafe fetch targets and malformed or well-formed toolset names without requiring outbound network access.