### PR TITLE
Fix: #1385  Qute content type configuration for plain text templates

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -266,6 +266,8 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 %test.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
 %test.quarkus.log.category."org.apache.http".level=INFO
 
+quarkus.qute.content-types.tpl=text/plain
+
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
 quarkus.smallrye-openapi.auto-add-security=false
 mp.openapi.scan.exclude.packages=ai.wanaku.backend.api.v1.oidc


### PR DESCRIPTION
Fixes: #1385

## Summary by Sourcery

Build:
- Add Qute content type mapping for .tpl templates to text/plain in application configuration.