### PR TITLE
Fix #1335: source wanaku-service OIDC secret from WANAKU_SERVICE_SECRET

### DIFF
--- a/deploy/auth/wanaku-config.json
+++ b/deploy/auth/wanaku-config.json
@@ -955,7 +955,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "mypasswd",
+      "secret": "${WANAKU_SERVICE_SECRET:mypasswd}",
       "redirectUris": [
         ""
       ],

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -2,10 +2,10 @@
 # WARNING: development / evaluation use only — DO NOT use this file in production.
 # It ships well-known, insecure default credentials:
 #   - Keycloak admin:    admin / admin
-#   - OIDC client secret for "wanaku-service": mypasswd (see ../auth/wanaku-config.json)
-# Before any non-local deployment you MUST rotate the Keycloak admin password and
-# regenerate the wanaku-service client secret (e.g. inject it via an environment
-# variable / secret manager instead of hardcoding it here and in wanaku-config.json).
+#   - OIDC client secret for "wanaku-service": defaults to "mypasswd" (override WANAKU_SERVICE_SECRET)
+# Before any non-local deployment you MUST rotate the Keycloak admin password and set a strong
+# WANAKU_SERVICE_SECRET environment variable. When set, it is applied to both the Keycloak realm
+# import and the capability services below; it defaults to "mypasswd" for local development only.
 # =============================================================================
 services:
   keycloak:
@@ -16,6 +16,8 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_PORT: 8080
       KC_HEALTH_ENABLED: "true"
+      # Substituted into the wanaku-service client secret during realm import.
+      WANAKU_SERVICE_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}
     ports:
       - "8543:8080"
     volumes:
@@ -32,8 +34,8 @@ services:
     environment:
       WANAKU_SERVICE_REGISTRATION_URI: http://localhost:8080/
       AUTH_SERVER: http://localhost:8543
-      # from wanaku-config.json
-      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: mypasswd
+      # Must match the wanaku-service client secret in the realm (WANAKU_SERVICE_SECRET).
+      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}
     network_mode: host
     depends_on:
       wanaku-router:


### PR DESCRIPTION
Closes #1335

The confidential `wanaku-service` OIDC client secret was committed as a real value (`mypasswd`) in
both the Keycloak realm export and docker-compose, so deploying the bundle unchanged ran with a
publicly known secret.

The secret is now sourced from `WANAKU_SERVICE_SECRET`, defaulting to `mypasswd` for local
development only:

- `deploy/auth/wanaku-config.json`: the client secret uses Keycloak realm-import substitution
  `${WANAKU_SERVICE_SECRET:mypasswd}`.
- `deploy/docker-compose/docker-compose.yml`: `WANAKU_SERVICE_SECRET` is passed to the Keycloak
  container (for realm import) and to the capability service's
  `QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET`, both `${WANAKU_SERVICE_SECRET:-mypasswd}`.

For production, set a strong `WANAKU_SERVICE_SECRET` and it is applied consistently to the realm and
the clients.

> [!NOTE]
> Please smoke-test with a local `docker compose up` to confirm Keycloak substitutes
> `${WANAKU_SERVICE_SECRET:...}` into the client secret during `--import-realm`. The default keeps
> dev working in any case; if substitution isn't applied on import I'll switch to a `kcadm`-based
> secret set instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Source the wanaku-service OIDC client secret from a configurable environment variable instead of hardcoding it for non-production deployments.

Bug Fixes:
- Eliminate the hardcoded wanaku-service OIDC client secret by wiring it through the WANAKU_SERVICE_SECRET environment variable across Keycloak realm import and dependent services.

Documentation:
- Clarify docker-compose documentation around the default wanaku-service OIDC client secret and how to override it via WANAKU_SERVICE_SECRET.