### PR TITLE
chore: set KC_HOSTNAME on Keycloak deployments in test plan

### DIFF
--- a/deploy/auth/keycloak.yaml
+++ b/deploy/auth/keycloak.yaml
@@ -31,6 +31,8 @@ spec:
               value: "xforwarded"
             - name: KC_HTTP_ENABLED
               value: "true"
+            - name: KC_HOSTNAME
+              value: "KEYCLOAK_HOST"
             - name: KC_HOSTNAME_STRICT
               value: "false"
           args:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,40 @@ wanaku auth login --url http://localhost:8080
 wanaku tools list --no-auth
 ```
 
+### Token issuer mismatch causes 401 on OpenShift / Kubernetes
+
+**Symptoms:**
+
+- External clients obtain tokens from Keycloak and send them to the router
+- The router rejects all tokens with HTTP 401
+- Keycloak and the router are both running, and the realm is configured correctly
+
+**Why this happens:**
+
+When Keycloak is accessed via an external route (e.g. `http://keycloak-wanaku-test.<cluster>/realms/wanaku`), tokens are stamped with that route URL as the issuer. The router, however, validates tokens against the internal service URL (`http://keycloak:8080/realms/wanaku`). Because the issuers don't match, every token is rejected.
+
+**Fix:**
+
+Set `KC_HOSTNAME` on the Keycloak deployment to match the external route or ingress host. This forces Keycloak to stamp the same issuer in all tokens regardless of how it is accessed:
+
+```shell
+# OpenShift
+KEYCLOAK_HOST=$(oc get route keycloak -n "${WANAKU_NAMESPACE}" -o jsonpath='{.spec.host}')
+oc set env deployment/keycloak \
+  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME_STRICT=false \
+  -n "${WANAKU_NAMESPACE}"
+
+# Kubernetes (use the Ingress host instead)
+KEYCLOAK_HOST=$(kubectl get ingress keycloak -n "${WANAKU_NAMESPACE}" -o jsonpath='{.spec.rules[0].host}')
+kubectl set env deployment/keycloak \
+  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME_STRICT=false \
+  -n "${WANAKU_NAMESPACE}"
+```
+
+The `deploy/auth/keycloak.yaml` manifest includes a `KEYCLOAK_HOST` placeholder for `KC_HOSTNAME` — replace it with your actual hostname before applying. See also the [Keycloak setup test plan](../tests/plans/common/keycloak-setup.md) for the full automated procedure.
+
 ## Capability Service Registration
 
 ### Capability services start but don't appear in the router

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -146,6 +146,40 @@ cat deploy/auth/keycloak-ingress.yaml | sed "s/KEYCLOAK_HOST/keycloak.$(minikube
 kubectl apply -f deploy/auth/keycloak-router.yaml
 ```
 
+#### Setting KC_HOSTNAME (required for external access)
+
+After exposing Keycloak, you **must** set the `KC_HOSTNAME` environment variable on the Keycloak deployment to match the
+external route or ingress host. Without this, tokens obtained via the external URL will have a different issuer than what
+the Wanaku router expects, causing all authenticated requests to fail with HTTP 401.
+
+- OpenShift
+
+```shell
+KEYCLOAK_HOST=$(kubectl get route keycloak -o jsonpath='{.spec.host}')
+kubectl set env deployment/keycloak \
+  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME_STRICT=false
+```
+
+- Minikube
+
+```shell
+KEYCLOAK_HOST=$(kubectl get ingress keycloak -o jsonpath='{.spec.rules[0].host}')
+kubectl set env deployment/keycloak \
+  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME_STRICT=false
+```
+
+Wait for the rollout to complete before proceeding:
+
+```shell
+kubectl rollout status deployment/keycloak --timeout=300s
+```
+
+> [!NOTE]
+> The `deploy/auth/keycloak.yaml` manifest includes a `KEYCLOAK_HOST` placeholder for `KC_HOSTNAME`. If you prefer to set
+> the hostname before deploying, replace the placeholder with your actual hostname in the manifest and skip this step.
+
 ### Importing the Wanaku Realm Configuration (via Wanaku CLI)
 
 The simplest way to import the realm configuration is using the Wanaku CLI. You can set admin credentials once via environment variables:

--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -155,7 +155,31 @@ fi
 echo "PASS: Keycloak host is ${KEYCLOAK_HOST}"
 ```
 
