### PR TITLE
Fix #1426: disable OTEL SDK by default in capabilities

### DIFF
--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/resources/application.properties
@@ -27,7 +27,9 @@ quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 %dev.quarkus.log.category."ai.wanaku.core.capabilities".level=DEBUG
 %test.quarkus.log.category."ai.wanaku.core.capabilities".level=INFO
 
-# OpenTelemetry configuration
+# OpenTelemetry configuration - disabled by default
+# Enable with -Dquarkus.otel.sdk.disabled=false and -Dquarkus.otel.exporter.otlp.endpoint=<endpoint>
+quarkus.otel.sdk.disabled=true
 quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
 quarkus.otel.exporter.otlp.traces.protocol=grpc
 quarkus.otel.resource.attributes=service.name=${wanaku.service.name:wanaku-capability},service.version=${quarkus.application.version}

--- a/deploy/docker-compose/docker-compose-noauth.yml
+++ b/deploy/docker-compose/docker-compose-noauth.yml
@@ -21,6 +21,7 @@ services:
       WANAKU_HTTP_AUTH: none
       QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED: "true"
       QUARKUS_HTTP_HOST: 0.0.0.0
+      QUARKUS_OTEL_SDK_DISABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     network_mode: host
     volumes:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -51,7 +51,8 @@ services:
       WANAKU_SERVICE_REGISTRATION_URI: http://localhost:8080/
       AUTH_SERVER: http://localhost:8543
       # Must match the wanaku-service client secret in the realm (WANAKU_SERVICE_SECRET).
-      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}      
+      QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET: ${WANAKU_SERVICE_SECRET:-mypasswd}
+      QUARKUS_OTEL_SDK_DISABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     network_mode: host
     depends_on:
@@ -69,6 +70,7 @@ services:
       QUARKUS_HTTP_HOST: 0.0.0.0
       AUTH_SERVER: http://localhost:8543
       AUTH_PROXY: http://localhost:8080
+      QUARKUS_OTEL_SDK_DISABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
     depends_on:
       keycloak:


### PR DESCRIPTION
## Summary

- Disable the OpenTelemetry SDK by default in the capabilities base (`quarkus.otel.sdk.disabled=true`), matching the router backend's existing behavior
- Explicitly enable OTEL in both docker-compose files via `QUARKUS_OTEL_SDK_DISABLED=false` where Jaeger + OTEL collector are available

## Test plan

- [ ] Start a capability service without Jaeger running — verify it registers successfully with no OTEL connection errors
- [ ] Run `docker-compose up` — verify OTEL traces appear in Jaeger at `localhost:16686`

## Summary by Sourcery

Disable OpenTelemetry SDK by default for capabilities while enabling it explicitly in docker-compose environments with tracing infrastructure.

Bug Fixes:
- Align OpenTelemetry default behavior for capability services to avoid connection errors when no collector is available.

Enhancements:
- Document how to enable OpenTelemetry SDK and configure OTLP endpoint via system properties.
- Ensure docker-compose deployments explicitly enable the OpenTelemetry SDK when Jaeger and OTEL collector services are available.