### PR TITLE
Fix #1338: bound uploaded service-catalog/template ZIP size to prevent zip-bomb DoS

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -24,6 +24,7 @@ import ai.wanaku.backend.api.v1.exceptions.ServiceTemplateNotFoundException;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.core.services.api.SafeZip;
 import ai.wanaku.core.services.api.ServiceCatalogIndex;
 import ai.wanaku.core.util.StringHelper;
 
@@ -188,7 +189,7 @@ public class ServiceTemplateBean {
         ServiceCatalogIndex index = parseIndex(template);
         Map<String, Map<String, String>> result = new HashMap<>();
 
-        byte[] zipBytes = Base64.getDecoder().decode(template.getData());
+        byte[] zipBytes = SafeZip.decodeArchive(template.getData());
         Map<String, String> fileContents = extractFileContents(zipBytes);
 
         for (String system : index.getServiceNames()) {
@@ -251,7 +252,7 @@ public class ServiceTemplateBean {
         }
 
         ServiceCatalogIndex index = parseIndex(template);
-        byte[] originalZip = Base64.getDecoder().decode(template.getData());
+        byte[] originalZip = SafeZip.decodeArchive(template.getData());
 
         String effectiveName = (serviceName != null && !serviceName.isBlank()) ? serviceName : index.getName();
 
@@ -287,9 +288,20 @@ public class ServiceTemplateBean {
             // Read all entries from template ZIP
             try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(templateZip))) {
                 ZipEntry entry;
+                int entryCount = 0;
+                long totalBytes = 0;
                 while ((entry = zis.getNextEntry()) != null) {
+                    if (++entryCount > SafeZip.MAX_ENTRIES) {
+                        throw new IOException(
+                                "Template ZIP has too many entries (max %d)".formatted(SafeZip.MAX_ENTRIES));
+                    }
                     String name = entry.getName();
-                    byte[] content = zis.readAllBytes();
+                    byte[] content = SafeZip.readEntry(zis, SafeZip.MAX_ENTRY_BYTES);
+                    totalBytes += content.length;
+                    if (totalBytes > SafeZip.MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                        throw new IOException("Template ZIP uncompressed size exceeds the maximum of %d bytes"
+                                .formatted(SafeZip.MAX_TOTAL_UNCOMPRESSED_BYTES));
+                    }
                     entries.put(name, content);
                     zis.closeEntry();
                 }
@@ -382,9 +394,19 @@ public class ServiceTemplateBean {
         Map<String, String> result = new HashMap<>();
         try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
             ZipEntry entry;
+            int entryCount = 0;
+            long totalBytes = 0;
             while ((entry = zis.getNextEntry()) != null) {
+                if (++entryCount > SafeZip.MAX_ENTRIES) {
+                    throw new IOException("Template ZIP has too many entries (max %d)".formatted(SafeZip.MAX_ENTRIES));
+                }
                 if (!entry.isDirectory()) {
-                    byte[] content = zis.readAllBytes();
+                    byte[] content = SafeZip.readEntry(zis, SafeZip.MAX_ENTRY_BYTES);
+                    totalBytes += content.length;
+                    if (totalBytes > SafeZip.MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                        throw new IOException("Template ZIP uncompressed size exceeds the maximum of %d bytes"
+                                .formatted(SafeZip.MAX_TOTAL_UNCOMPRESSED_BYTES));
+                    }
                     result.put(entry.getName(), new String(content));
                 }
                 zis.closeEntry();

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/SafeZip.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/SafeZip.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.core.services.api;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.zip.ZipInputStream;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+/**
+ * Bounds for decoding and reading uploaded ZIP archives, guarding against decompression-bomb /
+ * out-of-memory denial-of-service. The limits are deliberately generous for legitimate service
+ * catalogs and templates while rejecting pathological archives.
+ */
+public final class SafeZip {
+
+    /** Maximum size of a decoded ZIP archive, in bytes. */
+    public static final long MAX_ARCHIVE_BYTES = 50L * 1024 * 1024; // 50 MiB
+
+    /** Maximum number of entries allowed in an archive. */
+    public static final int MAX_ENTRIES = 10_000;
+
+    /** Maximum uncompressed size of a single entry, in bytes. */
+    public static final long MAX_ENTRY_BYTES = 50L * 1024 * 1024; // 50 MiB
+
+    /** Maximum total uncompressed size across all entries of an archive, in bytes. */
+    public static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 200L * 1024 * 1024; // 200 MiB
+
+    private SafeZip() {}
+
+    /**
+     * Base64-decodes an archive, rejecting input whose decoded size would exceed
+     * {@link #MAX_ARCHIVE_BYTES}.
+     *
+     * @param base64Data the Base64-encoded archive
+     * @return the decoded bytes
+     * @throws WanakuException if the data is missing, too large, or not valid Base64
+     */
+    public static byte[] decodeArchive(String base64Data) throws WanakuException {
+        if (base64Data == null) {
+            throw new WanakuException("Missing archive data");
+        }
+        // A Base64 string decodes to ~3/4 of its length; reject early, before allocating.
+        long approxDecoded = (long) (base64Data.length() / 4) * 3;
+        if (approxDecoded > MAX_ARCHIVE_BYTES) {
+            throw new WanakuException(
+                    "Archive exceeds the maximum allowed size of %d bytes".formatted(MAX_ARCHIVE_BYTES));
+        }
+        try {
+            return Base64.getDecoder().decode(base64Data);
+        } catch (IllegalArgumentException e) {
+            throw new WanakuException("Invalid Base64 data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Reads the current ZIP entry fully, failing if it expands beyond {@code maxBytes}. This guards
+     * against decompression bombs, where a small compressed entry expands to a huge uncompressed
+     * size — unlike {@link ZipInputStream#readAllBytes()}, which is unbounded.
+     *
+     * @param zis the zip input stream positioned at an entry
+     * @param maxBytes the maximum number of uncompressed bytes to read
+     * @return the entry contents
+     * @throws IOException if reading fails or the entry exceeds {@code maxBytes}
+     */
+    public static byte[] readEntry(ZipInputStream zis, long maxBytes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        long total = 0;
+        int read;
+        while ((read = zis.read(buffer)) != -1) {
+            total += read;
+            if (total > maxBytes) {
+                throw new IOException("ZIP entry exceeds the maximum allowed size of %d bytes".formatted(maxBytes));
+            }
+            out.write(buffer, 0, read);
+        }
+        return out.toByteArray();
+    }
+}

--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogIndex.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/ServiceCatalogIndex.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -67,13 +66,7 @@ public class ServiceCatalogIndex {
      * @throws WanakuException if the ZIP is invalid or required properties are missing
      */
     public static ServiceCatalogIndex fromBase64(String base64Data) throws WanakuException {
-        byte[] zipBytes;
-        try {
-            zipBytes = Base64.getDecoder().decode(base64Data);
-        } catch (IllegalArgumentException e) {
-            throw new WanakuException("Invalid Base64 data: " + e.getMessage());
-        }
-        return fromZipBytes(zipBytes);
+        return fromZipBytes(SafeZip.decodeArchive(base64Data));
     }
 
     /**
@@ -89,7 +82,11 @@ public class ServiceCatalogIndex {
 
         try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
             ZipEntry entry;
+            int entryCount = 0;
             while ((entry = zis.getNextEntry()) != null) {
+                if (++entryCount > SafeZip.MAX_ENTRIES) {
+                    throw new IOException("ZIP archive has too many entries (max %d)".formatted(SafeZip.MAX_ENTRIES));
+                }
                 String entryName = entry.getName();
 
                 // Protect against ZIP path traversal
@@ -99,7 +96,7 @@ public class ServiceCatalogIndex {
 
                 if (INDEX_FILE.equals(entryName)) {
                     props = new Properties();
-                    props.load(zis);
+                    props.load(new ByteArrayInputStream(SafeZip.readEntry(zis, SafeZip.MAX_ENTRY_BYTES)));
                 }
                 zis.closeEntry();
             }

--- a/core/core-services-api/src/test/java/ai/wanaku/core/services/api/SafeZipTest.java
+++ b/core/core-services-api/src/test/java/ai/wanaku/core/services/api/SafeZipTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.core.services.api;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SafeZipTest {
+
+    @Test
+    void decodeArchiveAcceptsSmallPayload() throws Exception {
+        byte[] data = "hello world".getBytes();
+        assertArrayEquals(data, SafeZip.decodeArchive(Base64.getEncoder().encodeToString(data)));
+    }
+
+    @Test
+    void decodeArchiveRejectsOversizedPayload() {
+        // A Base64 string whose decoded length would exceed the cap is rejected before decoding.
+        int tooLong = (int) (SafeZip.MAX_ARCHIVE_BYTES / 3 * 4) + 8;
+        String b64 = "A".repeat(tooLong);
+        assertThrows(WanakuException.class, () -> SafeZip.decodeArchive(b64));
+    }
+
+    @Test
+    void decodeArchiveRejectsInvalidBase64() {
+        assertThrows(WanakuException.class, () -> SafeZip.decodeArchive("not valid base64 !!!"));
+    }
+
+    @Test
+    void decodeArchiveRejectsNull() {
+        assertThrows(WanakuException.class, () -> SafeZip.decodeArchive(null));
+    }
+
+    @Test
+    void readEntryReadsWithinLimit() throws Exception {
+        byte[] payload = "0123456789".getBytes();
+        try (ZipInputStream zis = zipOf("ok.txt", payload)) {
+            zis.getNextEntry();
+            assertArrayEquals(payload, SafeZip.readEntry(zis, 1024));
+        }
+    }
+
+    @Test
+    void readEntryRejectsEntryOverLimit() throws Exception {
+        byte[] payload = "0123456789".getBytes(); // 10 bytes
+        try (ZipInputStream zis = zipOf("big.txt", payload)) {
+            zis.getNextEntry();
+            assertThrows(IOException.class, () -> SafeZip.readEntry(zis, 4)); // limit < entry size
+        }
+    }
+
+    private static ZipInputStream zipOf(String name, byte[] content) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(bos)) {
+            zos.putNextEntry(new ZipEntry(name));
+            zos.write(content);
+            zos.closeEntry();
+        }
+        return new ZipInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    }
+}


### PR DESCRIPTION
Closes #1338

The service-catalog and service-template paths decoded a Base64 ZIP entirely into memory and read
entries with the unbounded `ZipInputStream.readAllBytes()`, with no size, entry-count, or
decompression caps — a denial-of-service (zip-bomb / OOM) vector.

Adds a small `SafeZip` helper (in `core-services-api`) and applies it at the affected sites:

- `SafeZip.decodeArchive(...)` rejects Base64 input whose decoded size would exceed
  `MAX_ARCHIVE_BYTES` (50 MiB) **before** allocating — used by `ServiceCatalogIndex.fromBase64` and
  the two decode sites in `ServiceTemplateBean`.
- `SafeZip.readEntry(zis, max)` replaces `readAllBytes()`, failing if a single entry expands beyond
  `MAX_ENTRY_BYTES` (50 MiB) — used in both `ServiceTemplateBean` ZIP loops and for the
  `index.properties` load in `ServiceCatalogIndex`.
- Both loops also enforce `MAX_ENTRIES` (10 000) and a cumulative `MAX_TOTAL_UNCOMPRESSED_BYTES`
  (200 MiB) cap.

Limits are deliberately generous for real catalogs/templates while rejecting pathological archives.
New `SafeZipTest` covers the decode-size, invalid-input, and per-entry-limit guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce bounded ZIP handling for uploaded service catalog and template archives to mitigate decompression-bomb and OOM denial-of-service vectors.

Bug Fixes:
- Guard Base64-decoded service catalog and template ZIP payloads with size, entry-count, and decompression limits to prevent resource exhaustion when processing malicious archives.

Enhancements:
- Add a reusable SafeZip utility in core-services-api that enforces maximum archive size, per-entry size, total uncompressed size, and entry count when decoding and reading ZIP streams.

Tests:
- Add SafeZip unit tests covering accepted payloads and rejection of oversized, invalid, or over-limit ZIP entries and Base64 inputs.