### PR TITLE
chore: enforce CLI usage in test plans and replace curl calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ make install
 ## Test Plans
 
 - Test plans live under `tests/plans/`, reusable steps under `tests/plans/common/`
-- Guidelines for writing test plans are in `docs/contributing.md` (section "Writing Test Plans")
+- Guidelines for writing test plans are in `docs/contributing-test-plans.md`
 
 ## Acceptance Criteria
 

--- a/docs/contributing-test-plans.md
+++ b/docs/contributing-test-plans.md
@@ -121,7 +121,7 @@ Use `--ignore-not-found=true` on all delete commands and `2>/dev/null || true` o
 - [ ] Cleanup is idempotent
 - [ ] Shell constructs are POSIX-compatible
 
-## Feature Matrix 
+## Feature Matrix
 
 - OpenShift/Kubernetes
   - Does not support noauth (i.e.: running the router and capabilities without authentication, due to the need of re-augmentation).

--- a/docs/contributing-test-plans.md
+++ b/docs/contributing-test-plans.md
@@ -1,0 +1,127 @@
+# Writing Test Plans
+
+Test plans are Markdown documents under `tests/plans/` designed for execution by both humans and AI agents.
+
+## Structure
+
+A test plan has three layers:
+
+1. **Main plan** (`tests/plans/<name>.md`) — the test scenario with phases and assertions.
+2. **Common steps** (`tests/plans/common/*.md`) — reusable procedures shared across plans (Keycloak setup, namespace creation, cleanup).
+3. **Environment variables** — all configurable values declared upfront so the same plan works across versions and clusters.
+
+## Phases, not scripts
+
+Organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
+
+```text
+Phase 0: Manual prerequisites
+Phase 1: Environment setup
+Phase 2-N: Test scenarios
+Phase N+1: Cleanup
+```
+
+## Every step must be verifiable
+
+Each step needs: a command, an expected outcome, and a PASS/FAIL assertion. Avoid steps that only run a command without checking the result.
+
+```bash
+# Bad — runs but doesn't verify
+oc apply -f my-resource.yaml
+
+# Good — verifies the outcome
+oc apply -f my-resource.yaml
+oc wait myresource/name --for=condition=Ready --timeout=120s -n "${NAMESPACE}"
+```
+
+## Prefer polling over sleeping
+
+Use `oc wait`, `oc rollout status`, or a polling loop instead of fixed `sleep` calls. Clusters vary in speed — a 10s sleep that works locally may fail in CI and waste time on fast clusters.
+
+```bash
+# Bad
+sleep 15
+oc get deployment foo
+
+# Good — deterministic wait
+oc wait --for=condition=Available deployment/foo --timeout=120s -n "${NAMESPACE}"
+
+# Good — polling for deletion
+while oc get deployment foo -n "${NAMESPACE}" > /dev/null 2>&1; do
+  sleep 3
+done
+```
+
+## Parametrize images and versions
+
+Never hard-code image tags. Define environment variables with sensible defaults so the same plan can test different releases.
+
+```bash
+export MY_IMAGE="${MY_IMAGE:-quay.io/org/component:latest}"
+```
+
+Then use `${MY_IMAGE}` in CR specs and image assertions.
+
+## Extract reusable steps into common docs
+
+If a procedure appears in more than one plan (or is likely to), move it to `tests/plans/common/`. The common doc should:
+
+- List its prerequisites and required environment variables.
+- Document output variables it sets for subsequent steps.
+- Be self-contained — runnable without reading the main plan.
+
+Reference common docs from the main plan with a link and a brief note on what variables must be set before and after:
+
+```markdown
+Follow [common/keycloak-setup.md](common/keycloak-setup.md). After completion,
+`KEYCLOAK_URL` and `WANAKU_OIDC_SECRET` must be set.
+```
+
+## Keep the main plan lean
+
+The main plan should only contain logic unique to that test scenario. If a step duplicates a common doc, replace it with a reference. This prevents drift between documents.
+
+## Use the Wanaku CLI, not raw API clients
+
+Test plans **must** use the Wanaku CLI for all interactions with the router and Keycloak. Use either a native binary installed on the system or — preferably — the CLI jar file built from the codebase (`java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar`).
+
+Do **not** use `curl`, `wget`, `httpie`, or other HTTP clients to call Wanaku or Keycloak APIs unless the test is specifically oriented to verify HTTP-level behavior (e.g., checking raw HTTP status codes on health endpoints, testing SSE streaming headers, or verifying endpoint reachability before the CLI can connect).
+
+```bash
+# Bad — uses curl to list tools
+curl -s "${WANAKU_ROUTER_URL}/api/v1/tools" | jq '.data[].name'
+
+# Good — uses the CLI
+wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain
+
+# Acceptable — specifically testing HTTP endpoint reachability
+curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready"
+```
+
+## Shell compatibility
+
+Use POSIX-compatible constructs. Avoid bash-only features like `${!VAR}` (indirect expansion) since the executor may use zsh or sh. If bash is required, wrap the block in `bash -c '...'`.
+
+## Include negative tests
+
+Verify that invalid inputs are rejected gracefully — missing required fields, references to non-existent resources, malformed data. These often catch real bugs.
+
+## Cleanup must be idempotent
+
+Use `--ignore-not-found=true` on all delete commands and `2>/dev/null || true` on wait commands. A cleanup phase that fails on missing resources makes re-runs painful.
+
+## Checklist for new plans
+
+- [ ] All configurable values are environment variables with defaults
+- [ ] Common procedures reference shared docs, not inline copies
+- [ ] Every step has a PASS/FAIL assertion
+- [ ] No fixed `sleep` — use `oc wait`, `oc rollout status`, or polling
+- [ ] Uses the Wanaku CLI — no `curl`/`wget`/`httpie` against Wanaku or Keycloak unless specifically testing HTTP behavior
+- [ ] Negative tests are included
+- [ ] Cleanup is idempotent
+- [ ] Shell constructs are POSIX-compatible
+
+## Feature Matrix 
+
+- OpenShift/Kubernetes
+  - Does not support noauth (i.e.: running the router and capabilities without authentication, due to the need of re-augmentation).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -299,118 +299,12 @@ There are multiple ways you can test Wanaku and the integrations you develop.
 1. Wanaku's LLMchat page in the Web UI
 2. You can use the [MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) to easily test your tool or provider.
 3. Use the maintained test suites under `tests/integration`, `tests/mcp-servers`, and `tests/load`.
