### PR TITLE
chore: increase default router start wait from 5s to 30s

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuCliConfig.java
@@ -64,7 +64,7 @@ public interface WanakuCliConfig extends WanakuConfig {
      * Maximum number of seconds to wait for the local router readiness
      * endpoint before starting capability services.
      */
-    @WithDefault("5")
+    @WithDefault("30")
     int routerStartWaitSecs();
 
     @WithDefault("local")


### PR DESCRIPTION
## Summary
- Increase `routerStartWaitSecs` default from 5 to 30 seconds
- On Windows, the Quarkus router can take well over 5 seconds to start after re-augmentation
- The readiness check polls every 500ms, so faster machines still return immediately — the higher default only affects the maximum wait

## Test plan
- [ ] Run `wanaku start local` on Windows and confirm the router starts successfully
- [ ] Verify on Linux/Mac that startup still returns quickly (no unnecessary waiting)

## Summary by Sourcery

Increase the default maximum wait time for the local router readiness check.

Bug Fixes:
- Allow more time for the local router to become ready before capability services start, reducing startup failures on slower systems.

Enhancements:
- Raise the default routerStartWaitSecs configuration from 5 to 30 seconds to better accommodate slower router startups.