### PR TITLE
chore: extract common steps from operator test plans

### DIFF
--- a/tests/plans/common/openshift-login.md
+++ b/tests/plans/common/openshift-login.md
@@ -1,0 +1,30 @@
+# Common: OpenShift Login
+
+Reusable steps for logging in to an OpenShift cluster using a service account token.
+
+## Prerequisites
+
+- `oc` CLI installed
+- `OPENSHIFT_API_URL` environment variable set (e.g. `https://api.cluster.example.com:6443`)
+- `OPENSHIFT_SA_TOKEN` environment variable set (service account token)
+
+## Steps
+
+### 1. Log in to OpenShift
+
+```bash
+oc login "${OPENSHIFT_API_URL}" --token="${OPENSHIFT_SA_TOKEN}" --insecure-skip-tls-verify=true
+```
+
+### 2. Verify login
+
+```bash
+oc whoami
+# Expected: prints the service account name (e.g. system:serviceaccount:<namespace>:<sa-name>)
+
+oc whoami --show-server
+# Expected: prints the cluster API URL
+
+oc version
+# Expected: prints client and server version info
+```

--- a/tests/plans/common/wait-for-deletion.md
+++ b/tests/plans/common/wait-for-deletion.md
@@ -1,0 +1,41 @@
+# Common: Wait for Resource Deletion
+
+Reusable helper that polls for Kubernetes resource deletion instead of using a fixed sleep.
+
+## Prerequisites
+
+- `oc` CLI installed and logged in
+- `WANAKU_NAMESPACE` environment variable set
+
+## Helper function
+
+Define this function before use:
+
+```bash
+wait_for_deletion() {
+  local RESOURCE_TYPE="$1"
+  local RESOURCE_NAME="$2"
+  local NAMESPACE="$3"
+  local TIMEOUT="${4:-60}"
+  local INTERVAL=3
+  local ELAPSED=0
+
+  while oc get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; do
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+      echo "FAIL: ${RESOURCE_TYPE}/${RESOURCE_NAME} still exists after ${TIMEOUT}s"
+      return 1
+    fi
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+  echo "PASS: ${RESOURCE_TYPE}/${RESOURCE_NAME} deleted (${ELAPSED}s)"
+  return 0
+}
+```
+
+## Usage
+
+```bash
+wait_for_deletion deployment my-deployment "${WANAKU_NAMESPACE}" 60
+wait_for_deletion route my-route "${WANAKU_NAMESPACE}" 30
+```

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -4,7 +4,7 @@
 
 This test plan verifies the basic functionality of the Wanaku Kubernetes operator deployed on OpenShift. It covers operator installation, CRD lifecycle, reconciliation, Keycloak/OIDC integration, router and capability deployment, service catalog management, and cleanup.
 
-Every step except the initial `oc login` is fully automatable.
+Every step is fully automatable.
 
 ## Prerequisites
 
@@ -66,58 +66,13 @@ export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wan
 
 ### Helper: wait for resource deletion
 
-Several tests verify that owned resources are garbage-collected after CR deletion. This helper polls for deletion instead of using a fixed sleep.
-
-```bash
-wait_for_deletion() {
-  local RESOURCE_TYPE="$1"
-  local RESOURCE_NAME="$2"
-  local NAMESPACE="$3"
-  local TIMEOUT="${4:-60}"
-  local INTERVAL=3
-  local ELAPSED=0
-
-  while oc get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; do
-    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
-      echo "FAIL: ${RESOURCE_TYPE}/${RESOURCE_NAME} still exists after ${TIMEOUT}s"
-      return 1
-    fi
-    sleep ${INTERVAL}
-    ELAPSED=$((ELAPSED + INTERVAL))
-  done
-  echo "PASS: ${RESOURCE_TYPE}/${RESOURCE_NAME} deleted (${ELAPSED}s)"
-  return 0
-}
-```
+Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the `wait_for_deletion` function.
 
 ---
 
-## Phase 0: OpenShift Login (MANUAL)
+## Phase 0: OpenShift Login
 
-This is the only manual step in the plan.
-
-### Step 0.1: Log in to OpenShift
-
-Log in to the target OpenShift cluster:
-
-```bash
-oc login <cluster-api-url> --username=<username> --password=<password>
-# Or with a token:
-# oc login <cluster-api-url> --token=<token>
-```
-
-### Step 0.2: Verify login
-
-```bash
-oc whoami
-# Expected: prints the logged-in username
-
-oc whoami --show-server
-# Expected: prints the cluster API URL
-
-oc version
-# Expected: prints client and server version info
-```
+Follow [common/openshift-login.md](common/openshift-login.md) to log in to the target OpenShift cluster using a service account token.
 
 ---
 
@@ -946,37 +901,7 @@ wait_for_deletion route wanaku-test-router "${WANAKU_NAMESPACE}" 30
 
 ## Phase 11: Cleanup
 
