### PR TITLE
Fix #1326: authenticate the bare /api/v1/chat path

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -191,7 +191,7 @@ quarkus.http.auth.permission.health.policy=permit
 # tool-calls) must never be reachable anonymously. These carry a more specific path prefix than
 # the catch-all public rule below, so Quarkus' longest-prefix-wins matching gives them priority.
 # In "none" auth mode AuthConfigSource downgrades this policy to "permit" (see AuthConfigSource).
-quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*, /api/v1/chat/*, /api/v2/*
+quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*, /api/v1/chat, /api/v1/chat/*, /api/v2/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Restricted MCP namespaces


### PR DESCRIPTION
Closes #1326

Follow-up to #1322. `/api/v1/chat/*` was moved into the `authenticated` permission set, but the
bare `/api/v1/chat` (no trailing slash) still matched only the public `/api/v1/*` rule. This adds
`/api/v1/chat` to the authenticated paths so the bare path cannot be reached anonymously.

Verified: `LlmChatResourceTest` 3/3 green (runs in `none` auth mode, so the path stays permitted
there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the bare /api/v1/chat path is treated as authenticated and no longer accessible anonymously.