### PR TITLE
chore: disable LabelHelperTest on Windows

### DIFF
--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
@@ -16,11 +16,14 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(OS.WINDOWS)
 class LabelHelperTest {
 
     private WanakuPrinter printer;


### PR DESCRIPTION
## Summary
- Disable `LabelHelperTest` on Windows using `@DisabledOnOs(OS.WINDOWS)` as the terminal-based tests take too long to run on that platform.

## Test plan
- [ ] Verify CI passes on Linux/macOS
- [ ] Verify the tests are skipped on Windows CI

## Summary by Sourcery

Tests:
- Mark LabelHelperTest with a JUnit @DisabledOnOs(OS.WINDOWS) annotation so it is skipped on Windows runs.