### PR TITLE
Add test plan writing guide to contributing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ make install
 - `wanaku service deploy` packages and deploys directly to router REST API
 - Route ID extraction uses indentation-aware parsing (route-level only, ignores step-level IDs)
 
+## Test Plans
+
+- Test plans live under `tests/plans/`, reusable steps under `tests/plans/common/`
+- Guidelines for writing test plans are in `docs/contributing.md` (section "Writing Test Plans")
+
 ## Acceptance Criteria
 
 - Major features should have tests

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -295,7 +295,113 @@ There are multiple ways you can test Wanaku and the integrations you develop.
 1. Wanaku's LLMchat page in the Web UI
 2. You can use the [MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) to easily test your tool or provider.
 3. Use the maintained test suites under `tests/integration`, `tests/mcp-servers`, and `tests/load`.
-4. Any agent application (such as [HyperChat](https://github.com/BigSweetPotatoStudio/HyperChat))
+4. Follow or create test plans under `tests/plans/` (see [Writing Test Plans](#writing-test-plans) below).
+5. Any agent application (such as [HyperChat](https://github.com/BigSweetPotatoStudio/HyperChat))
+
+### Writing Test Plans
+
+Test plans are Markdown documents under `tests/plans/` designed for execution by both humans and AI agents.
+
+#### Structure
+
+A test plan has three layers:
+
+1. **Main plan** (`tests/plans/<name>.md`) — the test scenario with phases and assertions.
+2. **Common steps** (`tests/plans/common/*.md`) — reusable procedures shared across plans (Keycloak setup, namespace creation, cleanup).
+3. **Environment variables** — all configurable values declared upfront so the same plan works across versions and clusters.
+
+#### Phases, not scripts
+
+Organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
+
+```
+Phase 0: Manual prerequisites
+Phase 1: Environment setup
+Phase 2-N: Test scenarios
+Phase N+1: Cleanup
+```
+
+#### Every step must be verifiable
+
+Each step needs: a command, an expected outcome, and a PASS/FAIL assertion. Avoid steps that only run a command without checking the result.
+
+```bash
+# Bad — runs but doesn't verify
+oc apply -f my-resource.yaml
+
+# Good — verifies the outcome
+oc apply -f my-resource.yaml
+oc wait myresource/name --for=condition=Ready --timeout=120s -n "${NAMESPACE}"
+```
+
+#### Prefer polling over sleeping
+
+Use `oc wait`, `oc rollout status`, or a polling loop instead of fixed `sleep` calls. Clusters vary in speed — a 10s sleep that works locally may fail in CI and waste time on fast clusters.
+
+```bash
+# Bad
+sleep 15
+oc get deployment foo
+
+# Good — deterministic wait
+oc wait --for=condition=Available deployment/foo --timeout=120s -n "${NAMESPACE}"
+
+# Good — polling for deletion
+while oc get deployment foo -n "${NAMESPACE}" > /dev/null 2>&1; do
+  sleep 3
+done
+```
+
+#### Parametrize images and versions
+
+Never hard-code image tags. Define environment variables with sensible defaults so the same plan can test different releases.
+
+```bash
+export MY_IMAGE="${MY_IMAGE:-quay.io/org/component:latest}"
+```
+
+Then use `${MY_IMAGE}` in CR specs and image assertions.
+
+#### Extract reusable steps into common docs
+
+If a procedure appears in more than one plan (or is likely to), move it to `tests/plans/common/`. The common doc should:
+
+- List its prerequisites and required environment variables.
+- Document output variables it sets for subsequent steps.
+- Be self-contained — runnable without reading the main plan.
+
+Reference common docs from the main plan with a link and a brief note on what variables must be set before and after:
+
+```markdown
+Follow [common/keycloak-setup.md](common/keycloak-setup.md). After completion,
+`KEYCLOAK_URL` and `WANAKU_OIDC_SECRET` must be set.
+```
+
+#### Keep the main plan lean
+
+The main plan should only contain logic unique to that test scenario. If a step duplicates a common doc, replace it with a reference. This prevents drift between documents.
+
+#### Shell compatibility
+
+Use POSIX-compatible constructs. Avoid bash-only features like `${!VAR}` (indirect expansion) since the executor may use zsh or sh. If bash is required, wrap the block in `bash -c '...'`.
+
+#### Include negative tests
+
+Verify that invalid inputs are rejected gracefully — missing required fields, references to non-existent resources, malformed data. These often catch real bugs.
+
+#### Cleanup must be idempotent
+
+Use `--ignore-not-found=true` on all delete commands and `2>/dev/null || true` on wait commands. A cleanup phase that fails on missing resources makes re-runs painful.
+
+#### Checklist for new plans
+
+- [ ] All configurable values are environment variables with defaults
+- [ ] Common procedures reference shared docs, not inline copies
+- [ ] Every step has a PASS/FAIL assertion
+- [ ] No fixed `sleep` — use `oc wait`, `oc rollout status`, or polling
+- [ ] Negative tests are included
+- [ ] Cleanup is idempotent
+- [ ] Shell constructs are POSIX-compatible
 
 ## Deploying to the Development Environment
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -314,7 +314,7 @@ A test plan has three layers:
 
 Organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
 
-```
+```text
 Phase 0: Manual prerequisites
 Phase 1: Environment setup
 Phase 2-N: Test scenarios


### PR DESCRIPTION
## Summary

- Adds a "Writing Test Plans" section to `docs/contributing.md` covering structure, conventions, and a checklist for new plans
- Adds a pointer in `CLAUDE.md` directing to the contributing guide for test plan details

## Test plan

- [ ] Review guide content for completeness
- [ ] Verify CLAUDE.md pointer is accurate

## Summary by Sourcery

Document guidelines for authoring reusable, verifiable test plans and surface them in contributor and AI assistant docs.

Documentation:
- Add a "Writing Test Plans" section to the contributing guide outlining structure, conventions, and a checklist for test plans.
- Document the location and reuse conventions for test plans and common steps in CLAUDE.md so contributors and AI agents can find the guidelines.