### PR TITLE
Fix #1330: default-deny the public REST API surface

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -187,19 +187,23 @@ quarkus.http.auth.permission.oidcproxy.policy=permit
 quarkus.http.auth.permission.health.paths=/q/health/*
 quarkus.http.auth.permission.health.policy=permit
 
-# Management APIs, Data Store APIs, the LLM chat proxy and the v2 APIs (code execution and
-# tool-calls) must never be reachable anonymously. These carry a more specific path prefix than
-# the catch-all public rule below, so Quarkus' longest-prefix-wins matching gives them priority.
-# In "none" auth mode AuthConfigSource downgrades this policy to "permit" (see AuthConfigSource).
-quarkus.http.auth.permission.authenticated.paths=/api/v1/management/*, /api/v1/data-store/*, /api/v1/chat/*, /api/v2/*
+# Default-deny: ALL REST APIs require authentication. /api/v1/* and /api/v2/* carry a more specific
+# path prefix than the catch-all public rule below, so Quarkus' longest-prefix-wins matching gives
+# them priority over it. Only genuinely public paths (static UI, the public MCP namespace, health
+# and the OIDC discovery metadata) remain permitted. NOTE: under the default keycloak profile the
+# CLI must run `wanaku login` before it can call these endpoints. In "none" auth mode
+# AuthConfigSource downgrades this policy to "permit" (see AuthConfigSource).
+quarkus.http.auth.permission.authenticated.paths=/api/v1/*, /api/v2/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 
 # Restricted MCP namespaces
 quarkus.http.auth.permission.mcp-authenticated.paths=/mcp/*, /ns-0/*, /ns-1/*, /ns-2/*, /ns-3/*, /ns-4/*, /ns-5/*, /ns-6/*, /ns-7/*, /ns-8/*, /ns-9/*
 quarkus.http.auth.permission.mcp-authenticated.policy=authenticated
 
-# Public APIs and static resources
-quarkus.http.auth.permission.public.paths=/api/v1/*, /index.html, /*
+# Public: the admin UI static assets (SPA shell + Vite assets), the public MCP namespace
+# (/public/mcp) and the catch-all for other non-API resources. The sensitive REST APIs are covered
+# by the more-specific authenticated rule above, which therefore takes priority.
+quarkus.http.auth.permission.public.paths=/index.html, /*
 quarkus.http.auth.permission.public.policy=permit
 
 ## Admin UI, which requires authentication for all paths in the web interface

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/capabilities/AbstractCapabilitiesResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/capabilities/AbstractCapabilitiesResourceTest.java
@@ -227,7 +227,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
 
     @Test
     void testGetCapabilities_UpdatesWhenServiceAdded() {
-        int initialCount = given().when()
+        int initialCount = given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
@@ -256,7 +257,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
                 .extract()
                 .path("data.id");
 
-        given().when()
+        given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
@@ -303,7 +305,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
                 .path("data.id");
 
         // Verify it exists
-        given().when()
+        given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
@@ -329,7 +332,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
                 .statusCode(Response.Status.OK.getStatusCode());
 
         // Verify it's removed
-        given().when()
+        given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
@@ -351,7 +355,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
                                 .getStatusCode()); // Service registry accepts any string, validation happens at usage
 
         // Clean up
-        String serviceId = given().when()
+        String serviceId = given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
                 .extract()
@@ -375,13 +380,17 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
     }
 
     @Test
-    void testGetCapabilities_WithoutAuthentication_ShouldSucceed() {
-        // GET /api/v1/capabilities is a public endpoint and doesn't require authentication
-        given().when()
+    void testGetCapabilities_WithInvalidToken() {
+        // GET /api/v1/capabilities now requires authentication. When auth is enabled, a request with
+        // an invalid bearer token is rejected with 401; when auth is disabled the token is ignored
+        // and the endpoint responds normally.
+        int expected =
+                isAuthEnabled() ? Response.Status.UNAUTHORIZED.getStatusCode() : Response.Status.OK.getStatusCode();
+        given().header("Authorization", "Bearer invalid-token")
+                .when()
                 .get("/api/v1/capabilities")
                 .then()
-                .statusCode(Response.Status.OK.getStatusCode())
-                .body("data", notNullValue());
+                .statusCode(expected);
     }
 
     @Test
@@ -656,7 +665,8 @@ public abstract class AbstractCapabilitiesResourceTest extends WanakuRouterTest 
 
     @Test
     void testGetStaleCapabilities_WithNegativeMaxAge_ShouldHandleGracefully() {
-        given().queryParam("maxAgeSeconds", -1)
+        given().headers(getHeaders())
+                .queryParam("maxAgeSeconds", -1)
                 .when()
                 .get("/api/v1/capabilities/stale")
                 .then()

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/AbstractDiscoveryResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/management/discovery/AbstractDiscoveryResourceTest.java
@@ -48,7 +48,8 @@ public abstract class AbstractDiscoveryResourceTest extends WanakuRouterTest {
 
         LOG.infof("Created service with id %s", serviceId);
 
-        given().when()
+        given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities/")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
@@ -76,7 +77,8 @@ public abstract class AbstractDiscoveryResourceTest extends WanakuRouterTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode());
 
-        given().when()
+        given().headers(getHeaders())
+                .when()
                 .get("/api/v1/capabilities/")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())


### PR DESCRIPTION
Closes #1330

Inverts the router's REST authorization to default-deny: `/api/v1/*` and `/api/v2/*` now require
authentication, and only genuinely public paths (the admin UI static assets, the public MCP
namespace `/public/mcp`, `/q/health/*` and the OIDC discovery metadata) remain permitted. Quarkus'
longest-prefix-wins matching gives the `/api/v1/*` / `/api/v2/*` rules priority over the catch-all
`permit`.

Previously, with Keycloak enabled, the entire management surface (forwards, toolset-repos, tools,
resources, prompts, namespaces, capabilities, service-catalog, service-template — several of them
state-changing or SSRF-prone) was reachable anonymously. They now require a token.

**Behaviour change (agreed rollout):** the CLI default is left unchanged
(`wanaku.cli.auth.enabled=false`), so against a Keycloak-secured router users must now run
`wanaku login` before these endpoints respond. The admin UI already gates access behind `/admin`
(authenticated), so its API calls carry a token.

Verified: the noauth-profile resource tests pass (endpoints still reachable when the policy is
downgraded to permit). The keycloak-mode `*ResourceIT` tests authenticate with a Bearer token and
exercise the now-protected paths.

> [!NOTE]
> Please smoke-test `wanaku login` + a CLI call, and the admin UI, against a Keycloak router before
> merge — this changes the anonymous-access behaviour of the management API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Default-deny the router REST API so all /api/v1/* and /api/v2/* endpoints now require authentication, leaving only static UI, public MCP, health, and OIDC discovery metadata publicly accessible.

Bug Fixes:
- Prevent unauthenticated access to previously exposed management and data APIs by requiring authentication for all REST endpoints under /api/v1/* and /api/v2/*.

Enhancements:
- Clarify Quarkus HTTP auth configuration comments to document the default-deny behavior and the impact on CLI usage and public endpoints.