-### 5. Wait for Keycloak to respond
+### 5. Set KC_HOSTNAME to match the external route
+
+Setting `KC_HOSTNAME` ensures Keycloak stamps the same issuer in tokens regardless of whether
+they are obtained via the external route or internally. Without this, tokens obtained externally
+(e.g. `http://keycloak-wanaku-test.<cluster>/realms/wanaku`) will have a different issuer than
+what the router expects (`http://keycloak:8080/realms/wanaku`), causing 401 errors.
+
+```bash
+oc set env deployment/keycloak \
+  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME_STRICT=false \
+  -n "${WANAKU_NAMESPACE}"
+```
+
+Wait for the rollout to complete (the env change triggers a new pod):
+
+```bash
+oc rollout status deployment/keycloak \
+  --timeout=300s \
+  -n "${WANAKU_NAMESPACE}"
+```
+
+**Expected output:** `deployment "keycloak" successfully rolled out`
+
+### 6. Wait for Keycloak to respond
 
 ```bash
 MAX_RETRIES=30
@@ -175,7 +199,7 @@ for i in $(seq 1 ${MAX_RETRIES}); do
 done
 ```
 
-### 6. Import the Wanaku realm using the CLI
+### 7. Import the Wanaku realm using the CLI
 
 The Wanaku CLI imports a full realm configuration that includes:
 - The `wanaku` realm with all settings
@@ -205,7 +229,7 @@ fi
 echo "PASS: wanaku realm is accessible"
 ```
 
-### 7. Retrieve the OIDC client secret for wanaku-service
+### 8. Retrieve the OIDC client secret for wanaku-service
 
 The realm configuration sets the `wanaku-service` client secret via the Keycloak variable `${WANAKU_SERVICE_SECRET:mypasswd}`. By default this resolves to `mypasswd` unless the `WANAKU_SERVICE_SECRET` environment variable was set on the Keycloak container.
 
@@ -249,7 +273,7 @@ fi
 echo "PASS: OIDC secret retrieved (length: ${#WANAKU_OIDC_SECRET})"
 ```
 
-### 8. Verify the OIDC token endpoint works
+### 9. Verify the OIDC token endpoint works
 
 ```bash
 TOKEN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -265,9 +289,9 @@ fi
 echo "PASS: OIDC token endpoint works"
 ```
 
-### 9. Workaround: force-set the client secret if token request fails
+### 10. Workaround: force-set the client secret if token request fails
 
-When importing the realm via the CLI (not at Keycloak bootstrap), the variable `${WANAKU_SERVICE_SECRET:mypasswd}` may be stored literally instead of being resolved. If step 8 fails with HTTP 401, force-set the client secret:
+When importing the realm via the CLI (not at Keycloak bootstrap), the variable `${WANAKU_SERVICE_SECRET:mypasswd}` may be stored literally instead of being resolved. If step 9 fails with HTTP 401, force-set the client secret:
 
 ```bash
 if [ "${TOKEN_RESPONSE}" = "401" ]; then


### PR DESCRIPTION
## Summary

- Adds a new step (step 5) in `tests/plans/common/keycloak-setup.md` to set `KC_HOSTNAME` and `KC_HOSTNAME_STRICT=false` on the Keycloak deployment after retrieving the external route
- Waits for the rollout to complete before proceeding
- Renumbers subsequent steps (6-10) accordingly

This ensures Keycloak stamps a consistent issuer in tokens regardless of whether they are obtained via the external route or the internal service URL, preventing 401 errors from issuer mismatch.

Fixes #1416

## Summary by Sourcery

Update the Keycloak test plan to configure KC_HOSTNAME based on the external route to ensure consistent token issuers and prevent 401 errors.

Documentation:
- Document a new step to set KC_HOSTNAME and KC_HOSTNAME_STRICT on the Keycloak deployment and wait for the rollout to complete in the common Keycloak setup guide.
- Renumber subsequent Keycloak setup steps to reflect the inserted hostname configuration step.