### PR TITLE
chore(deps): bump jline.version from 3.30.6 to 4.2.1

### DIFF
--- a/apps/wanaku-cli/pom.xml
+++ b/apps/wanaku-cli/pom.xml
@@ -34,10 +34,11 @@
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
+                <classifier>jdk11</classifier>
             </dependency>
             <dependency>
                 <groupId>org.jline</groupId>
-                <artifactId>jline-console-ui</artifactId>
+                <artifactId>jline-prompt</artifactId>
                 <version>${jline.version}</version>
             </dependency>
 
@@ -127,11 +128,12 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
+            <classifier>jdk11</classifier>
         </dependency>
 
         <dependency>
             <groupId>org.jline</groupId>
-            <artifactId>jline-console-ui</artifactId>
+            <artifactId>jline-prompt</artifactId>
         </dependency>
 
         <dependency>

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
@@ -3,15 +3,21 @@ package ai.wanaku.cli.main.commands.capabilities;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.jline.consoleui.prompt.ConsolePrompt;
-import org.jline.consoleui.prompt.PromptResultItemIF;
-import org.jline.consoleui.prompt.builder.ListPromptBuilder;
-import org.jline.consoleui.prompt.builder.PromptBuilder;
+import org.jline.prompt.ListBuilder;
+import org.jline.prompt.ListResult;
+import org.jline.prompt.PromptBuilder;
+import org.jline.prompt.PromptResult;
+import org.jline.prompt.Prompter;
+import org.jline.prompt.PrompterConfig;
+import org.jline.prompt.PrompterFactory;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.CapabilitiesHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.CapabilitiesService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 import static ai.wanaku.cli.main.support.CapabilitiesHelper.API_TIMEOUT;
 import static ai.wanaku.cli.main.support.CapabilitiesHelper.fetchAndMergeCapabilities;
