### PR TITLE
chore: add @types/node to e2e test dependencies

### DIFF
--- a/tests/e2e/ui/package.json
+++ b/tests/e2e/ui/package.json
@@ -8,6 +8,7 @@
     "report": "npx playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.60.0"
+    "@playwright/test": "^1.60.0",
+    "@types/node": "^26.0.0"
   }
 }

--- a/tests/e2e/ui/yarn.lock
+++ b/tests/e2e/ui/yarn.lock
@@ -4,26 +4,38 @@
 
 "@playwright/test@^1.60.0":
   version "1.61.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.0.tgz#dcc3d43e581aab2985d70413309d89350e980ad8"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz"
   integrity sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==
   dependencies:
     playwright "1.61.0"
 
+"@types/node@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz"
+  integrity sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==
+  dependencies:
+    undici-types "~8.3.0"
+
 fsevents@2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 playwright-core@1.61.0:
   version "1.61.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0.tgz#caf8078b2a39cd7738dc75ec11cb3b47f385c3f0"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz"
   integrity sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==
 
 playwright@1.61.0:
   version "1.61.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.0.tgz#7082df3df08ffa82b11420ea5fae84a40bd16e3f"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz"
   integrity sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==
   dependencies:
     playwright-core "1.61.0"
   optionalDependencies:
     fsevents "2.3.2"
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==


### PR DESCRIPTION
## Summary
- Adds `@types/node` as a dev dependency to `tests/e2e/ui/` to fix TS2580 warning on `process` usage in `playwright.config.ts`

## Test plan
- [ ] Verify TS2580 warning is gone in IDE
- [ ] Run `npx playwright test` to confirm no regressions

## Summary by Sourcery

Build:
- Include @types/node as a dev dependency in the e2e UI test package.