### PR TITLE
Fix #1397: parameterize sql-tool template query and mark example credentials as placeholders

### DIFF
--- a/services/service-templates/src/main/services/sql-tool/sql/service.properties
+++ b/services/service-templates/src/main/services/sql-tool/sql/service.properties
@@ -1,6 +1,10 @@
 tool.description=Execute SQL queries against a relational database using camel-sql
-sql.query=SELECT 1
+# Predefined, parameterized query. The tool input is bound as a JDBC parameter (:#wanakuBody);
+# never concatenate tool input directly into the SQL text. Override sql.query at instantiation
+# time with the predefined statement your tool should run.
+sql.query=SELECT * FROM products WHERE name = :#wanakuBody
 forage.jdbc.db.kind=postgresql
-forage.jdbc.url=jdbc:postgresql://localhost:5432/product_catalog
-forage.jdbc.username=admin
-forage.jdbc.password=secret
+# Example/placeholder datasource settings - override all of these at instantiation time.
+forage.jdbc.url=jdbc:postgresql://localhost:5432/CHANGE_ME
+forage.jdbc.username=CHANGE_ME
+forage.jdbc.password=CHANGE_ME

--- a/services/service-templates/src/main/services/sql-tool/sql/wanaku-sql-tool.camel.yaml
+++ b/services/service-templates/src/main/services/sql-tool/sql/wanaku-sql-tool.camel.yaml
@@ -1,9 +1,17 @@
 - route:
     id: sql-tool
-    description: Execute SQL queries against a relational database
+    description: Execute a predefined, parameterized SQL query against a relational database
     from:
       uri: direct:wanaku
       steps:
+        # The tool input (wanaku_body) is exposed as a named parameter and is bound by camel-sql as
+        # a prepared-statement parameter (:#wanakuBody). Keep sql.query a fixed, predefined statement
+        # and reference the input via :#wanakuBody - never concatenate tool input into the SQL text.
+        - setHeader:
+            name: wanakuBody
+            expression:
+              simple:
+                expression: ${body}
         - setHeader:
             name: CamelSqlQuery
             expression:


### PR DESCRIPTION
Closes #1397

## Description

Improves the `sql-tool` service template example so it follows camel-sql best practices:

- The tool input is now exposed as a named parameter and bound by camel-sql as a prepared-statement
  parameter (`:#wanakuBody`), instead of an example that could be customised to interpolate input
  directly into the SQL text. The `sql.query` default now shows the parameterized form.
- The example datasource values in `service.properties` (`forage.jdbc.url`, `forage.jdbc.username`,
  `forage.jdbc.password`) are now obvious placeholders (`CHANGE_ME`) to be overridden at
  instantiation time.

## Changes

- `services/service-templates/src/main/services/sql-tool/sql/wanaku-sql-tool.camel.yaml`
- `services/service-templates/src/main/services/sql-tool/sql/service.properties`

## Verification

- `./mvnw -pl services/service-templates install` — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parameterize the sql-tool template query and clarify that example datasource credentials are placeholders to be overridden.

Bug Fixes:
- Ensure sql-tool template uses a parameterized query bound as a prepared statement instead of interpolating input into SQL text.

Enhancements:
- Expose tool input as a named parameter header for camel-sql and update route description to emphasize predefined, parameterized queries.
- Update default sql.query example to demonstrate safe parameter binding for tool input.

Documentation:
- Add inline comments explaining safe SQL usage and the need to keep queries predefined and parameterized in the sql-tool template.
- Clarify via comments that example datasource configuration values are placeholders to be replaced at instantiation time.