### PR TITLE
Fix #1327: harden CLI credential-store permission handling

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -4,11 +4,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Properties;
+import org.jboss.logging.Logger;
 
 /**
  * A credential store specifically designed for CLI authentication.
@@ -16,6 +19,8 @@ import java.util.Properties;
  * such as API tokens, refresh tokens, and authentication configuration.
  */
 public class AuthCredentialStore {
+
+    private static final Logger LOG = Logger.getLogger(AuthCredentialStore.class);
 
     private static final String DEFAULT_CREDENTIALS_FILE = "~/.wanaku/credentials";
     private static final String API_TOKEN_KEY = "api.token";
@@ -222,8 +227,12 @@ public class AuthCredentialStore {
         try {
             Path credentialsPath = Paths.get(credentialsUri);
             Path parentDir = credentialsPath.getParent();
-            if (parentDir != null && !Files.exists(parentDir)) {
-                Files.createDirectories(parentDir);
+            if (parentDir != null) {
+                if (!Files.exists(parentDir)) {
+                    Files.createDirectories(parentDir);
+                }
+                // Enforce owner-only access even if the directory already existed with broader
+                // permissions.
                 restrictPermissions(parentDir, "rwx------");
             }
         } catch (IOException e) {
@@ -240,13 +249,15 @@ public class AuthCredentialStore {
      * @throws IOException if the file cannot be created
      */
     private static void ensureSecureFile(Path path) throws IOException {
-        if (!Files.exists(path)) {
-            try {
-                Files.createFile(
-                        path, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
-                return;
-            } catch (UnsupportedOperationException e) {
-                // Non-POSIX filesystem (e.g. Windows): create then restrict best-effort below.
+        try {
+            // Create atomically with owner-only permissions: no exists()-then-create() race.
+            Files.createFile(path, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+            return;
+        } catch (FileAlreadyExistsException e) {
+            // Already present: fall through and re-assert the restricted permissions below.
+        } catch (UnsupportedOperationException e) {
+            // Non-POSIX filesystem (e.g. Windows): create if needed, then restrict best-effort below.
+            if (!Files.exists(path)) {
                 Files.createFile(path);
             }
         }
@@ -263,16 +274,24 @@ public class AuthCredentialStore {
     private static void restrictPermissions(Path path, String posixPermissions) {
         try {
             Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(posixPermissions));
+            return;
         } catch (UnsupportedOperationException | IOException e) {
-            // Non-POSIX filesystem (e.g. Windows): best-effort owner-only via java.io.File.
+            // Non-POSIX filesystem (e.g. Windows): best-effort owner-only via java.io.File. These
+            // calls can legitimately return false on such platforms (e.g. Windows cannot revoke
+            // read for "everyone"), so we surface a warning rather than failing the command.
+            boolean ownerExecutable =
+                    PosixFilePermissions.fromString(posixPermissions).contains(PosixFilePermission.OWNER_EXECUTE);
             File file = path.toFile();
-            file.setReadable(false, false);
-            file.setReadable(true, true);
-            file.setWritable(false, false);
-            file.setWritable(true, true);
-            if (posixPermissions.charAt(2) == 'x') {
-                file.setExecutable(false, false);
-                file.setExecutable(true, true);
+            boolean restricted = file.setReadable(false, false)
+                    & file.setReadable(true, true)
+                    & file.setWritable(false, false)
+                    & file.setWritable(true, true)
+                    & (!ownerExecutable || (file.setExecutable(false, false) & file.setExecutable(true, true)));
+            if (!restricted) {
+                LOG.warnf(
+                        "Could not fully restrict permissions on %s; it may be accessible to other users "
+                                + "on this filesystem",
+                        path);
             }
         }
     }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
@@ -1,6 +1,7 @@
 package ai.wanaku.cli.main.support;
 
 import java.net.URI;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -8,6 +9,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -165,6 +167,7 @@ class AuthCredentialStoreTest {
 
     @Test
     void shouldCreateCredentialsFileWithOwnerOnlyPermissions() throws Exception {
+        assumePosixFileSystem();
         credentialStore.storeApiToken("secret-token");
 
         Path credentialsFile = Paths.get(credentialStore.getCredentialsFile());
@@ -178,6 +181,7 @@ class AuthCredentialStoreTest {
 
     @Test
     void shouldCreateCredentialsDirectoryWithOwnerOnlyPermissions() throws Exception {
+        assumePosixFileSystem();
         Path nestedCredentials = tempDir.resolve("nested").resolve(".wanaku").resolve("credentials");
         AuthCredentialStore store = new AuthCredentialStore(nestedCredentials.toUri());
         store.storeApiToken("secret-token");
@@ -188,5 +192,11 @@ class AuthCredentialStoreTest {
                 PosixFilePermissions.fromString("rwx------"),
                 dirPerms,
                 "Credentials directory must not be accessible by group or others");
+    }
+
+    private static void assumePosixFileSystem() {
+        Assumptions.assumeTrue(
+                FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+                "POSIX file permissions are not supported on this filesystem");
     }
 }


### PR DESCRIPTION
Closes #1327

Follow-up to #1321, addressing the review feedback on the credential-store permission handling:

- `ensureSecureFile` now creates the file atomically with POSIX attributes and catches
  `FileAlreadyExistsException`, removing the `exists()`-then-`createFile()` TOCTOU window on the
  POSIX path.
- `restrictPermissions` checks the `File.set*` return values and logs a warning when the
  best-effort restriction can't be fully applied, instead of silently ignoring them. It does **not**
  throw, since these calls legitimately return `false` on non-POSIX platforms (e.g. Windows cannot
  revoke read for "everyone"), and throwing would break the CLI there. The owner-execute decision
  now uses `PosixFilePermission.OWNER_EXECUTE` instead of a positional character check.
- `ensureCredentialsDirectoryExists` enforces owner-only permissions even when the directory
  already exists with broader permissions.
- The POSIX-only permission tests now assume POSIX support so the suite stays portable.

Verified: `AuthCredentialStoreTest` 16/16 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden CLI credential-store file and directory permission handling across POSIX and non-POSIX filesystems and align tests with POSIX support assumptions.

Bug Fixes:
- Eliminate race conditions and enforce owner-only permissions when creating or reusing the credentials file and directory.
- Ensure permission restriction failures on non-POSIX filesystems are surfaced via logging instead of silently ignored.

Enhancements:
- Add logging when permission restrictions cannot be fully applied on a filesystem.
- Refine permission handling logic to derive owner-execute from POSIX permission flags rather than string positions.

Tests:
- Gate POSIX-specific credential-store permission tests on POSIX file attribute support to keep the test suite portable.