### PR TITLE
Fix #1172: use router navigation in ErrorBoundary and standardize error handling

### DIFF
--- a/apps/ui/admin/src/Pages/DataStores/AddDataStoreModal.tsx
+++ b/apps/ui/admin/src/Pages/DataStores/AddDataStoreModal.tsx
@@ -53,8 +53,7 @@ export const AddDataStoreModal: React.FC<AddDataStoreModalProps> = ({
       };
 
       onSubmit(dataStore);
-    } catch (error) {
-      console.error("Error reading file:", error);
+    } catch {
       setErrorText("Error reading file. Please try again.");
     }
   };

--- a/apps/ui/admin/src/Pages/DataStores/DataStoresPage.tsx
+++ b/apps/ui/admin/src/Pages/DataStores/DataStoresPage.tsx
@@ -21,8 +21,7 @@ export const DataStoresPage: React.FC = () => {
         setFetchedData((result.data.data as DataStore[]) || []);
         setIsLoading(false);
       })
-      .catch((error) => {
-        console.error("Error fetching data stores:", error);
+      .catch(() => {
         setErrorMessage("Failed to load data stores");
         setIsLoading(false);
       });
@@ -50,8 +49,7 @@ export const DataStoresPage: React.FC = () => {
       listDataStores().then((result) => {
         setFetchedData((result.data.data as DataStore[]) || []);
       });
-    } catch (error) {
-      console.error("Error adding data store:", error);
+    } catch {
       setErrorMessage("Error adding data store. Please try again.");
     }
   };
@@ -64,8 +62,7 @@ export const DataStoresPage: React.FC = () => {
       listDataStores().then((result) => {
         setFetchedData((result.data.data as DataStore[]) || []);
       });
-    } catch (error) {
-      console.error("Error deleting data store:", error);
+    } catch {
       setErrorMessage(`Failed to delete data store`);
     }
   };
@@ -94,8 +91,7 @@ export const DataStoresPage: React.FC = () => {
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error("Error downloading file:", error);
+    } catch {
       setErrorMessage("Failed to download file. Data may be corrupted.");
     }
   };

--- a/apps/ui/admin/src/Pages/DataStores/ViewDataStoreModal.tsx
+++ b/apps/ui/admin/src/Pages/DataStores/ViewDataStoreModal.tsx
@@ -37,8 +37,7 @@ export const ViewDataStoreModal: React.FC<ViewDataStoreModalProps> = ({
       const decoded = new TextDecoder("utf-8").decode(bytes);
       setDecodedContent(decoded);
       setIsLoading(false);
-    } catch (err) {
-      console.error("Error decoding data:", err);
+    } catch {
       setError("Failed to decode data. The content may be binary or corrupted.");
       setIsLoading(false);
     }

--- a/apps/ui/admin/src/Pages/Error/ErrorPage.tsx
+++ b/apps/ui/admin/src/Pages/Error/ErrorPage.tsx
@@ -1,5 +1,31 @@
 import {FunctionComponent} from "react";
+import {useRouteError, isRouteErrorResponse, Link} from "react-router-dom";
+import {InlineNotification, Button} from "@carbon/react";
 
 export const ErrorPage: FunctionComponent = () => {
-  return <h1>Error</h1>;
+  const error = useRouteError();
+
+  let message = "An unexpected error occurred.";
+  if (isRouteErrorResponse(error)) {
+    message = error.status === 404 ? "Page not found." : `${error.status}: ${error.statusText}`;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <div style={{padding: "2rem"}}>
+      <h1>Something went wrong</h1>
+      <InlineNotification
+        kind="error"
+        title="Error"
+        subtitle={message}
+        hideCloseButton
+      />
+      <Link to="/">
+        <Button kind="primary" style={{marginTop: "1rem"}}>
+          Go to Dashboard
+        </Button>
+      </Link>
+    </div>
+  );
 };

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -11,6 +11,7 @@ import {Send, Stop} from "@carbon/icons-react"
 import {LLMChatMessage} from "./LLMChatMessage"
 import {getUrl} from "../../custom-fetch"
 import {ToolReference} from "../../models"
+import {getErrorMessage} from "../../utils/error"
 
 
 interface ChatMessage {
@@ -88,7 +89,11 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
         setDisplayedMessages(chatHistory.current)
       }
     } catch (error) {
-      console.error("Error during conversation:", error)
+      if (!signal.aborted) {
+        const networkError = { role: "error", content: `Network error: ${getErrorMessage(error)}` } as const
+        chatHistory.current.push(networkError)
+        setDisplayedMessages([...chatHistory.current])
+      }
     } finally {
       setIsRunning(false)
     }

