### PR TITLE
Fix #1336: stop persisting the LLM API key in browser localStorage

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -9,6 +9,7 @@ import {
   isConfigStoredInLocalStorage,
   LLM_CONFIG,
   LlmConfig,
+  persistConfig,
   STORE_IN_LOCAL_STORAGE
 } from "./config.ts"
 import {LLMSelect} from "./LLMSelect"
@@ -26,7 +27,7 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
   
   function applyConfigChange(config: LlmConfig) {
     if (isStoredInLocalStorage) {
-      localStorage.setItem(LLM_CONFIG, JSON.stringify(config))
+      persistConfig(config)
     }
     onChange(config)
   }
@@ -35,7 +36,7 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
     <Form>
       <Stack gap={5}>
         <Toggle
-          labelText="Store in Local Storage"
+          labelText="Store LLM settings in Local Storage (the API key is never saved)"
           labelA="Off"
           labelB="On"
           toggled={isStoredInLocalStorage}
@@ -43,7 +44,7 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
             localStorage.setItem(STORE_IN_LOCAL_STORAGE, value.toString())
             setStoreInLocalStorage(value)
             if (value) {
-              localStorage.setItem(LLM_CONFIG, JSON.stringify(config))
+              persistConfig(config)
             } else {
               localStorage.removeItem(LLM_CONFIG)
             }
@@ -69,6 +70,7 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
         <PasswordInput
           id="api-key"
           labelText="API Key"
+          helperText="For your security the API key is kept only in memory for this session and is never saved to local storage."
           placeholder="Type your API key here..."
           value={config.apiKey}
           onChange={(event) => {

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -31,11 +31,22 @@ export function loadConfig(): LlmConfig {
     if (config) {
       try {
         return JSON.parse(config)
-      } catch (error) {
+      } catch {
         console.log("Error loading config: " + config)
         return defaultLlmConfig()
       }
     }
   }
   return defaultLlmConfig()
+}
+
+/**
+ * Persists the LLM config to local storage, excluding the API key. The API key is sensitive and is
+ * kept in memory for the current session only — it is never written to local storage (where it
+ * would be readable by any script/extension on the page).
+ */
+export function persistConfig(config: LlmConfig) {
+  // JSON.stringify drops undefined values, so the api key is omitted from the stored payload.
+  const safe: LlmConfig = { ...config, apiKey: undefined }
+  localStorage.setItem(LLM_CONFIG, JSON.stringify(safe))
 }


### PR DESCRIPTION
Closes #1336

The LLM chat UI persisted the entire config — including the provider API key — to `localStorage` in
cleartext when "Store in Local Storage" was enabled, where any XSS or browser extension on the page
could read it.

The API key is now excluded from what is stored: every write goes through a new `persistConfig()`
that strips `apiKey`. The key is kept in React state for the session only and must be re-entered
after a reload. The toggle label and a helper text on the API Key field make this explicit.
Provider/model/params/tools are still persisted as before. Also cleans up a pre-existing unused
catch binding in the same file so it lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stop persisting LLM API keys in browser local storage and clarify how LLM settings are stored.

Bug Fixes:
- Exclude the LLM provider API key from configuration data written to browser local storage, keeping it only in session memory.

Enhancements:
- Introduce a dedicated config persistence helper that strips sensitive fields before saving and reuse it across the LLM setup UI.
- Update the LLM settings toggle label and API key field helper text to clearly communicate that API keys are never stored persistently.