### PR TITLE
fix: OIDC configuration options

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -70,9 +70,14 @@ public class AuthConfigSource implements ConfigSource {
             Map<String, String> props = new HashMap<>();
             props.put("quarkus.oidc.enabled", "false");
             props.put("quarkus.oidc.discovery-enabled", "false");
+            props.put("quarkus.oidc.resource-metadata.enabled", "false");
+            props.put("quarkus.oidc.mcp.enabled", "false");
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
+            props.put("quarkus.oidc.mcp.resource-metadata.enabled", "false");
             for (int i = 0; i < MAX_NAMESPACES; i++) {
+                props.put("quarkus.oidc.ns-%d.enabled".formatted(i), "false");
                 props.put("quarkus.oidc.ns-%d.discovery-enabled".formatted(i), "false");
+                props.put("quarkus.oidc.ns-%d.resource-metadata.enabled".formatted(i), "false");
             }
             props.put("quarkus.oidc-proxy.enabled", "false");
             props.put("quarkus.http.auth.permission.authenticated.policy", "permit");

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -65,9 +65,14 @@ class AuthConfigSourceTest {
         assertEquals("false", props.get("quarkus.oidc.enabled"));
         assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
         assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", props.get("quarkus.oidc.resource-metadata.enabled"));
+        assertEquals("false", props.get("quarkus.oidc.mcp.enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
+        assertEquals("false", props.get("quarkus.oidc.mcp.resource-metadata.enabled"));
         for (int i = 0; i < 10; i++) {
+            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".enabled"));
             assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
+            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".resource-metadata.enabled"));
         }
         assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.mcp-authenticated.policy"));
@@ -85,9 +90,16 @@ class AuthConfigSourceTest {
         assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.resource-metadata.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.mcp.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.mcp.resource-metadata.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.resource-metadata.enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.discovery-enabled"));
+        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.resource-metadata.enabled"));
         assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -161,8 +161,13 @@ java -Dwanaku.http.auth=none -jar quarkus-run.jar
 > |---|---|---|
 > | `quarkus.oidc.enabled` | `false` | Disables OIDC entirely at runtime |
 > | `quarkus.oidc.discovery-enabled` | `false` | Prevents eager Keycloak connection at startup |
+> | `quarkus.oidc.resource-metadata.enabled` | `false` | Disables resource metadata endpoint |
+> | `quarkus.oidc.mcp.enabled` | `false` | Disables the MCP OIDC tenant |
 > | `quarkus.oidc.mcp.discovery-enabled` | `false` | Same, for the MCP OIDC tenant used by OidcProxy |
+> | `quarkus.oidc.mcp.resource-metadata.enabled` | `false` | Disables resource metadata for MCP tenant |
+> | `quarkus.oidc.ns-{1..10}.enabled` | `false` | Disables per-namespace OIDC tenants |
 > | `quarkus.oidc.ns-{1..10}.discovery-enabled` | `false` | Same, for per-namespace OIDC tenants |
+> | `quarkus.oidc.ns-{1..10}.resource-metadata.enabled` | `false` | Disables resource metadata for namespace tenants |
 > | `quarkus.oidc-proxy.enabled` | `false` | Disables the OIDC proxy |
 > | `quarkus.http.auth.permission.authenticated.policy` | `permit` | Opens management / data-store APIs |
 > | `quarkus.http.auth.permission.mcp-authenticated.policy` | `permit` | Opens MCP namespace endpoints |


### PR DESCRIPTION
Fixes: #1405

## Summary by Sourcery

Clarify and extend OIDC no-auth configuration handling so that all relevant tenants and resource-metadata endpoints are explicitly disabled when auth is turned off.

Bug Fixes:
- Ensure OIDC resource metadata, MCP tenant, and per-namespace OIDC tenants are fully disabled when auth is configured as none.

Documentation:
- Document the full set of OIDC-related configuration flags that are set when auth is disabled, including resource-metadata, MCP, and per-namespace tenant options.

Tests:
- Expand AuthConfigSource tests to cover the new OIDC disablement flags for resource metadata, MCP, and per-namespace tenants when auth is none.