### PR TITLE
chore: fix download URLs for early-access releases

### DIFF
--- a/get-wanaku.sh
+++ b/get-wanaku.sh
@@ -93,7 +93,11 @@ fetch_latest_version() {
 }
 
 build_download_url() {
-    local base="https://github.com/${REPO}/releases/download/${VERSION}"
+    local tag="${VERSION}"
+    if echo "$VERSION_NUM" | grep -q 'SNAPSHOT'; then
+        tag="early-access"
+    fi
+    local base="https://github.com/${REPO}/releases/download/${tag}"
 
     if [ "$PLATFORM" = "java" ]; then
         ARTIFACT="wanaku-cli-${VERSION_NUM}.zip"

--- a/src/jreleaser/changelog.tpl
+++ b/src/jreleaser/changelog.tpl
@@ -6,9 +6,9 @@ The CLI is used to manage and interact with the Wanaku MCP Router.
 
 | Platform | File |
 |---|---|
-| **Linux (x86_64)** | [wanaku-cli-{{projectVersion}}-linux-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}-linux-x86_64.zip) |
-| **macOS (Apple Silicon)** | [wanaku-cli-{{projectVersion}}-osx-aarch_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}-osx-aarch_64.zip) |
-| **Java (all platforms)** | [wanaku-cli-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-cli-{{projectVersion}}.zip) |
+| **Linux (x86_64)** | [wanaku-cli-{{projectVersion}}-linux-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-cli-{{projectVersion}}-linux-x86_64.zip) |
+| **macOS (Apple Silicon)** | [wanaku-cli-{{projectVersion}}-osx-aarch_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-cli-{{projectVersion}}-osx-aarch_64.zip) |
+| **Java (all platforms)** | [wanaku-cli-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-cli-{{projectVersion}}.zip) |
 
 > **Tip:** You can also install via JBang: `jbang app install wanaku@wanaku-ai/wanaku`
 
@@ -16,14 +16,14 @@ The CLI is used to manage and interact with the Wanaku MCP Router.
 
 | Component | File |
 |---|---|
-| Router Backend | [wanaku-router-backend-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-router-backend-{{projectVersion}}.zip) |
+| Router Backend | [wanaku-router-backend-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-router-backend-{{projectVersion}}.zip) |
 
 ### Capability Services (Tools)
 
 | Service | File |
 |---|---|
-| HTTP | [wanaku-tool-service-http-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-tool-service-http-{{projectVersion}}.zip) |
-| Exec | [wanaku-tool-service-exec-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/v{{projectVersion}}/wanaku-tool-service-exec-{{projectVersion}}.zip) |
+| HTTP | [wanaku-tool-service-http-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-tool-service-http-{{projectVersion}}.zip) |
+| Exec | [wanaku-tool-service-exec-{{projectVersion}}.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-tool-service-exec-{{projectVersion}}.zip) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix `get-wanaku.sh` to use the `early-access` release tag for SNAPSHOT versions instead of `v{version}`
- Fix `changelog.tpl` to use `{{tagName}}` instead of hardcoded `v{{projectVersion}}` in download URLs, so early-access releases point to the correct GitHub release

## Test plan
- [ ] Verify early-access release page download links resolve to `https://github.com/wanaku-ai/wanaku/releases/download/early-access/...`
- [ ] Verify normal release download links still resolve to `https://github.com/wanaku-ai/wanaku/releases/download/v{version}/...`
- [ ] Run `get-wanaku.sh` against a SNAPSHOT version and confirm it downloads from the `early-access` tag

## Summary by Sourcery

Update release download URLs to support early-access tags and ensure SNAPSHOT installs resolve correctly.

Bug Fixes:
- Ensure changelog download links use the dynamic release tag name so early-access releases point to the correct GitHub assets.
- Ensure the install script downloads SNAPSHOT versions from the early-access release tag instead of a versioned tag.

Documentation:
- Update changelog template download URLs to reference {{tagName}} rather than a hardcoded version tag.