### PR TITLE
Add wanaku mcp CLI commands for direct MCP server interaction

### DIFF
--- a/apps/wanaku-cli/pom.xml
+++ b/apps/wanaku-cli/pom.xml
@@ -85,6 +85,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ai.wanaku</groupId>
+            <artifactId>core-mcp-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/CliMain.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/CliMain.java
@@ -14,6 +14,7 @@ import ai.wanaku.cli.main.commands.configure.Configure;
 import ai.wanaku.cli.main.commands.datastores.DataStores;
 import ai.wanaku.cli.main.commands.forwards.Forwards;
 import ai.wanaku.cli.main.commands.man.Man;
+import ai.wanaku.cli.main.commands.mcp.Mcp;
 import ai.wanaku.cli.main.commands.namespaces.Namespaces;
 import ai.wanaku.cli.main.commands.prompts.Prompts;
 import ai.wanaku.cli.main.commands.resources.Resources;
@@ -39,6 +40,7 @@ import picocli.CommandLine;
             Tools.class,
             ToolSet.class,
             Namespaces.class,
+            Mcp.class,
             Man.class,
             Completion.class,
             DataStores.class,

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/Mcp.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/Mcp.java
@@ -1,0 +1,19 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "mcp",
+        description = "Interact with MCP servers directly",
+        subcommands = {McpTool.class, McpResource.class, McpPrompt.class})
+public class Mcp extends BaseCommand {
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        CommandLine.usage(this, System.out);
+        return EXIT_OK;
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -1,0 +1,70 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpGetPromptResult;
+import dev.langchain4j.mcp.client.McpPromptMessage;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "prompt",
+        description = "Get a prompt from an MCP server",
+        subcommands = {McpPromptList.class})
+public class McpPrompt extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    @CommandLine.Option(
+            names = {"--name"},
+            description = "Name of the prompt to get",
+            required = true)
+    String name;
+
+    @CommandLine.Option(
+            names = {"--arg"},
+            description = "Prompt argument in key=value format (repeatable)",
+            split = ",")
+    Map<String, String> args = new LinkedHashMap<>();
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            Map<String, Object> promptArgs = new LinkedHashMap<>(args);
+            McpGetPromptResult result = client.getPrompt(name, promptArgs);
+            List<McpPromptMessage> messages = result.messages();
+
+            if (messages.isEmpty()) {
+                printer.printInfoMessage("Prompt returned no messages");
+                return EXIT_OK;
+            }
+
+            for (McpPromptMessage message : messages) {
+                printer.println(message.toString());
+            }
+
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -20,14 +20,12 @@ public class McpPrompt extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--uri"},
-            description = "MCP server endpoint URI",
-            required = true)
+            description = "MCP server endpoint URI")
     String uri;
 
     @CommandLine.Option(
             names = {"--name"},
-            description = "Name of the prompt to get",
-            required = true)
+            description = "Name of the prompt to get")
     String name;
 
     @CommandLine.Option(
@@ -40,6 +38,14 @@ public class McpPrompt extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        if (uri == null) {
+            printer.printErrorMessage("Missing required option: --uri");
+            return EXIT_ERROR;
+        }
+        if (name == null) {
+            printer.printErrorMessage("Missing required option: --name");
+            return EXIT_ERROR;
+        }
         try (McpClient client = resolveClient()) {
             Map<String, Object> promptArgs = new LinkedHashMap<>(args);
             McpGetPromptResult result = client.getPrompt(name, promptArgs);
@@ -51,7 +57,7 @@ public class McpPrompt extends BaseCommand {
             }
 
             for (McpPromptMessage message : messages) {
-                printer.println(message.toString());
+                System.out.println(message.toString());
             }
 
             return EXIT_OK;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -1,0 +1,53 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.List;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "list", description = "List prompts available on an MCP server")
+public class McpPromptList extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            List<dev.langchain4j.mcp.client.McpPrompt> prompts = client.listPrompts();
+
+            if (prompts.isEmpty()) {
+                printer.printInfoMessage("No prompts found");
+                return EXIT_OK;
+            }
+
+            for (dev.langchain4j.mcp.client.McpPrompt prompt : prompts) {
+                printer.println(String.format("%-30s %s", prompt.name(), nullSafe(prompt.description())));
+            }
+
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+
+    private static String nullSafe(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -30,7 +30,7 @@ public class McpPromptList extends BaseCommand {
             }
 
             for (dev.langchain4j.mcp.client.McpPrompt prompt : prompts) {
-                printer.println(String.format("%-30s %s", prompt.name(), nullSafe(prompt.description())));
+                System.out.println(String.format("%-30s %s", prompt.name(), nullSafe(prompt.description())));
             }
 
             return EXIT_OK;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -1,0 +1,61 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.List;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpReadResourceResult;
+import dev.langchain4j.mcp.client.McpResourceContents;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "resource",
+        description = "Read a resource from an MCP server",
+        subcommands = {McpResourceList.class})
+public class McpResource extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    @CommandLine.Option(
+            names = {"--resource-uri"},
+            description = "URI of the resource to read",
+            required = true)
+    String resourceUri;
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            McpReadResourceResult result = client.readResource(resourceUri);
+            List<McpResourceContents> contents = result.contents();
+
+            if (contents.isEmpty()) {
+                printer.printInfoMessage("Resource returned no content");
+                return EXIT_OK;
+            }
+
+            for (McpResourceContents content : contents) {
+                printer.println(content.toString());
+            }
+
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -18,20 +18,26 @@ public class McpResource extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--uri"},
-            description = "MCP server endpoint URI",
-            required = true)
+            description = "MCP server endpoint URI")
     String uri;
 
     @CommandLine.Option(
             names = {"--resource-uri"},
-            description = "URI of the resource to read",
-            required = true)
+            description = "URI of the resource to read")
     String resourceUri;
 
     McpClient mcpClient;
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        if (uri == null) {
+            printer.printErrorMessage("Missing required option: --uri");
+            return EXIT_ERROR;
+        }
+        if (resourceUri == null) {
+            printer.printErrorMessage("Missing required option: --resource-uri");
+            return EXIT_ERROR;
+        }
         try (McpClient client = resolveClient()) {
             McpReadResourceResult result = client.readResource(resourceUri);
             List<McpResourceContents> contents = result.contents();
@@ -42,7 +48,7 @@ public class McpResource extends BaseCommand {
             }
 
             for (McpResourceContents content : contents) {
-                printer.println(content.toString());
+                System.out.println(content.toString());
             }
 
             return EXIT_OK;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -30,7 +30,7 @@ public class McpResourceList extends BaseCommand {
             }
 
             for (dev.langchain4j.mcp.client.McpResource resource : resources) {
-                printer.println(String.format(
+                System.out.println(String.format(
                         "%-30s %-40s %s",
                         nullSafe(resource.name()), nullSafe(resource.uri()), nullSafe(resource.mimeType())));
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -1,0 +1,55 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.List;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "list", description = "List resources available on an MCP server")
+public class McpResourceList extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            List<dev.langchain4j.mcp.client.McpResource> resources = client.listResources();
+
+            if (resources.isEmpty()) {
+                printer.printInfoMessage("No resources found");
+                return EXIT_OK;
+            }
+
+            for (dev.langchain4j.mcp.client.McpResource resource : resources) {
+                printer.println(String.format(
+                        "%-30s %-40s %s",
+                        nullSafe(resource.name()), nullSafe(resource.uri()), nullSafe(resource.mimeType())));
+            }
+
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+
+    private static String nullSafe(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -1,0 +1,77 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jline.terminal.Terminal;
+import io.vertx.core.json.JsonObject;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "tool",
+        description = "Call a tool on an MCP server",
+        subcommands = {McpToolList.class})
+public class McpTool extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    @CommandLine.Option(
+            names = {"--name"},
+            description = "Name of the tool to call",
+            required = true)
+    String name;
+
+    @CommandLine.Option(
+            names = {"--param"},
+            description = "Tool parameter in key=value format (repeatable)",
+            split = ",")
+    Map<String, String> params = new LinkedHashMap<>();
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            ToolExecutionRequest request = ToolExecutionRequest.builder()
+                    .name(name)
+                    .arguments(serializeParams(params))
+                    .build();
+
+            ToolExecutionResult result = client.executeTool(request);
+            if (result.isError()) {
+                printer.printErrorMessage(result.resultText());
+                return EXIT_ERROR;
+            }
+
+            printer.println(result.resultText());
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+
+    static String serializeParams(Map<String, String> params) {
+        JsonObject json = new JsonObject();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            json.put(entry.getKey(), entry.getValue());
+        }
+        return json.toString();
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -20,14 +20,12 @@ public class McpTool extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--uri"},
-            description = "MCP server endpoint URI",
-            required = true)
+            description = "MCP server endpoint URI")
     String uri;
 
     @CommandLine.Option(
             names = {"--name"},
-            description = "Name of the tool to call",
-            required = true)
+            description = "Name of the tool to call")
     String name;
 
     @CommandLine.Option(
@@ -40,6 +38,14 @@ public class McpTool extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        if (uri == null) {
+            printer.printErrorMessage("Missing required option: --uri");
+            return EXIT_ERROR;
+        }
+        if (name == null) {
+            printer.printErrorMessage("Missing required option: --name");
+            return EXIT_ERROR;
+        }
         try (McpClient client = resolveClient()) {
             ToolExecutionRequest request = ToolExecutionRequest.builder()
                     .name(name)
@@ -52,7 +58,7 @@ public class McpTool extends BaseCommand {
                 return EXIT_ERROR;
             }
 
-            printer.println(result.resultText());
+            System.out.println(result.resultText());
             return EXIT_OK;
         } catch (Exception e) {
             printer.printErrorMessage(e.getMessage());

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -1,0 +1,54 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.List;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "list", description = "List tools available on an MCP server")
+public class McpToolList extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--uri"},
+            description = "MCP server endpoint URI",
+            required = true)
+    String uri;
+
+    McpClient mcpClient;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        try (McpClient client = resolveClient()) {
+            List<ToolSpecification> tools = client.listTools();
+
+            if (tools.isEmpty()) {
+                printer.printInfoMessage("No tools found");
+                return EXIT_OK;
+            }
+
+            for (ToolSpecification tool : tools) {
+                printer.println(String.format("%-30s %s", tool.name(), nullSafe(tool.description())));
+            }
+
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage(e.getMessage());
+            return EXIT_ERROR;
+        }
+    }
+
+    private McpClient resolveClient() {
+        if (mcpClient != null) {
+            return mcpClient;
+        }
+        return ClientUtil.createClient(uri);
+    }
+
+    private static String nullSafe(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -31,7 +31,7 @@ public class McpToolList extends BaseCommand {
             }
 
             for (ToolSpecification tool : tools) {
-                printer.println(String.format("%-30s %s", tool.name(), nullSafe(tool.description())));
+                System.out.println(String.format("%-30s %s", tool.name(), nullSafe(tool.description())));
             }
 
             return EXIT_OK;

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
@@ -1,0 +1,76 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.Collections;
+import java.util.List;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.mcp.client.McpClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpPromptListTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpPromptList command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpPromptList();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+    }
+
+    @Test
+    @DisplayName("Should list prompts from MCP server")
+    void shouldListPrompts() throws Exception {
+        dev.langchain4j.mcp.client.McpPrompt prompt1 =
+                new dev.langchain4j.mcp.client.McpPrompt("greeting", "A greeting prompt", null);
+        dev.langchain4j.mcp.client.McpPrompt prompt2 =
+                new dev.langchain4j.mcp.client.McpPrompt("summary", "Summarizes text", null);
+
+        when(mcpClient.listPrompts()).thenReturn(List.of(prompt1, prompt2));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println(String.format("%-30s %s", "greeting", "A greeting prompt"));
+        verify(printer).println(String.format("%-30s %s", "summary", "Summarizes text"));
+    }
+
+    @Test
+    @DisplayName("Should show info when no prompts found")
+    void shouldShowInfoWhenEmpty() throws Exception {
+        when(mcpClient.listPrompts()).thenReturn(Collections.emptyList());
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).printInfoMessage("No prompts found");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.listPrompts()).thenThrow(new RuntimeException("connection refused"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("connection refused");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,12 +45,18 @@ class McpPromptListTest {
 
         when(mcpClient.listPrompts()).thenReturn(List.of(prompt1, prompt2));
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println(String.format("%-30s %s", "greeting", "A greeting prompt"));
-        verify(printer).println(String.format("%-30s %s", "summary", "Summarizes text"));
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            String output = captured.toString();
+            assertTrue(output.contains("greeting"));
+            assertTrue(output.contains("summary"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
@@ -1,0 +1,86 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpGetPromptResult;
+import dev.langchain4j.mcp.client.McpPromptMessage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpPromptTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpPrompt command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpPrompt();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+        command.name = "greeting";
+        command.args = new LinkedHashMap<>(Map.of("name", "Alice"));
+    }
+
+    @Test
+    @DisplayName("Should get prompt and print messages")
+    void shouldGetPromptAndPrintMessages() throws Exception {
+        McpPromptMessage message = mock(McpPromptMessage.class);
+        when(message.toString()).thenReturn("Hello Alice!");
+        McpGetPromptResult promptResult = mock(McpGetPromptResult.class);
+        when(promptResult.messages()).thenReturn(List.of(message));
+
+        when(mcpClient.getPrompt(eq("greeting"), any())).thenReturn(promptResult);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println("Hello Alice!");
+    }
+
+    @Test
+    @DisplayName("Should show info when prompt returns no messages")
+    void shouldShowInfoWhenEmpty() throws Exception {
+        McpGetPromptResult emptyResult = mock(McpGetPromptResult.class);
+        when(emptyResult.messages()).thenReturn(Collections.emptyList());
+
+        when(mcpClient.getPrompt(eq("greeting"), any())).thenReturn(emptyResult);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).printInfoMessage("Prompt returned no messages");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.getPrompt(eq("greeting"), any())).thenThrow(new RuntimeException("not found"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("not found");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -50,11 +53,16 @@ class McpPromptTest {
 
         when(mcpClient.getPrompt(eq("greeting"), any())).thenReturn(promptResult);
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println("Hello Alice!");
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertTrue(captured.toString().contains("Hello Alice!"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
@@ -1,0 +1,77 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.Collections;
+import java.util.List;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.mcp.client.McpClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpResourceListTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpResourceList command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpResourceList();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+    }
+
+    @Test
+    @DisplayName("Should list resources from MCP server")
+    void shouldListResources() throws Exception {
+        dev.langchain4j.mcp.client.McpResource res1 =
+                new dev.langchain4j.mcp.client.McpResource("file:///data.csv", "data.csv", "A data file", "text/csv");
+        dev.langchain4j.mcp.client.McpResource res2 = new dev.langchain4j.mcp.client.McpResource(
+                "file:///config.json", "config.json", "Config", "application/json");
+
+        when(mcpClient.listResources()).thenReturn(List.of(res1, res2));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println(String.format("%-30s %-40s %s", "data.csv", "file:///data.csv", "text/csv"));
+        verify(printer)
+                .println(String.format("%-30s %-40s %s", "config.json", "file:///config.json", "application/json"));
+    }
+
+    @Test
+    @DisplayName("Should show info when no resources found")
+    void shouldShowInfoWhenEmpty() throws Exception {
+        when(mcpClient.listResources()).thenReturn(Collections.emptyList());
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).printInfoMessage("No resources found");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.listResources()).thenThrow(new RuntimeException("connection refused"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("connection refused");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,13 +45,18 @@ class McpResourceListTest {
 
         when(mcpClient.listResources()).thenReturn(List.of(res1, res2));
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println(String.format("%-30s %-40s %s", "data.csv", "file:///data.csv", "text/csv"));
-        verify(printer)
-                .println(String.format("%-30s %-40s %s", "config.json", "file:///config.json", "application/json"));
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            String output = captured.toString();
+            assertTrue(output.contains("data.csv"));
+            assertTrue(output.contains("config.json"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
@@ -1,0 +1,78 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.Collections;
+import java.util.List;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpReadResourceResult;
+import dev.langchain4j.mcp.client.McpTextResourceContents;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpResourceTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpResource command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpResource();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+        command.resourceUri = "file:///test.txt";
+    }
+
+    @Test
+    @DisplayName("Should read resource and print content")
+    void shouldReadResourceAndPrintContent() throws Exception {
+        McpTextResourceContents textContent =
+                new McpTextResourceContents("file:///test.txt", "Hello from resource", "text/plain");
+        McpReadResourceResult readResult = new McpReadResourceResult(List.of(textContent));
+
+        when(mcpClient.readResource("file:///test.txt")).thenReturn(readResult);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println(textContent.toString());
+    }
+
+    @Test
+    @DisplayName("Should show info when resource returns no content")
+    void shouldShowInfoWhenEmpty() throws Exception {
+        McpReadResourceResult emptyResult = new McpReadResourceResult(Collections.emptyList());
+        when(mcpClient.readResource("file:///test.txt")).thenReturn(emptyResult);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).printInfoMessage("Resource returned no content");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.readResource("file:///test.txt")).thenThrow(new RuntimeException("not found"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("not found");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,11 +47,16 @@ class McpResourceTest {
 
         when(mcpClient.readResource("file:///test.txt")).thenReturn(readResult);
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println(textContent.toString());
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertTrue(captured.toString().contains("Hello from resource"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
@@ -1,0 +1,81 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.Collections;
+import java.util.List;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpToolListTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpToolList command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpToolList();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+    }
+
+    @Test
+    @DisplayName("Should list tools from MCP server")
+    void shouldListTools() throws Exception {
+        ToolSpecification tool1 = ToolSpecification.builder()
+                .name("echo")
+                .description("Echoes the input")
+                .build();
+        ToolSpecification tool2 = ToolSpecification.builder()
+                .name("add")
+                .description("Adds two numbers")
+                .build();
+
+        when(mcpClient.listTools()).thenReturn(List.of(tool1, tool2));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println(String.format("%-30s %s", "echo", "Echoes the input"));
+        verify(printer).println(String.format("%-30s %s", "add", "Adds two numbers"));
+    }
+
+    @Test
+    @DisplayName("Should show info when no tools found")
+    void shouldShowInfoWhenEmpty() throws Exception {
+        when(mcpClient.listTools()).thenReturn(Collections.emptyList());
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).printInfoMessage("No tools found");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.listTools()).thenThrow(new RuntimeException("connection refused"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("connection refused");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,12 +50,18 @@ class McpToolListTest {
 
         when(mcpClient.listTools()).thenReturn(List.of(tool1, tool2));
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println(String.format("%-30s %s", "echo", "Echoes the input"));
-        verify(printer).println(String.format("%-30s %s", "add", "Adds two numbers"));
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            String output = captured.toString();
+            assertTrue(output.contains("echo"));
+            assertTrue(output.contains("add"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -1,0 +1,96 @@
+package ai.wanaku.cli.main.commands.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpToolTest {
+
+    @Mock
+    McpClient mcpClient;
+
+    McpTool command;
+
+    @BeforeEach
+    void setUp() {
+        command = new McpTool();
+        command.mcpClient = mcpClient;
+        command.uri = "http://localhost:3001/mcp";
+        command.name = "echo";
+        command.params = new LinkedHashMap<>(Map.of("message", "hello"));
+    }
+
+    @Test
+    @DisplayName("Should call tool and print result")
+    void shouldCallToolAndPrintResult() throws Exception {
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenReturn(ToolExecutionResult.builder()
+                        .resultText("hello world")
+                        .isError(false)
+                        .build());
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_OK, result);
+        verify(printer).println("hello world");
+    }
+
+    @Test
+    @DisplayName("Should return error when tool execution fails")
+    void shouldReturnErrorWhenToolFails() throws Exception {
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenReturn(ToolExecutionResult.builder()
+                        .resultText("tool failed")
+                        .isError(true)
+                        .build());
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("tool failed");
+    }
+
+    @Test
+    @DisplayName("Should return error on exception")
+    void shouldReturnErrorOnException() throws Exception {
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should serialize params to JSON")
+    void shouldSerializeParamsToJson() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("key1", "value1");
+        params.put("key2", "value2");
+
+        String json = McpTool.serializeParams(params);
+
+        assertEquals("{\"key1\":\"value1\",\"key2\":\"value2\"}", json);
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.mcp;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,11 +49,16 @@ class McpToolTest {
                         .isError(false)
                         .build());
 
-        WanakuPrinter printer = mock(WanakuPrinter.class);
-        Integer result = command.doCall(null, printer);
-
-        assertEquals(BaseCommand.EXIT_OK, result);
-        verify(printer).println("hello world");
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured));
+        try {
+            Integer result = command.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+            assertTrue(captured.toString().contains("hello world"));
+        } finally {
+            System.setOut(original);
+        }
     }
 
     @Test
@@ -92,5 +100,25 @@ class McpToolTest {
         String json = McpTool.serializeParams(params);
 
         assertEquals("{\"key1\":\"value1\",\"key2\":\"value2\"}", json);
+    }
+
+    @Test
+    @DisplayName("Should return error when uri is missing")
+    void shouldReturnErrorWhenUriMissing() throws Exception {
+        command.uri = null;
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("Missing required option: --uri");
+    }
+
+    @Test
+    @DisplayName("Should return error when name is missing")
+    void shouldReturnErrorWhenNameMissing() throws Exception {
+        command.name = null;
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage("Missing required option: --name");
     }
 }

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -19,22 +19,49 @@ Every step except the initial `oc login` is fully automatable.
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} mcp tool list --uri ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) — zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
 ### Environment variables
 
 ```bash
-export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/mcp}"
+export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/public/mcp/sse}"
 ```
 
 ### MCP server setup
 
-An MCP server must be running and accessible at `MCP_SERVER_URI`. You can use the project's mock MCP server for testing:
+An MCP server must be running and accessible at `MCP_SERVER_URI`. Start the Wanaku stack locally:
 
 ```bash
-cd tests/mcp-servers/wanaku-performance-test-mock-mcp
-mvn quarkus:dev
+# Build first
+mvn -DskipTests -Pdist clean package
+
+# Start the local stack (auth disabled automatically)
+VERSION=$(cat core/core-util/target/classes/version.txt)
+java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
+  --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${VERSION}.zip \
+  --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${VERSION}.zip
 ```
 
-Or start a Wanaku router with capabilities registered.
+Wait for the router health check:
+
+```bash
+curl -sf http://localhost:8080/q/health/ready > /dev/null && echo "READY" || echo "NOT READY"
+```
+
+### Known limitations for local testing
+
+- **No resource providers in `wanaku start local`:** The local start command only supports tool services (`service-http`, `service-exec`, etc.). Resource providers (like `performancestaticfile`) are not available locally. Resource read tests (Phase 12) require a deployed environment.
+- **Prompts are not registered by default:** No prompt providers ship with the base installation. Prompt list/get tests will return empty results locally.
+- **MCP SSE path:** The public MCP endpoint is `/public/mcp/sse` (not `/mcp`). Using a wrong path will return connection errors.
 
 ---
 

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -1,0 +1,336 @@
+# Test Plan: Wanaku MCP CLI Commands
+
+## Overview
+
+This test plan verifies the `wanaku mcp` CLI commands for interacting directly with MCP servers. It covers tool invocation, resource reading, prompt retrieval, and listing operations.
+
+Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `curl` | any | `curl --version` |
+| `jq` | 1.6+ | `jq --version` |
+
+### Environment variables
+
+```bash
+export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/mcp}"
+```
+
+### MCP server setup
+
+An MCP server must be running and accessible at `MCP_SERVER_URI`. You can use the project's mock MCP server for testing:
+
+```bash
+cd tests/mcp-servers/wanaku-performance-test-mock-mcp
+mvn quarkus:dev
+```
+
+Or start a Wanaku router with capabilities registered.
+
+---
+
+## Phase 1: Help and Usage
+
+### Test 1.1: Verify `wanaku mcp` shows usage
+
+```bash
+OUTPUT=$(wanaku mcp 2>&1)
+echo "${OUTPUT}" | grep -q "tool" && echo "PASS: 'tool' subcommand listed" || echo "FAIL: 'tool' not in usage"
+echo "${OUTPUT}" | grep -q "resource" && echo "PASS: 'resource' subcommand listed" || echo "FAIL: 'resource' not in usage"
+echo "${OUTPUT}" | grep -q "prompt" && echo "PASS: 'prompt' subcommand listed" || echo "FAIL: 'prompt' not in usage"
+```
+
+### Test 1.2: Verify `wanaku mcp tool --help` shows options
+
+```bash
+OUTPUT=$(wanaku mcp tool --help 2>&1)
+echo "${OUTPUT}" | grep -q "\-\-uri" && echo "PASS: --uri option listed" || echo "FAIL: --uri not in help"
+echo "${OUTPUT}" | grep -q "\-\-name" && echo "PASS: --name option listed" || echo "FAIL: --name not in help"
+echo "${OUTPUT}" | grep -q "\-\-param" && echo "PASS: --param option listed" || echo "FAIL: --param not in help"
+echo "${OUTPUT}" | grep -q "list" && echo "PASS: 'list' subcommand listed" || echo "FAIL: 'list' not in help"
+```
+
+### Test 1.3: Verify `wanaku mcp resource --help` shows options
+
+```bash
+OUTPUT=$(wanaku mcp resource --help 2>&1)
+echo "${OUTPUT}" | grep -q "\-\-uri" && echo "PASS: --uri option listed" || echo "FAIL: --uri not in help"
+echo "${OUTPUT}" | grep -q "\-\-resource-uri" && echo "PASS: --resource-uri option listed" || echo "FAIL: --resource-uri not in help"
+echo "${OUTPUT}" | grep -q "list" && echo "PASS: 'list' subcommand listed" || echo "FAIL: 'list' not in help"
+```
+
+### Test 1.4: Verify `wanaku mcp prompt --help` shows options
+
+```bash
+OUTPUT=$(wanaku mcp prompt --help 2>&1)
+echo "${OUTPUT}" | grep -q "\-\-uri" && echo "PASS: --uri option listed" || echo "FAIL: --uri not in help"
+echo "${OUTPUT}" | grep -q "\-\-name" && echo "PASS: --name option listed" || echo "FAIL: --name not in help"
+echo "${OUTPUT}" | grep -q "\-\-arg" && echo "PASS: --arg option listed" || echo "FAIL: --arg not in help"
+echo "${OUTPUT}" | grep -q "list" && echo "PASS: 'list' subcommand listed" || echo "FAIL: 'list' not in help"
+```
+
+---
+
+## Phase 2: Required Option Validation
+
+### Test 2.1: `wanaku mcp tool` without `--uri` should fail
+
+```bash
+wanaku mcp tool --name test 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --uri rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --uri should fail"
+fi
+```
+
+### Test 2.2: `wanaku mcp tool` without `--name` should fail
+
+```bash
+wanaku mcp tool --uri "${MCP_SERVER_URI}" 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --name should fail"
+fi
+```
+
+### Test 2.3: `wanaku mcp resource` without `--resource-uri` should fail
+
+```bash
+wanaku mcp resource --uri "${MCP_SERVER_URI}" 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --resource-uri rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --resource-uri should fail"
+fi
+```
+
+### Test 2.4: `wanaku mcp tool list` without `--uri` should fail
+
+```bash
+wanaku mcp tool list 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --uri rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --uri should fail"
+fi
+```
+
+---
+
+## Phase 3: Tool Operations
+
+### Test 3.1: List tools from MCP server
+
+```bash
+OUTPUT=$(wanaku mcp tool list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool list returned successfully"
+  echo "Tools found:"
+  echo "${OUTPUT}"
+else
+  echo "FAIL: tool list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 3.2: Call a tool with parameters
+
+**Description:** Call a known tool on the MCP server with parameters and verify the result is printed.
+
+```bash
+# Replace TOOL_NAME with an actual tool from the server (e.g., "echo", "http-request")
+TOOL_NAME="${TEST_TOOL_NAME:-echo}"
+TOOL_PARAM="${TEST_TOOL_PARAM:-message=hello}"
+
+OUTPUT=$(wanaku mcp tool --uri "${MCP_SERVER_URI}" --name "${TOOL_NAME}" --param "${TOOL_PARAM}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool call returned successfully"
+  echo "Result: ${OUTPUT}"
+else
+  echo "FAIL: tool call failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 3.3: Call a tool with multiple parameters
+
+```bash
+TOOL_NAME="${TEST_TOOL_NAME:-echo}"
+
+OUTPUT=$(wanaku mcp tool --uri "${MCP_SERVER_URI}" --name "${TOOL_NAME}" --param key1=value1 --param key2=value2 --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool call with multiple params succeeded"
+else
+  echo "FAIL: tool call with multiple params failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 3.4: Call a non-existent tool should fail
+
+```bash
+OUTPUT=$(wanaku mcp tool --uri "${MCP_SERVER_URI}" --name "non-existent-tool-12345" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: non-existent tool call failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: non-existent tool call should have failed"
+fi
+```
+
+---
+
+## Phase 4: Resource Operations
+
+### Test 4.1: List resources from MCP server
+
+```bash
+OUTPUT=$(wanaku mcp resource list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource list returned successfully"
+  echo "Resources found:"
+  echo "${OUTPUT}"
+else
+  echo "FAIL: resource list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 4.2: Read a resource
+
+**Description:** Read a known resource from the MCP server and verify content is printed.
+
+```bash
+# Replace RESOURCE_URI with an actual resource URI from the server
+RESOURCE_URI="${TEST_RESOURCE_URI:-file:///test}"
+
+OUTPUT=$(wanaku mcp resource --uri "${MCP_SERVER_URI}" --resource-uri "${RESOURCE_URI}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource read returned successfully"
+  echo "Content: ${OUTPUT}"
+else
+  echo "FAIL: resource read failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 4.3: Read a non-existent resource should fail
+
+```bash
+OUTPUT=$(wanaku mcp resource --uri "${MCP_SERVER_URI}" --resource-uri "file:///non-existent-12345" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: non-existent resource read failed as expected"
+else
+  echo "WARN: non-existent resource read did not fail — server may return empty content"
+fi
+```
+
+---
+
+## Phase 5: Prompt Operations
+
+### Test 5.1: List prompts from MCP server
+
+```bash
+OUTPUT=$(wanaku mcp prompt list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: prompt list returned successfully"
+  echo "Prompts found:"
+  echo "${OUTPUT}"
+else
+  echo "FAIL: prompt list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 5.2: Get a prompt with arguments
+
+**Description:** Render a known prompt from the MCP server with arguments.
+
+```bash
+# Replace PROMPT_NAME with an actual prompt from the server
+PROMPT_NAME="${TEST_PROMPT_NAME:-greeting}"
+PROMPT_ARG="${TEST_PROMPT_ARG:-name=Alice}"
+
+OUTPUT=$(wanaku mcp prompt --uri "${MCP_SERVER_URI}" --name "${PROMPT_NAME}" --arg "${PROMPT_ARG}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: prompt get returned successfully"
+  echo "Messages: ${OUTPUT}"
+else
+  echo "FAIL: prompt get failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 5.3: Get a non-existent prompt should fail
+
+```bash
+OUTPUT=$(wanaku mcp prompt --uri "${MCP_SERVER_URI}" --name "non-existent-prompt-12345" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: non-existent prompt get failed as expected"
+else
+  echo "FAIL: non-existent prompt get should have failed"
+fi
+```
+
+---
+
+## Phase 6: Connection Error Handling
+
+### Test 6.1: Connecting to a non-existent server should fail gracefully
+
+```bash
+OUTPUT=$(wanaku mcp tool list --uri "http://localhost:59999/mcp" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: connection to non-existent server failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: connection to non-existent server should fail"
+fi
+```
+
+### Test 6.2: Invalid URI should fail gracefully
+
+```bash
+OUTPUT=$(wanaku mcp tool list --uri "not-a-valid-uri" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: invalid URI failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: invalid URI should fail"
+fi
+```
+
+---
+
+## Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 1 | 1.1-1.4 | Help and usage output | Medium |
+| 2 | 2.1-2.4 | Required option validation | High |
+| 3 | 3.1-3.4 | Tool list, call, multi-param, non-existent | Critical |
+| 4 | 4.1-4.3 | Resource list, read, non-existent | Critical |
+| 5 | 5.1-5.3 | Prompt list, get, non-existent | Critical |
+| 6 | 6.1-6.2 | Connection error handling | High |

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -2,9 +2,12 @@
 
 ## Overview
 
-This test plan verifies the `wanaku mcp` CLI commands for interacting directly with MCP servers. It covers tool invocation, resource reading, prompt retrieval, and listing operations.
+This test plan verifies the `wanaku mcp` CLI commands for interacting directly with MCP servers. It is split into two parts:
 
-Every step is fully automatable.
+- **Part 1 — Unit-level validation:** Help output, required option enforcement, and basic command behavior against any MCP server.
+- **Part 2 — End-to-end with real capabilities:** Full deployment on OpenShift with the operator, HTTP capability service, and real external APIs (currency conversion).
+
+Every step except the initial `oc login` is fully automatable.
 
 ## Prerequisites
 
@@ -324,7 +327,7 @@ fi
 
 ---
 
-## Test Summary Matrix
+## Part 1 Summary
 
 | Phase | Test ID | Test Name | Priority |
 |-------|---------|-----------|----------|
@@ -334,3 +337,497 @@ fi
 | 4 | 4.1-4.3 | Resource list, read, non-existent | Critical |
 | 5 | 5.1-5.3 | Prompt list, get, non-existent | Critical |
 | 6 | 6.1-6.2 | Connection error handling | High |
+
+---
+---
+
+# Part 2 — End-to-End: MCP CLI with Real Capabilities on OpenShift
+
+## Overview
+
+This part deploys a full Wanaku stack via the operator (router + HTTP capability), registers real HTTP tools (currency conversion, cat facts), and verifies end-to-end tool invocation through the `wanaku mcp` CLI commands against the deployed router's MCP endpoints.
+
+The first `oc login` step is manual; everything else is automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `oc` | 4.12+ | `oc version --client` |
+| `helm` | 3.x | `helm version --short` |
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `curl` | any | `curl --version` |
+| `jq` | 1.6+ | `jq --version` |
+
+### Environment variables
+
+```bash
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-mcp-test}"
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
+export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
+```
+
+### Helper: wait for resource deletion
+
+```bash
+wait_for_deletion() {
+  local RESOURCE_TYPE="$1"
+  local RESOURCE_NAME="$2"
+  local NAMESPACE="$3"
+  local TIMEOUT="${4:-60}"
+  local INTERVAL=3
+  local ELAPSED=0
+
+  while oc get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; do
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+      echo "FAIL: ${RESOURCE_TYPE}/${RESOURCE_NAME} still exists after ${TIMEOUT}s"
+      return 1
+    fi
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+  echo "PASS: ${RESOURCE_TYPE}/${RESOURCE_NAME} deleted (${ELAPSED}s)"
+  return 0
+}
+```
+
+---
+
+## Phase 7: OpenShift Login (MANUAL)
+
+This is the only manual step in Part 2.
+
+### Step 7.1: Log in to OpenShift
+
+```bash
+oc login <cluster-api-url> --username=<username> --password=<password>
+```
+
+### Step 7.2: Verify login
+
+```bash
+oc whoami
+oc whoami --show-server
+```
+
+---
+
+## Phase 8: Deploy the Wanaku Stack
+
+### Step 8.1: Create namespace
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) to create and verify the namespace.
+
+### Step 8.2: Deploy Keycloak
+
+Follow [common/keycloak-setup.md](common/keycloak-setup.md). After completion, verify:
+
+```bash
+for VAR_NAME in KEYCLOAK_HOST KEYCLOAK_URL WANAKU_OIDC_SECRET; do
+  eval "VAL=\${${VAR_NAME}}"
+  if [ -z "${VAL}" ]; then
+    echo "FAIL: ${VAR_NAME} is not set"
+    exit 1
+  fi
+  echo "PASS: ${VAR_NAME} is set"
+done
+```
+
+### Step 8.3: Install the operator
+
+Follow [common/operator-deployment.md](common/operator-deployment.md) to install the operator via Helm.
+
+### Step 8.4: Create WanakuRouter
+
+```bash
+cat <<EOF | oc apply -n "${WANAKU_NAMESPACE}" -f -
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuRouter
+metadata:
+  name: wanaku-mcp-test-router
+spec:
+  auth:
+    authServer: "http://keycloak:8080"
+    authProxy: "auto"
+  router:
+    image: ${WANAKU_ROUTER_IMAGE}
+    imagePullPolicy: Always
+EOF
+```
+
+**Wait for Ready:**
+
+```bash
+oc wait wanakurouter/wanaku-mcp-test-router \
+  --for=condition=Ready \
+  --timeout=120s \
+  -n "${WANAKU_NAMESPACE}"
+```
+
+### Step 8.5: Create WanakuCapability (HTTP tool service)
+
+```bash
+cat <<EOF | oc apply -n "${WANAKU_NAMESPACE}" -f -
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCapability
+metadata:
+  name: wanaku-mcp-test-capabilities
+spec:
+  auth:
+    authServer: "http://keycloak:8080"
+    authProxy: "auto"
+  secrets:
+    oidcCredentialsSecret: "${WANAKU_OIDC_SECRET}"
+  routerRef: wanaku-mcp-test-router
+  capabilities:
+    - name: wanaku-http
+      image: ${WANAKU_CAPABILITY_HTTP_IMAGE}
+      imagePullPolicy: Always
+EOF
+```
+
+**Wait for Ready:**
+
+```bash
+oc wait wanakucapability/wanaku-mcp-test-capabilities \
+  --for=condition=Ready \
+  --timeout=120s \
+  -n "${WANAKU_NAMESPACE}"
+```
+
+### Step 8.6: Wait for all pods to be ready
+
+```bash
+oc wait --for=condition=ready pod -l app=wanaku-http \
+  --timeout=120s -n "${WANAKU_NAMESPACE}"
+echo "PASS: HTTP capability pod is ready"
+```
+
+### Step 8.7: Set router URL variables
+
+```bash
+export WANAKU_ROUTER_HOST=$(oc get route wanaku-mcp-test-router -n "${WANAKU_NAMESPACE}" -o jsonpath='{.spec.host}')
+export WANAKU_ROUTER_URL="http://${WANAKU_ROUTER_HOST}"
+export WANAKU_MCP_SSE_URI="${WANAKU_ROUTER_URL}/public/mcp/sse"
+
+if [ -z "${WANAKU_ROUTER_HOST}" ]; then
+  echo "FAIL: could not retrieve router host from route"
+  exit 1
+fi
+echo "PASS: router URL is ${WANAKU_ROUTER_URL}"
+echo "PASS: MCP SSE URI is ${WANAKU_MCP_SSE_URI}"
+```
+
+### Step 8.8: Wait for router health
+
+```bash
+MAX_RETRIES=24
+RETRY_INTERVAL=5
+for i in $(seq 1 ${MAX_RETRIES}); do
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready" 2>/dev/null || echo "000")
+  if [ "${HTTP_CODE}" = "200" ]; then
+    echo "PASS: router is healthy (attempt ${i})"
+    break
+  fi
+  if [ "${i}" -eq "${MAX_RETRIES}" ]; then
+    echo "FAIL: router not healthy after ${MAX_RETRIES} attempts (last HTTP ${HTTP_CODE})"
+    exit 1
+  fi
+  echo "Waiting for router... (attempt ${i}, HTTP ${HTTP_CODE})"
+  sleep ${RETRY_INTERVAL}
+done
+```
+
+---
+
+## Phase 9: Register Real HTTP Tools
+
+### Test 9.1: Register the currency conversion tool
+
+```bash
+${WANAKU_CLI:-wanaku} tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name free-currency-conversion-api \
+  --namespace public \
+  --description "Free currency conversion API" \
+  --uri "https://economia.awesomeapi.com.br/last/{firstCurrency}-{secondCurrency}" \
+  --type http \
+  --property "firstCurrency:string,The first currency (3 letter code, e.g.: USD, EUR)" \
+  --property "secondCurrency:string,The second currency (3 letter code, e.g.: BRL, CZK)" \
+  --required firstCurrency \
+  --required secondCurrency
+
+if [ $? -eq 0 ]; then
+  echo "PASS: currency conversion tool registered"
+else
+  echo "FAIL: could not register currency conversion tool"
+  exit 1
+fi
+```
+
+### Test 9.2: Register the cat facts tool
+
+```bash
+${WANAKU_CLI:-wanaku} tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name meow-facts \
+  --namespace public \
+  --description "Retrieve random facts about cats" \
+  --uri "https://meowfacts.herokuapp.com?count={count}" \
+  --type http \
+  --property "count:int,The number of facts to retrieve" \
+  --required count
+
+if [ $? -eq 0 ]; then
+  echo "PASS: meow-facts tool registered"
+else
+  echo "FAIL: could not register meow-facts tool"
+  exit 1
+fi
+```
+
+### Test 9.3: Verify tools are listed via REST API
+
+```bash
+TOOLS_RESPONSE=$(curl -s "${WANAKU_ROUTER_URL}/api/v1/tools" 2>/dev/null)
+echo "${TOOLS_RESPONSE}" | jq -r '.data[].name' 2>/dev/null | sort
+
+echo "${TOOLS_RESPONSE}" | jq -e '.data[] | select(.name == "free-currency-conversion-api")' > /dev/null 2>&1 \
+  && echo "PASS: currency conversion tool is listed" \
+  || echo "FAIL: currency conversion tool not found in API response"
+
+echo "${TOOLS_RESPONSE}" | jq -e '.data[] | select(.name == "meow-facts")' > /dev/null 2>&1 \
+  && echo "PASS: meow-facts tool is listed" \
+  || echo "FAIL: meow-facts tool not found in API response"
+```
+
+---
+
+## Phase 10: List Tools via MCP CLI
+
+### Test 10.1: List tools via MCP SSE endpoint
+
+```bash
+OUTPUT=$(wanaku mcp tool list --uri "${WANAKU_MCP_SSE_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: wanaku mcp tool list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: tool list succeeded"
+echo "${OUTPUT}"
+
+echo "${OUTPUT}" | grep -q "free-currency-conversion-api" \
+  && echo "PASS: currency conversion tool visible via MCP" \
+  || echo "FAIL: currency conversion tool not visible via MCP"
+
+echo "${OUTPUT}" | grep -q "meow-facts" \
+  && echo "PASS: meow-facts tool visible via MCP" \
+  || echo "FAIL: meow-facts tool not visible via MCP"
+```
+
+---
+
+## Phase 11: Invoke Real Tools via MCP CLI
+
+### Test 11.1: Call the currency conversion tool (USD to EUR)
+
+**Description:** Invoke the currency conversion API via the deployed HTTP capability and verify the response contains exchange rate data.
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name free-currency-conversion-api \
+  --param firstCurrency=USD \
+  --param secondCurrency=EUR \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+echo "Output: ${OUTPUT}"
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: currency conversion tool call failed"
+  exit 1
+fi
+
+# The API returns JSON with currency pair data (e.g., "USDEUR")
+echo "${OUTPUT}" | grep -qi "USD" \
+  && echo "PASS: response contains currency data" \
+  || echo "FAIL: response does not contain expected currency data"
+```
+
+### Test 11.2: Call the currency conversion tool (EUR to BRL)
+
+**Description:** Verify a different currency pair also works, confirming parameter interpolation.
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name free-currency-conversion-api \
+  --param firstCurrency=EUR \
+  --param secondCurrency=BRL \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: EUR-BRL conversion tool call failed"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -qi "EUR" \
+  && echo "PASS: EUR-BRL response contains currency data" \
+  || echo "FAIL: EUR-BRL response does not contain expected data"
+```
+
+### Test 11.3: Call the cat facts tool
+
+**Description:** Invoke meow-facts and verify the response contains fact data.
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name meow-facts \
+  --param count=2 \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+echo "Output: ${OUTPUT}"
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: meow-facts tool call failed"
+  exit 1
+fi
+
+# Response should be non-empty and contain some data
+if [ -n "${OUTPUT}" ]; then
+  echo "PASS: meow-facts returned data"
+else
+  echo "FAIL: meow-facts returned empty response"
+fi
+```
+
+### Test 11.4: Call a tool with missing required parameters
+
+**Description:** The MCP server or capability should handle missing required parameters gracefully.
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name free-currency-conversion-api \
+  --param firstCurrency=USD \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+# Missing secondCurrency — the API may return an error or the capability may reject it
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing required parameter caused an error (expected)"
+else
+  echo "WARN: missing required parameter did not fail — check if API returned an error in the response body"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 12: List Resources via MCP CLI
+
+### Test 12.1: List resources via MCP SSE endpoint
+
+```bash
+OUTPUT=$(wanaku mcp resource list --uri "${WANAKU_MCP_SSE_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: wanaku mcp resource list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "PASS: resource list succeeded"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 13: List Prompts via MCP CLI
+
+### Test 13.1: List prompts via MCP SSE endpoint
+
+```bash
+OUTPUT=$(wanaku mcp prompt list --uri "${WANAKU_MCP_SSE_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: wanaku mcp prompt list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "PASS: prompt list succeeded"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 14: Cleanup
+
+### Step 14.1: Remove registered tools
+
+```bash
+${WANAKU_CLI:-wanaku} tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name free-currency-conversion-api 2>/dev/null || true
+
+${WANAKU_CLI:-wanaku} tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name meow-facts 2>/dev/null || true
+
+echo "PASS: tools removed"
+```
+
+### Step 14.2: Delete capability and router CRs
+
+```bash
+oc delete wanakucapability wanaku-mcp-test-capabilities -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
+wait_for_deletion deployment wanaku-http "${WANAKU_NAMESPACE}" 60
+
+oc delete wanakurouter wanaku-mcp-test-router -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
+wait_for_deletion deployment wanaku-mcp-test-router-mcp-router "${WANAKU_NAMESPACE}" 60
+```
+
+### Step 14.3: Full cleanup
+
+Follow [common/cleanup.md](common/cleanup.md) for remaining teardown (Keycloak, operator, namespace).
+
+---
+
+## Full Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority | Part |
+|-------|---------|-----------|----------|------|
+| 1 | 1.1-1.4 | Help and usage output | Medium | 1 |
+| 2 | 2.1-2.4 | Required option validation | High | 1 |
+| 3 | 3.1-3.4 | Tool list, call, multi-param, non-existent | Critical | 1 |
+| 4 | 4.1-4.3 | Resource list, read, non-existent | Critical | 1 |
+| 5 | 5.1-5.3 | Prompt list, get, non-existent | Critical | 1 |
+| 6 | 6.1-6.2 | Connection error handling | High | 1 |
+| 7 | 7.1-7.2 | OpenShift login (MANUAL) | Critical | 2 |
+| 8 | 8.1-8.8 | Stack deployment (operator, router, capability) | Critical | 2 |
+| 9 | 9.1-9.3 | Register real HTTP tools | Critical | 2 |
+| 10 | 10.1 | List tools via MCP SSE endpoint | Critical | 2 |
+| 11 | 11.1-11.4 | Invoke real tools (currency, cat facts, missing param) | Critical | 2 |
+| 12 | 12.1 | List resources via MCP endpoint | High | 2 |
+| 13 | 13.1 | List prompts via MCP endpoint | High | 2 |
+| 14 | 14.1-14.3 | Cleanup | Critical | 2 |

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -368,6 +368,7 @@ export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-mcp-test}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
+export WANAKU_PROVIDER_STATIC_FILE_IMAGE="${WANAKU_PROVIDER_STATIC_FILE_IMAGE:-quay.io/wanaku/wanaku-provider-performance-static-file:latest}"
 ```
 
 ### Helper: wait for resource deletion
@@ -486,6 +487,9 @@ spec:
     - name: wanaku-http
       image: ${WANAKU_CAPABILITY_HTTP_IMAGE}
       imagePullPolicy: Always
+    - name: wanaku-static-file
+      image: ${WANAKU_PROVIDER_STATIC_FILE_IMAGE}
+      imagePullPolicy: Always
 EOF
 ```
 
@@ -504,6 +508,10 @@ oc wait wanakucapability/wanaku-mcp-test-capabilities \
 oc wait --for=condition=ready pod -l app=wanaku-http \
   --timeout=120s -n "${WANAKU_NAMESPACE}"
 echo "PASS: HTTP capability pod is ready"
+
+oc wait --for=condition=ready pod -l app=wanaku-static-file \
+  --timeout=120s -n "${WANAKU_NAMESPACE}"
+echo "PASS: static file provider pod is ready"
 ```
 
 ### Step 8.7: Set router URL variables
@@ -741,9 +749,42 @@ fi
 
 ---
 
-## Phase 12: List Resources via MCP CLI
+## Phase 12: Register and Read Resources via MCP CLI
 
-### Test 12.1: List resources via MCP SSE endpoint
+### Test 12.1: Register a resource backed by the static file provider
+
+**Description:** Expose a resource via the CLI that is backed by the `performancestaticfile` provider type. The static file provider returns the fixed content `1234567890`.
+
+```bash
+${WANAKU_CLI:-wanaku} resources expose \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --location "performancestaticfile://test-file.txt" \
+  --type performancestaticfile \
+  --name "test-static-resource" \
+  --namespace public \
+  --description "A static file resource for MCP CLI testing" \
+  --mimeType "text/plain"
+
+if [ $? -eq 0 ]; then
+  echo "PASS: static file resource registered"
+else
+  echo "FAIL: could not register static file resource"
+  exit 1
+fi
+```
+
+### Test 12.2: Verify resource is listed via REST API
+
+```bash
+RESOURCES_RESPONSE=$(curl -s "${WANAKU_ROUTER_URL}/api/v1/resources" 2>/dev/null)
+
+echo "${RESOURCES_RESPONSE}" | jq -e '.data[] | select(.name == "test-static-resource")' > /dev/null 2>&1 \
+  && echo "PASS: test-static-resource is listed in REST API" \
+  || echo "FAIL: test-static-resource not found in REST API response"
+```
+
+### Test 12.3: List resources via MCP SSE endpoint
 
 ```bash
 OUTPUT=$(wanaku mcp resource list --uri "${WANAKU_MCP_SSE_URI}" --plain 2>&1)
@@ -752,8 +793,54 @@ EXIT_CODE=$?
 if [ "${EXIT_CODE}" -ne 0 ]; then
   echo "FAIL: wanaku mcp resource list failed (exit code ${EXIT_CODE})"
   echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: resource list succeeded"
+echo "${OUTPUT}"
+
+echo "${OUTPUT}" | grep -q "test-static-resource" \
+  && echo "PASS: test-static-resource visible via MCP" \
+  || echo "FAIL: test-static-resource not visible via MCP"
+```
+
+### Test 12.4: Read the static file resource via MCP
+
+**Description:** Read the registered resource through the MCP endpoint. The static file provider should return its fixed content (`1234567890`).
+
+```bash
+OUTPUT=$(wanaku mcp resource \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --resource-uri "performancestaticfile://test-file.txt" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+echo "Output: ${OUTPUT}"
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: resource read failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "1234567890" \
+  && echo "PASS: resource content matches expected static data" \
+  || echo "FAIL: resource content does not contain expected '1234567890'"
+```
+
+### Test 12.5: Read a non-existent resource via MCP
+
+```bash
+OUTPUT=$(wanaku mcp resource \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --resource-uri "performancestaticfile://does-not-exist.txt" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: non-existent resource read failed as expected (exit code ${EXIT_CODE})"
 else
-  echo "PASS: resource list succeeded"
+  echo "WARN: non-existent resource read did not fail — server may return empty content"
   echo "${OUTPUT}"
 fi
 ```
@@ -781,7 +868,7 @@ fi
 
 ## Phase 14: Cleanup
 
-### Step 14.1: Remove registered tools
+### Step 14.1: Remove registered tools and resources
 
 ```bash
 ${WANAKU_CLI:-wanaku} tools remove \
@@ -794,7 +881,12 @@ ${WANAKU_CLI:-wanaku} tools remove \
   --no-auth \
   --name meow-facts 2>/dev/null || true
 
-echo "PASS: tools removed"
+${WANAKU_CLI:-wanaku} resources remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name test-static-resource 2>/dev/null || true
+
+echo "PASS: tools and resources removed"
 ```
 
 ### Step 14.2: Delete capability and router CRs
@@ -828,6 +920,6 @@ Follow [common/cleanup.md](common/cleanup.md) for remaining teardown (Keycloak, 
 | 9 | 9.1-9.3 | Register real HTTP tools | Critical | 2 |
 | 10 | 10.1 | List tools via MCP SSE endpoint | Critical | 2 |
 | 11 | 11.1-11.4 | Invoke real tools (currency, cat facts, missing param) | Critical | 2 |
-| 12 | 12.1 | List resources via MCP endpoint | High | 2 |
+| 12 | 12.1-12.5 | Register, list, and read resources via MCP endpoint | Critical | 2 |
 | 13 | 13.1 | List prompts via MCP endpoint | High | 2 |
 | 14 | 14.1-14.3 | Cleanup | Critical | 2 |


### PR DESCRIPTION
## Summary

- Add `wanaku mcp` command group with `tool`, `resource`, and `prompt` subcommands for interacting directly with MCP servers via LangChain4j's MCP client
- Each subcommand supports a `list` operation to discover available tools/resources/prompts
- Includes 19 unit tests covering happy paths, error handling, and edge cases
- Adds a test plan at `tests/plans/mcp-cli-commands.md`

### Usage

```
wanaku mcp tool list --uri http://localhost:3001/mcp
wanaku mcp tool --uri http://localhost:3001/mcp --name echo --param message=hello
wanaku mcp resource list --uri http://localhost:3001/mcp
wanaku mcp resource --uri http://localhost:3001/mcp --resource-uri file:///data.csv
wanaku mcp prompt list --uri http://localhost:3001/mcp
wanaku mcp prompt --uri http://localhost:3001/mcp --name greeting --arg name=Alice
```

## Test plan

- [x] `mvn verify` passes for CLI module (19 new tests, 0 failures)
- [ ] Manual test against a running MCP server
- [ ] Verify `--help` output for all command levels
- [ ] Verify error handling for unreachable servers

## Summary by Sourcery

Add a new `wanaku mcp` CLI command group for interacting with MCP servers, including tool, resource, and prompt operations, wired into the main CLI and backed by the core MCP client.

New Features:
- Introduce `wanaku mcp` command group with `tool`, `resource`, and `prompt` subcommands for direct MCP server interaction.
- Support listing and invoking MCP tools, listing and reading resources, and listing and rendering prompts via the CLI.

Build:
- Add `core-mcp-client` module as a dependency of the CLI application.

Tests:
- Add unit tests for MCP tool invocation, tool listing, resource reading and listing, and prompt retrieval and listing, including error handling paths.
- Add an executable test plan document for MCP CLI commands covering usage, validation, operations, and connection error handling.