### PR TITLE
[UI] Storing model and API key for each LLM separately

### DIFF
--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -8,9 +8,9 @@ import {
   Tile
 } from "@carbon/react"
 import {Send, Stop} from "@carbon/icons-react"
-import {LlmConfig} from "./config"
 import {LLMChatMessage} from "./LLMChatMessage"
 import {getUrl} from "../../custom-fetch"
+import {ToolReference} from "../../models"
 
 
 interface ChatMessage {
@@ -18,13 +18,22 @@ interface ChatMessage {
   content: string
 }
 
-interface LLMChatAreaProps {
-  config: LlmConfig
+export interface LlmChatConfig {
+  llm: string
+  model?: string
+  apiKey?: string
+  selectedTools: ToolReference[]
+  extraLlmParams?: string
+  systemPrompt?: string
 }
 
-export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
+interface LLMChatAreaProps {
+  config: LlmChatConfig
+  onSystemPromptChange: (systemPrompt: string) => void
+}
+
+export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPromptChange }) => {
   
-  const [systemPrompt, setSystemPrompt] = useState("You are an assistant that can use tools.")
   const [userPrompt, setUserPrompt] = useState("")
   const [displayedMessages, setDisplayedMessages] = useState<ChatMessage[]>([])
   const [isRunning, setIsRunning] = useState(false)
@@ -54,12 +63,12 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
         },
         body: JSON.stringify({
           llm: config.llm,
-          model: config.llmModel,
+          model: config.model,
           apiKey: config.apiKey,
-          systemPrompt: systemPrompt,
+          systemPrompt: config.systemPrompt,
           userPrompt: userPrompt,
           chatHistory: filteredChatHistory(),
-          selectedTools: config.tools.map(tool => tool.name),
+          selectedTools: config.selectedTools.map(tool => tool.name),
           extraLlmParams: config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {}
         })
       })
