### PR TITLE
Fix #1334: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -24,14 +24,14 @@ jobs:
             echo "ref=main" >> $GITHUB_OUTPUT
           fi
       - name: Checkout Wanaku Capabilities SDK
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: wanaku-ai/wanaku-capabilities-java-sdk
           persist-credentials: false
           ref: ${{ steps.sdk-ref.outputs.ref }}
           path: wanaku-capabilities-java-sdk
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -40,11 +40,11 @@ jobs:
         run: mvn --no-transfer-progress -DskipTests clean install
         working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: graalvm/setup-graalvm@v1.5.4
+      - uses: graalvm/setup-graalvm@329c42c5f4c343bceb505f0b28cc8499bc2bf174 # v1.5.4
         with:
           java-version: '21'
           distribution: 'graalvm'
@@ -53,7 +53,7 @@ jobs:
           cache: maven
 
       - name: Login to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -68,7 +68,7 @@ jobs:
           clean package
 
       - name: Run JReleaser (Linux)
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jreleaser-release-linux
           path: |

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -58,9 +58,9 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -75,7 +75,7 @@ jobs:
           echo "ref=main" >> $GITHUB_OUTPUT
         fi
     - name: Checkout Wanaku Capabilities SDK
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
@@ -89,7 +89,7 @@ jobs:
       run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
     - name: Login to Container Registry
       if: env.QUAY_USERNAME != '' && env.QUAY_PASSWORD != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -119,7 +119,7 @@ jobs:
       run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-reports-${{ matrix.os }}
         path: 'target/reports/'
@@ -134,10 +134,10 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Login to Container Registry
         if: env.QUAY_USERNAME != '' && env.QUAY_PASSWORD != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,5 +19,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -66,14 +66,14 @@ jobs:
           echo "ref=main" >> $GITHUB_OUTPUT
         fi
     - name: Checkout Wanaku Capabilities SDK
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: wanaku-ai/wanaku-capabilities-java-sdk
         persist-credentials: false
         ref: ${{ steps.sdk-ref.outputs.ref }}
         path: wanaku-capabilities-java-sdk
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -81,7 +81,7 @@ jobs:
     - name: Build Wanaku Capabilities SDK
       run: mvn --no-transfer-progress -DskipTests clean install
       working-directory: ${{ github.workspace }}/wanaku-capabilities-java-sdk
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Build with Maven
       run: mvn -B --no-transfer-progress install --file pom.xml
     - name: Generate Test Reports
@@ -89,7 +89,7 @@ jobs:
       run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: test-reports-${{ matrix.os }}
         path: 'target/reports/'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: wanaku-${{ github.event.inputs.currentDevelopmentVersion }}
 
-      - uses: graalvm/setup-graalvm@v1.5.4
+      - uses: graalvm/setup-graalvm@329c42c5f4c343bceb505f0b28cc8499bc2bf174 # v1.5.4
         with:
           java-version: '21'
           distribution: 'graalvm'
@@ -41,7 +41,7 @@ jobs:
         run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Login to Container Registry
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -71,7 +71,7 @@ jobs:
           mvn --no-transfer-progress -Pdist -Dnative -DskipTests clean package
       - name: Run JReleaser
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -81,7 +81,7 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Run JReleaser (Cli - macOS)
         if: matrix.os != 'ubuntu-latest' && matrix.os != 'ubuntu-24.04-arm'
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         with:
           arguments: 'full-release --exclude-distribution=cli'
         env:
@@ -96,7 +96,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jreleaser-release-${{ matrix.os }}
           path: |
@@ -107,10 +107,10 @@ jobs:
     needs: release-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/wanaku'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.releaseBranch }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 21
           distribution: 'zulu'


### PR DESCRIPTION
Closes #1334

Pins the third-party (and GitHub-owned `actions/*`) Actions that were referenced by mutable tags to
their current commit SHAs, keeping the tag as a trailing comment for readability and Dependabot. A
mutable tag can be silently re-pointed by the action owner; the release/build workflows hold GPG
signing keys and registry credentials, so pinning closes that supply-chain vector.

Pinned: `actions/checkout` (v6), `actions/setup-java` (v5), `actions/upload-artifact` (v4),
`docker/login-action` (v3), `jreleaser/release-action` (v2), `graalvm/setup-graalvm` (v1.5.4),
`DavidAnson/markdownlint-cli2-action` (v19). `depsreview.yaml` was already SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Pin third-party and actions/* GitHub Actions in all workflows to their current commit SHAs while retaining version tags as comments.