### PR TITLE
Set the default image - if none specified to 0.1.3

### DIFF
--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -19,7 +19,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: "wanaku-mcp-router"
-          image: quay.io/wanaku/wanaku-router-backend:0.0.8
+          image: quay.io/wanaku/wanaku-router-backend:0.1.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Change the wanaku-mcp-router container image tag from 0.0.8 to 0.1.3 in the router deployment manifest.