@@ -127,9 +136,10 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config }) => {
             id="system-input"
             labelText="System message"
             placeholder="Type system message here..."
-            value={systemPrompt}
+            value={config.systemPrompt}
             onChange={(event) => {
-              setSystemPrompt(event.target.value)
+              const systemPrompt = event.target.value
+              onSystemPromptChange(systemPrompt)
             }}
             rows={4}
           />

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -2,14 +2,42 @@ import React, {useState} from "react"
 import "highlight.js/styles/atom-one-dark.css"
 import {LLMSetup} from "./LLMSetup.tsx"
 import {LLMTools} from "./LLMTools.tsx"
-import {LLMChatArea} from "./LLMChatArea.tsx"
+import {LLMChatArea, LlmChatConfig} from "./LLMChatArea"
 import {Column, Grid} from "@carbon/react"
-import {LlmConfig, loadConfig} from "./config.ts"
+import {
+  isConfigStoredInLocalStorage,
+  LLM_CONFIG,
+  LlmConfig,
+  loadConfig,
+  persistConfig,
+  STORE_IN_LOCAL_STORAGE
+} from "./config"
 
 
 export const LLMChatPage: React.FC = () => {
   
+  const [isStoredInLocalStorage, setStoreInLocalStorage] = useState(isConfigStoredInLocalStorage())
   const [config, setConfig] = useState<LlmConfig>(loadConfig())
+  
+  
+  function applyConfigChange(config: LlmConfig) {
+    if (isStoredInLocalStorage) {
+      persistConfig(config)
+    }
+    setConfig(config)
+  }
+  
+  function createChatConfig(): LlmChatConfig {
+    const llm = config.selectedLlm
+    return {
+      llm: llm,
+      model: config.llms[llm].selectedModel,
+      apiKey: config.llms[llm].apiKey,
+      extraLlmParams: config.llms[llm].extraLlmParams,
+      selectedTools: config.selectedTools,
+      systemPrompt: config.systemPrompt
+    }
+  }
   
   return (
     <div>
@@ -18,19 +46,34 @@ export const LLMChatPage: React.FC = () => {
         <Column lg={4}>
           <LLMSetup
             config={config}
-            onChange={(config: LlmConfig) => {
-              setConfig({ ...config })}
-            }
+            stored={isStoredInLocalStorage}
+            onConfigChange={(config: LlmConfig) => {
+              applyConfigChange(config)
+            }}
+            onStoredChange={(value: boolean) => {
+              localStorage.setItem(STORE_IN_LOCAL_STORAGE, value.toString())
+              setStoreInLocalStorage(value)
+              if (value) {
+                persistConfig(config)
+              } else {
+                localStorage.removeItem(LLM_CONFIG)
+              }
+            }}
           />
           <LLMTools
-            selectedTools={config.tools}
-            onSelectionChange={(tools) => {
-              setConfig({ ...config, tools })
+            selectedTools={config.selectedTools}
+            onSelectionChange={(selectedTools) => {
+              applyConfigChange({ ...config, selectedTools })
             }}
           />
         </Column>
         <Column lg={12}>
-          <LLMChatArea config={config} />
+          <LLMChatArea
+            config={createChatConfig()}
+            onSystemPromptChange={(systemPrompt) => {
+              applyConfigChange({ ...config, systemPrompt })
+            }}
+          />
         </Column>
       </Grid>
     </div>

--- a/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMSetup.tsx
@@ -1,37 +1,32 @@
-import React, {useState} from "react"
+import React from "react"
 import {
   Form,
-  PasswordInput, Stack,
+  PasswordInput,
+  Stack,
   TextArea,
   Toggle
 } from "@carbon/react"
-import {
-  isConfigStoredInLocalStorage,
-  LLM_CONFIG,
-  LlmConfig,
-  persistConfig,
-  STORE_IN_LOCAL_STORAGE
-} from "./config.ts"
+import {LlmConfig, OLLAMA} from "./config"
 import {LLMSelect} from "./LLMSelect"
 import {LLMModelComboBox} from "./LLMModelComboBox"
 
 
 interface LLMSetupProps {
   config: LlmConfig
-  onChange: (config: LlmConfig) => void
+  stored: boolean
+  onConfigChange: (config: LlmConfig) => void
+  onStoredChange: (store: boolean) => void
 }
 
-export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
+export const LLMSetup: React.FC<LLMSetupProps> = ({ config, stored, onConfigChange, onStoredChange }) => {
+
+  const selectedLlm = config.selectedLlm
+  const selectedModel = config.llms[selectedLlm].selectedModel
+  const apiKey = config.llms[selectedLlm].apiKey
+  const extraLlmParams = config.llms[selectedLlm].extraLlmParams
   
-  const [isStoredInLocalStorage, setStoreInLocalStorage] = useState<boolean>(isConfigStoredInLocalStorage())
-  
-  function applyConfigChange(config: LlmConfig) {
-    if (isStoredInLocalStorage) {
-      persistConfig(config)
-    }
-    onChange(config)
-  }
-  
+  const isApiKeyRequired = selectedLlm !== OLLAMA
+
   return (
     <Form>
       <Stack gap={5}>
@@ -39,54 +34,53 @@ export const LLMSetup: React.FC<LLMSetupProps> = ({ config, onChange }) => {
           labelText="Store LLM settings in Local Storage (the API key is never saved)"
           labelA="Off"
           labelB="On"
-          toggled={isStoredInLocalStorage}
-          onToggle={(value: boolean) => {
-            localStorage.setItem(STORE_IN_LOCAL_STORAGE, value.toString())
-            setStoreInLocalStorage(value)
-            if (value) {
-              persistConfig(config)
-            } else {
-              localStorage.removeItem(LLM_CONFIG)
-            }
-          }}
+          toggled={stored}
+          onToggle={onStoredChange}
           id="enabledLocalStorage"
         />
         <LLMSelect
           id="base-url"
           labelText="LLM API"
-          value={config.llm || ""}
-          onChange={(llm: string) => {
-            applyConfigChange({ ...config, llm })
+          value={selectedLlm}
+          onChange={(selectedLlm: string) => {
+            onConfigChange({ ...config, selectedLlm })
           }}
         />
         <LLMModelComboBox
           labelText="LLM Model"
-          llm={config.llm || ""}
-          value={config.llmModel}
-          onChange={(llmModel) => {
-            applyConfigChange({ ...config, llmModel })
+          llm={selectedLlm}
+          value={selectedModel}
+          onChange={(selectedModel: string) => {
+            const newConfig = structuredClone(config)
+            newConfig.llms[selectedLlm].selectedModel = selectedModel
+            onConfigChange(newConfig)
           }}
         />
-        <PasswordInput
-          id="api-key"
-          labelText="API Key"
-          helperText="For your security the API key is kept only in memory for this session and is never saved to local storage."
-          placeholder="Type your API key here..."
-          value={config.apiKey}
-          onChange={(event) => {
-            const apiKey = event.target.value
-            applyConfigChange({ ...config, apiKey })
-          }}
-          size="md"
-        />
+        {isApiKeyRequired && (
+          <PasswordInput
+            id="api-key"
+            labelText="API Key"
+            placeholder="Type your API key here..."
+            value={apiKey}
+            onChange={(event) => {
+              const apiKey = event.target.value
+              const newConfig = structuredClone(config)
+              newConfig.llms[selectedLlm].apiKey = apiKey
+              onConfigChange(newConfig)
+            }}
+            size="md"
+          />
+        )}
         <TextArea
           id="extra-llm-input"
           labelText="Extra LLM Parameters"
           placeholder='Json format, e.g. {"max_tokens":400,"temperature":0.7,"tool_choice":"auto"}'
-          value={config.extraLlmParams}
+          value={extraLlmParams}
           onChange={(event) => {
             const extraLlmParams = event.target.value
-            applyConfigChange({ ...config, extraLlmParams })
+            const newConfig = structuredClone(config)
+            newConfig.llms[selectedLlm].extraLlmParams = extraLlmParams
+            onConfigChange(newConfig)
           }}
           rows={4}
         />

--- a/apps/ui/admin/src/Pages/LLMChat/config.ts
+++ b/apps/ui/admin/src/Pages/LLMChat/config.ts
@@ -1,38 +1,84 @@
 import {ToolReference} from "../../models"
 
+export const STORE_IN_LOCAL_STORAGE = "storeInLocalStorage"
+export const LLM_CONFIG = "llmConfig"
+
+export const ANTHROPIC = "Anthropic"
+export const GEMINI = "Gemini"
+export const MISTRAL = "Mistral"
+export const OLLAMA = "Ollama"
+export const OPENAI = "OpenAi"
+
+const DEFAULT_EXTRA_LLM_PARAMS = ""
+const DEFAULT_SYSTEM_PROMPT = "You are helpful assistant that can use tools."
+const DEFAULT_LLM = "Mistral"
+const DEFAULT_ANTHROPIC_MODEL = "claude-4-6-sonnet"
+const DEFAULT_GEMINI_MODEL = "gemini-3.5-flash"
+const DEFAULT_MISTRAL_MODEL = "mistral-small-latest"
+const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini"
 
 export interface LlmConfig {
-  llm?: string | null
-  llmModel?: string
-  apiKey?: string
-  extraLlmParams?: string
-  tools: ToolReference[]
+  selectedLlm: string
+  llms: Record<string, { selectedModel: string, apiKey?: string, extraLlmParams: string } >
+  selectedTools: ToolReference[]
+  systemPrompt: string
 }
 
 export function defaultLlmConfig(): LlmConfig {
   return {
-    llm: "Mistral",
-    llmModel: "mistral-small-latest",
-    extraLlmParams: '{"max_tokens": 400, "temperature": 0.7, "tool_choice": "auto"}',
-    tools: []
+    selectedLlm: DEFAULT_LLM,
+    selectedTools: [],
+    llms: {
+      [ANTHROPIC]: createSubconfig(DEFAULT_ANTHROPIC_MODEL),
+      [GEMINI]: createSubconfig(DEFAULT_GEMINI_MODEL),
+      [MISTRAL]: createSubconfig(DEFAULT_MISTRAL_MODEL),
+      [OLLAMA]: createSubconfig(""),
+      [OPENAI]: createSubconfig(DEFAULT_OPENAI_MODEL)
+    },
+    systemPrompt: DEFAULT_SYSTEM_PROMPT
   }
 }
-
-export const STORE_IN_LOCAL_STORAGE = "storeInLocalStorage"
-export const LLM_CONFIG = "llmConfig"
 
 export function isConfigStoredInLocalStorage() {
   return localStorage.getItem(STORE_IN_LOCAL_STORAGE) === "true"
 }
 
+function createSubconfig(model: string) {
+  return { selectedModel: model, extraLlmParams: DEFAULT_EXTRA_LLM_PARAMS }
+}
+
+function parseConfig(json: string): LlmConfig {
+  const config: LlmConfig = JSON.parse(json)
+  config.selectedLlm ??= DEFAULT_LLM
+  config.llms ??= {}
+  config.llms[ANTHROPIC] ??= createSubconfig(DEFAULT_ANTHROPIC_MODEL)
+  config.llms[ANTHROPIC].selectedModel ??= DEFAULT_ANTHROPIC_MODEL
+  config.llms[ANTHROPIC].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.llms[GEMINI] ??= createSubconfig(DEFAULT_GEMINI_MODEL)
+  config.llms[GEMINI].selectedModel ??= DEFAULT_GEMINI_MODEL
+  config.llms[GEMINI].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.llms[MISTRAL] ??= createSubconfig(DEFAULT_MISTRAL_MODEL)
+  config.llms[MISTRAL].selectedModel ??= DEFAULT_MISTRAL_MODEL
+  config.llms[MISTRAL].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.llms[OLLAMA] ??= createSubconfig("")
+  config.llms[OLLAMA].selectedModel ??= ""
+  config.llms[OLLAMA].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.llms[OPENAI] ??= createSubconfig(DEFAULT_OPENAI_MODEL)
+  config.llms[OPENAI].selectedModel ??= DEFAULT_OPENAI_MODEL
+  config.llms[OPENAI].extraLlmParams ??= DEFAULT_EXTRA_LLM_PARAMS
+  config.selectedTools ??= []
+  config.systemPrompt ??= DEFAULT_SYSTEM_PROMPT
+  return config
+}
+
 export function loadConfig(): LlmConfig {
   if (isConfigStoredInLocalStorage()) {
-    const config = localStorage.getItem(LLM_CONFIG)
-    if (config) {
+    const configJson = localStorage.getItem(LLM_CONFIG)
+    if (configJson) {
       try {
-        return JSON.parse(config)
-      } catch {
-        console.log("Error loading config: " + config)
+        return parseConfig(configJson)
+      } catch (error) {
+        console.log(`Error loading config: ${error}`)
         return defaultLlmConfig()
       }
     }
@@ -47,6 +93,9 @@ export function loadConfig(): LlmConfig {
  */
 export function persistConfig(config: LlmConfig) {
   // JSON.stringify drops undefined values, so the api key is omitted from the stored payload.
-  const safe: LlmConfig = { ...config, apiKey: undefined }
-  localStorage.setItem(LLM_CONFIG, JSON.stringify(safe))
+  const safeConfig: LlmConfig = structuredClone(config)
+  for (let llm in safeConfig.llms) {
+    safeConfig.llms[llm].apiKey = undefined
+  }
+  localStorage.setItem(LLM_CONFIG, JSON.stringify(safeConfig))
 }


### PR DESCRIPTION
LLM Chat enhancement

This enhancement stores LLM model and API key for each LLM separately, allowing the user to conveniently switch between multiple LLMs.

Key changes:
- LLM model and API key are linked to specific LLM
- System prompt is stored as well 
- if broken, the LLM config tries to repair itself by providing default values
- API key field is not displayed for Ollama, since there is no use for it

Note: API key are still deleted before saving to local storage to comply with recent code change

## Summary by Sourcery

Store per-LLM chat configuration and propagate it through the UI

New Features:
- Maintain separate model, API key, extra parameters, and system prompt per LLM provider and use the selected LLM’s config when sending chat requests

Enhancements:
- Persist and restore the new LLM configuration structure from local storage with automatic repair/defaulting for missing fields
- Move the system prompt into the shared LLM config so it is retained across sessions and reflected in the chat area
- Hide the API key input when Ollama is selected, since it does not require an API key