### PR TITLE
chore: refresh auto-generated OpenAPI spec files

### DIFF
--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -668,6 +668,55 @@
           }
         }
       },
+      "ToolCallRecord" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "eventId" : {
+            "type" : "string"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "timestamp" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "toolName" : {
+            "type" : "string"
+          },
+          "toolType" : {
+            "type" : "string"
+          },
+          "connectionId" : {
+            "type" : "string"
+          },
+          "serviceId" : {
+            "type" : "string"
+          },
+          "serviceAddress" : {
+            "type" : "string"
+          },
+          "error" : {
+            "type" : "boolean"
+          },
+          "duration" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "errorCategory" : {
+            "type" : "string"
+          },
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "argumentKeys" : {
+            "type" : "string"
+          }
+        }
+      },
       "ToolPayload" : {
         "type" : "object",
         "properties" : {
@@ -926,6 +975,20 @@
           }
         }
       },
+      "WanakuResponseListToolCallRecord" : {
+        "type" : "object",
+        "properties" : {
+          "error" : {
+            "$ref" : "#/components/schemas/WanakuError"
+          },
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ToolCallRecord"
+            }
+          }
+        }
+      },
       "WanakuResponseListToolReference" : {
         "type" : "object",
         "properties" : {
@@ -1063,6 +1126,17 @@
           },
           "data" : {
             "$ref" : "#/components/schemas/SystemStatistics"
+          }
+        }
+      },
+      "WanakuResponseToolCallRecord" : {
+        "type" : "object",
+        "properties" : {
+          "error" : {
+            "$ref" : "#/components/schemas/WanakuError"
+          },
+          "data" : {
+            "$ref" : "#/components/schemas/ToolCallRecord"
           }
         }
       },
@@ -1244,27 +1318,6 @@
         "tags" : [ "Capabilities Resource" ]
       }
     },
-    "/api/v1/chat/allowlist" : {
-      "get" : {
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "summary" : "Get Base Urls",
-        "tags" : [ "Llm Chat Resource" ]
-      }
-    },
     "/api/v1/chat/completions" : {
       "post" : {
         "requestBody" : {
@@ -1281,7 +1334,7 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "application/json" : {
+              "text/plain" : {
                 "schema" : {
                   "type" : "string"
                 }
@@ -1290,6 +1343,56 @@
           }
         },
         "summary" : "Code Completions",
+        "tags" : [ "Llm Chat Resource" ]
+      }
+    },
+    "/api/v1/chat/llms" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Get Allowed Llms",
+        "tags" : [ "Llm Chat Resource" ]
+      }
+    },
+    "/api/v1/chat/{llm}/models" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "llm",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Get Models",
         "tags" : [ "Llm Chat Resource" ]
       }
     },
@@ -3134,6 +3237,79 @@
         },
         "summary" : "Stream Results",
         "tags" : [ "Code Execution Resource" ]
+      }
+    },
+    "/api/v2/tool-calls/history" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "connectionId",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toolName",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WanakuResponseListToolCallRecord"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "List History",
+        "tags" : [ "Tool Call Resource" ]
+      },
+      "delete" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WanakuResponseInteger"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Clear History",
+        "tags" : [ "Tool Call Resource" ]
+      }
+    },
+    "/api/v2/tool-calls/history/{eventId}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "eventId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/WanakuResponseToolCallRecord"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Get History Event",
+        "tags" : [ "Tool Call Resource" ]
       }
     },
     "/api/v2/tool-calls/notifications" : {

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -456,6 +456,39 @@ components:
           type: string
         serviceSystem:
           type: string
+    ToolCallRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        eventId:
+          type: string
+        eventType:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+        toolName:
+          type: string
+        toolType:
+          type: string
+        connectionId:
+          type: string
+        serviceId:
+          type: string
+        serviceAddress:
+          type: string
+        error:
+          type: boolean
+        duration:
+          type: integer
+          format: int64
+        errorCategory:
+          type: string
+        errorMessage:
+          type: string
+        argumentKeys:
+          type: string
     ToolPayload:
       type: object
       properties:
@@ -623,6 +656,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/StaleCapabilityInfo"
+    WanakuResponseListToolCallRecord:
+      type: object
+      properties:
+        error:
+          $ref: "#/components/schemas/WanakuError"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ToolCallRecord"
     WanakuResponseListToolReference:
       type: object
       properties:
@@ -713,6 +755,13 @@ components:
           $ref: "#/components/schemas/WanakuError"
         data:
           $ref: "#/components/schemas/SystemStatistics"
+    WanakuResponseToolCallRecord:
+      type: object
+      properties:
+        error:
+          $ref: "#/components/schemas/WanakuError"
+        data:
+          $ref: "#/components/schemas/ToolCallRecord"
     WanakuResponseToolReference:
       type: object
       properties:
@@ -832,20 +881,6 @@ paths:
       summary: Tools State
       tags:
       - Capabilities Resource
-  /api/v1/chat/allowlist:
-    get:
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-      summary: Get Base Urls
-      tags:
-      - Llm Chat Resource
   /api/v1/chat/completions:
     post:
       requestBody:
@@ -858,10 +893,44 @@ paths:
         "200":
           description: OK
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
       summary: Code Completions
+      tags:
+      - Llm Chat Resource
+  /api/v1/chat/llms:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+      summary: Get Allowed Llms
+      tags:
+      - Llm Chat Resource
+  /api/v1/chat/{llm}/models:
+    get:
+      parameters:
+      - name: llm
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+      summary: Get Models
       tags:
       - Llm Chat Resource
   /api/v1/data-store:
@@ -2109,6 +2178,56 @@ paths:
       summary: Stream Results
       tags:
       - Code Execution Resource
+  /api/v2/tool-calls/history:
+    get:
+      parameters:
+      - name: connectionId
+        in: query
+        schema:
+          type: string
+      - name: toolName
+        in: query
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WanakuResponseListToolCallRecord"
+      summary: List History
+      tags:
+      - Tool Call Resource
+    delete:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WanakuResponseInteger"
+      summary: Clear History
+      tags:
+      - Tool Call Resource
+  /api/v2/tool-calls/history/{eventId}:
+    get:
+      parameters:
+      - name: eventId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WanakuResponseToolCallRecord"
+      summary: Get History Event
+      tags:
+      - Tool Call Resource
   /api/v2/tool-calls/notifications:
     get:
       responses:


### PR DESCRIPTION
## Summary

- Refreshes the auto-generated `openapi.json` and `openapi.yaml` files to include schemas added in recent commits (e.g., `ToolCallRecord`, `WanakuResponseListToolCallRecord`, tool-call history endpoints)

## Test plan

- [ ] No code changes — auto-generated files only
- [ ] Build produces identical output

## Summary by Sourcery

Update the OpenAPI specification artifacts to reflect newly available chat and tool-call APIs.

Enhancements:
- Document ToolCallRecord and related response wrapper schemas in the OpenAPI spec.
- Expose tool-call history list, clear, and detail endpoints in the OpenAPI documentation.
- Update chat LLM endpoints in the OpenAPI spec to cover completions, allowed LLMs, and per-LLM model listing.