### PR TITLE
Fix #1396: validate serviceName/serviceSystem identifiers on template instantiation

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.api.v1.exceptions.ServiceTemplateNotFoundException;
@@ -43,6 +44,13 @@ public class ServiceTemplateBean {
 
     /** Label value used to identify service template entries. */
     public static final String LABEL_TYPE_VALUE = "template";
+
+    /**
+     * Allowed characters for the optional service name / system identifiers that callers may supply
+     * when instantiating a template. These values are used to build catalog entry names, so they are
+     * restricted to a conservative identifier charset.
+     */
+    private static final Pattern SYSTEM_IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
 
     @Inject
     Instance<DataStoreRepository> dataStoreRepositoryInstance;
@@ -243,6 +251,8 @@ public class ServiceTemplateBean {
     public DataStore instantiate(
             String templateName, Map<String, String> userProperties, String serviceName, String serviceSystem)
             throws WanakuException {
+        validateOptionalIdentifier(serviceName, "serviceName");
+        validateOptionalIdentifier(serviceSystem, "serviceSystem");
         LOG.debugf(
                 "Instantiating template '%s' with %d properties",
                 templateName, userProperties != null ? userProperties.size() : 0);
@@ -276,6 +286,17 @@ public class ServiceTemplateBean {
             return serviceCatalogBean.deploy(catalog);
         } catch (IOException e) {
             throw new WanakuException("Failed to build catalog ZIP: %s".formatted(e.getMessage()));
+        }
+    }
+
+    private static void validateOptionalIdentifier(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        if (value.contains("..") || !SYSTEM_IDENTIFIER_PATTERN.matcher(value).matches()) {
+            throw new WanakuException(
+                    "Invalid %s '%s': only letters, digits, '.', '_' and '-' are allowed (and no '..')"
+                            .formatted(fieldName, value));
         }
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBeanTest.java
@@ -13,6 +13,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -83,6 +85,17 @@ class ServiceTemplateBeanTest {
         Properties indexProps = extractIndexProperties(catalogArg.getData());
         assertEquals("my-service", indexProps.getProperty("catalog.name"));
         assertEquals("sys1", indexProps.getProperty("catalog.services"));
+    }
+
+    @Test
+    void testInstantiateRejectsInvalidServiceName() {
+        assertThrows(
+                WanakuException.class, () -> serviceTemplateBean.instantiate("my-service", Map.of(), "bad name", null));
+    }
+
+    @Test
+    void testInstantiateRejectsInvalidServiceSystem() {
+        assertThrows(WanakuException.class, () -> serviceTemplateBean.instantiate("my-service", Map.of(), null, ".."));
     }
 
     @Test


### PR DESCRIPTION
Closes #1396

## Description

When instantiating a service template, the optional `serviceName` and `serviceSystem` values are
used to build catalog entry names and to remap index property keys
(`ServiceTemplateBean.instantiate` → `modifyIndexProperties` / `ForageDependencyAppender`). They
were consumed as-is without checking that they are well-formed system identifiers.

This change validates both values against a conservative identifier charset (`[A-Za-z0-9._-]+`, and
no `..`) at the start of `instantiate`, so only well-formed identifiers are accepted. Blank/`null`
values remain allowed (they fall back to the template defaults).

## Changes

- `ServiceTemplateBean`: add `SYSTEM_IDENTIFIER_PATTERN` + `validateOptionalIdentifier(...)`, called
  for `serviceName` and `serviceSystem`.
- `ServiceTemplateBeanTest`: add tests asserting invalid `serviceName`/`serviceSystem` are rejected.

## Verification

- `./mvnw -pl apps/wanaku-router-backend -am install -DskipTests` — BUILD SUCCESS.
- `ServiceTemplateBeanTest` — Tests run: 13, Failures: 0, Errors: 0, Skipped: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate optional service identifiers during service template instantiation to avoid malformed catalog entries

Bug Fixes:
- Reject invalid serviceName and serviceSystem values that contain disallowed characters or consecutive dots when instantiating service templates

Tests:
- Add unit tests ensuring instantiate rejects invalid serviceName and serviceSystem inputs