### PR TITLE
Fix #1333: harden operator-managed pods and restrict CR-supplied images

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
@@ -200,6 +200,7 @@ public final class CapabilityResourceFactory {
         service.setName(serviceName);
 
         String serviceImage = capabilitiesSpec.getImage();
+        OperatorUtil.validateImageAllowed(serviceImage);
         service.setImage(serviceImage);
 
         // Resolve pull policy with fallback chain: component -> global -> default

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorUtil.java
@@ -2,8 +2,10 @@ package ai.wanaku.operator.util;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
@@ -30,7 +32,50 @@ public final class OperatorUtil {
     public static final String DEFAULT_PULL_POLICY = "IfNotPresent";
     public static final Set<String> VALID_PULL_POLICIES = Set.of("Always", "IfNotPresent", "Never");
 
+    /** Optional comma-separated allowlist of permitted container-image prefixes. */
+    public static final String ALLOWED_IMAGE_PREFIXES = "wanaku.operator.allowed-image-prefixes";
+
     private OperatorUtil() {}
+
+    /**
+     * Validates a custom-resource-supplied container image against the optional allowlist
+     * {@value #ALLOWED_IMAGE_PREFIXES} (comma-separated registry/repository prefixes). When the
+     * allowlist is empty (the default) any image is permitted; when configured, the image must
+     * start with one of the prefixes, otherwise reconciliation fails. This prevents a principal
+     * able to create/patch a {@code WanakuCapability}/{@code WanakuRouter} from scheduling an
+     * arbitrary, untrusted image.
+     *
+     * @param image the image reference from the custom resource (may be null or blank)
+     * @throws IllegalArgumentException if the image is not in the configured allowlist
+     */
+    public static void validateImageAllowed(String image) {
+        String allowlist = ConfigProvider.getConfig()
+                .getOptionalValue(ALLOWED_IMAGE_PREFIXES, String.class)
+                .orElse("");
+        validateImageAllowed(image, allowlist);
+    }
+
+    /**
+     * Package-private variant taking the allowlist explicitly, so the matching logic can be unit
+     * tested without configuration.
+     *
+     * @param image the image reference from the custom resource (may be null or blank)
+     * @param allowlist comma-separated allowed prefixes (empty disables the check)
+     * @throws IllegalArgumentException if the image is not in the allowlist
+     */
+    static void validateImageAllowed(String image, String allowlist) {
+        if (allowlist == null || allowlist.isBlank() || image == null || image.isBlank()) {
+            return;
+        }
+        boolean allowed = Arrays.stream(allowlist.split(","))
+                .map(String::trim)
+                .filter(prefix -> !prefix.isEmpty())
+                .anyMatch(image::startsWith);
+        if (!allowed) {
+            throw new IllegalArgumentException(
+                    "Container image '%s' is not in the allowed registries (%s)".formatted(image, allowlist));
+        }
+    }
 
     /**
      * Creates a Ready condition for a custom resource status.

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
@@ -75,6 +75,7 @@ public final class RouterResourceFactory {
         if (resource.getSpec().getRouter() != null
                 && resource.getSpec().getRouter().getImage() != null
                 && !resource.getSpec().getRouter().getImage().isEmpty()) {
+            OperatorUtil.validateImageAllowed(resource.getSpec().getRouter().getImage());
             routerContainer.setImage(resource.getSpec().getRouter().getImage());
             LOG.infof(
                     "Using custom router image: %s",
@@ -253,6 +254,7 @@ public final class RouterResourceFactory {
             final String image = routerSpec.getImage();
 
             if (image != null) {
+                OperatorUtil.validateImageAllowed(image);
                 service.setImage(image);
             }
 

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/camel-integration-capability-deployment.yaml
@@ -17,6 +17,13 @@ spec:
       containers:
       - name: camel-integration-capability
         image: quay.io/wanaku/camel-integration-capability:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         env:
         - name: REGISTRATION_URL
           value: ""

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-capability-deployment.yaml
@@ -26,6 +26,13 @@ spec:
         image: ""
         imagePullPolicy: IfNotPresent
         name: wanaku-capability
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 9000
           name: grpc

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -13,10 +13,19 @@ spec:
       labels:
         app: ""
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: "wanaku-mcp-router"
           image: quay.io/wanaku/wanaku-router-backend:0.0.8
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: AUTH_SERVER
               value: ""

--- a/apps/wanaku-operator/src/main/resources/application.properties
+++ b/apps/wanaku-operator/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 # Wanaku Operator Configuration
 
+# Optional allowlist of container-image prefixes the operator will deploy from custom resources
+# (comma-separated registry/repository prefixes). Empty (the default) allows any image; when set,
+# a WanakuCapability/WanakuRouter image that does not start with one of these prefixes is rejected.
+# wanaku.operator.allowed-image-prefixes=quay.io/wanaku/
+
 # HTTP Configuration
 quarkus.http.port=8081
 quarkus.devservices.enabled=false

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorUtilTest.java
@@ -10,8 +10,10 @@ import ai.wanaku.operator.wanaku.WanakuRouterSpec;
 import ai.wanaku.operator.wanaku.WanakuTypes;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OperatorUtilTest {
 
@@ -171,6 +173,33 @@ class OperatorUtilTest {
                 .build());
         router.setSpec(new WanakuRouterSpec());
         assertEquals("wanaku", OperatorUtil.resolveAuthRealm(router));
+    }
+
+    @Test
+    void validateImageAllowedAllowsAnyImageWhenAllowlistEmpty() {
+        assertDoesNotThrow(() -> OperatorUtil.validateImageAllowed("docker.io/library/anything:latest", ""));
+        assertDoesNotThrow(() -> OperatorUtil.validateImageAllowed("docker.io/library/anything:latest", "  "));
+    }
+
+    @Test
+    void validateImageAllowedAcceptsImageMatchingAllowlistedPrefix() {
+        assertDoesNotThrow(() ->
+                OperatorUtil.validateImageAllowed("quay.io/wanaku/wanaku-tool-service-http:latest", "quay.io/wanaku/"));
+        assertDoesNotThrow(() ->
+                OperatorUtil.validateImageAllowed("registry.internal/team/x:1", "quay.io/wanaku/, registry.internal/"));
+    }
+
+    @Test
+    void validateImageAllowedRejectsImageOutsideAllowlist() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OperatorUtil.validateImageAllowed("docker.io/evil/payload:latest", "quay.io/wanaku/"));
+    }
+
+    @Test
+    void validateImageAllowedSkipsBlankImage() {
+        assertDoesNotThrow(() -> OperatorUtil.validateImageAllowed(null, "quay.io/wanaku/"));
+        assertDoesNotThrow(() -> OperatorUtil.validateImageAllowed("", "quay.io/wanaku/"));
     }
 
     private static WanakuCapability createCapabilityWithRealm(String realm) {


### PR DESCRIPTION
Closes #1333

Hardens the workloads the operator generates and constrains the container image taken from custom
resources.

**Pod hardening** — adds a `securityContext` to the three operator-managed Deployment templates:
- `wanaku-router-deployment.yaml`: pod-level `runAsNonRoot` + `seccompProfile: RuntimeDefault` and
  container-level `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]` (the router image is
  the Quarkus UBI9 runtime, which runs non-root).
- `wanaku-capability-deployment.yaml` / `camel-integration-capability-deployment.yaml`: the same
  container-level hardening **without** `runAsNonRoot`, because a `WanakuCapability` image is
  caller-supplied and may legitimately not run as non-root; operators can add `runAsNonRoot` for
  images that support it.

**CR image allowlist** — `OperatorUtil.validateImageAllowed(...)` is now called before every
`setImage(...)` of a CR-supplied image (capability + router). It is governed by the optional
`wanaku.operator.allowed-image-prefixes` (comma-separated registry/repository prefixes). The default
is empty = no restriction (no behaviour change); when configured, reconciliation rejects images that
don't match an allowed prefix, so a tenant with CR create/patch rights can't schedule an arbitrary
image. Covered by new `OperatorUtilTest` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden operator-managed workloads and restrict which custom-resource-specified container images the operator will deploy.

New Features:
- Introduce an optional configuration property to allowlist container image prefixes that the operator may use from custom resources, rejecting images outside the list.

Enhancements:
- Add pod and container securityContext settings to operator-managed deployments to run workloads with a more restrictive security posture.

Documentation:
- Document the optional container-image prefix allowlist configuration property in application.properties.

Tests:
- Add unit tests covering the container-image allowlist validation logic, including allowed, rejected, and blank-image scenarios.