--- a/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -1,9 +1,9 @@
-import React, {useState} from "react"
+import React, {useEffect, useState} from "react"
 import "highlight.js/styles/atom-one-dark.css"
 import {LLMSetup} from "./LLMSetup.tsx"
 import {LLMTools} from "./LLMTools.tsx"
 import {LLMChatArea, LlmChatConfig} from "./LLMChatArea"
-import {Column, Grid} from "@carbon/react"
+import {Column, Grid, ToastNotification} from "@carbon/react"
 import {
   isConfigStoredInLocalStorage,
   LLM_CONFIG,
@@ -18,6 +18,14 @@ export const LLMChatPage: React.FC = () => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState(isConfigStoredInLocalStorage())
   const [config, setConfig] = useState<LlmConfig>(loadConfig())
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (errorMessage) {
+      const timer = setTimeout(() => setErrorMessage(null), 10000);
+      return () => clearTimeout(timer);
+    }
+  }, [errorMessage]);
   
   
   function applyConfigChange(config: LlmConfig) {
@@ -41,6 +49,16 @@ export const LLMChatPage: React.FC = () => {
   
   return (
     <div>
+      {errorMessage && (
+        <ToastNotification
+          kind="error"
+          title="Error"
+          subtitle={errorMessage}
+          onCloseButtonClick={() => setErrorMessage(null)}
+          timeout={10000}
+          style={{float: "right"}}
+        />
+      )}
       <h1 className="title">LLM Chat for testing</h1>
       <Grid fullWidth>
         <Column lg={4}>
@@ -65,6 +83,7 @@ export const LLMChatPage: React.FC = () => {
             onSelectionChange={(selectedTools) => {
               applyConfigChange({ ...config, selectedTools })
             }}
+            onError={(msg) => setErrorMessage(msg)}
           />
         </Column>
         <Column lg={12}>

--- a/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
+++ b/apps/ui/admin/src/Pages/LLMChat/LLMTools.tsx
@@ -7,14 +7,16 @@ import {
 import React, {useEffect, useState} from "react"
 import {useTools} from "../../hooks/api/use-tools"
 import {ToolReference} from "../../models"
+import {getErrorMessage} from "../../utils/error"
 
 
 interface LLMToolsProps {
   selectedTools: ToolReference[]
   onSelectionChange: (tools: ToolReference[]) => void
+  onError?: (message: string) => void
 }
 
-export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionChange }) => {
+export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionChange, onError }) => {
   
   const [tools, setTools] = useState<ToolReference[]>([])
   const [isLoading, setLoading] = useState(true)
@@ -26,7 +28,7 @@ export const LLMTools: React.FC<LLMToolsProps> = ({ selectedTools, onSelectionCh
         const tools = await fetchTools()
         setTools(tools)
       } catch (error) {
-        console.error("Failed to load tools", error)
+        onError?.(getErrorMessage(error))
         setTools([])
       } finally {
         setLoading(false)

--- a/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
+++ b/apps/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
@@ -60,8 +60,7 @@ export const NamespacesPage: React.FC = () => {
       setIsModalOpen(false);
       setErrorMessage(null);
       await refreshNamespaces();
-    } catch (error) {
-      console.error("Error creating namespace:", error);
+    } catch {
       setIsModalOpen(false);
       setErrorMessage("Error creating namespace. The name or path may already be in use.");
     }
@@ -72,8 +71,7 @@ export const NamespacesPage: React.FC = () => {
       await updateNamespace(namespace);
       setErrorMessage(null);
       await refreshNamespaces();
-    } catch (error) {
-      console.error("Error updating namespace:", error);
+    } catch {
       setErrorMessage("Error updating namespace.");
     } finally {
       handleModalClose();
@@ -85,8 +83,7 @@ export const NamespacesPage: React.FC = () => {
       if (!namespace.id) return;
       await removeNamespace(namespace.id);
       await refreshNamespaces();
-    } catch (error) {
-      console.error("Error deleting namespace:", error);
+    } catch {
       setErrorMessage(`Failed to delete namespace: ${namespace.name || namespace.path}`);
     }
   };

--- a/apps/ui/admin/src/Pages/Prompts/PromptsModal.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsModal.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from "react"
 import {PromptReference} from "../../models"
-import {Modal, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, TextArea, TextInput} from "@carbon/react"
+import {InlineNotification, Modal, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, TextArea, TextInput} from "@carbon/react"
 import {NamespaceSelect} from "../Namespaces/NamespaceSelect"
 
 
@@ -17,8 +17,10 @@ export const PromptModal: React.FC<PromptModalProps> = ({ onSubmit, onRequestClo
   const [argumentsJson, setArgumentsJson] = useState("")
   const [toolReferences, setToolReferences] = useState("")
   const [selectedNamespace, setSelectedNamespace] = useState("")
-  
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
   const handleSubmit = () => {
+    setJsonError(null)
     try {
       const messages = messagesJson ? JSON.parse(messagesJson) : []
       const args = argumentsJson ? JSON.parse(argumentsJson) : []
@@ -32,8 +34,8 @@ export const PromptModal: React.FC<PromptModalProps> = ({ onSubmit, onRequestClo
         toolReferences: toolRefs,
         namespace: selectedNamespace
       })
-    } catch (error) {
-      console.error("Invalid JSON in prompt data:", error)
+    } catch {
+      setJsonError("Invalid JSON in messages or arguments fields")
     }
   }
   
@@ -46,6 +48,14 @@ export const PromptModal: React.FC<PromptModalProps> = ({ onSubmit, onRequestClo
       onRequestSubmit={handleSubmit}
       onRequestClose={onRequestClose}
     >
+      {jsonError && (
+        <InlineNotification
+          kind="error"
+          title="Invalid JSON"
+          subtitle={jsonError}
+          onCloseButtonClick={() => setJsonError(null)}
+        />
+      )}
       <Tabs>
         <TabList>
           <Tab>Overview</Tab>

--- a/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/apps/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -50,8 +50,7 @@ export const PromptsPage: React.FC = () => {
       setErrorMessage(null);
 
       await updatePrompts();
-    } catch (error) {
-      console.error("Error adding prompt:", error);
+    } catch {
       setIsAddModalOpen(false);
       setErrorMessage("Error adding prompt: The prompt name must be unique");
     }
@@ -61,8 +60,7 @@ export const PromptsPage: React.FC = () => {
     try {
       await removePrompt(promptName!);
       await updatePrompts();
-    } catch (error) {
-      console.error("Error deleting prompt:", error);
+    } catch {
       setErrorMessage(`Failed to delete prompt: ${promptName}`);
     }
   };

--- a/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourceModal.tsx
@@ -12,9 +12,10 @@ interface ResourceModalProps {
   openedResource?: ResourceReference
   onSubmit: (resource: ResourceReference) => void
   onCancel: () => void
+  onError?: (message: string) => void
 }
 
-export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, onSubmit, onCancel }) => {
+export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, onSubmit, onCancel, onError }) => {
   
   const [name, setName] = useState(openedResource?.name)
   const [description, setDescription] = useState(openedResource?.description)
@@ -102,6 +103,7 @@ export const ResourceModal: React.FC<ResourceModalProps> = ({ openedResource, on
                 value={type}
                 onChange={setType}
                 apiCall={listManagementResources}
+                onError={onError}
               />
               <ComboBox
                 id="resource-mime-type"

--- a/apps/ui/admin/src/Pages/Resources/ResourcesPage.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourcesPage.tsx
@@ -4,6 +4,7 @@ import {RefreshHandle, ResourcesTable} from "./ResourcesTable"
 import React, {useRef, useState} from "react"
 import {ResourceReference} from "../../models"
 import {useResources} from "../../hooks/api/use-resources"
+import {getErrorMessage} from "../../utils/error"
 
 
 export const ResourcesPage: React.FC = () => {
@@ -31,7 +32,7 @@ export const ResourcesPage: React.FC = () => {
     try {
       await exposeResource(resource)
     } catch (error) {
-      setErrorMessage(`Error adding resource: ${error}`)
+      setErrorMessage(`Error adding resource: ${getErrorMessage(error)}`)
     } finally {
       setModalOpen(false)
       refreshResources()
@@ -42,7 +43,7 @@ export const ResourcesPage: React.FC = () => {
     try {
       await updateResource(resource)
     } catch (error) {
-      setErrorMessage(`Error updating resource: ${error}`)
+      setErrorMessage(`Error updating resource: ${getErrorMessage(error)}`)
     } finally {
       setOpenedResource(undefined)
       setModalOpen(false)
@@ -54,7 +55,7 @@ export const ResourcesPage: React.FC = () => {
     try {
       await removeResource(resourceName)
     } catch (error) {
-      setErrorMessage(`Error deleting resource: ${error}`)
+      setErrorMessage(`Error deleting resource: ${getErrorMessage(error)}`)
     } finally {
       refreshResources()
     }
@@ -89,6 +90,7 @@ export const ResourcesPage: React.FC = () => {
             setModalOpen(true)
           }}
           onDelete={handleDeleteResource}
+          onError={(msg) => setErrorMessage(msg)}
           ref={resourceTableRef}
         />
       </div>
@@ -97,6 +99,7 @@ export const ResourcesPage: React.FC = () => {
           openedResource={openedResource}
           onSubmit={handleModalSubmit}
           onCancel={handleModalCancel}
+          onError={(msg) => setErrorMessage(msg)}
         />
       )}
     </div>

--- a/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/apps/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -20,6 +20,7 @@ import {Param, ResourceReference} from "../../models"
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import {useResources} from "../../hooks/api/use-resources"
 import {TableEmptyState} from "../EmptyTableState"
+import {getErrorMessage} from "../../utils/error"
 
 
 export interface RefreshHandle {
@@ -30,10 +31,11 @@ interface ResourcesTableProps {
   onAdd: () => void
   onEdit: (resource: ResourceReference) => void
   onDelete: (resourceName: string) => void
+  onError?: (message: string) => void
   ref?: RefObject<RefreshHandle>
 }
 
-export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, onDelete, ref }) => {
+export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, onDelete, onError, ref }) => {
   
   const [resources, setResources] = useState<ResourceReference[]>([])
   const [isLoading, setLoading] = useState(true)
@@ -57,7 +59,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, o
       const resources = result.data.data as ResourceReference[]
       setResources(resources)
     } catch (error) {
-      console.error(error)
+      onError?.(getErrorMessage(error))
     } finally {
       setLoading(false)
     }

--- a/apps/ui/admin/src/Pages/ServiceCatalog/ServiceCatalogPage.tsx
+++ b/apps/ui/admin/src/Pages/ServiceCatalog/ServiceCatalogPage.tsx
@@ -56,8 +56,7 @@ export const ServiceCatalogPage: React.FC = () => {
         const body = result.data as { data: ServiceCatalogSummary[] };
         setCatalogs(body.data || []);
         setIsLoading(false);
-      } catch (error) {
-        console.error("Error fetching service catalogs:", error);
+      } catch {
         setErrorMessage("Failed to load service catalogs");
         setIsLoading(false);
       }
@@ -72,8 +71,7 @@ export const ServiceCatalogPage: React.FC = () => {
         const body = result.data as { data: ServiceTemplateSummary[] };
         setTemplates(body.data || []);
         setIsLoadingTemplates(false);
-      } catch (error) {
-        console.error("Error fetching service templates:", error);
+      } catch {
         setErrorMessage("Failed to load service templates");
         setIsLoadingTemplates(false);
       }
@@ -105,8 +103,7 @@ export const ServiceCatalogPage: React.FC = () => {
       await removeServiceCatalog(name);
       setSuccessMessage(`Service catalog '${name}' deleted successfully`);
       fetchCatalogs();
-    } catch (error) {
-      console.error("Error deleting service catalog:", error);
+    } catch {
       setErrorMessage(`Failed to delete service catalog '${name}'`);
     }
   };

--- a/apps/ui/admin/src/Pages/ServiceCatalog/ServiceCatalogPage.tsx
+++ b/apps/ui/admin/src/Pages/ServiceCatalog/ServiceCatalogPage.tsx
@@ -121,8 +121,8 @@ export const ServiceCatalogPage: React.FC = () => {
       const result = await getServiceCatalog(name);
       const body = result.data as { data: ServiceCatalogDetail };
       return body.data;
-    } catch (error) {
-      console.error("Error fetching catalog detail:", error);
+    } catch {
+      setErrorMessage("Failed to load catalog details");
       return null;
     }
   };

--- a/apps/ui/admin/src/Pages/ServiceCatalog/ToolsetReposTab.tsx
+++ b/apps/ui/admin/src/Pages/ServiceCatalog/ToolsetReposTab.tsx
@@ -60,8 +60,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       const result = await listRepos();
       setRepos(result.data.data || []);
       setIsLoading(false);
-    } catch (error) {
-      console.error("Error fetching toolset repos:", error);
+    } catch {
       onError("Failed to load toolset repositories");
       setIsLoading(false);
     }
@@ -87,8 +86,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       setAddBranch("main");
       setAddDescription("");
       loadRepos();
-    } catch (error) {
-      console.error("Error adding repo:", error);
+    } catch {
       onError("Failed to add toolset repository");
     }
   };
@@ -108,8 +106,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       setEditBranch("");
       setEditDescription("");
       loadRepos();
-    } catch (error) {
-      console.error("Error updating repo:", error);
+    } catch {
       onError("Failed to update toolset repository");
     }
   };
@@ -120,8 +117,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       onSuccess(`Toolset repository '${name}' removed`);
       setDeleteTarget(null);
       loadRepos();
-    } catch (error) {
-      console.error("Error removing repo:", error);
+    } catch {
       onError(`Failed to remove repository '${name}'`);
     }
   };
@@ -132,8 +128,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
     try {
       const result = await browseRepo(name);
       setBrowseCatalog(result.data.data ?? null);
-    } catch (error) {
-      console.error("Error browsing repo:", error);
+    } catch {
       onError(`Failed to browse repository '${name}'`);
       setBrowseTarget(null);
     } finally {
@@ -148,8 +143,7 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       setImportToolsetName(toolsetName);
       setImportTools(tools);
       setSelectedToolIds(tools.filter((t: ToolReference) => t.name).map((t: ToolReference) => t.name!));
-    } catch (error) {
-      console.error("Error fetching toolset:", error);
+    } catch {
       onError(`Failed to fetch toolset '${toolsetName}'`);
     }
   };
@@ -161,8 +155,8 @@ export const ToolsetReposTab: React.FC<ToolsetReposTabProps> = ({onError, onSucc
       try {
         await postApiV1Tools(tool);
         imported++;
-      } catch (error) {
-        console.error(`Error importing tool '${tool.name}':`, error);
+      } catch {
+        // failed tools counted by absence from imported count
       }
     }
     onSuccess(`Imported ${imported} tool(s) from '${importToolsetName}'`);

--- a/apps/ui/admin/src/Pages/Targets/TargetTypeSelect.tsx
+++ b/apps/ui/admin/src/Pages/Targets/TargetTypeSelect.tsx
@@ -1,19 +1,22 @@
 import {Select, SelectItem, SelectSkeleton} from "@carbon/react";
 import React, {useEffect, useState} from "react";
 import {ServiceTarget} from "../../models";
+import {getErrorMessage} from "../../utils/error";
 
 interface TargetTypeSelectProps {
   value: string;
   onChange: (value: string) => void;
   apiCall: () => Promise<any>;
+  onError?: (message: string) => void;
 }
 
 export const TargetTypeSelect: React.FC<TargetTypeSelectProps> = ({
   value,
   onChange,
-  apiCall
+  apiCall,
+  onError
 }) => {
-  
+
   const [targetTypes, setTargetTypes] = useState<ServiceTarget[]>([])
   const [isLoading, setLoading] = useState(true)
 
@@ -25,9 +28,12 @@ export const TargetTypeSelect: React.FC<TargetTypeSelectProps> = ({
           const targetTypes: ServiceTarget[] = result.data.data
           setTargetTypes(targetTypes)
         } else {
-          console.error(`Error fetching target types: ${result.status}`)
+          onError?.(`Failed to load target types: ${result.status}`)
           setTargetTypes([])
         }
+      } catch (error) {
+        onError?.(getErrorMessage(error))
+        setTargetTypes([])
       } finally {
         setLoading(false)
       }

--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "@carbon/react"
 import React, {useRef, useState} from "react"
 import {ToolReference} from "../../models"
-import {ToolParserError, Tools} from "./tools"
+import {Tools} from "./tools"
 import {ImportToolsetTable} from "./ImportToolsetTable"
 import {getErrorMessage} from "../../utils/error"
 
@@ -107,12 +107,8 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
       const tools: ToolReference[] = Tools.parse(toolsetJson!)
       onSubmit(tools)
     } catch (error) {
-      if (error instanceof SyntaxError || error instanceof ToolParserError) {
-        setInvalidJson(true)
-        setInvalidJsonText(error.message)
-      } else {
-        console.error(error)
-      }
+      setInvalidJson(true)
+      setInvalidJsonText(error instanceof Error ? error.message : "Failed to parse toolset")
     }
   }
   

--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
@@ -2,6 +2,7 @@ import {
   Column,
   ContentSwitcher,
   Grid,
+  InlineNotification,
   Modal,
   Stack,
   Switch,
@@ -12,6 +13,7 @@ import React, {useRef, useState} from "react"
 import {ToolReference} from "../../models"
 import {ToolParserError, Tools} from "./tools"
 import {ImportToolsetTable} from "./ImportToolsetTable"
+import {getErrorMessage} from "../../utils/error"
 
 
 interface ImportToolsetModalProps {
@@ -34,6 +36,7 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
   const [step, setStep] = useState(0)
   const [contentSwitcherEnabled, setContentSwitcherEnabled] = useState(true)
   const [viewMode, setViewMode] = useState(VIEW_MODE_TABLE)
+  const [fetchError, setFetchError] = useState<string | null>(null)
   const selectedTools = useRef<ToolReference[]>([])
 
   
@@ -86,10 +89,11 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
       } else if (isToolsetUrlValid()) {
         // try to fetch toolset and proceed to next step
         try {
+          setFetchError(null)
           await fetchToolset()
           setStep(step + 1)
         } catch (error) {
-          console.error(error)
+          setFetchError(getErrorMessage(error))
         }
       } else {
         // URL is invalid
@@ -123,6 +127,14 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
       onRequestClose={onCancel}
     >
       <Stack gap={7}>
+        {fetchError && (
+          <InlineNotification
+            kind="error"
+            title="Fetch failed"
+            subtitle={fetchError}
+            onCloseButtonClick={() => setFetchError(null)}
+          />
+        )}
         {step === 0 && (
           <TextInput
             id="toolset-url"

--- a/apps/ui/admin/src/Pages/Tools/ToolModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ToolModal.tsx
@@ -22,13 +22,15 @@ interface ToolModalProps {
   tool?: ToolReference
   onSubmit: (tool: ToolReference) => void
   onRequestClose: () => void
+  onError?: (message: string) => void
 }
 
 export const ToolModal: React.FC<ToolModalProps> = ({
   tools,
   tool,
   onSubmit,
-  onRequestClose
+  onRequestClose,
+  onError
 }) => {
   const [namespaces, setNamespaces] = useState<Namespace[]>([])
   const [toolName, setToolName] = useState(tool?.name || "")
@@ -69,8 +71,9 @@ export const ToolModal: React.FC<ToolModalProps> = ({
         configurationURI,
         secretsURI
       })
-    } catch (error) {
-      console.error("Invalid JSON in input schema:", error)
+    } catch {
+      setInputSchemaInvalid(true)
+      setInputSchemaInvalidText("Invalid JSON in input schema")
     }
   }
   
@@ -157,6 +160,7 @@ export const ToolModal: React.FC<ToolModalProps> = ({
               value={toolType}
               onChange={setToolType}
               apiCall={listManagementTools}
+              onError={onError}
             />
             <TextInput
               id="input-schema"

--- a/apps/ui/admin/src/Pages/Tools/ToolsPage.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ToolsPage.tsx
@@ -67,8 +67,7 @@ export const ToolsPage: React.FC = () => {
       setErrorMessage(null);
 
       await updateTools();
-    } catch (error) {
-      console.error("Error adding tool:", error);
+    } catch {
       setIsAddModalOpen(false);
       setErrorMessage("Error adding tool: The tool name must be unique");
     }
@@ -79,8 +78,8 @@ export const ToolsPage: React.FC = () => {
       await updateTool(tool)
       setErrorMessage(null)
       await updateTools();
-    } catch (error) {
-      console.error("Error updating tool:", error)
+    } catch {
+      setErrorMessage(`Error updating tool: ${tool.name}`)
     } finally {
       handleToolModalClose()
     }
@@ -88,13 +87,16 @@ export const ToolsPage: React.FC = () => {
 
   const handleImportToolset = async (tools: ToolReference[]) => {
     setErrorMessage(null);
+    const failedTools: string[] = [];
     for (const tool of tools) {
       try {
         await addTool(tool);
-      } catch (error) {
-        console.error("Error adding tool:", error);
-        setErrorMessage(`Failed to add tool: ${tool.name}`);
+      } catch {
+        failedTools.push(tool.name || "unknown");
       }
+    }
+    if (failedTools.length > 0) {
+      setErrorMessage(`Failed to import: ${failedTools.join(", ")}`);
     }
     setIsImportModalOpen(false);
     await updateTools();
@@ -105,8 +107,7 @@ export const ToolsPage: React.FC = () => {
       if (!toolName) return;
       await removeTool(toolName);
       await updateTools();
-    } catch (error) {
-      console.error("Error deleting tool:", error);
+    } catch {
       setErrorMessage(`Failed to delete tool: ${toolName}`);
     }
   };
@@ -145,6 +146,7 @@ export const ToolsPage: React.FC = () => {
             tool={openedTool}
             onRequestClose={handleToolModalClose}
             onSubmit={handleToolModalSubmit}
+            onError={(msg) => setErrorMessage(msg)}
           />
         )}
         {isImportModalOpen && (

--- a/apps/ui/admin/src/components/Content.tsx
+++ b/apps/ui/admin/src/components/Content.tsx
@@ -1,10 +1,14 @@
 import {Content} from '@carbon/react';
-import {Outlet} from "react-router-dom";
+import {Outlet, useLocation} from "react-router-dom";
+import ErrorBoundary from "./ErrorBoundary";
 
 function ContentComponent() {
+    const location = useLocation();
     return (
         <Content id="main-content">
-            <Outlet />
+            <ErrorBoundary key={location.pathname}>
+                <Outlet />
+            </ErrorBoundary>
         </Content>
     );
 }

--- a/apps/ui/admin/src/components/ErrorBoundary.tsx
+++ b/apps/ui/admin/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode } from "react";
+import { Component, ErrorInfo, ReactNode } from "react";
 import { InlineNotification, Button } from "@carbon/react";
 
 interface Props {
@@ -20,7 +20,7 @@ class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("Uncaught error in page component:", error, info);
   }
 

--- a/apps/ui/admin/src/components/ErrorBoundary.tsx
+++ b/apps/ui/admin/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, ReactNode } from "react";
+import { InlineNotification, Button } from "@carbon/react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("Uncaught error in page component:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: "2rem" }}>
+          <InlineNotification
+            kind="error"
+            title="Something went wrong"
+            subtitle={this.state.error?.message || "An unexpected error occurred"}
+            hideCloseButton
+          />
+          <Button
+            kind="primary"
+            style={{ marginTop: "1rem" }}
+            onClick={() => {
+              window.location.hash = "#/";
+              this.setState({ hasError: false, error: null });
+            }}
+          >
+            Go to Dashboard
+          </Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/apps/ui/admin/src/components/ErrorBoundary.tsx
+++ b/apps/ui/admin/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
 import { InlineNotification, Button } from "@carbon/react";
 
 interface Props {
@@ -8,6 +9,22 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+}
+
+function DashboardButton({ onReset }: { onReset: () => void }) {
+  const navigate = useNavigate();
+  return (
+    <Button
+      kind="primary"
+      style={{ marginTop: "1rem" }}
+      onClick={() => {
+        onReset();
+        navigate("/");
+      }}
+    >
+      Go to Dashboard
+    </Button>
+  );
 }
 
 class ErrorBoundary extends Component<Props, State> {
@@ -34,16 +51,7 @@ class ErrorBoundary extends Component<Props, State> {
             subtitle={this.state.error?.message || "An unexpected error occurred"}
             hideCloseButton
           />
-          <Button
-            kind="primary"
-            style={{ marginTop: "1rem" }}
-            onClick={() => {
-              window.location.hash = "#/";
-              this.setState({ hasError: false, error: null });
-            }}
-          >
-            Go to Dashboard
-          </Button>
+          <DashboardButton onReset={() => this.setState({ hasError: false, error: null })} />
         </div>
       );
     }

--- a/apps/ui/admin/src/main.tsx
+++ b/apps/ui/admin/src/main.tsx
@@ -4,6 +4,10 @@ import {RouterProvider} from "react-router-dom";
 import "./index.scss";
 import {router} from './router';
 
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("Unhandled promise rejection:", event.reason);
+});
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <RouterProvider router={router} />

--- a/apps/ui/admin/src/utils/error.ts
+++ b/apps/ui/admin/src/utils/error.ts
@@ -1,0 +1,9 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "An unexpected error occurred";
+}


### PR DESCRIPTION
## Summary

Follow-up to #1409, addressing the review suggestions:

- **Router navigation in ErrorBoundary**: Replace `window.location.hash` with `useNavigate` via a `DashboardButton` functional wrapper component, so navigation is consistent with the rest of the app and works for non-hash routers
- **Standardize error handling**: Remove remaining redundant `console.error` calls in `AddDataStoreModal`, `ViewDataStoreModal`, and `ServiceCatalogPage` where error state is already set. Surface unexpected errors in `ImportToolsetModal.handleSubmit` to the user via inline validation instead of console-only logging

## Test plan

- [ ] Trigger a render error in a page component — ErrorBoundary should show error + "Go to Dashboard" button that navigates via router
- [ ] Upload an invalid file in Add Data Store modal — should show error text without console.error
- [ ] View a data store with corrupted data — should show decode error without console.error
- [ ] Import toolset with unexpected error in JSON — should show inline validation error
- [ ] Fetch catalog detail failure — should show toast notification

## Summary by Sourcery

Introduce a shared error boundary and centralized error messaging across admin UI pages to provide consistent, user-visible error handling and router-based recovery navigation.

New Features:
- Add a router-aware ErrorBoundary wrapper around routed content with a dashboard navigation reset action.
- Enhance the error page to display detailed route error information and a button that returns users to the dashboard.
- Surface inline and toast-based error notifications in LLM chat, prompt editing, tool import, and resource management flows.

Bug Fixes:
- Ensure failures when importing toolsets, loading tools, or fetching catalog details are surfaced to users instead of only logging to the console.
- Handle invalid JSON and corrupted data inputs more gracefully in prompts, tools, data store upload/view, and toolset parsing flows.
- Prevent silent failures in LLM chat requests by appending a network error message into the conversation when calls fail.

Enhancements:
- Standardize error handling across tools, resources, namespaces, prompts, data stores, and service catalog pages by replacing console logging with user-facing error messages.
- Introduce a reusable getErrorMessage helper to normalize error messages from unknown error types.
- Propagate optional onError callbacks through shared components such as TargetTypeSelect, LLMTools, ResourcesTable, and ResourceModal for better error reporting.