-4. Follow or create test plans under `tests/plans/` (see [Writing Test Plans](#writing-test-plans) below).
+4. Follow or create test plans under `tests/plans/` (see [Writing Test Plans](contributing-test-plans.md)).
 5. Any agent application (such as [HyperChat](https://github.com/BigSweetPotatoStudio/HyperChat))
 
 ### Writing Test Plans
 
-Test plans are Markdown documents under `tests/plans/` designed for execution by both humans and AI agents.
-
-#### Structure
-
-A test plan has three layers:
-
-1. **Main plan** (`tests/plans/<name>.md`) — the test scenario with phases and assertions.
-2. **Common steps** (`tests/plans/common/*.md`) — reusable procedures shared across plans (Keycloak setup, namespace creation, cleanup).
-3. **Environment variables** — all configurable values declared upfront so the same plan works across versions and clusters.
-
-#### Phases, not scripts
-
-Organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
-
-```text
-Phase 0: Manual prerequisites
-Phase 1: Environment setup
-Phase 2-N: Test scenarios
-Phase N+1: Cleanup
-```
-
-#### Every step must be verifiable
-
-Each step needs: a command, an expected outcome, and a PASS/FAIL assertion. Avoid steps that only run a command without checking the result.
-
-```bash
-# Bad — runs but doesn't verify
-oc apply -f my-resource.yaml
-
-# Good — verifies the outcome
-oc apply -f my-resource.yaml
-oc wait myresource/name --for=condition=Ready --timeout=120s -n "${NAMESPACE}"
-```
-
-#### Prefer polling over sleeping
-
-Use `oc wait`, `oc rollout status`, or a polling loop instead of fixed `sleep` calls. Clusters vary in speed — a 10s sleep that works locally may fail in CI and waste time on fast clusters.
-
-```bash
-# Bad
-sleep 15
-oc get deployment foo
-
-# Good — deterministic wait
-oc wait --for=condition=Available deployment/foo --timeout=120s -n "${NAMESPACE}"
-
-# Good — polling for deletion
-while oc get deployment foo -n "${NAMESPACE}" > /dev/null 2>&1; do
-  sleep 3
-done
-```
-
-#### Parametrize images and versions
-
-Never hard-code image tags. Define environment variables with sensible defaults so the same plan can test different releases.
-
-```bash
-export MY_IMAGE="${MY_IMAGE:-quay.io/org/component:latest}"
-```
-
-Then use `${MY_IMAGE}` in CR specs and image assertions.
-
-#### Extract reusable steps into common docs
-
-If a procedure appears in more than one plan (or is likely to), move it to `tests/plans/common/`. The common doc should:
-
-- List its prerequisites and required environment variables.
-- Document output variables it sets for subsequent steps.
-- Be self-contained — runnable without reading the main plan.
-
-Reference common docs from the main plan with a link and a brief note on what variables must be set before and after:
-
-```markdown
-Follow [common/keycloak-setup.md](common/keycloak-setup.md). After completion,
-`KEYCLOAK_URL` and `WANAKU_OIDC_SECRET` must be set.
-```
-
-#### Keep the main plan lean
-
-The main plan should only contain logic unique to that test scenario. If a step duplicates a common doc, replace it with a reference. This prevents drift between documents.
-
-#### Shell compatibility
-
-Use POSIX-compatible constructs. Avoid bash-only features like `${!VAR}` (indirect expansion) since the executor may use zsh or sh. If bash is required, wrap the block in `bash -c '...'`.
-
-#### Include negative tests
-
-Verify that invalid inputs are rejected gracefully — missing required fields, references to non-existent resources, malformed data. These often catch real bugs.
-
-#### Cleanup must be idempotent
-
-Use `--ignore-not-found=true` on all delete commands and `2>/dev/null || true` on wait commands. A cleanup phase that fails on missing resources makes re-runs painful.
-
-#### Checklist for new plans
-
-- [ ] All configurable values are environment variables with defaults
-- [ ] Common procedures reference shared docs, not inline copies
-- [ ] Every step has a PASS/FAIL assertion
-- [ ] No fixed `sleep` — use `oc wait`, `oc rollout status`, or polling
-- [ ] Negative tests are included
-- [ ] Cleanup is idempotent
-- [ ] Shell constructs are POSIX-compatible
-
-#### Feature Matrix 
-
-- OpenShift/Kubernetes
-  - Does not support noauth (i.e.: running the router and capabilities without authentication, due to the need of re-augmentation).
+See [contributing-test-plans.md](contributing-test-plans.md) for the full guide on writing test plans.
 
 ## Deploying to the Development Environment
 

--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -7,7 +7,8 @@ Reusable steps for deploying and configuring Keycloak as the OIDC provider for W
 - Namespace created (see [namespace-setup.md](namespace-setup.md))
 - `WANAKU_NAMESPACE` environment variable set
 - `WANAKU_REPO_ROOT` environment variable set (path to the wanaku repository root)
-- `jq` and `curl` available
+- `jq` available
+- `curl` available (only for Keycloak readiness polling — all Wanaku/Keycloak API calls use the CLI)
 - `wanaku` CLI available on `PATH`, **or** the project built with `mvn verify` (to use the jar directly)
 
 ## Variables
@@ -233,90 +234,86 @@ echo "PASS: wanaku realm is accessible"
 
 The realm configuration sets the `wanaku-service` client secret via the Keycloak variable `${WANAKU_SERVICE_SECRET:mypasswd}`. By default this resolves to `mypasswd` unless the `WANAKU_SERVICE_SECRET` environment variable was set on the Keycloak container.
 
-To retrieve the actual secret from Keycloak, obtain an admin token and query the API:
+Retrieve the actual secret using the CLI:
 
 ```bash
-# Obtain an admin token
-KEYCLOAK_ADMIN_TOKEN=$(curl -s \
-  -d "client_id=admin-cli" \
-  -d "username=${KEYCLOAK_ADMIN_USER}" \
-  -d "password=${KEYCLOAK_ADMIN_PASS}" \
-  -d "grant_type=password" \
-  "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
+CREDENTIALS_OUTPUT=$(${WANAKU_CLI} credentials show \
+  --keycloak-url "${KEYCLOAK_URL}" \
+  --admin-username "${KEYCLOAK_ADMIN_USER}" \
+  --admin-password "${KEYCLOAK_ADMIN_PASS}" \
+  --client-id wanaku-service \
+  --show-secret \
+  --plain 2>&1)
 
-if [ -z "${KEYCLOAK_ADMIN_TOKEN}" ] || [ "${KEYCLOAK_ADMIN_TOKEN}" = "null" ]; then
-  echo "FAIL: could not obtain Keycloak admin token"
-  exit 1
-fi
-
-# Get the internal UUID of the wanaku-service client
-WANAKU_SERVICE_UUID=$(curl -s \
-  -H "Authorization: Bearer ${KEYCLOAK_ADMIN_TOKEN}" \
-  "${KEYCLOAK_URL}/admin/realms/wanaku/clients?clientId=wanaku-service" \
-  | jq -r '.[0].id')
-
-if [ -z "${WANAKU_SERVICE_UUID}" ] || [ "${WANAKU_SERVICE_UUID}" = "null" ]; then
-  echo "FAIL: could not find UUID for client wanaku-service"
-  exit 1
-fi
-
-# Retrieve the secret
-export WANAKU_OIDC_SECRET=$(curl -s \
-  -H "Authorization: Bearer ${KEYCLOAK_ADMIN_TOKEN}" \
-  "${KEYCLOAK_URL}/admin/realms/wanaku/clients/${WANAKU_SERVICE_UUID}/client-secret" \
-  | jq -r '.value')
+export WANAKU_OIDC_SECRET=$(echo "${CREDENTIALS_OUTPUT}" | grep "Client Secret:" | sed 's/.*Client Secret: //')
 
 if [ -z "${WANAKU_OIDC_SECRET}" ] || [ "${WANAKU_OIDC_SECRET}" = "null" ]; then
   echo "FAIL: could not retrieve OIDC secret"
+  echo "${CREDENTIALS_OUTPUT}"
   exit 1
 fi
 echo "PASS: OIDC secret retrieved (length: ${#WANAKU_OIDC_SECRET})"
 ```
 
-### 9. Verify the OIDC token endpoint works
+### 9. Verify the OIDC login works
 
 ```bash
-TOKEN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-  -d "client_id=wanaku-service" \
-  -d "client_secret=${WANAKU_OIDC_SECRET}" \
-  -d "grant_type=client_credentials" \
-  "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token")
+${WANAKU_CLI} auth login \
+  --auth-server "${KEYCLOAK_URL}" \
+  --username "${KEYCLOAK_ADMIN_USER}" \
+  --password "${KEYCLOAK_ADMIN_PASS}" \
+  --plain 2>&1
 
-if [ "${TOKEN_RESPONSE}" != "200" ]; then
-  echo "FAIL: token endpoint returned HTTP ${TOKEN_RESPONSE}"
-  exit 1
+LOGIN_EXIT=$?
+
+if [ "${LOGIN_EXIT}" -ne 0 ]; then
+  echo "FAIL: OIDC login failed (exit code ${LOGIN_EXIT})"
+  LOGIN_FAILED=true
+else
+  echo "PASS: OIDC login works"
+  LOGIN_FAILED=false
 fi
-echo "PASS: OIDC token endpoint works"
 ```
 
-### 10. Workaround: force-set the client secret if token request fails
+### 10. Workaround: regenerate the client secret if login fails
 
-When importing the realm via the CLI (not at Keycloak bootstrap), the variable `${WANAKU_SERVICE_SECRET:mypasswd}` may be stored literally instead of being resolved. If step 9 fails with HTTP 401, force-set the client secret:
+When importing the realm via the CLI (not at Keycloak bootstrap), the variable `${WANAKU_SERVICE_SECRET:mypasswd}` may be stored literally instead of being resolved. If step 9 failed, regenerate the secret:
 
 ```bash
-if [ "${TOKEN_RESPONSE}" = "401" ]; then
-  echo "WARN: OIDC secret may be stored literally — force-setting via Admin API"
+if [ "${LOGIN_FAILED}" = "true" ]; then
+  echo "WARN: OIDC secret may be stored literally — regenerating via CLI"
 
-  curl -s -X PUT \
-    -H "Authorization: Bearer ${KEYCLOAK_ADMIN_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "{\"type\":\"secret\",\"value\":\"${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}\"}" \
-    "${KEYCLOAK_URL}/admin/realms/wanaku/clients/${WANAKU_SERVICE_UUID}/client-secret"
+  ${WANAKU_CLI} credentials regenerate \
+    --keycloak-url "${KEYCLOAK_URL}" \
+    --admin-username "${KEYCLOAK_ADMIN_USER}" \
+    --admin-password "${KEYCLOAK_ADMIN_PASS}" \
+    --client-id wanaku-service \
+    --show-secret \
+    --plain 2>&1
 
-  export WANAKU_OIDC_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
+  # Re-retrieve the new secret
+  CREDENTIALS_OUTPUT=$(${WANAKU_CLI} credentials show \
+    --keycloak-url "${KEYCLOAK_URL}" \
+    --admin-username "${KEYCLOAK_ADMIN_USER}" \
+    --admin-password "${KEYCLOAK_ADMIN_PASS}" \
+    --client-id wanaku-service \
+    --show-secret \
+    --plain 2>&1)
 
-  # Re-verify
-  TOKEN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-    -d "client_id=wanaku-service" \
-    -d "client_secret=${WANAKU_OIDC_SECRET}" \
-    -d "grant_type=client_credentials" \
-    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token")
+  export WANAKU_OIDC_SECRET=$(echo "${CREDENTIALS_OUTPUT}" | grep "Client Secret:" | sed 's/.*Client Secret: //')
 
-  if [ "${TOKEN_RESPONSE}" != "200" ]; then
-    echo "FAIL: token endpoint still failing after secret reset (HTTP ${TOKEN_RESPONSE})"
+  # Re-verify login
+  ${WANAKU_CLI} auth login \
+    --auth-server "${KEYCLOAK_URL}" \
+    --username "${KEYCLOAK_ADMIN_USER}" \
+    --password "${KEYCLOAK_ADMIN_PASS}" \
+    --plain 2>&1
+
+  if [ $? -ne 0 ]; then
+    echo "FAIL: OIDC login still failing after secret regeneration"
     exit 1
   fi
-  echo "PASS: OIDC token endpoint works after secret reset"
+  echo "PASS: OIDC login works after secret regeneration"
 fi
 ```
 

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -16,7 +16,6 @@ Every step except the initial `oc login` is fully automatable.
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
 | `wanaku` | 0.2.0+ | `wanaku --version` |
-| `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 
 ### CLI invocation
@@ -51,7 +50,7 @@ java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
   --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${VERSION}.zip
 ```
 
-Wait for the router health check:
+Wait for the router health check (curl is used here specifically to test HTTP-level readiness):
 
 ```bash
 curl -sf http://localhost:8080/q/health/ready > /dev/null && echo "READY" || echo "NOT READY"
@@ -385,7 +384,6 @@ The first `oc login` step is manual; everything else is automatable.
 | `oc` | 4.12+ | `oc version --client` |
 | `helm` | 3.x | `helm version --short` |
 | `wanaku` | 0.2.0+ | `wanaku --version` |
-| `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 
 ### Environment variables
@@ -626,19 +624,18 @@ else
 fi
 ```
 
-### Test 9.3: Verify tools are listed via REST API
+### Test 9.3: Verify tools are listed via CLI
 
 ```bash
-TOOLS_RESPONSE=$(curl -s "${WANAKU_ROUTER_URL}/api/v1/tools" 2>/dev/null)
-echo "${TOOLS_RESPONSE}" | jq -r '.data[].name' 2>/dev/null | sort
+TOOLS_OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --no-auth --plain 2>&1)
 
-echo "${TOOLS_RESPONSE}" | jq -e '.data[] | select(.name == "free-currency-conversion-api")' > /dev/null 2>&1 \
+echo "${TOOLS_OUTPUT}" | grep -q "free-currency-conversion-api" \
   && echo "PASS: currency conversion tool is listed" \
-  || echo "FAIL: currency conversion tool not found in API response"
+  || echo "FAIL: currency conversion tool not found"
 
-echo "${TOOLS_RESPONSE}" | jq -e '.data[] | select(.name == "meow-facts")' > /dev/null 2>&1 \
+echo "${TOOLS_OUTPUT}" | grep -q "meow-facts" \
   && echo "PASS: meow-facts tool is listed" \
-  || echo "FAIL: meow-facts tool not found in API response"
+  || echo "FAIL: meow-facts tool not found"
 ```
 
 ---
@@ -801,14 +798,14 @@ else
 fi
 ```
 
-### Test 12.2: Verify resource is listed via REST API
+### Test 12.2: Verify resource is listed via CLI
 
 ```bash
-RESOURCES_RESPONSE=$(curl -s "${WANAKU_ROUTER_URL}/api/v1/resources" 2>/dev/null)
+RESOURCES_OUTPUT=$(wanaku resources list --host "${WANAKU_ROUTER_URL}" --no-auth --plain 2>&1)
 
-echo "${RESOURCES_RESPONSE}" | jq -e '.data[] | select(.name == "test-static-resource")' > /dev/null 2>&1 \
-  && echo "PASS: test-static-resource is listed in REST API" \
-  || echo "FAIL: test-static-resource not found in REST API response"
+echo "${RESOURCES_OUTPUT}" | grep -q "test-static-resource" \
+  && echo "PASS: test-static-resource is listed" \
+  || echo "FAIL: test-static-resource not found"
 ```
 
 ### Test 12.3: List resources via MCP SSE endpoint


### PR DESCRIPTION
## Summary

- Add guideline to test plan docs: test plans **must** use the Wanaku CLI for all Wanaku/Keycloak interactions, not `curl`/`wget`/`httpie` (unless specifically testing HTTP-level behavior)
- Replace `curl /api/v1/tools` and `curl /api/v1/resources` in `mcp-cli-commands.md` with `wanaku tools list` and `wanaku resources list`
- Replace Keycloak admin API curl calls in `keycloak-setup.md` (admin token + client UUID + secret retrieval) with `wanaku credentials show`, `wanaku auth login`, and `wanaku credentials regenerate`
- Extract "Writing Test Plans" section from `contributing.md` into dedicated `contributing-test-plans.md`
- Update `CLAUDE.md` to reference the new file

## Test plan

- [ ] Verify `docs/contributing-test-plans.md` renders correctly and contains the full guidelines
- [ ] Verify `docs/contributing.md` links to the new file
- [ ] Verify `mcp-cli-commands.md` no longer lists `curl` as a prerequisite and uses CLI for tools/resources listing
- [ ] Verify `keycloak-setup.md` uses CLI commands for credential retrieval and OIDC verification

## Summary by Sourcery

Enforce use of the Wanaku CLI instead of raw HTTP clients in test plans and centralize test-plan authoring guidance into a dedicated document.

Documentation:
- Document test-plan authoring guidelines in a new docs/contributing-test-plans.md file and reference it from contributing.md and CLAUDE.md.
- Clarify that Wanaku and Keycloak interactions in test plans should use the Wanaku CLI, allowing curl only when explicitly testing HTTP-level behavior.
- Update Keycloak setup and MCP CLI command test-plan docs to use Wanaku CLI commands instead of direct REST API curl calls for tools, resources, and credential flows.

Tests:
- Adjust existing test plans to verify tools and resources via the Wanaku CLI rather than REST API endpoints, while retaining curl only for router readiness checks.