### PR TITLE
feat: centralize Wanaku home directory resolution and update related paths

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -12,6 +12,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Properties;
 import org.jboss.logging.Logger;
+import ai.wanaku.core.util.WanakuHome;
 
 /**
  * A credential store specifically designed for CLI authentication.
@@ -22,7 +23,7 @@ public class AuthCredentialStore {
 
     private static final Logger LOG = Logger.getLogger(AuthCredentialStore.class);
 
-    private static final String DEFAULT_CREDENTIALS_FILE = "~/.wanaku/credentials";
+    private static final String DEFAULT_CREDENTIALS_FILE = WanakuHome.get() + File.separator + "credentials";
     private static final String API_TOKEN_KEY = "api.token";
     private static final String REFRESH_TOKEN_KEY = "refresh.token";
     private static final String AUTH_MODE_KEY = "auth.mode";
@@ -297,7 +298,7 @@ public class AuthCredentialStore {
     }
 
     private static URI resolveCredentialsPath(String credentialsPath) {
-        String resolvedPath = credentialsPath;
+        String resolvedPath = WanakuHome.expandPlaceholders(credentialsPath);
         if (resolvedPath.startsWith("~/")) {
             resolvedPath = System.getProperty("user.home") + resolvedPath.substring(1);
         }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/RuntimeConstants.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/RuntimeConstants.java
@@ -1,6 +1,7 @@
 package ai.wanaku.cli.main.support;
 
 import java.io.File;
+import ai.wanaku.core.util.WanakuHome;
 
 public class RuntimeConstants {
     public static final String WANAKU_ROUTER_BACKEND = "wanaku-router-backend";
@@ -8,7 +9,7 @@ public class RuntimeConstants {
     private RuntimeConstants() {}
 
     public static String wanakuHomeDir() {
-        return System.getProperty("user.home") + File.separator + ".wanaku";
+        return WanakuHome.get();
     }
 
     public static String wanakuCacheDir() {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/RuntimeConstantsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/RuntimeConstantsTest.java
@@ -1,6 +1,7 @@
 package ai.wanaku.cli.main.support;
 
 import java.io.File;
+import ai.wanaku.core.util.WanakuHome;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,8 +11,18 @@ class RuntimeConstantsTest {
 
     @Test
     void wanakuHomeDirUsesCurrentUserHome() {
-        String expected = System.getProperty("user.home") + File.separator + ".wanaku";
+        String expected = WanakuHome.get();
         assertEquals(expected, RuntimeConstants.wanakuHomeDir());
+    }
+
+    @Test
+    void wanakuHomeDirDefaultsToUserHomeDotWanaku() {
+        String userHome = System.getProperty("user.home");
+        assertNotNull(userHome);
+        String expected = userHome + File.separator + ".wanaku";
+        // When no wanaku.home system property is set, it should default to user.home/.wanaku
+        // This test validates the default behavior - in test env wanaku.home may not be set
+        assertEquals(expected, WanakuHome.get());
     }
 
     @Test
@@ -30,6 +41,6 @@ class RuntimeConstantsTest {
     void directoriesReflectSystemProperty() {
         String userHome = System.getProperty("user.home");
         assertNotNull(userHome);
-        assertEquals(userHome + File.separator + ".wanaku", RuntimeConstants.wanakuHomeDir());
+        assertEquals(WanakuHome.get(), RuntimeConstants.wanakuHomeDir());
     }
 }

--- a/apps/wanaku-router-backend/README.md
+++ b/apps/wanaku-router-backend/README.md
@@ -67,7 +67,7 @@ auth.server=http://localhost:8543
 quarkus.oidc.client-id=wanaku-mcp-router
 
 # Persistence
-wanaku.persistence.infinispan.base-folder=${user.home}/.wanaku/router/
+wanaku.persistence.infinispan.base-folder=${wanaku.home}/router/
 
 # MCP
 quarkus.mcp.server.traffic-logging.enabled=true

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/providers/InfinispanConfigurationProvider.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/providers/InfinispanConfigurationProvider.java
@@ -11,9 +11,10 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.core.util.WanakuHome;
 
 public class InfinispanConfigurationProvider {
-    @ConfigProperty(name = "wanaku.persistence.infinispan.base-folder", defaultValue = "${user.home}/.wanaku/router/")
+    @ConfigProperty(name = "wanaku.persistence.infinispan.base-folder", defaultValue = "${wanaku.home}/router/")
     String baseFolder;
 
     @ConfigProperty(name = "wanaku.persistence.infinispan.max-entries", defaultValue = "10000")
@@ -53,6 +54,6 @@ public class InfinispanConfigurationProvider {
     }
 
     private String resolveBaseFolder() {
-        return baseFolder.replace("${user.home}", System.getProperty("user.home"));
+        return WanakuHome.expandPlaceholders(baseFolder);
     }
 }

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -21,6 +21,9 @@ wanaku.bridge.grpc.transport.deadline-seconds=10
 # set to true (against TLS-enabled capability endpoints) when traffic crosses untrusted segments.
 wanaku.bridge.grpc.transport.tls.enabled=false
 
+# Wanaku home directory (can be overridden via system property wanaku.home or env var WANAKU_HOME)
+wanaku.home=${user.home}/.wanaku
+
 # Chat LLM proxy allowlist
 wanaku.chat.allowlist=Ollama,OpenAi,Mistral,Gemini,Anthropic
 
@@ -272,7 +275,7 @@ quarkus.log.category."io.quarkiverse.mcp".level=INFO
 
 %local.quarkus.log.console.enabled=false
 %local.quarkus.log.file.enabled=true
-%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/wanaku-router.log
+%local.quarkus.log.file.path=${wanaku.home}/local/logs/wanaku-router.log
 %local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %local.quarkus.log.category."ai.wanaku".level=DEBUG
 %local.quarkus.log.category."io.quarkiverse.mcp".level=DEBUG

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
@@ -19,6 +19,7 @@ import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.capabilities.discovery.DefaultRegistrationManager;
 import ai.wanaku.core.exchange.v1.PropertySchema;
 import ai.wanaku.core.service.discovery.client.DiscoveryService;
+import ai.wanaku.core.util.WanakuHome;
 
 import static ai.wanaku.core.util.discovery.DiscoveryUtil.resolveRegistrationAddress;
 
@@ -141,7 +142,7 @@ public class ServicesHelper {
      * Resolves the canonical service home directory path.
      * <p>
      * This method resolves the service home directory by expanding any
-     * {@code ${user.home}}
+     * {@code ${wanaku.home}} and {@code ${user.home}}
      * placeholders and appending the service name. The result is a fully qualified
      * path
      * where service-specific data and configuration can be stored.
@@ -150,7 +151,7 @@ public class ServicesHelper {
      * @return the canonical service home directory path
      */
     public static String getCanonicalServiceHome(WanakuServiceConfig config) {
-        String home = config.serviceHome().replace("${user.home}", System.getProperty("user.home"));
+        String home = WanakuHome.expandPlaceholders(config.serviceHome());
         return java.nio.file.Path.of(home).resolve(config.name()).normalize().toString();
     }
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/config/WanakuServiceConfig.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/config/WanakuServiceConfig.java
@@ -16,15 +16,15 @@ public interface WanakuServiceConfig extends WanakuConfig {
      * Returns the base directory where service-specific data and configuration will be stored.
      * <p>
      * The service home directory is used to persist service instance data, configuration files,
-     * and other service-specific artifacts. The path may contain the {@code ${user.home}}
+     * and other service-specific artifacts. The path may contain the {@code ${wanaku.home}}
      * placeholder, which will be expanded at runtime to the user's home directory.
      * <p>
-     * By default, this is set to {@code ${user.home}/.wanaku/services/}, and each service
+     * By default, this is set to {@code ${wanaku.home}/services/}, and each service
      * will have its own subdirectory based on its service name.
      *
      * @return the service home directory path, potentially containing placeholders
      */
-    @WithDefault("${user.home}/.wanaku/services/")
+    @WithDefault("${wanaku.home}/services/")
     String serviceHome();
 
     /**

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -3,6 +3,9 @@ quarkus.package.jar.type=mutable-jar
 
 wanaku.http.auth=keycloak
 
+# Wanaku home directory (can be overridden via system property wanaku.home or env var WANAKU_HOME)
+wanaku.home=${user.home}/.wanaku
+
 quarkus.oidc-client.enabled=true
 
 # Address of the Keycloak authentication server - adjust to your Keycloak instance
@@ -38,7 +41,7 @@ quarkus.otel.propagators=tracecontext,baggage
 
 %local.quarkus.log.console.enabled=false
 %local.quarkus.log.file.enabled=true
-%local.quarkus.log.file.path=${user.home}/.wanaku/local/logs/${wanaku.service.name:wanaku-capability}.log
+%local.quarkus.log.file.path=${wanaku.home}/local/logs/${wanaku.service.name:wanaku-capability}.log
 %local.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [traceId=%X{traceId}, requestId=%X{requestId}] %s%e%n
 %local.quarkus.log.category."ai.wanaku".level=DEBUG
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/ServicesHelperTest.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/test/java/ai/wanaku/core/capabilities/common/ServicesHelperTest.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.core.util.WanakuHome;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,17 @@ class ServicesHelperTest {
         TestServiceConfig config = new TestServiceConfig("my-service", "${user.home}/.wanaku");
         String result = ServicesHelper.getCanonicalServiceHome(config);
         assertEquals(java.nio.file.Path.of(userHome, ".wanaku", "my-service").toString(), result);
+    }
+
+    @Test
+    void getCanonicalServiceHomeExpandsWanakuHomePlaceholder() {
+        // Create a minimal config implementation for testing with ${wanaku.home}
+        TestServiceConfig config = new TestServiceConfig("my-service", "${wanaku.home}/services");
+        String result = ServicesHelper.getCanonicalServiceHome(config);
+        assertEquals(
+                java.nio.file.Path.of(WanakuHome.get(), "services", "my-service")
+                        .toString(),
+                result);
     }
 
     @Test

--- a/core/core-util/src/main/java/ai/wanaku/core/util/WanakuHome.java
+++ b/core/core-util/src/main/java/ai/wanaku/core/util/WanakuHome.java
@@ -1,0 +1,71 @@
+package ai.wanaku.core.util;
+
+import java.io.File;
+
+/**
+ * Centralized resolution of the Wanaku home directory.
+ * <p>
+ * The wanaku home directory is resolved in the following order:
+ * <ol>
+ *   <li>System property {@code wanaku.home}</li>
+ *   <li>Environment variable {@code WANAKU_HOME}</li>
+ *   <li>Default: {@code ${user.home}/.wanaku}</li>
+ * </ol>
+ */
+public class WanakuHome {
+
+    private static final String WANAKU_HOME_SYS_PROP = "wanaku.home";
+    private static final String WANAKU_HOME_ENV_VAR = "WANAKU_HOME";
+
+    private WanakuHome() {}
+
+    /**
+     * Returns the default Wanaku home directory path.
+     * <p>
+     * This is a method (not a static field) to avoid GraalVM native image
+     * build-time evaluation which would capture the build machine's home directory.
+     *
+     * @return the default path to the Wanaku home directory
+     */
+    private static String defaultWanakuHome() {
+        return System.getProperty("user.home") + File.separator + ".wanaku";
+    }
+
+    /**
+     * Returns the resolved Wanaku home directory path.
+     *
+     * @return the path to the Wanaku home directory
+     */
+    public static String get() {
+        String home = System.getProperty(WANAKU_HOME_SYS_PROP);
+        if (home != null && !home.isBlank()) {
+            return home;
+        }
+
+        home = System.getenv(WANAKU_HOME_ENV_VAR);
+        if (home != null && !home.isBlank()) {
+            return home;
+        }
+
+        return defaultWanakuHome();
+    }
+
+    /**
+     * Expands placeholders in a path string.
+     * <p>
+     * Currently supported placeholders:
+     * <ul>
+     *   <li>{@code ${wanaku.home}} - expands to the Wanaku home directory</li>
+     *   <li>{@code ${user.home}} - expands to the user's home directory</li>
+     * </ul>
+     *
+     * @param path the path string potentially containing placeholders
+     * @return the path with placeholders expanded
+     */
+    public static String expandPlaceholders(String path) {
+        if (path == null) {
+            return null;
+        }
+        return path.replace("${wanaku.home}", get()).replace("${user.home}", System.getProperty("user.home"));
+    }
+}

--- a/core/core-util/src/test/java/ai/wanaku/core/util/WanakuHomeTest.java
+++ b/core/core-util/src/test/java/ai/wanaku/core/util/WanakuHomeTest.java
@@ -1,0 +1,91 @@
+package ai.wanaku.core.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WanakuHomeTest {
+
+    @Test
+    void expandPlaceholders_expandsWanakuHome() {
+        withSystemProperty("wanaku.home", "/custom/wanaku", () -> {
+            String result = WanakuHome.expandPlaceholders("${wanaku.home}/data");
+            assertNotNull(result);
+            assertEquals("/custom/wanaku/data", result);
+        });
+    }
+
+    @Test
+    void expandPlaceholders_expandsUserHome() {
+        withSystemProperty("user.home", "/test/user/home", () -> {
+            String result = WanakuHome.expandPlaceholders("${user.home}/data");
+            assertEquals("/test/user/home/data", result);
+        });
+    }
+
+    @Test
+    void expandPlaceholders_expandsBoth() {
+        withSystemProperties(
+                new Property[] {
+                    new Property("wanaku.home", "/custom/wanaku"), new Property("user.home", "/test/user/home")
+                },
+                () -> {
+                    String result = WanakuHome.expandPlaceholders("${wanaku.home}/${user.home}/data");
+                    assertEquals("/custom/wanaku//test/user/home/data", result);
+                });
+    }
+
+    @Test
+    void expandPlaceholders_returnsOriginalWhenNoPlaceholders() {
+        String result = WanakuHome.expandPlaceholders("/plain/path");
+        assertEquals("/plain/path", result);
+    }
+
+    @Test
+    void expandPlaceholders_returnsNullForNull() {
+        String result = WanakuHome.expandPlaceholders(null);
+        assertNull(result);
+    }
+
+    @Test
+    void expandPlaceholders_handlesEmptyString() {
+        String result = WanakuHome.expandPlaceholders("");
+        assertEquals("", result);
+    }
+
+    private void withSystemProperty(String name, String value, Runnable test) {
+        String original = System.getProperty(name);
+        System.setProperty(name, value);
+        try {
+            test.run();
+        } finally {
+            if (original != null) {
+                System.setProperty(name, original);
+            } else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
+    private void withSystemProperties(Property[] properties, Runnable test) {
+        String[] originals = new String[properties.length];
+        for (int i = 0; i < properties.length; i++) {
+            originals[i] = System.getProperty(properties[i].name);
+            System.setProperty(properties[i].name, properties[i].value);
+        }
+        try {
+            test.run();
+        } finally {
+            for (int i = 0; i < properties.length; i++) {
+                if (originals[i] != null) {
+                    System.setProperty(properties[i].name, originals[i]);
+                } else {
+                    System.clearProperty(properties[i].name);
+                }
+            }
+        }
+    }
+
+    private record Property(String name, String value) {}
+}

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -195,7 +195,7 @@ These `wanaku.router.health-check.*` properties control the periodic health prob
 
 | Property                                    | Description                                                                   |
 |---------------------------------------------|-------------------------------------------------------------------------------|
-| `wanaku.persistence.infinispan.base-folder` | Where to store Infinispan files (defaults to `${user.home}/.wanaku/router/`). |
+| `wanaku.persistence.infinispan.base-folder` | Where to store Infinispan files (defaults to `${wanaku.home}/router/`). |
 | `wanaku.infinispan.max-state-count`         | `10` - The maximum number of historical states to keep for each service.      |
 
 ### Namespaces

--- a/docs/internals-persistence.md
+++ b/docs/internals-persistence.md
@@ -365,13 +365,12 @@ public abstract class AbstractWanakuSerializationContextInitializer
 public class InfinispanConfigurationProvider {
 
     @ConfigProperty(name = "wanaku.persistence.infinispan.base-folder",
-                   defaultValue = "${user.home}/.wanaku/router/")
+                   defaultValue = "${wanaku.home}/router/")
     String baseFolder;
 
     @Produces
     Configuration newConfiguration() {
-        String location = baseFolder.replace(
-            "${user.home}", System.getProperty("user.home"));
+        String location = WanakuHome.expandPlaceholders(baseFolder);
         Files.createDirectories(Paths.get(location));
 
         return new ConfigurationBuilder()

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -372,7 +372,7 @@ quarkus.log.category."ai.wanaku".level=DEBUG
 
 **Why this happens:**
 
-The Infinispan data directory defaults to `${user.home}/.wanaku/router/`. In container images, this resolves to `/home/jboss/.wanaku/router/`. Running the container with a different UID or mounting a host directory with incompatible permissions causes Infinispan's `SoftIndexFileStore` to fail.
+The Infinispan data directory defaults to `${wanaku.home}/router/`. In container images, this resolves to `/home/jboss/.wanaku/router/`. Running the container with a different UID or mounting a host directory with incompatible permissions causes Infinispan's `SoftIndexFileStore` to fail.
 
 **Fix:**
 


### PR DESCRIPTION
Closes: #1398

## Summary by Sourcery

Centralize resolution of the Wanaku home directory across CLI, router backend, and capabilities components, and update configuration, docs, and tests to use the new abstraction and placeholders.

Enhancements:
- Introduce a core WanakuHome utility for resolving the Wanaku home directory via system property, environment variable, or user.home fallback.
- Update runtime constants, credential storage, service configuration, and Infinispan configuration to use WanakuHome-based path resolution and placeholder expansion instead of hardcoded user.home paths.
- Standardize configuration properties and logging paths to use a wanaku.home config placeholder for router and capabilities modules.

Documentation:
- Align configuration and persistence documentation to reference wanaku.home-based defaults instead of user.home-based paths.

Tests:
- Add unit tests for WanakuHome placeholder expansion and resolution behavior, and adjust existing CLI and capabilities tests to validate the new wanaku.home-based path handling.