@@ -158,28 +164,24 @@ public class CapabilitiesShow extends BaseCommand {
 
         printer.printWarningMessage("Multiple capabilities found for the " + service + " service. Please choose one.");
 
-        ConsolePrompt.UiConfig uiConfig = new ConsolePrompt.UiConfig("=> ", "[]", "[x]", "-");
-        ConsolePrompt prompt = new ConsolePrompt(terminal, uiConfig);
+        Prompter prompter =
+                PrompterFactory.create(terminal, PrompterConfig.custom("=> ", "[]", "[x]", "-", null, false));
+        PromptBuilder builder = prompter.newBuilder();
 
-        PromptBuilder builder = prompt.getPromptBuilder();
-
-        // Create interactive selection prompt
-        ListPromptBuilder listPromptBuilder =
+        ListBuilder listPromptBuilder =
                 builder.createListPrompt().name(SELECTION_PROMPT_NAME).message("Select a capability instance:");
 
         // Add each capability as a selectable option with formatted display text
         for (int i = 0; i < capabilities.size(); i++) {
             CapabilitiesHelper.PrintableCapability capability = capabilities.get(i);
             String displayText = formatCapabilityChoice(capability);
-
             listPromptBuilder.newItem(String.valueOf(i)).text(displayText).add();
         }
         listPromptBuilder.addPrompt();
-
         try {
-            Map<String, PromptResultItemIF> result = prompt.prompt(builder.build());
-            int selectedIndex =
-                    Integer.parseInt(result.get(SELECTION_PROMPT_NAME).getResult());
+            Map<String, ? extends PromptResult<?>> result = prompter.prompt(List.of(), builder.build());
+            ListResult selection = (ListResult) result.get(SELECTION_PROMPT_NAME);
+            int selectedIndex = Integer.parseInt(selection.getSelectedId());
             printCapabilityDetails(printer, capabilities.get(selectedIndex));
             return EXIT_OK;
         } catch (Exception e) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
@@ -10,11 +10,15 @@ import java.util.Map;
 import org.jline.builtins.ConfigurationPath;
 import org.jline.builtins.Nano;
 import org.jline.builtins.Options;
-import org.jline.consoleui.elements.ConfirmChoice;
-import org.jline.consoleui.prompt.ConsolePrompt;
-import org.jline.consoleui.prompt.PromptResultItemIF;
-import org.jline.consoleui.prompt.builder.ListPromptBuilder;
-import org.jline.consoleui.prompt.builder.PromptBuilder;
+import org.jline.prompt.ConfirmResult;
+import org.jline.prompt.ListBuilder;
+import org.jline.prompt.ListResult;
+import org.jline.prompt.Prompt;
+import org.jline.prompt.PromptBuilder;
+import org.jline.prompt.PromptResult;
+import org.jline.prompt.Prompter;
+import org.jline.prompt.PrompterConfig;
+import org.jline.prompt.PrompterFactory;
 import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -116,18 +120,19 @@ public class ToolsEdit extends BaseCommand {
      * @throws IOException if an I/O error occurs during the prompt.
      */
     public boolean confirm(Terminal terminal, ToolReference tool) throws IOException {
-        ConsolePrompt prompt = new ConsolePrompt(terminal);
-        PromptBuilder builder = prompt.getPromptBuilder();
+        Prompter prompter = PrompterFactory.create(terminal);
+        PromptBuilder builder = prompter.newBuilder();
         // Create a simple yes/no prompt
 
-        builder.createConfirmPromp()
+        builder.createConfirmPrompt()
                 .name("continue")
                 .message("Do you want to update the '" + tool.getName() + "' tool?")
-                .defaultValue(ConfirmChoice.ConfirmationValue.NO)
+                .defaultValue(false)
                 .addPrompt();
 
-        Map<String, PromptResultItemIF> result = prompt.prompt(builder.build());
-        return "YES".equalsIgnoreCase(result.get("continue").getResult());
+        Map<String, ? extends PromptResult<? extends Prompt>> result = prompter.prompt(List.of(), builder.build());
+        ConfirmResult confirmResult = (ConfirmResult) result.get("continue");
+        return confirmResult.isConfirmed();
     }
 
     /**
@@ -168,22 +173,22 @@ public class ToolsEdit extends BaseCommand {
      */
     public ToolReference selectTool(Terminal terminal, List<ToolReference> list) throws IOException {
 
-        ConsolePrompt.UiConfig uiConfig = new ConsolePrompt.UiConfig("=> ", "[]", "[x]", "-");
-        ConsolePrompt prompt = new ConsolePrompt(terminal, uiConfig);
+        Prompter prompter =
+                PrompterFactory.create(terminal, PrompterConfig.custom("=> ", "[]", "[x]", "-", null, false));
+        PromptBuilder builder = prompter.newBuilder();
 
-        PromptBuilder builder = prompt.getPromptBuilder();
-
-        ListPromptBuilder lpb = builder.createListPrompt()
+        ListBuilder lpb = builder.createListPrompt()
                 .name("tool")
                 .message("Choose the tool you want to edit:")
                 .pageSize(5);
 
         List<Item> items = formatTable(list);
 
-        items.stream().forEach(x -> lpb.newItem().text(x.text).name(x.id).add());
+        items.stream().forEach(x -> lpb.newItem(x.id).text(x.text).add());
         lpb.addPrompt();
-        Map<String, PromptResultItemIF> result = prompt.prompt(builder.build());
-        String toolId = result.get("tool").getResult();
+        Map<String, ? extends PromptResult<? extends Prompt>> result = prompter.prompt(List.of(), builder.build());
+        ListResult selection = (ListResult) result.get("tool");
+        String toolId = selection.getSelectedId();
         ToolReference tool =
                 list.stream().filter(x -> x.getId().equals(toolId)).findFirst().orElse(null);
         return tool;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/CommandHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/CommandHelper.java
@@ -1,11 +1,14 @@
 package ai.wanaku.cli.main.support;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import org.jline.consoleui.elements.ConfirmChoice;
-import org.jline.consoleui.prompt.ConsolePrompt;
-import org.jline.consoleui.prompt.PromptResultItemIF;
-import org.jline.consoleui.prompt.builder.PromptBuilder;
+import org.jline.prompt.ConfirmResult;
+import org.jline.prompt.Prompt;
+import org.jline.prompt.PromptBuilder;
+import org.jline.prompt.PromptResult;
+import org.jline.prompt.Prompter;
+import org.jline.prompt.PrompterFactory;
 import org.jline.terminal.Terminal;
 
 /**
@@ -26,17 +29,18 @@ public class CommandHelper {
      * @throws IOException if an I/O error occurs during the prompt.
      */
     public static boolean confirm(Terminal terminal, String message) throws IOException {
-        ConsolePrompt prompt = new ConsolePrompt(terminal);
-        PromptBuilder builder = prompt.getPromptBuilder();
+        Prompter prompter = PrompterFactory.create(terminal);
+        PromptBuilder builder = prompter.newBuilder();
         // Create a simple yes/no prompt
 
-        builder.createConfirmPromp()
+        builder.createConfirmPrompt()
                 .name("continue")
                 .message(message)
-                .defaultValue(ConfirmChoice.ConfirmationValue.NO)
+                .defaultValue(false)
                 .addPrompt();
 
-        Map<String, PromptResultItemIF> result = prompt.prompt(builder.build());
-        return "YES".equalsIgnoreCase(result.get("continue").getResult());
+        Map<String, ? extends PromptResult<? extends Prompt>> result = prompter.prompt(List.of(), builder.build());
+        ConfirmResult confirmResult = (ConfirmResult) result.get("continue");
+        return confirmResult.isConfirmed();
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -158,27 +158,16 @@ public class WanakuPrinter extends DefaultPrinter {
     public static Terminal terminalInstance() throws IOException {
         if (plainMode) {
             // Plain mode: route I/O through System.in/System.out with no ANSI escapes
-            // Disable all native providers (JNI, JNA, Jansi) to avoid loading issues
-            return newBuilder()
-                    .jansi(false)
-                    .jni(false)
-                    .jna(false)
-                    .color(false)
-                    .system(true)
-                    .build();
+            // Disable JNI and colors to avoid loading issues
+            return newBuilder().jni(false).color(false).build();
         }
 
         try {
-            // First attempt: Jansi-backed terminal with color support
-            return newBuilder().jansi(true).color(true).jna(false).build();
+            // First attempt: system terminal with color support
+            return newBuilder().build();
         } catch (Exception e) {
-            // Second attempt: without Jansi (native library may be unavailable)
-            try {
-                return newBuilder().jansi(false).jna(false).build();
-            } catch (Exception ex) {
-                // Final fallback: dumb terminal (no colors, but always works)
-                return TerminalBuilder.builder().dumb(true).build();
-            }
+            // Final fallback: dumb terminal (no colors, but always works)
+            return TerminalBuilder.builder().dumb(true).build();
         }
     }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
         <commons-pool2.version>2.13.1</commons-pool2.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <swagger-core.version>2.2.50</swagger-core.version>
-        <jline.version>3.30.6</jline.version>
+        <jline.version>4.2.1</jline.version>
         <swagger-parser.version>2.1.44</swagger-parser.version>
         <quarkus-infinispan-embedded.version>2.0.1</quarkus-infinispan-embedded.version>
         <!-- TEMPORARY: quarkus-infinispan-embedded wrongly set infinispan to 16.0.9


### PR DESCRIPTION
- use jdk11 classifier to be compatible to jdk 21
- fixed deprecations

## Summary by Sourcery

Update CLI to use JLine 4.x prompt APIs and JDK 11–compatible terminal while simplifying terminal fallback handling.

Bug Fixes:
- Ensure JLine terminal usage is compatible with JDK 21 by using the JDK 11 classifier artifacts.

Enhancements:
- Migrate interactive prompts from jline-console-ui to jline-prompt across CLI commands.
- Simplify terminal initialization and fallback behavior in WanakuPrinter to rely on the new JLine defaults.

Build:
- Bump JLine dependency from 3.30.6 to 4.2.1 and switch console UI dependency to jline-prompt with the jdk11 classifier where required.