### PR TITLE
Fix #1320: warn that the docker-compose ships insecure default credentials

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,3 +1,12 @@
+# =============================================================================
+# WARNING: development / evaluation use only — DO NOT use this file in production.
+# It ships well-known, insecure default credentials:
+#   - Keycloak admin:    admin / admin
+#   - OIDC client secret for "wanaku-service": mypasswd (see ../auth/wanaku-config.json)
+# Before any non-local deployment you MUST rotate the Keycloak admin password and
+# regenerate the wanaku-service client secret (e.g. inject it via an environment
+# variable / secret manager instead of hardcoding it here and in wanaku-config.json).
+# =============================================================================
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.6.1


### PR DESCRIPTION
Closes #1320

The compose file ships `admin/admin` and the `mypasswd` OIDC client secret with no warning. This adds a clear development-only header instructing operators to rotate both before any non-local deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document the insecure default credentials in the development docker-compose file and clarify that it is not suitable for production use.