### PR TITLE
Fix #1318: add a hardened securityContext to the operator Deployment

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         app.kubernetes.io/version: 0.1.1-SNAPSHOT
         app.kubernetes.io/name: wanaku-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - env:
             - name: KUBERNETES_NAMESPACE
@@ -57,6 +61,11 @@ spec:
             successThreshold: {{ .Values.app.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
           name: wanaku-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.app.ports.http }}
               name: http


### PR DESCRIPTION
Closes #1318

The operator Deployment ran with no hardened `securityContext`. This adds pod-level `runAsNonRoot` + seccomp `RuntimeDefault` and container-level `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`. The operator image is the Quarkus UBI9 runtime (non-root), so it stays compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the Kubernetes security context for the wanaku-operator Deployment.

Enhancements:
- Add pod-level security context enforcing non-root execution and RuntimeDefault seccomp profile for the operator Deployment.
- Add container-level security context disabling privilege escalation and dropping all Linux capabilities for the operator container.