### PR TITLE
Fix #1332: pin OIDC well-known forwarder target to the configured proxy

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
@@ -4,11 +4,10 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
 
+import java.net.URI;
 import java.net.http.HttpClient;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -18,8 +17,8 @@ public class OAuthAuthorizationServerWellKnownResource {
     @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
     String oidcProxyRootPath;
 
-    @Context
-    UriInfo uriInfo;
+    @ConfigProperty(name = "auth.proxy", defaultValue = "http://localhost:8080")
+    String authProxy;
 
     private final OpenIdConfigurationForwarder forwarder = new OpenIdConfigurationForwarder(HttpClient.newHttpClient());
 
@@ -36,6 +35,19 @@ public class OAuthAuthorizationServerWellKnownResource {
     }
 
     private Response forwardToOpenIdConfiguration() {
-        return forwarder.forward(uriInfo != null ? uriInfo.getBaseUri() : null, oidcProxyRootPath);
+        return forwarder.forward(proxyBaseUri(), oidcProxyRootPath);
+    }
+
+    /**
+     * The base URI the OIDC metadata is fetched from. It is pinned to the configured local OIDC
+     * proxy ({@code auth.proxy}) rather than derived from the inbound request, so a caller cannot
+     * steer the server's outbound request to an arbitrary host via the {@code Host} /
+     * {@code X-Forwarded-*} headers (SSRF).
+     *
+     * @return the trusted base URI (always ending with {@code /})
+     */
+    URI proxyBaseUri() {
+        String base = (authProxy != null && !authProxy.isBlank()) ? authProxy.trim() : "http://localhost:8080";
+        return URI.create(base.endsWith("/") ? base : base + "/");
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.backend.api.v1.oidc;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the OIDC well-known forwarder target is pinned to the configured proxy and is not
+ * influenced by the inbound request (SSRF guard).
+ */
+class OAuthAuthorizationServerWellKnownResourceTest {
+
+    @Test
+    void proxyBaseUriUsesConfiguredAuthProxy() {
+        OAuthAuthorizationServerWellKnownResource resource = new OAuthAuthorizationServerWellKnownResource();
+        resource.authProxy = "http://localhost:8543";
+
+        assertEquals(URI.create("http://localhost:8543/"), resource.proxyBaseUri());
+    }
+
+    @Test
+    void proxyBaseUriKeepsExistingTrailingSlash() {
+        OAuthAuthorizationServerWellKnownResource resource = new OAuthAuthorizationServerWellKnownResource();
+        resource.authProxy = "http://internal-proxy:9000/";
+
+        assertEquals(URI.create("http://internal-proxy:9000/"), resource.proxyBaseUri());
+    }
+
+    @Test
+    void proxyBaseUriFallsBackToLoopbackWhenUnset() {
+        OAuthAuthorizationServerWellKnownResource resource = new OAuthAuthorizationServerWellKnownResource();
+        resource.authProxy = "   ";
+
+        assertEquals(URI.create("http://localhost:8080/"), resource.proxyBaseUri());
+    }
+}


### PR DESCRIPTION
Closes #1332

`OAuthAuthorizationServerWellKnownResource` passed `uriInfo.getBaseUri()` — derived from the inbound
request's `Host` / `X-Forwarded-*` headers — to the OIDC well-known forwarder, which then issued an
outbound GET to that host and reflected the response. Behind a proxy that honours forwarded headers,
that allows a caller to steer the server's request to an arbitrary host (read-side SSRF).

The forward target is now pinned to the configured local OIDC proxy (`auth.proxy`, default
`http://localhost:8080`), independent of the request. The forwarder utility is unchanged (it still
fetches whatever base it is handed), so its existing tests are untouched; a new unit test covers the
resource's `proxyBaseUri()`.

Verified: `OAuthAuthorizationServerWellKnownResourceTest` 3/3, `OpenIdConfigurationForwarderTest`
3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin the OIDC authorization server well-known metadata forwarding target to a trusted, configured local proxy instead of deriving it from inbound request headers to mitigate SSRF risk.

Bug Fixes:
- Prevent SSRF by ensuring OIDC well-known metadata is always fetched from the configured auth proxy rather than request-controlled hosts.

Tests:
- Add unit tests to verify the OIDC well-known resource derives its proxy base URI from the configured auth proxy, preserves trailing slashes, and falls back to a loopback default when unset.