### PR TITLE
Fix #726: add Infinispan persistence for tool call events

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/toolcalls/ToolCallResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/toolcalls/ToolCallResource.java
@@ -18,20 +18,26 @@ package ai.wanaku.backend.api.v2.toolcalls;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
 
+import java.util.List;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 import io.smallrye.mutiny.Multi;
 import ai.wanaku.backend.common.ToolCallEvent;
+import ai.wanaku.backend.common.ToolCallRecord;
+import ai.wanaku.backend.core.persistence.api.ToolCallRecordRepository;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
 /**
  * JAX-RS REST resource for tool call debugging endpoints.
@@ -59,6 +65,9 @@ public class ToolCallResource {
     @Inject
     @Channel("tool-call-event")
     Multi<ToolCallEvent> toolCallEvents;
+
+    @Inject
+    ToolCallRecordRepository toolCallRecordRepository;
 
     @PostConstruct
     void initialize() {
@@ -127,5 +136,39 @@ public class ToolCallResource {
                         .name(event.getEventType().asValue())
                         .data(event)
                         .build());
+    }
+
+    @GET
+    @Path("/history")
+    @Produces(MediaType.APPLICATION_JSON)
+    public WanakuResponse<List<ToolCallRecord>> listHistory(
+            @QueryParam("toolName") String toolName, @QueryParam("connectionId") String connectionId) {
+
+        List<ToolCallRecord> records;
+        if (toolName != null && !toolName.isBlank()) {
+            records = toolCallRecordRepository.findByToolName(toolName);
+        } else if (connectionId != null && !connectionId.isBlank()) {
+            records = toolCallRecordRepository.findByConnectionId(connectionId);
+        } else {
+            records = toolCallRecordRepository.listAll();
+        }
+
+        return new WanakuResponse<>(records);
+    }
+
+    @GET
+    @Path("/history/{eventId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public WanakuResponse<ToolCallRecord> getHistoryEvent(@PathParam("eventId") String eventId) {
+        ToolCallRecord record = toolCallRecordRepository.findById(eventId);
+        return new WanakuResponse<>(record);
+    }
+
+    @DELETE
+    @Path("/history")
+    @Produces(MediaType.APPLICATION_JSON)
+    public WanakuResponse<Integer> clearHistory() {
+        int removed = toolCallRecordRepository.removeAll();
+        return new WanakuResponse<>(removed);
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/toolcalls/ToolCallResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v2/toolcalls/ToolCallResource.java
@@ -37,6 +37,7 @@ import io.smallrye.mutiny.Multi;
 import ai.wanaku.backend.common.ToolCallEvent;
 import ai.wanaku.backend.common.ToolCallRecord;
 import ai.wanaku.backend.core.persistence.api.ToolCallRecordRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
 /**
@@ -161,6 +162,9 @@ public class ToolCallResource {
     @Produces(MediaType.APPLICATION_JSON)
     public WanakuResponse<ToolCallRecord> getHistoryEvent(@PathParam("eventId") String eventId) {
         ToolCallRecord record = toolCallRecordRepository.findById(eventId);
+        if (record == null) {
+            throw new ResourceNotFoundException(eventId);
+        }
         return new WanakuResponse<>(record);
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/CodeExecutionBridge.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 import ai.wanaku.backend.common.ToolCallEvent;
 import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceNotFoundException;
@@ -53,7 +52,7 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
 
     private final ServiceResolver serviceResolver;
     private final WanakuBridgeTransport transport;
-    private final MutinyEmitter<ToolCallEvent> toolCallEventEmitter;
+    private final EventNotifier eventNotifier;
 
     /**
      * Creates a new CodeExecutionBridge with the specified service resolver and transport.
@@ -69,19 +68,17 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
     }
 
     /**
-     * Creates a new CodeExecutionBridge with the specified service resolver, transport, and event emitter.
+     * Creates a new CodeExecutionBridge with the specified service resolver, transport, and event notifier.
      *
      * @param serviceResolver the resolver for locating code execution services
      * @param transport the transport for gRPC communication
-     * @param toolCallEventEmitter the emitter for tool call events (nullable)
+     * @param eventNotifier the notifier for tool call events (nullable)
      */
     public CodeExecutionBridge(
-            ServiceResolver serviceResolver,
-            WanakuBridgeTransport transport,
-            MutinyEmitter<ToolCallEvent> toolCallEventEmitter) {
+            ServiceResolver serviceResolver, WanakuBridgeTransport transport, EventNotifier eventNotifier) {
         this.serviceResolver = serviceResolver;
         this.transport = transport;
-        this.toolCallEventEmitter = toolCallEventEmitter;
+        this.eventNotifier = eventNotifier;
     }
 
     /**
@@ -108,7 +105,7 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
 
         // Emit STARTED event
         ToolCallEvent startedEvent = null;
-        if (toolCallEventEmitter != null) {
+        if (eventNotifier != null) {
             startedEvent = emitStartedEvent(engineType, language, service, request);
         }
 
@@ -123,9 +120,9 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
             return new CloseableCodeExecutionIterator(replyIterator, finalStartedEvent, startTime, this);
         } catch (Exception e) {
             // Emit FAILED event
-            if (toolCallEventEmitter != null && startedEvent != null) {
+            if (eventNotifier != null && startedEvent != null) {
                 long duration = Duration.between(startTime, Instant.now()).toMillis();
-                emitFailedEvent(
+                eventNotifier.emitFailedEvent(
                         startedEvent.getEventId(),
                         ToolCallEvent.ErrorCategory.SERVICE_UNAVAILABLE,
                         e.getMessage(),
@@ -221,28 +218,20 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
 
     private void emitCompletionEvent(
             ToolCallEvent startedEvent, Instant startTime, boolean hasError, String errorMessage) {
-        if (toolCallEventEmitter == null || startedEvent == null) {
+        if (eventNotifier == null || startedEvent == null) {
             return;
         }
         long duration = Duration.between(startTime, Instant.now()).toMillis();
         if (hasError) {
-            emitFailedEvent(
+            eventNotifier.emitFailedEvent(
                     startedEvent.getEventId(), ToolCallEvent.ErrorCategory.EXECUTION_ERROR, errorMessage, duration);
         } else {
-            emitCompletedEvent(startedEvent.getEventId(), "Code execution completed", duration);
+            eventNotifier.emitCompletedEvent(startedEvent.getEventId(), "Code execution completed", duration);
         }
     }
 
     /**
      * Resolves a code execution service by matching serviceType, serviceSubType, and serviceName.
-     * <p>
-     * This method uses the service resolver to locate the appropriate service
-     * and throws an exception if no service is found.
-     *
-     * @param engineType the engine type (serviceSubType)
-     * @param language the language (serviceName)
-     * @return the resolved service target
-     * @throws ServiceNotFoundException if no matching service is found
      */
     private ServiceTarget resolveService(String engineType, String language) {
         LOG.debugf(
@@ -262,22 +251,12 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
 
     /**
      * Builds a gRPC CodeExecutionRequest from the SDK request.
-     * <p>
-     * The code in the request is expected to be base64-encoded and will be
-     * decoded before being sent to the code execution service.
-     * </p>
-     *
-     * @param engineType the engine type
-     * @param language the programming language
-     * @param request the SDK code execution request
-     * @return the gRPC code execution request
      */
     private ai.wanaku.core.exchange.v1.CodeExecutionRequest buildGrpcRequest(
             String engineType, String language, CodeExecutionRequest request) {
 
         String uri = String.format("code-execution-engine://%s/%s", engineType, language);
 
-        // Decode the base64-encoded code
         String decodedCode = decodeBase64Code(request.getCode());
 
         ai.wanaku.core.exchange.v1.CodeExecutionRequest.Builder builder =
@@ -286,7 +265,6 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
                         .setCode(decodedCode)
                         .setTimeout(request.getTimeout());
 
-        // Convert List<String> arguments to Map<String, String> with indexed keys
         List<String> arguments = request.getArguments();
         if (arguments != null && !arguments.isEmpty()) {
             for (int i = 0; i < arguments.size(); i++) {
@@ -294,7 +272,6 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
             }
         }
 
-        // Add environment variables if present
         Map<String, String> environment = request.getEnvironment();
         if (environment != null && !environment.isEmpty()) {
             builder.putAllEnvironment(environment);
@@ -303,13 +280,6 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
         return builder.build();
     }
 
-    /**
-     * Decodes base64-encoded code to plain text.
-     *
-     * @param base64Code the base64-encoded code string
-     * @return the decoded code as a UTF-8 string
-     * @throws IllegalArgumentException if the input is not valid base64
-     */
     private String decodeBase64Code(String base64Code) {
         if (StringHelper.isEmpty(base64Code)) {
             return "";
@@ -320,26 +290,16 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
             return new String(decodedBytes, StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
             LOG.warnf("Failed to decode base64 code, using raw value: %s", e.getMessage());
-            // If decoding fails, assume the code is not base64-encoded and return as-is
             return base64Code;
         }
     }
 
-    /**
-     * Emits a STARTED event for a code execution call.
-     * <p>
-     * Note: Arguments are redacted to avoid exposing potentially sensitive data.
-     * Only metadata about the arguments (count) is logged, not the actual values.
-     * </p>
-     */
     private ToolCallEvent emitStartedEvent(
             String engineType, String language, ServiceTarget service, CodeExecutionRequest request) {
         try {
             Map<String, String> arguments = new HashMap<>();
             arguments.put("engineType", engineType);
             arguments.put("language", language);
-            // Redact raw argument values to avoid leaking secrets or large payloads.
-            // Only emit safe metadata about the arguments.
             if (request.getArguments() != null && !request.getArguments().isEmpty()) {
                 arguments.put("argCount", String.valueOf(request.getArguments().size()));
                 arguments.put("argsRedacted", "true");
@@ -350,51 +310,19 @@ public class CodeExecutionBridge implements CodeExecutorBridge {
             ToolCallEvent event = ToolCallEvent.started(
                     toolName,
                     "code-execution-engine",
-                    "code-execution", // connectionId for code execution
+                    "code-execution",
                     service.getId(),
                     service.toAddress(),
                     arguments,
-                    new HashMap<>(), // no headers for code execution
-                    "[CODE]", // redact actual code
+                    new HashMap<>(),
+                    "[CODE]",
                     "",
                     "");
 
-            if (toolCallEventEmitter.hasRequests()) {
-                toolCallEventEmitter.sendAndForget(event);
-            }
-            return event;
+            return eventNotifier.emit(event);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to emit STARTED event for code execution %s/%s", engineType, language);
             return null;
-        }
-    }
-
-    /**
-     * Emits a COMPLETED event for a successful code execution.
-     */
-    private void emitCompletedEvent(String eventId, String content, long duration) {
-        try {
-            ToolCallEvent event = ToolCallEvent.completed(eventId, content, duration);
-            if (toolCallEventEmitter.hasRequests()) {
-                toolCallEventEmitter.sendAndForget(event);
-            }
-        } catch (Exception e) {
-            LOG.warnf(e, "Failed to emit COMPLETED event for %s", eventId);
-        }
-    }
-
-    /**
-     * Emits a FAILED event for a failed code execution.
-     */
-    private void emitFailedEvent(
-            String eventId, ToolCallEvent.ErrorCategory category, String errorMessage, long duration) {
-        try {
-            ToolCallEvent event = ToolCallEvent.failed(eventId, category, errorMessage, null, duration);
-            if (toolCallEventEmitter.hasRequests()) {
-                toolCallEventEmitter.sendAndForget(event);
-            }
-        } catch (Exception e) {
-            LOG.warnf(e, "Failed to emit FAILED event for %s", eventId);
         }
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/EventNotifier.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/EventNotifier.java
@@ -1,6 +1,12 @@
 package ai.wanaku.backend.bridge;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
 import java.util.Map;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.smallrye.reactive.messaging.MutinyEmitter;
@@ -14,14 +20,17 @@ import ai.wanaku.core.util.CollectionsHelper;
  * Responsible for emitting tool call lifecycle events (started, completed, failed)
  * to a reactive messaging channel for UI observability.
  */
+@ApplicationScoped
 public class EventNotifier {
     private static final Logger LOG = Logger.getLogger(EventNotifier.class);
 
-    private final MutinyEmitter<ToolCallEvent> emitter;
+    @Inject
+    @Channel("tool-call-event")
+    @OnOverflow(OnOverflow.Strategy.DROP)
+    MutinyEmitter<ToolCallEvent> emitter;
 
-    public EventNotifier(MutinyEmitter<ToolCallEvent> emitter) {
-        this.emitter = emitter;
-    }
+    @Inject
+    Event<ToolCallEvent> cdiEvent;
 
     /**
      * Emits a STARTED event for a tool call.
@@ -51,10 +60,7 @@ public class EventNotifier {
                     request.getConfigurationUri(),
                     request.getSecretsUri());
 
-            if (emitter.hasRequests()) {
-                emitter.sendAndForget(event);
-            }
-            return event;
+            return emit(event);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to emit STARTED event for tool %s", toolReference.getName());
             return null;
@@ -71,9 +77,7 @@ public class EventNotifier {
     public void emitCompletedEvent(String eventId, String content, long duration) {
         try {
             ToolCallEvent event = ToolCallEvent.completed(eventId, content, duration);
-            if (emitter.hasRequests()) {
-                emitter.sendAndForget(event);
-            }
+            emit(event);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to emit COMPLETED event for %s", eventId);
         }
@@ -91,9 +95,7 @@ public class EventNotifier {
             String eventId, ToolCallEvent.ErrorCategory category, String errorMessage, long duration) {
         try {
             ToolCallEvent event = ToolCallEvent.failed(eventId, category, errorMessage, null, duration);
-            if (emitter.hasRequests()) {
-                emitter.sendAndForget(event);
-            }
+            emit(event);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to emit FAILED event for %s", eventId);
         }
@@ -130,5 +132,13 @@ public class EventNotifier {
         }
 
         return ToolCallEvent.ErrorCategory.UNKNOWN;
+    }
+
+    ToolCallEvent emit(ToolCallEvent event) {
+        if (emitter.hasRequests()) {
+            emitter.sendAndForget(event);
+        }
+        cdiEvent.fireAsync(event);
+        return event;
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/EventNotifier.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/EventNotifier.java
@@ -1,7 +1,6 @@
 package ai.wanaku.backend.bridge;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.smallrye.reactive.messaging.MutinyEmitter;
@@ -10,8 +9,6 @@ import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
 import ai.wanaku.core.util.CollectionsHelper;
-
-import static ai.wanaku.capabilities.sdk.api.util.ReservedArgumentNames.AUTH_PREFIX;
 
 /**
  * Responsible for emitting tool call lifecycle events (started, completed, failed)
@@ -41,11 +38,7 @@ public class EventNotifier {
             ServiceTarget service,
             ToolInvokeRequest request) {
         try {
-            // Filter out auth args so they never appear in events
-            Map<String, Object> safeArgs = toolArguments.args().entrySet().stream()
-                    .filter(e -> e.getKey() == null || !e.getKey().startsWith(AUTH_PREFIX))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            Map<String, String> argumentsMap = CollectionsHelper.toStringStringMap(safeArgs);
+            Map<String, String> argumentsMap = CollectionsHelper.toStringStringMap(toolArguments.args());
             ToolCallEvent event = ToolCallEvent.started(
                     toolReference.getName(),
                     toolReference.getType(),

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ToolCallPersistenceObserver.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/ToolCallPersistenceObserver.java
@@ -1,0 +1,47 @@
+package ai.wanaku.backend.bridge;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import io.quarkus.scheduler.Scheduled;
+import ai.wanaku.backend.common.ToolCallEvent;
+import ai.wanaku.backend.common.ToolCallRecord;
+import ai.wanaku.backend.core.persistence.api.ToolCallRecordRepository;
+
+@ApplicationScoped
+public class ToolCallPersistenceObserver {
+    private static final Logger LOG = Logger.getLogger(ToolCallPersistenceObserver.class);
+
+    @Inject
+    ToolCallRecordRepository repository;
+
+    @ConfigProperty(name = "wanaku.tool-call-logging.retention-days", defaultValue = "7")
+    int retentionDays;
+
+    void onToolCallEvent(@ObservesAsync ToolCallEvent event) {
+        try {
+            ToolCallRecord record = ToolCallRecord.fromEvent(event);
+            repository.persist(record);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to persist tool call event %s", event.getEventId());
+        }
+    }
+
+    @Scheduled(every = "{wanaku.tool-call-logging.cleanup-interval:24h}")
+    void cleanupExpiredRecords() {
+        try {
+            long cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS).toEpochMilli();
+            int deleted = repository.deleteOlderThan(cutoff);
+            if (deleted > 0) {
+                LOG.infof("Cleaned up %d expired tool call records (older than %d days)", deleted, retentionDays);
+            }
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to clean up expired tool call records");
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
@@ -37,6 +37,8 @@ public class ToolCallEvent {
             Pattern.compile("(?i)(authorization|x-api-key|api-key|auth-token|bearer|cookie|session)");
     private static final Pattern SENSITIVE_FIELD_PATTERN =
             Pattern.compile("(?i)(password|secret|token|apikey|api_key|credentials)");
+    private static final String AUTH_ARG_PREFIX = "wanaku_auth_";
+    private static final String META_ARG_PREFIX = "wanaku_meta_";
 
     /**
      * Event type indicating the lifecycle stage.
@@ -152,7 +154,7 @@ public class ToolCallEvent {
         event.connectionId = connectionId;
         event.serviceId = serviceId;
         event.serviceAddress = serviceAddress;
-        event.arguments = arguments;
+        event.arguments = redactArguments(arguments);
         event.headers = redactHeaders(headers);
         event.body = redactBody(body);
         event.configurationURI = configurationURI;
@@ -199,6 +201,27 @@ public class ToolCallEvent {
         event.errorDetails = errorDetails;
         event.duration = duration;
         return event;
+    }
+
+    /**
+     * Redacts arguments by removing reserved prefixes and masking sensitive values.
+     */
+    private static Map<String, String> redactArguments(Map<String, String> arguments) {
+        if (arguments == null) {
+            return null;
+        }
+        Map<String, String> redacted = new HashMap<>();
+        arguments.forEach((key, value) -> {
+            if (key != null && (key.startsWith(AUTH_ARG_PREFIX) || key.startsWith(META_ARG_PREFIX))) {
+                return;
+            }
+            if (key != null && SENSITIVE_FIELD_PATTERN.matcher(key).find()) {
+                redacted.put(key, REDACTED);
+            } else {
+                redacted.put(key, value);
+            }
+        });
+        return redacted;
     }
 
     /**

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallEvent.java
@@ -23,6 +23,9 @@ import java.util.regex.Pattern;
 import ai.wanaku.core.util.StringHelper;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import static ai.wanaku.capabilities.sdk.api.util.ReservedArgumentNames.AUTH_PREFIX;
+import static ai.wanaku.capabilities.sdk.api.util.ReservedArgumentNames.METADATA_PREFIX;
+
 /**
  * Event representing a tool call invocation lifecycle.
  * <p>
@@ -37,8 +40,6 @@ public class ToolCallEvent {
             Pattern.compile("(?i)(authorization|x-api-key|api-key|auth-token|bearer|cookie|session)");
     private static final Pattern SENSITIVE_FIELD_PATTERN =
             Pattern.compile("(?i)(password|secret|token|apikey|api_key|credentials)");
-    private static final String AUTH_ARG_PREFIX = "wanaku_auth_";
-    private static final String META_ARG_PREFIX = "wanaku_meta_";
 
     /**
      * Event type indicating the lifecycle stage.
@@ -212,7 +213,7 @@ public class ToolCallEvent {
         }
         Map<String, String> redacted = new HashMap<>();
         arguments.forEach((key, value) -> {
-            if (key != null && (key.startsWith(AUTH_ARG_PREFIX) || key.startsWith(META_ARG_PREFIX))) {
+            if (key != null && (key.startsWith(AUTH_PREFIX) || key.startsWith(METADATA_PREFIX))) {
                 return;
             }
             if (key != null && SENSITIVE_FIELD_PATTERN.matcher(key).find()) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallRecord.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolCallRecord.java
@@ -1,0 +1,175 @@
+package ai.wanaku.backend.common;
+
+import java.util.UUID;
+import ai.wanaku.capabilities.sdk.api.types.WanakuEntity;
+
+/**
+ * Persisted audit record for tool call events.
+ * Contains only non-sensitive fields safe for long-term storage.
+ */
+public class ToolCallRecord implements WanakuEntity<String> {
+
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
+
+    private String id;
+    private String eventId;
+    private String eventType;
+    private long timestamp;
+    private String toolName;
+    private String toolType;
+    private String connectionId;
+    private String serviceId;
+    private String serviceAddress;
+    private boolean error;
+    private long duration;
+    private String errorCategory;
+    private String errorMessage;
+    private String argumentKeys;
+
+    public ToolCallRecord() {}
+
+    public static ToolCallRecord fromEvent(ToolCallEvent event) {
+        ToolCallRecord record = new ToolCallRecord();
+        record.id = UUID.randomUUID().toString();
+        record.eventId = event.getEventId();
+        record.eventType = event.getEventType() != null ? event.getEventType().asValue() : null;
+        record.timestamp = event.getTimestamp() != null ? event.getTimestamp().toEpochMilli() : 0;
+        record.toolName = event.getToolName();
+        record.toolType = event.getToolType();
+        record.connectionId = event.getConnectionId();
+        record.serviceId = event.getServiceId();
+        record.serviceAddress = event.getServiceAddress();
+        record.error = Boolean.TRUE.equals(event.getIsError());
+        record.duration = event.getDuration() != null ? event.getDuration() : 0;
+        record.errorCategory =
+                event.getErrorCategory() != null ? event.getErrorCategory().asValue() : null;
+        record.errorMessage = truncate(event.getErrorMessage());
+
+        if (event.getArguments() != null && !event.getArguments().isEmpty()) {
+            record.argumentKeys = String.join(",", event.getArguments().keySet());
+        }
+
+        return record;
+    }
+
+    private static String truncate(String value) {
+        if (value == null || value.length() <= MAX_ERROR_MESSAGE_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_ERROR_MESSAGE_LENGTH);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public String getToolType() {
+        return toolType;
+    }
+
+    public void setToolType(String toolType) {
+        this.toolType = toolType;
+    }
+
+    public String getConnectionId() {
+        return connectionId;
+    }
+
+    public void setConnectionId(String connectionId) {
+        this.connectionId = connectionId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public String getServiceAddress() {
+        return serviceAddress;
+    }
+
+    public void setServiceAddress(String serviceAddress) {
+        this.serviceAddress = serviceAddress;
+    }
+
+    public boolean isError() {
+        return error;
+    }
+
+    public void setError(boolean error) {
+        this.error = error;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public String getErrorCategory() {
+        return errorCategory;
+    }
+
+    public void setErrorCategory(String errorCategory) {
+        this.errorCategory = errorCategory;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getArgumentKeys() {
+        return argumentKeys;
+    }
+
+    public void setArgumentKeys(String argumentKeys) {
+        this.argumentKeys = argumentKeys;
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/api/ToolCallRecordRepository.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/api/ToolCallRecordRepository.java
@@ -1,0 +1,13 @@
+package ai.wanaku.backend.core.persistence.api;
+
+import java.util.List;
+import ai.wanaku.backend.common.ToolCallRecord;
+
+public interface ToolCallRecordRepository extends WanakuRepository<ToolCallRecord, String> {
+
+    List<ToolCallRecord> findByToolName(String toolName);
+
+    List<ToolCallRecord> findByConnectionId(String connectionId);
+
+    int deleteOlderThan(long timestampMillis);
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/api/ToolCallRecordRepository.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/api/ToolCallRecordRepository.java
@@ -3,11 +3,36 @@ package ai.wanaku.backend.core.persistence.api;
 import java.util.List;
 import ai.wanaku.backend.common.ToolCallRecord;
 
+/**
+ * Repository for persisted tool call audit records.
+ * <p>
+ * Stores non-sensitive metadata about tool invocations for historical queries
+ * and debugging. Records are automatically created from CDI events fired by
+ * {@code EventNotifier} and cleaned up by a scheduled retention job.
+ */
 public interface ToolCallRecordRepository extends WanakuRepository<ToolCallRecord, String> {
 
+    /**
+     * Finds all records for the given tool name.
+     *
+     * @param toolName the tool name to search for
+     * @return list of matching records, or an empty list if none found
+     */
     List<ToolCallRecord> findByToolName(String toolName);
 
+    /**
+     * Finds all records for the given connection ID.
+     *
+     * @param connectionId the MCP connection ID to search for
+     * @return list of matching records, or an empty list if none found
+     */
     List<ToolCallRecord> findByConnectionId(String connectionId);
 
+    /**
+     * Deletes all records with a timestamp older than the given cutoff.
+     *
+     * @param timestampMillis the epoch-millis cutoff; records older than this are deleted
+     * @return the number of records deleted
+     */
     int deleteOlderThan(long timestampMillis);
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/InfinispanPersistenceConfiguration.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/InfinispanPersistenceConfiguration.java
@@ -10,6 +10,7 @@ import ai.wanaku.backend.core.persistence.api.ForwardReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.NamespaceRepository;
 import ai.wanaku.backend.core.persistence.api.PromptReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.ResourceReferenceRepository;
+import ai.wanaku.backend.core.persistence.api.ToolCallRecordRepository;
 import ai.wanaku.backend.core.persistence.api.ToolReferenceRepository;
 
 public class InfinispanPersistenceConfiguration {
@@ -48,5 +49,10 @@ public class InfinispanPersistenceConfiguration {
     @Produces
     DataStoreRepository dataStoreRepository() {
         return new InfinispanDataStoreRepository(cacheManager, configuration);
+    }
+
+    @Produces
+    ToolCallRecordRepository toolCallRecordRepository() {
+        return new InfinispanToolCallRecordRepository(cacheManager, configuration);
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/InfinispanToolCallRecordRepository.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/InfinispanToolCallRecordRepository.java
@@ -1,0 +1,59 @@
+package ai.wanaku.backend.core.persistence.infinispan;
+
+import java.util.List;
+import java.util.UUID;
+import org.infinispan.commons.api.query.Query;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.manager.EmbeddedCacheManager;
+import ai.wanaku.backend.common.ToolCallRecord;
+import ai.wanaku.backend.core.persistence.api.ToolCallRecordRepository;
+
+public class InfinispanToolCallRecordRepository extends AbstractInfinispanRepository<ToolCallRecord, String>
+        implements ToolCallRecordRepository {
+
+    public InfinispanToolCallRecordRepository(EmbeddedCacheManager cacheManager, Configuration configuration) {
+        super(cacheManager, configuration);
+    }
+
+    @Override
+    protected String entityName() {
+        return "tool-call-record";
+    }
+
+    @Override
+    protected Class<ToolCallRecord> entityType() {
+        return ToolCallRecord.class;
+    }
+
+    @Override
+    protected String newId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public List<ToolCallRecord> findByToolName(String toolName) {
+        Query<ToolCallRecord> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.backend.common.ToolCallRecord r where r.toolName = :toolName");
+        query.setParameter("toolName", toolName);
+        return query.execute().list();
+    }
+
+    @Override
+    public List<ToolCallRecord> findByConnectionId(String connectionId) {
+        Query<ToolCallRecord> query = cacheManager
+                .getCache(entityName())
+                .query("from ai.wanaku.backend.common.ToolCallRecord r where r.connectionId = :connectionId");
+        query.setParameter("connectionId", connectionId);
+        return query.execute().list();
+    }
+
+    @Override
+    public int deleteOlderThan(long timestampMillis) {
+        Query<Object[]> query = cacheManager
+                .getCache(entityName())
+                .query("DELETE FROM ai.wanaku.backend.common.ToolCallRecord r WHERE r.timestamp < :cutoff");
+        query.setParameter("cutoff", timestampMillis);
+        return query.executeStatement();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/ToolCallRecordMarshaller.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/ToolCallRecordMarshaller.java
@@ -1,0 +1,58 @@
+package ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller;
+
+import java.io.IOException;
+import org.infinispan.protostream.MessageMarshaller;
+import ai.wanaku.backend.common.ToolCallRecord;
+
+public class ToolCallRecordMarshaller implements MessageMarshaller<ToolCallRecord> {
+
+    @Override
+    public String getTypeName() {
+        return ToolCallRecord.class.getCanonicalName();
+    }
+
+    @Override
+    public Class<? extends ToolCallRecord> getJavaClass() {
+        return ToolCallRecord.class;
+    }
+
+    @Override
+    public ToolCallRecord readFrom(ProtoStreamReader reader) throws IOException {
+        ToolCallRecord record = new ToolCallRecord();
+        record.setId(reader.readString("id"));
+        record.setEventId(reader.readString("eventId"));
+        record.setEventType(reader.readString("eventType"));
+        Long ts = reader.readLong("timestamp");
+        record.setTimestamp(ts != null ? ts : 0);
+        record.setToolName(reader.readString("toolName"));
+        record.setToolType(reader.readString("toolType"));
+        record.setConnectionId(reader.readString("connectionId"));
+        record.setServiceId(reader.readString("serviceId"));
+        record.setServiceAddress(reader.readString("serviceAddress"));
+        record.setError(reader.readBoolean("error"));
+        Long dur = reader.readLong("duration");
+        record.setDuration(dur != null ? dur : 0);
+        record.setErrorCategory(reader.readString("errorCategory"));
+        record.setErrorMessage(reader.readString("errorMessage"));
+        record.setArgumentKeys(reader.readString("argumentKeys"));
+        return record;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, ToolCallRecord record) throws IOException {
+        writer.writeString("id", record.getId());
+        writer.writeString("eventId", record.getEventId());
+        writer.writeString("eventType", record.getEventType());
+        writer.writeLong("timestamp", record.getTimestamp());
+        writer.writeString("toolName", record.getToolName());
+        writer.writeString("toolType", record.getToolType());
+        writer.writeString("connectionId", record.getConnectionId());
+        writer.writeString("serviceId", record.getServiceId());
+        writer.writeString("serviceAddress", record.getServiceAddress());
+        writer.writeBoolean("error", record.isError());
+        writer.writeLong("duration", record.getDuration());
+        writer.writeString("errorCategory", record.getErrorCategory());
+        writer.writeString("errorMessage", record.getErrorMessage());
+        writer.writeString("argumentKeys", record.getArgumentKeys());
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ToolCallRecordSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/ToolCallRecordSchema.java
@@ -1,0 +1,17 @@
+package ai.wanaku.backend.core.persistence.infinispan.protostream.schema;
+
+import org.infinispan.protostream.SerializationContext;
+import ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller.ToolCallRecordMarshaller;
+
+public class ToolCallRecordSchema extends AbstractWanakuSerializationContextInitializer {
+
+    @Override
+    public String getName() {
+        return "tool_call_record.proto";
+    }
+
+    @Override
+    public void registerMarshallers(SerializationContext serCtx) {
+        serCtx.registerMarshaller(new ToolCallRecordMarshaller());
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/CodeExecutionProvider.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/CodeExecutionProvider.java
@@ -21,16 +21,13 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Logger;
 import io.quarkus.arc.DefaultBean;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 import ai.wanaku.backend.bridge.CodeExecutionBridge;
 import ai.wanaku.backend.bridge.CodeExecutorBridge;
+import ai.wanaku.backend.bridge.EventNotifier;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
 import ai.wanaku.backend.bridge.transports.grpc.GrpcTransport;
-import ai.wanaku.backend.common.ToolCallEvent;
 import ai.wanaku.backend.core.mcp.providers.ServiceRegistry;
 import ai.wanaku.backend.service.support.FirstAvailable;
 import ai.wanaku.backend.service.support.ServiceResolver;
@@ -55,9 +52,7 @@ public class CodeExecutionProvider {
     Instance<ServiceRegistry> serviceRegistryInstance;
 
     @Inject
-    @Channel("tool-call-event")
-    @OnOverflow(OnOverflow.Strategy.DROP)
-    MutinyEmitter<ToolCallEvent> toolCallEventEmitter;
+    EventNotifier eventNotifier;
 
     ServiceRegistry serviceRegistry;
 
@@ -83,6 +78,6 @@ public class CodeExecutionProvider {
         LOG.info("Creating CodeExecutionBridge");
         ServiceResolver resolver = new FirstAvailable(serviceRegistry);
         WanakuBridgeTransport transport = new GrpcTransport();
-        return new CodeExecutionBridge(resolver, transport, toolCallEventEmitter);
+        return new CodeExecutionBridge(resolver, transport, eventNotifier);
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/providers/ToolsProvider.java
@@ -4,16 +4,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.OnOverflow;
 import org.jboss.logging.Logger;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.reactive.messaging.MutinyEmitter;
 import ai.wanaku.backend.bridge.EventNotifier;
 import ai.wanaku.backend.bridge.InvokerBridge;
 import ai.wanaku.backend.bridge.ToolsBridge;
 import ai.wanaku.backend.bridge.WanakuBridgeTransport;
-import ai.wanaku.backend.common.ToolCallEvent;
 import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.core.util.VersionHelper;
 import picocli.CommandLine;
@@ -35,9 +31,7 @@ public class ToolsProvider {
     WanakuBridgeTransport transport;
 
     @Inject
-    @Channel("tool-call-event")
-    @OnOverflow(OnOverflow.Strategy.DROP)
-    MutinyEmitter<ToolCallEvent> toolCallEventEmitter;
+    EventNotifier eventNotifier;
 
     @Produces
     ToolsBridge getToolsBridge() {
@@ -46,6 +40,6 @@ public class ToolsProvider {
         }
 
         LOG.infof("Wanaku version %s is starting", VersionHelper.VERSION);
-        return new InvokerBridge(serviceResolver, transport, new EventNotifier(toolCallEventEmitter));
+        return new InvokerBridge(serviceResolver, transport, eventNotifier);
     }
 }

--- a/apps/wanaku-router-backend/src/main/resources/META-INF/services/org.infinispan.protostream.SerializationContextInitializer
+++ b/apps/wanaku-router-backend/src/main/resources/META-INF/services/org.infinispan.protostream.SerializationContextInitializer
@@ -13,3 +13,4 @@ ai.wanaku.backend.core.persistence.infinispan.protostream.schema.ToolReferenceSc
 ai.wanaku.backend.core.persistence.infinispan.protostream.schema.ServiceTargetSchema
 ai.wanaku.backend.core.persistence.infinispan.protostream.schema.ActivityRecordSchema
 ai.wanaku.backend.core.persistence.infinispan.protostream.schema.CodeExecutionTaskSchema
+ai.wanaku.backend.core.persistence.infinispan.protostream.schema.ToolCallRecordSchema

--- a/apps/wanaku-router-backend/src/main/resources/proto/tool_call_record.proto
+++ b/apps/wanaku-router-backend/src/main/resources/proto/tool_call_record.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package ai.wanaku.backend.common;
+
+message ToolCallRecord {
+  string id = 1;
+  string eventId = 2;
+  string eventType = 3;
+  fixed64 timestamp = 4;
+  string toolName = 5;
+  string toolType = 6;
+  string connectionId = 7;
+  string serviceId = 8;
+  string serviceAddress = 9;
+  bool error = 10;
+  fixed64 duration = 11;
+  string errorCategory = 12;
+  string errorMessage = 13;
+  string argumentKeys = 14;
+}


### PR DESCRIPTION
## Summary

- Centralizes argument redaction in `ToolCallEvent.started()` (fixes #1345)
- Converts `EventNotifier` to a CDI bean that fires async CDI events alongside the existing Reactive Messaging channel
- Refactors `CodeExecutionBridge` to use `EventNotifier`, eliminating duplicated event emission logic
- Adds `ToolCallRecord` entity with only non-sensitive audit fields persisted to Infinispan
- Adds scheduled cleanup (default 7 days retention, configurable via `wanaku.tool-call-logging.retention-days`)
- Adds REST endpoints for historical queries (`GET /api/v2/tool-calls/history`, `GET /api/v2/tool-calls/history/{eventId}`, `DELETE /api/v2/tool-calls/history`)

## Test plan

- [ ] Verify SSE streaming still works unchanged on the tool calls debug page
- [ ] Invoke a tool and confirm a `ToolCallRecord` is persisted (query via history endpoint)
- [ ] Verify sensitive fields (headers, body, content, argument values) are NOT in the persisted record
- [ ] Verify `wanaku_auth_` and `wanaku_meta_` prefixed arguments are stripped by redaction
- [ ] Test scheduled cleanup deletes old records
- [ ] Test history endpoints filter by `toolName` and `connectionId`

## Summary by Sourcery

Add persistent, privacy-safe auditing and querying of tool call events backed by Infinispan.

New Features:
- Persist non-sensitive tool call audit records to Infinispan via a new ToolCallRecord entity and repository.
- Expose REST endpoints to list, filter, fetch, and clear historical tool call records.
- Introduce a scheduled cleanup job to automatically delete tool call records older than a configurable retention period.
- Publish tool call lifecycle events as asynchronous CDI events in addition to the existing reactive messaging channel.

Bug Fixes:
- Ensure tool call argument redaction consistently strips reserved auth/meta arguments and masks sensitive fields before events are emitted or persisted.

Enhancements:
- Refactor event emission through a centralized EventNotifier bean used by both tools and code execution bridges, eliminating duplicated lifecycle event logic.
- Extend ToolCallEvent to centralize redaction of arguments, headers, and body, and derive persisted audit fields from events.
- Wire Infinispan integration for tool call records, including protostream schema and marshaller configuration.