### PR TITLE
Fix #1319: set least-privilege GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -37,6 +37,11 @@ on:
       - javadoc-warm.sh
       - .*
 
+# Least-privilege default for the automatically-provided GITHUB_TOKEN. Jobs that need more
+# (e.g. publishing) should opt in with a narrower job-level permissions block.
+permissions:
+  contents: read
+
 env:
   PROJECTS: ${{ github.workspace }}
   CONTAINER_REGISTRY: ${{ vars.CONTAINER_REGISTRY || 'quay.io' }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -11,6 +11,10 @@ on:
       - "capabilities/README.md"
       - ".markdownlint-cli2.yaml"
 
+# Least-privilege default for the automatically-provided GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -32,6 +32,11 @@ on:
       - javadoc-warm.sh
       - .*
 
+# Least-privilege default for the automatically-provided GITHUB_TOKEN. PR builds run untrusted
+# fork code and must not be able to write to the repository.
+permissions:
+  contents: read
+
 env:
   PROJECTS: ${{ github.workspace }}
 


### PR DESCRIPTION
Closes #1319

Three workflows declared no `permissions:` block, so `GITHUB_TOKEN` inherited the default (often read-write); `pr-builds.yml` builds untrusted fork code. This adds top-level `permissions: contents: read` to each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restrict default GITHUB_TOKEN permissions to read-only in CI workflows to follow least-privilege principles.

CI:
- Set top-level read-only contents permissions for GITHUB_TOKEN in main build workflow.
- Set top-level read-only contents permissions for GITHUB_TOKEN in pull request build workflow handling untrusted fork code.
- Set top-level read-only contents permissions for GITHUB_TOKEN in markdown lint workflow.