### PR TITLE
chore: fix jar path in wanaku.bat for Windows

### DIFF
--- a/apps/wanaku-cli/src/main/scripts/wanaku.bat
+++ b/apps/wanaku-cli/src/main/scripts/wanaku.bat
@@ -8,4 +8,4 @@ if exist "%~dp0wanaku-cli.exe" (
     exit /b %ERRORLEVEL%
 )
 
-@java -jar "%~dp0..\quarkus-run.jar" %*
+@java -jar "%~dp0quarkus-run.jar" %*


### PR DESCRIPTION
## Summary
- Fix incorrect jar path in `wanaku.bat` — `%~dp0..\quarkus-run.jar` pointed to the parent directory instead of the script's own directory
- Changed to `%~dp0quarkus-run.jar` so `wanaku.bat start local` works on Windows

## Test plan
- [ ] Run `wanaku.bat start local` on Windows and confirm the router starts

## Summary by Sourcery

Bug Fixes:
- Correct quarkus-run.jar path in wanaku.bat so the CLI starts correctly on Windows.