### PR TITLE
Fix #1316: create the CLI credentials file with owner-only (0600) permissions

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -1,10 +1,13 @@
 package ai.wanaku.cli.main.support;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Properties;
 
 /**
@@ -203,7 +206,13 @@ public class AuthCredentialStore {
             Properties props = loadProperties();
 
             props.setProperty(key, value);
-            props.store(Files.newOutputStream(credentialsPath), "Wanaku CLI Authentication Credentials");
+
+            // Make sure the file exists with owner-only permissions BEFORE writing secrets to it,
+            // so access and refresh tokens are never momentarily world-readable.
+            ensureSecureFile(credentialsPath);
+            try (OutputStream out = Files.newOutputStream(credentialsPath)) {
+                props.store(out, "Wanaku CLI Authentication Credentials");
+            }
         } catch (IOException e) {
             throw new RuntimeException("Failed to store credential: " + key, e);
         }
@@ -215,9 +224,56 @@ public class AuthCredentialStore {
             Path parentDir = credentialsPath.getParent();
             if (parentDir != null && !Files.exists(parentDir)) {
                 Files.createDirectories(parentDir);
+                restrictPermissions(parentDir, "rwx------");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to create credentials directory", e);
+        }
+    }
+
+    /**
+     * Ensures the credentials file exists with owner-only ({@code 0600}) permissions. On a POSIX
+     * filesystem the file is created atomically with the restricted permissions; on a non-POSIX
+     * filesystem it falls back to a best-effort restriction via the {@link File} API.
+     *
+     * @param path the credentials file path
+     * @throws IOException if the file cannot be created
+     */
+    private static void ensureSecureFile(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            try {
+                Files.createFile(
+                        path, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+                return;
+            } catch (UnsupportedOperationException e) {
+                // Non-POSIX filesystem (e.g. Windows): create then restrict best-effort below.
+                Files.createFile(path);
+            }
+        }
+        restrictPermissions(path, "rw-------");
+    }
+
+    /**
+     * Best-effort restriction of a path to owner-only permissions, tolerating non-POSIX
+     * filesystems where POSIX permissions are unavailable.
+     *
+     * @param path the file or directory to restrict
+     * @param posixPermissions the desired POSIX permission string (e.g. {@code rw-------})
+     */
+    private static void restrictPermissions(Path path, String posixPermissions) {
+        try {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(posixPermissions));
+        } catch (UnsupportedOperationException | IOException e) {
+            // Non-POSIX filesystem (e.g. Windows): best-effort owner-only via java.io.File.
+            File file = path.toFile();
+            file.setReadable(false, false);
+            file.setReadable(true, true);
+            file.setWritable(false, false);
+            file.setWritable(true, true);
+            if (posixPermissions.charAt(2) == 'x') {
+                file.setExecutable(false, false);
+                file.setExecutable(true, true);
+            }
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
@@ -1,7 +1,12 @@
 package ai.wanaku.cli.main.support;
 
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,5 +161,32 @@ class AuthCredentialStoreTest {
     @Test
     void shouldReturnNullWhenClientIdNotSet() {
         assertNull(credentialStore.getClientId());
+    }
+
+    @Test
+    void shouldCreateCredentialsFileWithOwnerOnlyPermissions() throws Exception {
+        credentialStore.storeApiToken("secret-token");
+
+        Path credentialsFile = Paths.get(credentialStore.getCredentialsFile());
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(credentialsFile);
+
+        assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                perms,
+                "Credentials file must not be readable by group or others");
+    }
+
+    @Test
+    void shouldCreateCredentialsDirectoryWithOwnerOnlyPermissions() throws Exception {
+        Path nestedCredentials = tempDir.resolve("nested").resolve(".wanaku").resolve("credentials");
+        AuthCredentialStore store = new AuthCredentialStore(nestedCredentials.toUri());
+        store.storeApiToken("secret-token");
+
+        Set<PosixFilePermission> dirPerms = Files.getPosixFilePermissions(nestedCredentials.getParent());
+
+        assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                dirPerms,
+                "Credentials directory must not be accessible by group or others");
     }
 }


### PR DESCRIPTION
Closes #1316

The CLI wrote `~/.wanaku/credentials` (access + refresh tokens) with default permissions, leaving it world-readable (`0644`). This creates the file `0600` and the directory `0700` via POSIX permissions, with a best-effort fallback on non-POSIX filesystems. Covered by `AuthCredentialStoreTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten filesystem permissions for the WANAKU CLI credentials storage to ensure tokens and related secrets are only accessible to the owning user.

Bug Fixes:
- Prevent the CLI from creating a world-readable credentials file by ensuring it is created and written with owner-only (0600) permissions.
- Ensure the credentials directory is created with owner-only (0700) permissions to avoid exposure of stored authentication data.

Tests:
- Add tests verifying that the credentials file is created with rw------- permissions on POSIX filesystems.
- Add tests verifying that the credentials directory is created with rwx------ permissions on POSIX filesystems.