### PR TITLE
Fix #1374: handle null auth spec in operator for noauth mode

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariableHelper.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/EnvironmentVariableHelper.java
@@ -28,14 +28,18 @@ public final class EnvironmentVariableHelper {
     public static List<EnvVar> computeWanakuCapabilitiesEnvVars(
             WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
 
-        final String authServer = resource.getSpec().getAuth().getAuthServer();
-
-        List<EnvVar> envVars = buildCommonEnvVars(
-                resource,
-                authServer,
-                EnvironmentVariables.AUTH_SERVER,
-                EnvironmentVariables.WANAKU_SERVICE_REGISTRATION_URI,
-                EnvironmentVariables.QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET);
+        List<EnvVar> envVars;
+        WanakuTypes.AuthSpec authSpec = resource.getSpec().getAuth();
+        if (authSpec != null) {
+            envVars = buildCommonEnvVars(
+                    resource,
+                    authSpec.getAuthServer(),
+                    EnvironmentVariables.AUTH_SERVER,
+                    EnvironmentVariables.WANAKU_SERVICE_REGISTRATION_URI,
+                    EnvironmentVariables.QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET);
+        } else {
+            envVars = new java.util.ArrayList<>();
+        }
 
         addCustomVars(capabilitiesSpec.getEnv(), envVars);
         return envVars;
@@ -51,15 +55,21 @@ public final class EnvironmentVariableHelper {
     public static List<EnvVar> computeCamelIntegrationCapabilitiesEnvVars(
             WanakuCapability resource, WanakuCapabilitySpec.CapabilitiesSpec capabilitiesSpec) {
 
-        String realm = OperatorUtil.resolveAuthRealm(resource);
-        String authServerValue = resource.getSpec().getAuth().getAuthServer() + "/realms/" + realm;
+        List<EnvVar> envVars;
+        WanakuTypes.AuthSpec authSpec = resource.getSpec().getAuth();
+        if (authSpec != null) {
+            String realm = OperatorUtil.resolveAuthRealm(resource);
+            String authServerValue = authSpec.getAuthServer() + "/realms/" + realm;
 
-        List<EnvVar> envVars = buildCommonEnvVars(
-                resource,
-                authServerValue,
-                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT,
-                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_REGISTRATION_URL,
-                EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_SECRET);
+            envVars = buildCommonEnvVars(
+                    resource,
+                    authServerValue,
+                    EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT,
+                    EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_REGISTRATION_URL,
+                    EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_SECRET);
+        } else {
+            envVars = new java.util.ArrayList<>();
+        }
 
         envVars.add(new EnvVarBuilder()
                 .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_NAME)

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
@@ -208,38 +208,37 @@ public final class RouterResourceFactory {
                 .findFirst()
                 .get();
 
-        final String authServer = resource.getSpec().getAuth().getAuthServer();
-
-        // If a proxy is not defined,
-        String authProxy = resource.getSpec().getAuth().getAuthProxy();
-        if ("auto".equals(authProxy)) {
-            // TODO: needs to support https
-            authProxy = String.format("http://%s", host);
-        } else {
-            if (authProxy == null) {
-                authProxy = authServer;
-            }
-        }
-
-        String realm = OperatorUtil.resolveAuthRealm(resource);
-
-        EnvVar authServerEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_SERVER)
-                .withValue(authServer)
-                .build();
-        EnvVar authProxyEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_PROXY)
-                .withValue(authProxy)
-                .build();
-        EnvVar authRealmEnv = new EnvVarBuilder()
-                .withName(EnvironmentVariables.AUTH_REALM)
-                .withValue(realm)
-                .build();
-
         List<EnvVar> envVars = new java.util.ArrayList<>();
-        envVars.add(authServerEnv);
-        envVars.add(authProxyEnv);
-        envVars.add(authRealmEnv);
+
+        final WanakuTypes.AuthSpec authSpec = resource.getSpec().getAuth();
+        if (authSpec != null) {
+            final String authServer = authSpec.getAuthServer();
+
+            String authProxy = authSpec.getAuthProxy();
+            if ("auto".equals(authProxy)) {
+                // TODO: needs to support https
+                authProxy = String.format("http://%s", host);
+            } else {
+                if (authProxy == null) {
+                    authProxy = authServer;
+                }
+            }
+
+            String realm = OperatorUtil.resolveAuthRealm(resource);
+
+            envVars.add(new EnvVarBuilder()
+                    .withName(EnvironmentVariables.AUTH_SERVER)
+                    .withValue(authServer)
+                    .build());
+            envVars.add(new EnvVarBuilder()
+                    .withName(EnvironmentVariables.AUTH_PROXY)
+                    .withValue(authProxy)
+                    .build());
+            envVars.add(new EnvVarBuilder()
+                    .withName(EnvironmentVariables.AUTH_REALM)
+                    .withValue(realm)
+                    .build());
+        }
 
         final WanakuRouterSpec.RouterSpec routerSpec = resource.getSpec().getRouter();
 


### PR DESCRIPTION
## Summary

- Guard `getAuth()` calls with null checks in `RouterResourceFactory.setupBackendContainer()` and both methods in `EnvironmentVariableHelper`
- When `auth` spec is absent (noauth mode), auth-related env vars are simply skipped instead of causing a NullPointerException

## Test plan

- [ ] Deploy operator and create a WanakuRouter CR without an `auth` block — reconciliation should succeed
- [ ] Deploy with an `auth` block — auth env vars should still be set as before

## Summary by Sourcery

Handle missing authentication configuration in operator resources without failing.

Bug Fixes:
- Avoid NullPointerExceptions in router backend container setup when the auth specification is absent.
- Prevent NullPointerExceptions when computing capabilities environment variables if the auth specification is missing.