### PR TITLE
Fix #1317: require authentication for code-execution, tool-calls and chat endpoints

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -187,8 +187,11 @@ quarkus.http.auth.permission.oidcproxy.policy=permit
 quarkus.http.auth.permission.health.paths=/q/health/*
 quarkus.http.auth.permission.health.policy=permit
 
-# Management APIs and the Data Store APIs
-quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*
+# Management APIs, Data Store APIs, the LLM chat proxy and the v2 APIs (code execution and
+# tool-calls) must never be reachable anonymously. These carry a more specific path prefix than
+# the catch-all public rule below, so Quarkus' longest-prefix-wins matching gives them priority.
+# In "none" auth mode AuthConfigSource downgrades this policy to "permit" (see AuthConfigSource).
+quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*, /api/v1/chat/*, /api/v2/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Restricted MCP namespaces
@@ -196,7 +199,7 @@ quarkus.http.auth.permission.mcp-authenticated.paths=/mcp/*, /ns-0/*, /ns-1/*, /
 quarkus.http.auth.permission.mcp-authenticated.policy=authenticated
 
 # Public APIs and static resources
-quarkus.http.auth.permission.public.paths=/api/v1/*, /api/v2/*, /index.html, /*
+quarkus.http.auth.permission.public.paths=/api/v1/*, /index.html, /*
 quarkus.http.auth.permission.public.policy=permit
 
 ## Admin UI, which requires authentication for all paths in the web interface


### PR DESCRIPTION
Closes #1317

The code-execution (`/api/v2/*`) and chat (`/api/v1/chat`) endpoints were reachable unauthenticated even with Keycloak enabled. This moves `/api/v2/*` and `/api/v1/chat/*` into the `authenticated` permission set; the `none` auth mode still downgrades it to `permit` via `AuthConfigSource`, so dev/test flows are unaffected (verified locally: `LlmChatResourceTest`, `DataStoresResourceTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require authentication for previously public LLM chat and v2 code-execution/tool-call endpoints.

Bug Fixes:
- Protect /api/v1/chat/* and /api/v2/* endpoints from unauthenticated access when authentication is enabled by moving them into the authenticated permission set.

Enhancements:
- Tighten public vs authenticated path configuration so longest-prefix matching consistently prioritizes sensitive management, data-store, chat, and v2 APIs over the catch-all public rule.