### PR TITLE
Fix #1417: forward auth token to MCP SSE message sub-endpoint

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -71,6 +71,6 @@ public class McpPrompt extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -44,7 +44,7 @@ public class McpPromptList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -62,6 +62,6 @@ public class McpResource extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -46,7 +46,7 @@ public class McpResourceList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -70,7 +70,7 @@ public class McpTool extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 
     static String serializeParams(Map<String, String> params) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -45,7 +45,7 @@ public class McpToolList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri);
+        return ClientUtil.createClient(uri, authTokenOverride);
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptListTest.java
@@ -6,17 +6,21 @@ import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -81,5 +85,26 @@ class McpPromptListTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        when(tokenClient.listPrompts()).thenReturn(Collections.emptyList());
+
+        McpPromptList cmd = new McpPromptList();
+        new CommandLine(cmd).parseArgs("--uri", "http://localhost:9999/mcp/sse", "--token", "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpPromptTest.java
@@ -8,21 +8,25 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.McpGetPromptResult;
 import dev.langchain4j.mcp.client.McpPromptMessage;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -90,5 +94,37 @@ class McpPromptTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("not found");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        McpGetPromptResult emptyResult = mock(McpGetPromptResult.class);
+        when(emptyResult.messages()).thenReturn(Collections.emptyList());
+        when(tokenClient.getPrompt(eq("greeting"), any())).thenReturn(emptyResult);
+
+        McpPrompt cmd = new McpPrompt();
+        new CommandLine(cmd)
+                .parseArgs(
+                        "--uri",
+                        "http://localhost:9999/mcp/sse",
+                        "--name",
+                        "greeting",
+                        "--arg",
+                        "name=Alice",
+                        "--token",
+                        "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceListTest.java
@@ -6,17 +6,21 @@ import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -81,5 +85,26 @@ class McpResourceListTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        when(tokenClient.listResources()).thenReturn(Collections.emptyList());
+
+        McpResourceList cmd = new McpResourceList();
+        new CommandLine(cmd).parseArgs("--uri", "http://localhost:9999/mcp/sse", "--token", "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpResourceTest.java
@@ -6,19 +6,23 @@ import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.McpReadResourceResult;
 import dev.langchain4j.mcp.client.McpTextResourceContents;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -82,5 +86,34 @@ class McpResourceTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("not found");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        McpReadResourceResult emptyResult = new McpReadResourceResult(Collections.emptyList());
+        when(tokenClient.readResource("file:///test.txt")).thenReturn(emptyResult);
+
+        McpResource cmd = new McpResource();
+        new CommandLine(cmd)
+                .parseArgs(
+                        "--uri",
+                        "http://localhost:9999/mcp/sse",
+                        "--resource-uri",
+                        "file:///test.txt",
+                        "--token",
+                        "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
@@ -6,18 +6,22 @@ import java.util.Collections;
 import java.util.List;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.McpClient;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,5 +90,26 @@ class McpToolListTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        when(tokenClient.listTools()).thenReturn(Collections.emptyList());
+
+        McpToolList cmd = new McpToolList();
+        new CommandLine(cmd).parseArgs("--uri", "http://localhost:9999/mcp/sse", "--token", "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -6,20 +6,24 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolExecutionResult;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -120,5 +124,39 @@ class McpToolTest {
         Integer result = command.doCall(null, printer);
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("Missing required option: --name");
+    }
+
+    @Test
+    @DisplayName("Should forward auth token to MCP client")
+    void shouldForwardAuthToken() throws Exception {
+        McpClient tokenClient = mock(McpClient.class);
+        when(tokenClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenReturn(ToolExecutionResult.builder()
+                        .resultText("ok")
+                        .isError(false)
+                        .build());
+
+        McpTool cmd = new McpTool();
+        new CommandLine(cmd)
+                .parseArgs(
+                        "--uri",
+                        "http://localhost:9999/mcp/sse",
+                        "--name",
+                        "echo",
+                        "--param",
+                        "msg=hi",
+                        "--token",
+                        "my-secret-token");
+
+        try (MockedStatic<ClientUtil> clientUtil = mockStatic(ClientUtil.class)) {
+            clientUtil
+                    .when(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"))
+                    .thenReturn(tokenClient);
+
+            Integer result = cmd.doCall(null, mock(WanakuPrinter.class));
+            assertEquals(BaseCommand.EXIT_OK, result);
+
+            clientUtil.verify(() -> ClientUtil.createClient("http://localhost:9999/mcp/sse", "my-secret-token"));
+        }
     }
 }

--- a/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
+++ b/core/core-mcp-client/src/main/java/ai/wanaku/core/mcp/client/ClientUtil.java
@@ -15,7 +15,15 @@ import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 public class ClientUtil {
 
     public static McpClient createClient(String address) {
-        return createClient(address, null);
+        return createClient(address, (McpHeadersSupplier) null);
+    }
+
+    public static McpClient createClient(String address, String token) {
+        String normalizedToken = token != null ? token.trim() : null;
+        McpHeadersSupplier tokenHeaders = (normalizedToken != null && !normalizedToken.isEmpty())
+                ? callContext -> Map.of("Authorization", "Bearer " + normalizedToken)
+                : null;
+        return createClient(address, tokenHeaders);
     }
 
     public static McpClient createClient(String address, McpHeadersSupplier headersSupplier) {


### PR DESCRIPTION
## Summary

- Add `ClientUtil.createClient(String address, String token)` overload that wraps the Bearer token in an `McpHeadersSupplier` and delegates to `createClient(String, McpHeadersSupplier)` — integrates cleanly with OTel trace context propagation
- Blank/empty tokens are normalized to null (no malformed `Authorization: Bearer ` header)
- Update all 6 MCP CLI commands to forward `authTokenOverride` to `ClientUtil.createClient`
- Add token forwarding tests to all 6 MCP command test classes using `MockedStatic<ClientUtil>` and picocli arg parsing

## Test plan

- [x] All 309 existing CLI tests pass
- [x] New tests verify each MCP command forwards the `--token` value to `ClientUtil.createClient(uri, token)`
- [x] Full reactor build succeeds
- [ ] Manual verification: `wanaku mcp tool list --uri $ROUTER_URL/mcp/sse --token $TOKEN` against OIDC-protected router