### PR TITLE
Add service account setup for operator test plans

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -290,6 +290,10 @@ video that shows how to use the MCP Inspector to perform these steps.
 
 ## Testing
 
+> [!IMPORTANT]
+> When running operator test plans on OpenShift, use a dedicated service account instead of your personal (admin) credentials.
+> See [Service Account Setup](../tests/plans/setup/service-account-setup.md) for instructions.
+
 There are multiple ways you can test Wanaku and the integrations you develop.
 
 1. Wanaku's LLMchat page in the Web UI

--- a/tests/plans/setup/create-service-account.sh
+++ b/tests/plans/setup/create-service-account.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+TOKEN_DURATION="${TOKEN_DURATION:-8760h}"
+
+echo "=== Wanaku Test Service Account Setup ==="
+echo "Namespace: ${WANAKU_NAMESPACE}"
+
+# 1. Create namespace if it doesn't exist
+if oc get namespace "${WANAKU_NAMESPACE}" > /dev/null 2>&1; then
+  echo "PASS: namespace ${WANAKU_NAMESPACE} already exists"
+else
+  oc new-project "${WANAKU_NAMESPACE}" --display-name="Wanaku Operator Test" 2>/dev/null \
+    || oc create namespace "${WANAKU_NAMESPACE}"
+  echo "PASS: namespace ${WANAKU_NAMESPACE} created"
+fi
+
+# 2. Create the ServiceAccount
+if oc get serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}" > /dev/null 2>&1; then
+  echo "PASS: serviceaccount wanaku-test-runner already exists"
+else
+  oc create serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}"
+  echo "PASS: serviceaccount wanaku-test-runner created"
+fi
+
+# 3. Create the ClusterRole with minimum required permissions
+cat <<EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wanaku-test-runner
+  labels:
+    app.kubernetes.io/part-of: wanaku-test
+rules:
+  # Namespace/project management
+  - apiGroups: ["", "project.openshift.io"]
+    resources: ["namespaces", "projects", "projectrequests"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+
+  # CRDs (Helm install/uninstall)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # RBAC (Helm creates ClusterRoles/Bindings for the operator)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Core resources
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "services", "persistentvolumeclaims",
+                 "configmaps", "secrets", "serviceaccounts", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Deployments and ReplicaSets
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # OpenShift Routes
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Ingresses
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Wanaku custom resources
+  - apiGroups: ["wanaku.ai"]
+    resources: ["wanakurouters", "wanakurouters/status", "wanakurouters/finalizers",
+                 "wanakucapabilities", "wanakucapabilities/status", "wanakucapabilities/finalizers",
+                 "wanakuservicecatalogs", "wanakuservicecatalogs/status", "wanakuservicecatalogs/finalizers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Self subject access review (oc auth can-i)
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["selfsubjectaccessreviews"]
+    verbs: ["create"]
+EOF
+echo "PASS: clusterrole wanaku-test-runner applied"
+
+# 4. Bind the ClusterRole to the ServiceAccount
+if oc get clusterrolebinding wanaku-test-runner > /dev/null 2>&1; then
+  echo "PASS: clusterrolebinding wanaku-test-runner already exists"
+else
+  oc create clusterrolebinding wanaku-test-runner \
+    --clusterrole=wanaku-test-runner \
+    --serviceaccount="${WANAKU_NAMESPACE}:wanaku-test-runner"
+  echo "PASS: clusterrolebinding wanaku-test-runner created"
+fi
+
+# 5. Generate a token
+echo ""
+echo "=== Service Account Token ==="
+TOKEN=$(oc create token wanaku-test-runner -n "${WANAKU_NAMESPACE}" --duration="${TOKEN_DURATION}")
+echo "${TOKEN}"
+echo ""
+echo "To log in as this service account:"
+echo "  oc login <cluster-api-url> --token=<token-above>"
+echo ""
+echo "To verify:"
+echo "  oc whoami"
+echo "  # Expected: system:serviceaccount:${WANAKU_NAMESPACE}:wanaku-test-runner"

--- a/tests/plans/setup/service-account-setup.md
+++ b/tests/plans/setup/service-account-setup.md
@@ -1,0 +1,57 @@
+# Service Account Setup for Test Plans
+
+Running operator test plans with your personal (admin) credentials is dangerous. This guide creates a dedicated service account with only the permissions the test plans require.
+
+## Prerequisites
+
+- `oc` CLI logged in as a cluster admin (one-time setup)
+- The `wanaku-test` namespace (created by the test plans or manually)
+
+## Quick Start
+
+From the repository root:
+
+```bash
+# Create the service account and RBAC
+./tests/plans/setup/create-service-account.sh
+
+# Save the token for CI or local use
+export WANAKU_TEST_TOKEN=$(oc create token wanaku-test-runner -n wanaku-test --duration=8760h)
+```
+
+Then log in as the service account instead of your admin user:
+
+```bash
+oc login <cluster-api-url> --token=${WANAKU_TEST_TOKEN}
+oc whoami
+# Expected: system:serviceaccount:wanaku-test:wanaku-test-runner
+```
+
+## What the Service Account Can Do
+
+| Allowed | Not Allowed |
+|---|---|
+| Create/delete test namespaces | Manage nodes or machines |
+| Install/uninstall the operator Helm chart | Manage PVs or StorageClasses |
+| CRUD on deployments, services, routes, PVCs | Manage SecurityContextConstraints |
+| CRUD on Wanaku custom resources (CRDs) | Manage OLM operators |
+| Read pod logs, exec into pods | Impersonate other users |
+| Manage ClusterRoles/Bindings (for Helm) | Access cluster infrastructure |
+
+## Token Management
+
+The `create-service-account.sh` script prints a token valid for 1 year. For CI systems, store it as a secret (e.g., GitHub Actions `OPENSHIFT_SA_TOKEN`).
+
+To rotate the token:
+
+```bash
+oc create token wanaku-test-runner -n wanaku-test --duration=8760h
+```
+
+## Teardown
+
+To remove the service account and all RBAC resources:
+
+```bash
+./tests/plans/setup/teardown-service-account.sh
+```

--- a/tests/plans/setup/teardown-service-account.sh
+++ b/tests/plans/setup/teardown-service-account.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+
+echo "=== Wanaku Test Service Account Teardown ==="
+echo "Namespace: ${WANAKU_NAMESPACE}"
+
+oc delete clusterrolebinding wanaku-test-runner --ignore-not-found=true
+echo "PASS: clusterrolebinding deleted"
+
+oc delete clusterrole wanaku-test-runner --ignore-not-found=true
+echo "PASS: clusterrole deleted"
+
+oc delete serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
+echo "PASS: serviceaccount deleted"
+
+echo ""
+echo "Done. The namespace ${WANAKU_NAMESPACE} was not deleted (it may contain other resources)."


### PR DESCRIPTION
## Summary

- Adds `tests/plans/setup/` with scripts and docs for creating a least-privilege service account to run operator test plans on OpenShift
- `create-service-account.sh` creates the SA, ClusterRole, ClusterRoleBinding, and prints a login token
- `teardown-service-account.sh` removes the RBAC resources
- Updates `docs/contributing.md` to reference the service account setup

This avoids running operator tests with personal admin credentials, reducing the blast radius if something goes wrong.

## Test plan
- [ ] Run `create-service-account.sh` on an OpenShift cluster and verify the SA is created with correct RBAC
- [ ] Log in with the generated token and verify `oc whoami` shows the service account
- [ ] Run the operator test plan using the SA token
- [ ] Run `teardown-service-account.sh` and verify cleanup

## Summary by Sourcery

Add dedicated OpenShift service account tooling and docs for running operator test plans without personal admin credentials.

Documentation:
- Document operator test plan service account setup and reference it from the contributor testing guide.

Tests:
- Introduce scripts to create and tear down a least-privilege OpenShift service account and RBAC for running operator test plans.