-Follow [common/cleanup.md](common/cleanup.md) for full teardown. Quick inline version:
-
-```bash
-# Delete any remaining Wanaku CRs
-oc delete wanakuservicecatalog --all -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-oc delete wanakucapability --all -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-oc delete wanakurouter --all -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-
-# Wait for operator-managed resources to drain
-oc wait --for=delete deployment -l component=wanaku-router-backend -n "${WANAKU_NAMESPACE}" --timeout=60s 2>/dev/null || true
-
-# Delete test ConfigMaps
-oc delete configmap -l wanaku-test=true -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-
-# Delete Keycloak
-oc delete deployment keycloak -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-oc delete service keycloak -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-oc delete route keycloak -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-oc delete pvc keycloak-data-pvc -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
-
-# Uninstall operator
-helm uninstall wanaku-operator --namespace "${WANAKU_NAMESPACE}"
-
-# Final verification
-echo "--- Remaining resources ---"
-oc get all -n "${WANAKU_NAMESPACE}"
-echo "--- Wanaku custom resources ---"
-oc get wanakurouter,wanakucapability,wanakuservicecatalog -n "${WANAKU_NAMESPACE}" 2>/dev/null || echo "None"
-echo "--- Helm releases ---"
-helm list --namespace "${WANAKU_NAMESPACE}"
-```
+Follow [common/cleanup.md](common/cleanup.md) for full teardown.
 
 ---
 
@@ -984,7 +909,7 @@ helm list --namespace "${WANAKU_NAMESPACE}"
 
 | Phase | Test ID | Test Name | Priority |
 |-------|---------|-----------|----------|
-| 0 | 0.1-0.2 | OpenShift login (MANUAL) | Critical |
+| 0 | — | OpenShift login | Critical |
 | 1 | 1.1-1.2 | Environment setup | Critical |
 | 2 | — | Operator installation and health | Critical |
 | 3 | 3.1-3.8 | WanakuRouter lifecycle and reconciliation | Critical |

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -4,7 +4,7 @@
 
 This test plan verifies the WanakuCamelRoute CRD feature on OpenShift. The WanakuCamelRoute lets users define Apache Camel routes and MCP tool/resource metadata inline in a Kubernetes CR. The operator packages the route into a service catalog ZIP and deploys it to the router via REST API.
 
-Every step except the initial `oc login` is fully automatable.
+Every step is fully automatable.
 
 ## Prerequisites
 
@@ -68,29 +68,7 @@ export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
 
 ### Helper: wait for resource deletion
 
-Several tests verify that resources are cleaned up after CR deletion. This helper polls for deletion instead of using a fixed sleep.
-
-```bash
-wait_for_deletion() {
-  local RESOURCE_TYPE="$1"
-  local RESOURCE_NAME="$2"
-  local NAMESPACE="$3"
-  local TIMEOUT="${4:-60}"
-  local INTERVAL=3
-  local ELAPSED=0
-
-  while oc get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -n "${NAMESPACE}" > /dev/null 2>&1; do
-    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
-      echo "FAIL: ${RESOURCE_TYPE}/${RESOURCE_NAME} still exists after ${TIMEOUT}s"
-      return 1
-    fi
-    sleep ${INTERVAL}
-    ELAPSED=$((ELAPSED + INTERVAL))
-  done
-  echo "PASS: ${RESOURCE_TYPE}/${RESOURCE_NAME} deleted (${ELAPSED}s)"
-  return 0
-}
-```
+Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the `wait_for_deletion` function.
 
 ### Helper: obtain a Bearer token from Keycloak
 
@@ -169,32 +147,9 @@ MCP_URI="http://localhost:18080/public/mcp"
 
 ---
 
-## Phase 0: OpenShift Login (MANUAL)
+## Phase 0: OpenShift Login
 
-This is the only manual step in the plan.
-
-### Step 0.1: Log in to OpenShift
-
-Log in to the target OpenShift cluster:
-
-```bash
-oc login <cluster-api-url> --username=<username> --password=<password>
-# Or with a token:
-# oc login <cluster-api-url> --token=<token>
-```
-
-### Step 0.2: Verify login
-
-```bash
-oc whoami
-# Expected: prints the logged-in username
-
-oc whoami --show-server
-# Expected: prints the cluster API URL
-
-oc version
-# Expected: prints client and server version info
-```
+Follow [common/openshift-login.md](common/openshift-login.md) to log in to the target OpenShift cluster using a service account token.
 
 ---
 
@@ -1370,7 +1325,7 @@ Follow [common/cleanup.md](common/cleanup.md) for full teardown.
 
 | Phase | Test ID | Test Name | Priority |
 |-------|---------|-----------|----------|
-| 0 | 0.1-0.2 | OpenShift login (MANUAL) | Critical |
+| 0 | — | OpenShift login | Critical |
 | 1 | 1.1-1.2 | Environment setup | Critical |
 | 2 | 2.1-2.2 | Operator installation + CamelRoute CRD/RBAC | Critical |
 | 3 | 3.1-3.3 | WanakuRouter setup and readiness | Critical |


### PR DESCRIPTION
## Summary

- Extracted OpenShift login steps to `common/openshift-login.md` — now automated via service account token instead of manual username/password
- Extracted `wait_for_deletion` helper to `common/wait-for-deletion.md` — was duplicated in both operator test plans
- Removed inline cleanup from `operator-basic-functionality.md` Phase 11 — just references `common/cleanup.md` now to avoid drift
- Updated both test plans to mark all steps as fully automatable

## Test plan
- [ ] Verify common steps are referenced correctly in both test plans
- [ ] Verify no broken links to common step files

## Summary by Sourcery

Deduplicate shared operator test plan steps into common reusable docs and align both operator test plans to be fully automatable.

Enhancements:
- Extract shared OpenShift login instructions into a common service-account-based login document and reference it from both operator test plans.
- Extract the wait_for_deletion helper script into a shared common document and reference it from both operator test plans.
- Simplify cleanup instructions in the basic operator test plan to rely solely on the existing common cleanup documentation.
- Update operator test plan metadata to remove manual-step designation and reflect that all phases are fully automatable.