### PR TITLE
Fix #1415: proxy Keycloak token endpoint through the router

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@Path("/realms/{realm}/protocol/openid-connect")
+public class KeycloakTokenProxyResource {
+
+    private static final Logger LOG = Logger.getLogger(KeycloakTokenProxyResource.class);
+
+    @ConfigProperty(name = "auth.server", defaultValue = "http://localhost:8543")
+    String authServer;
+
+    @ConfigProperty(name = "auth.realm", defaultValue = "wanaku")
+    String configuredRealm;
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response proxyToken(
+            @PathParam("realm") String realm, @HeaderParam("Authorization") String authorization, String formBody) {
+
+        if (!configuredRealm.equals(realm)) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        URI target = URI.create(authServer + "/realms/" + realm + "/protocol/openid-connect/token");
+        HttpRequest.Builder builder = HttpRequest.newBuilder(target)
+                .POST(HttpRequest.BodyPublishers.ofString(formBody != null ? formBody : ""))
+                .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED);
+
+        if (authorization != null && !authorization.isBlank()) {
+            builder.header("Authorization", authorization);
+        }
+
+        try {
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return Response.ok(response.body(), MediaType.APPLICATION_JSON).build();
+            }
+
+            LOG.warnf("Keycloak token request to %s returned %d", target, response.statusCode());
+            return Response.status(response.statusCode())
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(response.body())
+                    .build();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.errorf(e, "Interrupted while proxying token request to %s", target);
+            return Response.status(Response.Status.BAD_GATEWAY).build();
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed to proxy token request to %s", target);
+            return Response.status(Response.Status.BAD_GATEWAY).build();
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -184,7 +184,7 @@ quarkus.oidc-proxy.root-path=/q/oidc
 quarkus.oidc-proxy.tenant-id=mcp
 
 # Paths used by the OIDC Proxy, which need to be public
-quarkus.http.auth.permission.oidcproxy.paths=/.well-known/oauth-protected-resource/*, /.well-known/oauth-authorization-server/*, /q/oidc/*
+quarkus.http.auth.permission.oidcproxy.paths=/.well-known/oauth-protected-resource/*, /.well-known/oauth-authorization-server/*, /q/oidc/*, /realms/*/protocol/openid-connect/*
 quarkus.http.auth.permission.oidcproxy.policy=permit
 
 # Health check paths must be publicly accessible for K8s probes

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResourceIT.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResourceIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.backend.api.v1.oidc;
+
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(KeycloakTokenProxyResourceIT.Profile.class)
+class KeycloakTokenProxyResourceIT {
+
+    @Test
+    void proxiesClientCredentialsTokenRequest() {
+        given().contentType("application/x-www-form-urlencoded")
+                .body("grant_type=client_credentials&client_id=wanaku-service&client_secret=secret")
+                .when()
+                .post("/realms/wanaku/protocol/openid-connect/token")
+                .then()
+                .statusCode(200)
+                .body("access_token", equalTo("test-token"))
+                .body("token_type", equalTo("Bearer"));
+    }
+
+    @Test
+    void returnsNotFoundForUnknownRealm() {
+        given().contentType("application/x-www-form-urlencoded")
+                .body("grant_type=client_credentials&client_id=test&client_secret=secret")
+                .when()
+                .post("/realms/unknown-realm/protocol/openid-connect/token")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void forwardsBadRequestFromKeycloak() {
+        given().contentType("application/x-www-form-urlencoded")
+                .body("grant_type=invalid")
+                .when()
+                .post("/realms/wanaku/protocol/openid-connect/token")
+                .then()
+                .statusCode(400)
+                .body("error", equalTo("unsupported_grant_type"));
+    }
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.oidc-proxy.enabled", "false",
+                    "quarkus.oidc.enabled", "false",
+                    "auth.server", "http://localhost:${quarkus.http.port}/test-keycloak",
+                    "auth.realm", "wanaku");
+        }
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/KeycloakTokenProxyResourceTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Wanaku AI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KeycloakTokenProxyResourceTest {
+
+    @Test
+    void rejectsRealmMismatch() {
+        KeycloakTokenProxyResource resource = new KeycloakTokenProxyResource();
+        resource.authServer = "http://keycloak:8080";
+        resource.configuredRealm = "wanaku";
+
+        Response response = resource.proxyToken("other-realm", null, "grant_type=client_credentials");
+
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/TestKeycloakTokenResource.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/TestKeycloakTokenResource.java
@@ -1,0 +1,31 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+@Path("/test-keycloak/realms/wanaku/protocol/openid-connect")
+public class TestKeycloakTokenResource {
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response token(@HeaderParam("Authorization") String authorization, String formBody) {
+        if (formBody != null && formBody.contains("grant_type=client_credentials")) {
+            String json = "{\"access_token\":\"test-token\",\"token_type\":\"Bearer\",\"expires_in\":300}";
+            return Response.ok(json, MediaType.APPLICATION_JSON).build();
+        }
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity("{\"error\":\"unsupported_grant_type\"}")
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `KeycloakTokenProxyResource` that forwards `POST /realms/{realm}/protocol/openid-connect/token` to the configured Keycloak `AUTH_SERVER`, allowing external MCP clients to obtain tokens through the router when `authProxy` is set
- Adds `/realms/*/protocol/openid-connect/*` to the public OIDC permission rule so token requests bypass the default-deny policy
- Validates the requested realm matches the configured `auth.realm` (returns 404 otherwise)

## Test plan

- [x] Unit test: realm mismatch returns 404
- [x] Integration test: `client_credentials` token request proxied successfully (200)
- [x] Integration test: unknown realm returns 404
- [x] Integration test: bad request forwarded from Keycloak (400)
- [ ] Manual: deploy on OpenShift with `authProxy: "auto"` and verify token endpoint is accessible through the router route

## Summary by Sourcery

Proxy Keycloak token endpoint through the router and ensure it is publicly accessible for the configured realm only.

New Features:
- Expose a /realms/{realm}/protocol/openid-connect/token endpoint on the router that forwards token requests to the configured Keycloak auth server.

Enhancements:
- Allow public access to Keycloak OIDC protocol paths required for token acquisition while preserving default-deny for other routes.
- Validate that token requests target the configured authentication realm and return 404 for mismatches, propagating Keycloak error responses where appropriate.

Tests:
- Add unit and integration tests covering successful client_credentials token proxying, realm mismatch handling, and propagation of bad request errors from Keycloak.