### PR TITLE
Add 11 E2E test plans for local CLI workflows

### DIFF
--- a/tests/plans/api-v2-features.md
+++ b/tests/plans/api-v2-features.md
@@ -1,0 +1,659 @@
+# Test Plan: REST API v2 Features
+
+## Overview
+
+This test plan verifies the v2 REST API features that have no CLI equivalent: tool call history/notifications and code execution. Since these endpoints are REST-only, `curl` is the correct client per the contributing guidelines.
+
+The plan is split into two areas:
+
+- **Tool Call History and Notifications** (Phases 2-4) -- exercises the `/api/v2/tool-calls/` endpoints for listing, retrieving, streaming, and clearing tool call records.
+- **Code Execution** (Phase 5) -- exercises the `/api/v2/code-execution-engine/` endpoints for submitting code and streaming results. Requires a configured execution engine; tests are marked SKIP when unavailable.
+
+Every step except the initial build is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `curl` | 7.68+ | `curl --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn --version` |
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/public/mcp/sse}"
+export V2_BASE="${WANAKU_ROUTER_URL}/api/v2"
+```
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} tools list --host "${WANAKU_ROUTER_URL}" --plain
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Response format
+
+All v2 JSON endpoints (except code execution POST) return the standard `WanakuResponse` wrapper:
+
+```json
+{"error": null, "data": <payload>}
+```
+
+Use `.data` to extract the payload in jq expressions.
+
+---
+
+## Phase 0: Prerequisite Verification
+
+### Test 0.1: Verify required tools are installed
+
+```bash
+TOOLS_OK=true
+
+curl --version > /dev/null 2>&1 \
+  && echo "PASS: curl is available" \
+  || { echo "FAIL: curl is not installed"; TOOLS_OK=false; }
+
+jq --version > /dev/null 2>&1 \
+  && echo "PASS: jq is available" \
+  || { echo "FAIL: jq is not installed"; TOOLS_OK=false; }
+
+wanaku --version > /dev/null 2>&1 \
+  && echo "PASS: wanaku CLI is available" \
+  || { echo "FAIL: wanaku CLI is not installed"; TOOLS_OK=false; }
+
+if [ "${TOOLS_OK}" = "false" ]; then
+  echo "FAIL: missing required tools -- aborting"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start the Wanaku stack locally.
+
+After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, and `CLI_JAR` must be set.
+
+### Test 1.1: Verify router health
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready")
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: router is healthy"
+else
+  echo "FAIL: router not healthy (HTTP ${HTTP_CODE})"
+  exit 1
+fi
+```
+
+### Test 1.2: Register a test tool for generating history
+
+Register an HTTP tool so that tool calls can generate history records.
+
+```bash
+wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name api-v2-test-tool \
+  --namespace public \
+  --description "Temporary tool for v2 API testing" \
+  --uri "https://meowfacts.herokuapp.com?count={count}" \
+  --type http \
+  --property "count:int,Number of facts to retrieve" \
+  --required count
+
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: test tool registered"
+else
+  echo "FAIL: could not register test tool (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 1.3: Verify test tool is listed
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "api-v2-test-tool" \
+  && echo "PASS: api-v2-test-tool is listed" \
+  || echo "FAIL: api-v2-test-tool not found in tools list"
+```
+
+---
+
+## Phase 2: Tool Call History
+
+### Test 2.1: Invoke a tool via MCP to generate history
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${MCP_SERVER_URI}" \
+  --name api-v2-test-tool \
+  --param count=1 \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool invocation succeeded -- history should be recorded"
+else
+  echo "FAIL: tool invocation failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 2.2: List tool call history -- verify at least one entry
+
+```bash
+RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history")
+COUNT=$(echo "${RESPONSE}" | jq '.data | length')
+
+if [ "${COUNT}" -gt 0 ]; then
+  echo "PASS: history contains ${COUNT} record(s)"
+else
+  echo "FAIL: history is empty after tool invocation"
+  echo "${RESPONSE}"
+fi
+```
+
+### Test 2.3: List tool call history -- verify response structure
+
+```bash
+RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history")
+
+# Verify the WanakuResponse wrapper has the expected shape
+echo "${RESPONSE}" | jq -e '.data' > /dev/null 2>&1 \
+  && echo "PASS: response has 'data' field" \
+  || echo "FAIL: response missing 'data' field"
+
+# Verify at least one record has expected fields
+echo "${RESPONSE}" | jq -e '.data[0].eventId' > /dev/null 2>&1 \
+  && echo "PASS: record has 'eventId'" \
+  || echo "FAIL: record missing 'eventId'"
+
+echo "${RESPONSE}" | jq -e '.data[0].eventType' > /dev/null 2>&1 \
+  && echo "PASS: record has 'eventType'" \
+  || echo "FAIL: record missing 'eventType'"
+
+echo "${RESPONSE}" | jq -e '.data[0].toolName' > /dev/null 2>&1 \
+  && echo "PASS: record has 'toolName'" \
+  || echo "FAIL: record missing 'toolName'"
+
+echo "${RESPONSE}" | jq -e '.data[0].timestamp' > /dev/null 2>&1 \
+  && echo "PASS: record has 'timestamp'" \
+  || echo "FAIL: record missing 'timestamp'"
+```
+
+### Test 2.4: Get a specific history event by ID
+
+```bash
+# Extract the first event ID from history
+EVENT_ID=$(curl -s "${V2_BASE}/tool-calls/history" | jq -r '.data[0].id')
+
+if [ -z "${EVENT_ID}" ] || [ "${EVENT_ID}" = "null" ]; then
+  echo "FAIL: could not extract event ID from history"
+else
+  RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history/${EVENT_ID}")
+  RETURNED_ID=$(echo "${RESPONSE}" | jq -r '.data.id')
+
+  if [ "${RETURNED_ID}" = "${EVENT_ID}" ]; then
+    echo "PASS: retrieved event matches requested ID (${EVENT_ID})"
+  else
+    echo "FAIL: returned ID (${RETURNED_ID}) does not match requested (${EVENT_ID})"
+    echo "${RESPONSE}"
+  fi
+fi
+```
+
+### Test 2.5: Filter history by toolName query parameter
+
+```bash
+RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history?toolName=api-v2-test-tool")
+COUNT=$(echo "${RESPONSE}" | jq '.data | length')
+
+if [ "${COUNT}" -gt 0 ]; then
+  # Verify all returned records match the filter
+  MISMATCH=$(echo "${RESPONSE}" | jq '[.data[] | select(.toolName != "api-v2-test-tool")] | length')
+  if [ "${MISMATCH}" -eq 0 ]; then
+    echo "PASS: toolName filter returned ${COUNT} matching record(s)"
+  else
+    echo "FAIL: toolName filter returned ${MISMATCH} record(s) with wrong toolName"
+  fi
+else
+  echo "FAIL: toolName filter returned no records"
+fi
+```
+
+### Test 2.6: Filter history by connectionId query parameter
+
+```bash
+# Extract a connectionId from an existing record
+CONNECTION_ID=$(curl -s "${V2_BASE}/tool-calls/history" | jq -r '.data[0].connectionId')
+
+if [ -z "${CONNECTION_ID}" ] || [ "${CONNECTION_ID}" = "null" ]; then
+  echo "SKIP: no connectionId available to test filter"
+else
+  RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history?connectionId=${CONNECTION_ID}")
+  COUNT=$(echo "${RESPONSE}" | jq '.data | length')
+
+  if [ "${COUNT}" -gt 0 ]; then
+    echo "PASS: connectionId filter returned ${COUNT} record(s)"
+  else
+    echo "FAIL: connectionId filter returned no records"
+  fi
+fi
+```
+
+---
+
+## Phase 3: Tool Call Notifications (SSE)
+
+### Test 3.1: Verify SSE notifications endpoint connects
+
+Connect to the SSE endpoint with a short timeout to verify it returns HTTP 200 and the correct Content-Type.
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Accept: text/event-stream" \
+  --max-time 3 \
+  "${V2_BASE}/tool-calls/notifications" 2>/dev/null || echo "000")
+
+# SSE endpoints return 200 even though curl may exit non-zero due to timeout
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: SSE notifications endpoint returned HTTP 200"
+else
+  echo "FAIL: SSE notifications endpoint returned HTTP ${HTTP_CODE}"
+fi
+```
+
+### Test 3.2: Verify SSE stream receives events on tool invocation
+
+Start the SSE listener in the background, invoke a tool, then check for events.
+
+```bash
+SSE_OUTPUT_FILE=$(mktemp)
+
+# Start SSE listener in background with a timeout
+curl -s -N \
+  -H "Accept: text/event-stream" \
+  --max-time 30 \
+  "${V2_BASE}/tool-calls/notifications" > "${SSE_OUTPUT_FILE}" 2>/dev/null &
+SSE_PID=$!
+
+# Give SSE connection time to establish
+sleep 2
+
+# Invoke a tool to generate an event
+wanaku mcp tool \
+  --uri "${MCP_SERVER_URI}" \
+  --name api-v2-test-tool \
+  --param count=1 \
+  --plain > /dev/null 2>&1
+
+# Wait for the event to propagate
+sleep 5
+
+# Kill the SSE listener
+kill "${SSE_PID}" 2>/dev/null || true
+wait "${SSE_PID}" 2>/dev/null || true
+
+# Check if any SSE events were received
+if [ -s "${SSE_OUTPUT_FILE}" ]; then
+  if grep -q "event:" "${SSE_OUTPUT_FILE}" || grep -q "data:" "${SSE_OUTPUT_FILE}"; then
+    echo "PASS: SSE stream received events"
+  else
+    echo "WARN: SSE stream had data but no recognizable event/data lines"
+    cat "${SSE_OUTPUT_FILE}"
+  fi
+else
+  echo "FAIL: SSE stream received no data"
+fi
+
+rm -f "${SSE_OUTPUT_FILE}"
+```
+
+### Test 3.3: Verify SSE connection-specific notifications endpoint connects
+
+```bash
+# Use a synthetic connection ID
+TEST_CONN_ID="test-connection-12345"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Accept: text/event-stream" \
+  --max-time 3 \
+  "${V2_BASE}/tool-calls/notifications/${TEST_CONN_ID}" 2>/dev/null || echo "000")
+
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: connection-specific SSE endpoint returned HTTP 200"
+else
+  echo "FAIL: connection-specific SSE endpoint returned HTTP ${HTTP_CODE}"
+fi
+```
+
+---
+
+## Phase 4: Clear Tool Call History
+
+### Test 4.1: Delete all tool call history
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${V2_BASE}/tool-calls/history")
+
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: DELETE history returned HTTP 200"
+else
+  echo "FAIL: DELETE history returned HTTP ${HTTP_CODE}"
+fi
+```
+
+### Test 4.2: Verify history is empty after deletion
+
+```bash
+RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history")
+COUNT=$(echo "${RESPONSE}" | jq '.data | length')
+
+if [ "${COUNT}" -eq 0 ]; then
+  echo "PASS: history is empty after deletion"
+else
+  echo "FAIL: history still contains ${COUNT} record(s) after deletion"
+fi
+```
+
+### Test 4.3: Delete history when already empty (idempotent)
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${V2_BASE}/tool-calls/history")
+
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: DELETE on empty history returned HTTP 200 (idempotent)"
+else
+  echo "FAIL: DELETE on empty history returned HTTP ${HTTP_CODE}"
+fi
+```
+
+---
+
+## Phase 5: Code Execution
+
+**NOTE:** Code execution requires a configured execution engine (e.g., `jvm`, `interpreted`). If no engine is available locally, all tests in this phase should be marked **SKIP**.
+
+### Prerequisite check
+
+```bash
+export CODE_EXEC_ENGINE="${CODE_EXEC_ENGINE:-jvm}"
+export CODE_EXEC_LANGUAGE="${CODE_EXEC_LANGUAGE:-java}"
+
+echo "Testing code execution with engine=${CODE_EXEC_ENGINE}, language=${CODE_EXEC_LANGUAGE}"
+echo "If no engine is configured, tests in Phase 5 will fail -- mark them as SKIP."
+```
+
+### Test 5.1: Submit code for execution
+
+Submit a simple code snippet and verify the response contains a task ID and stream URL.
+
+```bash
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"code": "System.out.println(\"Hello from Wanaku\");", "timeout": 30000}' \
+  "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}")
+
+HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+BODY=$(echo "${RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "201" ]; then
+  echo "PASS: code submission returned HTTP 201 Created"
+
+  TASK_ID=$(echo "${BODY}" | jq -r '.taskId')
+  STREAM_URL=$(echo "${BODY}" | jq -r '.streamUrl')
+  STATUS=$(echo "${BODY}" | jq -r '.status')
+
+  if [ -n "${TASK_ID}" ] && [ "${TASK_ID}" != "null" ]; then
+    echo "PASS: response contains taskId (${TASK_ID})"
+  else
+    echo "FAIL: response missing taskId"
+  fi
+
+  if [ -n "${STREAM_URL}" ] && [ "${STREAM_URL}" != "null" ]; then
+    echo "PASS: response contains streamUrl"
+  else
+    echo "FAIL: response missing streamUrl"
+  fi
+
+  if [ "${STATUS}" = "PENDING" ]; then
+    echo "PASS: initial status is PENDING"
+  else
+    echo "WARN: initial status is '${STATUS}' (expected PENDING)"
+  fi
+
+  # Save for next test
+  export SAVED_TASK_ID="${TASK_ID}"
+  export SAVED_STREAM_URL="${STREAM_URL}"
+else
+  echo "SKIP: code submission returned HTTP ${HTTP_CODE} -- engine may not be configured"
+  echo "${BODY}"
+  export SAVED_TASK_ID=""
+fi
+```
+
+### Test 5.2: Stream execution results via SSE
+
+```bash
+if [ -z "${SAVED_TASK_ID}" ]; then
+  echo "SKIP: no task ID from previous test"
+else
+  SSE_OUTPUT_FILE=$(mktemp)
+
+  curl -s -N \
+    -H "Accept: text/event-stream" \
+    --max-time 35 \
+    "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}/${SAVED_TASK_ID}" \
+    > "${SSE_OUTPUT_FILE}" 2>/dev/null || true
+
+  if [ -s "${SSE_OUTPUT_FILE}" ]; then
+    echo "PASS: SSE stream returned data for task ${SAVED_TASK_ID}"
+
+    if grep -q "event:" "${SSE_OUTPUT_FILE}"; then
+      echo "PASS: stream contains SSE event lines"
+    else
+      echo "WARN: stream has data but no 'event:' lines"
+    fi
+  else
+    echo "WARN: SSE stream returned no data (execution may have completed before connection)"
+  fi
+
+  rm -f "${SSE_OUTPUT_FILE}"
+fi
+```
+
+### Test 5.3: Verify Location header is set on POST response
+
+```bash
+LOCATION=$(curl -s -D - \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"code": "System.out.println(\"test\");", "timeout": 5000}' \
+  "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}" \
+  -o /dev/null 2>/dev/null | grep -i "^location:" | tr -d '\r')
+
+if [ -n "${LOCATION}" ]; then
+  echo "PASS: Location header is present: ${LOCATION}"
+else
+  echo "SKIP: Location header not present -- engine may not be configured"
+fi
+```
+
+---
+
+## Phase 6: Negative Tests
+
+### Test 6.1: Get non-existent history event -- expect 404
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  "${V2_BASE}/tool-calls/history/non-existent-event-id-12345")
+
+if [ "${HTTP_CODE}" = "404" ]; then
+  echo "PASS: non-existent event ID returned HTTP 404"
+else
+  echo "FAIL: non-existent event ID returned HTTP ${HTTP_CODE} (expected 404)"
+fi
+```
+
+### Test 6.2: Submit code with empty body -- expect 400
+
+```bash
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"code": ""}' \
+  "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}")
+
+HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+BODY=$(echo "${RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "400" ]; then
+  echo "PASS: empty code returned HTTP 400"
+
+  ERROR_TYPE=$(echo "${BODY}" | jq -r '.error' 2>/dev/null)
+  if [ "${ERROR_TYPE}" = "VALIDATION_ERROR" ]; then
+    echo "PASS: error type is VALIDATION_ERROR"
+  else
+    echo "WARN: error type is '${ERROR_TYPE}' (expected VALIDATION_ERROR)"
+  fi
+elif [ "${HTTP_CODE}" = "500" ]; then
+  echo "SKIP: empty code returned HTTP 500 -- engine may not be configured"
+else
+  echo "FAIL: empty code returned HTTP ${HTTP_CODE} (expected 400)"
+fi
+```
+
+### Test 6.3: Submit code with null code field -- expect 400
+
+```bash
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"timeout": 5000}' \
+  "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}")
+
+HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+
+if [ "${HTTP_CODE}" = "400" ]; then
+  echo "PASS: missing code field returned HTTP 400"
+elif [ "${HTTP_CODE}" = "500" ]; then
+  echo "SKIP: missing code field returned HTTP 500 -- engine may not be configured"
+else
+  echo "FAIL: missing code field returned HTTP ${HTTP_CODE} (expected 400)"
+fi
+```
+
+### Test 6.4: Submit code with excessive timeout -- expect 400
+
+```bash
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"code": "print(1)", "timeout": 999999999}' \
+  "${V2_BASE}/code-execution-engine/${CODE_EXEC_ENGINE}/${CODE_EXEC_LANGUAGE}")
+
+HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+
+if [ "${HTTP_CODE}" = "400" ]; then
+  echo "PASS: excessive timeout returned HTTP 400"
+elif [ "${HTTP_CODE}" = "500" ]; then
+  echo "SKIP: excessive timeout returned HTTP 500 -- engine may not be configured"
+else
+  echo "FAIL: excessive timeout returned HTTP ${HTTP_CODE} (expected 400)"
+fi
+```
+
+### Test 6.5: Verify history endpoint with non-matching toolName filter returns empty
+
+```bash
+RESPONSE=$(curl -s "${V2_BASE}/tool-calls/history?toolName=non-existent-tool-12345")
+COUNT=$(echo "${RESPONSE}" | jq '.data | length')
+
+if [ "${COUNT}" -eq 0 ]; then
+  echo "PASS: toolName filter for non-existent tool returned empty list"
+else
+  echo "FAIL: toolName filter for non-existent tool returned ${COUNT} record(s)"
+fi
+```
+
+---
+
+## Phase 7: Cleanup
+
+### Step 7.1: Remove test tool
+
+```bash
+wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name api-v2-test-tool 2>/dev/null || true
+
+echo "PASS: test tool removed"
+```
+
+### Step 7.2: Clear any remaining history
+
+```bash
+curl -s -X DELETE "${V2_BASE}/tool-calls/history" > /dev/null 2>&1 || true
+echo "PASS: history cleared"
+```
+
+### Step 7.3: Stop Wanaku
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+else
+  echo "SKIP: no WANAKU_PID set"
+fi
+```
+
+---
+
+## Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Prerequisite tool verification | Critical |
+| 1 | 1.1 | Router health check | Critical |
+| 1 | 1.2-1.3 | Register and verify test tool | Critical |
+| 2 | 2.1 | Invoke tool to generate history | Critical |
+| 2 | 2.2 | List history -- at least one entry | Critical |
+| 2 | 2.3 | List history -- verify response structure | High |
+| 2 | 2.4 | Get specific history event by ID | Critical |
+| 2 | 2.5 | Filter history by toolName | High |
+| 2 | 2.6 | Filter history by connectionId | High |
+| 3 | 3.1 | SSE notifications endpoint connects | Critical |
+| 3 | 3.2 | SSE stream receives events on tool call | Critical |
+| 3 | 3.3 | Connection-specific SSE endpoint connects | High |
+| 4 | 4.1 | Delete all history | Critical |
+| 4 | 4.2 | Verify history empty after deletion | Critical |
+| 4 | 4.3 | Delete on empty history (idempotent) | Medium |
+| 5 | 5.1 | Submit code -- verify 201 + taskId/streamUrl | High |
+| 5 | 5.2 | Stream execution results via SSE | High |
+| 5 | 5.3 | Verify Location header on POST | Medium |
+| 6 | 6.1 | Non-existent event ID -- 404 | High |
+| 6 | 6.2 | Empty code field -- 400 | High |
+| 6 | 6.3 | Missing code field -- 400 | High |
+| 6 | 6.4 | Excessive timeout -- 400 | Medium |
+| 6 | 6.5 | Non-matching toolName filter -- empty list | Medium |
+| 7 | 7.1-7.3 | Cleanup | Critical |

--- a/tests/plans/archetype-full-lifecycle.md
+++ b/tests/plans/archetype-full-lifecycle.md
@@ -1,0 +1,700 @@
+# Test Plan: Capability Archetype Full Lifecycle
+
+## Overview
+
+This test plan verifies the full lifecycle of a capability generated from a Wanaku archetype: scaffold, build, start, register with the router, and invoke via MCP. It extends the existing build-only archetype test (`tests/archetype-tests/test-archetypes.sh`) to cover runtime behavior.
+
+The plan covers four archetype variants:
+
+- **Quarkus tool service** (default `--type quarkus`)
+- **Camel tool service** (`--type camel`)
+- **Quarkus resource provider** (default `--type quarkus`)
+- **Camel resource provider** (`--type camel`)
+
+Every step except "Phase 0: Prerequisites" is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} capabilities create tool --name ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export WANAKU_MCP_SSE_URI="${WANAKU_MCP_SSE_URI:-${WANAKU_ROUTER_URL}/public/mcp/sse}"
+export TOOL_HTTP_PORT="${TOOL_HTTP_PORT:-9010}"
+export CAMEL_TOOL_HTTP_PORT="${CAMEL_TOOL_HTTP_PORT:-9011}"
+```
+
+### Helper: poll for capability registration
+
+```bash
+wait_for_capability() {
+  local SERVICE_NAME="$1"
+  local HOST="${2:-${WANAKU_ROUTER_URL}}"
+  local TIMEOUT="${3:-120}"
+  local INTERVAL=5
+  local ELAPSED=0
+
+  while true; do
+    OUTPUT=$(wanaku capabilities list --host "${HOST}" --plain 2>&1)
+    if echo "${OUTPUT}" | grep -q "${SERVICE_NAME}"; then
+      echo "PASS: capability '${SERVICE_NAME}' registered (${ELAPSED}s)"
+      return 0
+    fi
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+      echo "FAIL: capability '${SERVICE_NAME}' not registered after ${TIMEOUT}s"
+      return 1
+    fi
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+}
+```
+
+### Helper: poll for process readiness
+
+```bash
+wait_for_process_health() {
+  local PORT="$1"
+  local TIMEOUT="${2:-60}"
+  local INTERVAL=3
+  local ELAPSED=0
+
+  while true; do
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${PORT}/q/health/ready" 2>/dev/null || echo "000")
+    if [ "${HTTP_CODE}" = "200" ]; then
+      echo "PASS: process on port ${PORT} is healthy (${ELAPSED}s)"
+      return 0
+    fi
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+      echo "FAIL: process on port ${PORT} not healthy after ${TIMEOUT}s (last HTTP ${HTTP_CODE})"
+      return 1
+    fi
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+}
+```
+
+---
+
+## Phase 0: Verify Prerequisites
+
+### Test 0.1: Java is available
+
+```bash
+java -version 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: java is available"
+else
+  echo "FAIL: java is not available"
+  exit 1
+fi
+```
+
+### Test 0.2: Maven is available
+
+```bash
+mvn -version 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: mvn is available"
+else
+  echo "FAIL: mvn is not available"
+  exit 1
+fi
+```
+
+### Test 0.3: Wanaku CLI is available
+
+```bash
+wanaku --version 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: wanaku CLI is available"
+else
+  echo "FAIL: wanaku CLI is not available"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Start the Router
+
+Follow [common/start-local.md](common/start-local.md) to build and start the local Wanaku stack.
+
+After completion, `VERSION`, `CLI_JAR`, `WANAKU_ROUTER_URL`, and `WANAKU_PID` must be set.
+
+### Test 1.1: Verify router is healthy
+
+```bash
+MAX_RETRIES=30
+RETRY_INTERVAL=5
+for i in $(seq 1 ${MAX_RETRIES}); do
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready" 2>/dev/null || echo "000")
+  if [ "${HTTP_CODE}" = "200" ]; then
+    echo "PASS: router is healthy (attempt ${i})"
+    break
+  fi
+  if [ "${i}" -eq "${MAX_RETRIES}" ]; then
+    echo "FAIL: router not healthy after ${MAX_RETRIES} attempts (last HTTP ${HTTP_CODE})"
+    exit 1
+  fi
+  sleep ${RETRY_INTERVAL}
+done
+```
+
+### Test 1.2: Verify CLI can connect to the router
+
+```bash
+wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI can connect to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 2: Scaffold a Quarkus Tool Capability
+
+### Test 2.1: Create a temporary working directory
+
+```bash
+ARCHETYPE_WORK_DIR=$(mktemp -d)
+echo "Working directory: ${ARCHETYPE_WORK_DIR}"
+if [ -d "${ARCHETYPE_WORK_DIR}" ]; then
+  echo "PASS: temp directory created"
+else
+  echo "FAIL: could not create temp directory"
+  exit 1
+fi
+```
+
+### Test 2.2: Scaffold the tool project
+
+```bash
+cd "${ARCHETYPE_WORK_DIR}"
+wanaku capabilities create tool --name e2e-test-tool
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: scaffolding succeeded"
+else
+  echo "FAIL: scaffolding failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 2.3: Verify project structure
+
+The tool archetype generates a directory named `wanaku-tool-service-<sanitized-name>`. Dashes in the name are removed during sanitization.
+
+```bash
+TOOL_PROJECT_DIR="${ARCHETYPE_WORK_DIR}/wanaku-tool-service-e2etesttool"
+if [ -d "${TOOL_PROJECT_DIR}" ]; then
+  echo "PASS: project directory exists"
+else
+  echo "FAIL: expected directory ${TOOL_PROJECT_DIR} not found"
+  ls -1 "${ARCHETYPE_WORK_DIR}"
+  exit 1
+fi
+
+for FILE in pom.xml src/main/java src/main/resources/application.properties; do
+  if [ -e "${TOOL_PROJECT_DIR}/${FILE}" ]; then
+    echo "PASS: ${FILE} exists"
+  else
+    echo "FAIL: ${FILE} not found in project"
+  fi
+done
+```
+
+---
+
+## Phase 3: Build the Quarkus Tool Capability
+
+### Test 3.1: Build with distribution profile
+
+```bash
+cd "${TOOL_PROJECT_DIR}"
+mvn -DskipTests -Pdist clean package
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: build succeeded"
+else
+  echo "FAIL: build failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 3.2: Verify distribution ZIP was created
+
+```bash
+TOOL_DIST=$(find "${TOOL_PROJECT_DIR}/target/distributions" -name "*.zip" -type f 2>/dev/null | head -1)
+if [ -n "${TOOL_DIST}" ]; then
+  echo "PASS: distribution ZIP found: ${TOOL_DIST}"
+else
+  echo "FAIL: no distribution ZIP in target/distributions/"
+  ls -lR "${TOOL_PROJECT_DIR}/target/distributions/" 2>/dev/null
+  exit 1
+fi
+```
+
+### Test 3.3: Verify Quarkus runner JAR exists
+
+```bash
+TOOL_RUNNER="${TOOL_PROJECT_DIR}/target/quarkus-app/quarkus-run.jar"
+if [ -f "${TOOL_RUNNER}" ]; then
+  echo "PASS: quarkus runner JAR exists"
+else
+  echo "FAIL: quarkus runner JAR not found at ${TOOL_RUNNER}"
+  exit 1
+fi
+```
+
+---
+
+## Phase 4: Start and Register the Tool Capability
+
+### Test 4.1: Start the capability as a background process
+
+The generated capability uses the service name `e2etesttool` (derived from `--name e2e-test-tool` with dashes removed and lowercased). Start it on a dedicated port and point it at the router for registration.
+
+```bash
+java -jar "${TOOL_RUNNER}" \
+  -Dquarkus.http.port=${TOOL_HTTP_PORT} \
+  -Dwanaku.service.registration.uri=${WANAKU_ROUTER_URL} &
+TOOL_CAPABILITY_PID=$!
+echo "Tool capability started with PID ${TOOL_CAPABILITY_PID}"
+
+if [ -n "${TOOL_CAPABILITY_PID}" ]; then
+  echo "PASS: capability process launched"
+else
+  echo "FAIL: capability process did not launch"
+  exit 1
+fi
+```
+
+### Test 4.2: Wait for capability health check
+
+```bash
+wait_for_process_health "${TOOL_HTTP_PORT}" 60
+```
+
+### Test 4.3: Wait for capability to register with the router
+
+```bash
+wait_for_capability "e2etesttool" "${WANAKU_ROUTER_URL}" 120
+```
+
+### Test 4.4: Verify capability appears in capabilities list
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "e2etesttool" \
+  && echo "PASS: e2etesttool is listed in capabilities" \
+  || echo "FAIL: e2etesttool not found in capabilities list"
+```
+
+---
+
+## Phase 5: Invoke the Tool via MCP
+
+### Test 5.1: Register a tool backed by the new capability type
+
+The generated capability's service name is `e2etesttool`. Register a tool that uses this type. The default archetype creates a capability that accepts a URI but does not perform real work -- this test verifies the routing path, not the tool output.
+
+```bash
+wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name e2e-lifecycle-tool \
+  --namespace public \
+  --description "E2E lifecycle test tool" \
+  --uri "e2etesttool://test" \
+  --type e2etesttool \
+  --property "input:string,Test input parameter" \
+  --required input
+
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool registered"
+else
+  echo "FAIL: tool registration failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 5.2: Verify the tool is listed
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "e2e-lifecycle-tool" \
+  && echo "PASS: e2e-lifecycle-tool appears in tools list" \
+  || echo "FAIL: e2e-lifecycle-tool not found in tools list"
+```
+
+### Test 5.3: Verify the tool is visible via MCP
+
+```bash
+OUTPUT=$(wanaku mcp tool list --uri "${WANAKU_MCP_SSE_URI}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: mcp tool list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "${OUTPUT}" | grep -q "e2e-lifecycle-tool" \
+    && echo "PASS: e2e-lifecycle-tool visible via MCP" \
+    || echo "FAIL: e2e-lifecycle-tool not visible via MCP"
+fi
+```
+
+### Test 5.4: Invoke the tool via MCP
+
+The default archetype tool may not return meaningful data, but the call should succeed (the request reaches the capability and comes back without error).
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name e2e-lifecycle-tool \
+  --param input=hello \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+echo "Output: ${OUTPUT}"
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool invocation succeeded"
+else
+  echo "WARN: tool invocation returned non-zero (exit code ${EXIT_CODE}) -- check if archetype default handler returns an error"
+fi
+```
+
+### Test 5.5: Invoke the tool with a missing required parameter
+
+```bash
+OUTPUT=$(wanaku mcp tool \
+  --uri "${WANAKU_MCP_SSE_URI}" \
+  --name e2e-lifecycle-tool \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing required parameter caused an error (expected)"
+else
+  echo "WARN: missing required parameter did not fail -- check response body for error"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 6: Scaffold and Build a Camel Tool Capability
+
+### Test 6.1: Scaffold a Camel tool project
+
+```bash
+cd "${ARCHETYPE_WORK_DIR}"
+wanaku capabilities create tool --name e2e-test-camel --type camel
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: Camel tool scaffolding succeeded"
+else
+  echo "FAIL: Camel tool scaffolding failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 6.2: Verify Camel tool project structure
+
+```bash
+CAMEL_TOOL_DIR="${ARCHETYPE_WORK_DIR}/wanaku-tool-service-e2etestcamel"
+if [ -d "${CAMEL_TOOL_DIR}" ]; then
+  echo "PASS: Camel tool project directory exists"
+else
+  echo "FAIL: expected directory ${CAMEL_TOOL_DIR} not found"
+  ls -1 "${ARCHETYPE_WORK_DIR}"
+  exit 1
+fi
+
+for FILE in pom.xml src/main/java src/main/resources/application.properties; do
+  if [ -e "${CAMEL_TOOL_DIR}/${FILE}" ]; then
+    echo "PASS: ${FILE} exists"
+  else
+    echo "FAIL: ${FILE} not found in Camel tool project"
+  fi
+done
+```
+
+### Test 6.3: Build the Camel tool with distribution profile
+
+```bash
+cd "${CAMEL_TOOL_DIR}"
+mvn -DskipTests -Pdist clean package
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: Camel tool build succeeded"
+else
+  echo "FAIL: Camel tool build failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 6.4: Verify Camel tool distribution ZIP
+
+```bash
+CAMEL_TOOL_DIST=$(find "${CAMEL_TOOL_DIR}/target/distributions" -name "*.zip" -type f 2>/dev/null | head -1)
+if [ -n "${CAMEL_TOOL_DIST}" ]; then
+  echo "PASS: Camel tool distribution ZIP found: ${CAMEL_TOOL_DIST}"
+else
+  echo "FAIL: no Camel tool distribution ZIP in target/distributions/"
+  exit 1
+fi
+```
+
+---
+
+## Phase 7: Scaffold and Build a Quarkus Resource Provider
+
+### Test 7.1: Scaffold a resource provider
+
+```bash
+cd "${ARCHETYPE_WORK_DIR}"
+wanaku capabilities create resource --name e2e-test-provider
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource provider scaffolding succeeded"
+else
+  echo "FAIL: resource provider scaffolding failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 7.2: Verify resource provider project structure
+
+```bash
+PROVIDER_DIR="${ARCHETYPE_WORK_DIR}/wanaku-provider-e2etestprovider"
+if [ -d "${PROVIDER_DIR}" ]; then
+  echo "PASS: resource provider project directory exists"
+else
+  echo "FAIL: expected directory ${PROVIDER_DIR} not found"
+  ls -1 "${ARCHETYPE_WORK_DIR}"
+  exit 1
+fi
+
+for FILE in pom.xml src/main/java src/main/resources/application.properties; do
+  if [ -e "${PROVIDER_DIR}/${FILE}" ]; then
+    echo "PASS: ${FILE} exists"
+  else
+    echo "FAIL: ${FILE} not found in resource provider project"
+  fi
+done
+```
+
+### Test 7.3: Build the resource provider with distribution profile
+
+```bash
+cd "${PROVIDER_DIR}"
+mvn -DskipTests -Pdist clean package
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource provider build succeeded"
+else
+  echo "FAIL: resource provider build failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 7.4: Verify resource provider distribution ZIP
+
+```bash
+PROVIDER_DIST=$(find "${PROVIDER_DIR}/target/distributions" -name "*.zip" -type f 2>/dev/null | head -1)
+if [ -n "${PROVIDER_DIST}" ]; then
+  echo "PASS: resource provider distribution ZIP found: ${PROVIDER_DIST}"
+else
+  echo "FAIL: no resource provider distribution ZIP in target/distributions/"
+  exit 1
+fi
+```
+
+---
+
+## Phase 8: Scaffold and Build a Camel Resource Provider
+
+### Test 8.1: Scaffold a Camel resource provider
+
+```bash
+cd "${ARCHETYPE_WORK_DIR}"
+wanaku capabilities create resource --name e2e-test-camel-provider --type camel
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: Camel resource provider scaffolding succeeded"
+else
+  echo "FAIL: Camel resource provider scaffolding failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 8.2: Verify Camel resource provider project structure
+
+```bash
+CAMEL_PROVIDER_DIR="${ARCHETYPE_WORK_DIR}/wanaku-provider-e2etestcamelprovider"
+if [ -d "${CAMEL_PROVIDER_DIR}" ]; then
+  echo "PASS: Camel resource provider project directory exists"
+else
+  echo "FAIL: expected directory ${CAMEL_PROVIDER_DIR} not found"
+  ls -1 "${ARCHETYPE_WORK_DIR}"
+  exit 1
+fi
+
+for FILE in pom.xml src/main/java src/main/resources/application.properties; do
+  if [ -e "${CAMEL_PROVIDER_DIR}/${FILE}" ]; then
+    echo "PASS: ${FILE} exists"
+  else
+    echo "FAIL: ${FILE} not found in Camel resource provider project"
+  fi
+done
+```
+
+### Test 8.3: Build the Camel resource provider with distribution profile
+
+```bash
+cd "${CAMEL_PROVIDER_DIR}"
+mvn -DskipTests -Pdist clean package
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: Camel resource provider build succeeded"
+else
+  echo "FAIL: Camel resource provider build failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 8.4: Verify Camel resource provider distribution ZIP
+
+```bash
+CAMEL_PROVIDER_DIST=$(find "${CAMEL_PROVIDER_DIR}/target/distributions" -name "*.zip" -type f 2>/dev/null | head -1)
+if [ -n "${CAMEL_PROVIDER_DIST}" ]; then
+  echo "PASS: Camel resource provider distribution ZIP found: ${CAMEL_PROVIDER_DIST}"
+else
+  echo "FAIL: no Camel resource provider distribution ZIP in target/distributions/"
+  exit 1
+fi
+```
+
+---
+
+## Phase 9: Negative Tests
+
+### Test 9.1: Scaffold with missing `--name` should fail
+
+```bash
+wanaku capabilities create tool 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --name should have failed"
+fi
+```
+
+### Test 9.2: Register a tool with a non-existent capability type should fail
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name nonexistent-type-tool \
+  --namespace public \
+  --description "Tool with invalid type" \
+  --uri "nonexistent://test" \
+  --type nonexistent-type-that-does-not-exist \
+  --property "x:string,test" 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: registering tool with non-existent capability type failed (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: registering tool with non-existent capability type should have failed"
+fi
+```
+
+---
+
+## Phase 10: Cleanup
+
+### Step 10.1: Remove the registered tool
+
+```bash
+wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name e2e-lifecycle-tool 2>/dev/null || true
+echo "PASS: test tool removed (or was already absent)"
+```
+
+### Step 10.2: Stop the tool capability process
+
+```bash
+if [ -n "${TOOL_CAPABILITY_PID}" ]; then
+  kill "${TOOL_CAPABILITY_PID}" 2>/dev/null || true
+  wait "${TOOL_CAPABILITY_PID}" 2>/dev/null || true
+  echo "PASS: tool capability process stopped (PID ${TOOL_CAPABILITY_PID})"
+fi
+```
+
+### Step 10.3: Stop the router
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: router process stopped (PID ${WANAKU_PID})"
+fi
+```
+
+### Step 10.4: Remove temporary working directory
+
+```bash
+if [ -n "${ARCHETYPE_WORK_DIR}" ] && [ -d "${ARCHETYPE_WORK_DIR}" ]; then
+  rm -rf "${ARCHETYPE_WORK_DIR}"
+  echo "PASS: temp directory removed"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1-0.3 | Prerequisites (java, mvn, wanaku) | Critical |
+| 1 | 1.1-1.2 | Start and verify router | Critical |
+| 2 | 2.1-2.3 | Scaffold Quarkus tool capability | Critical |
+| 3 | 3.1-3.3 | Build Quarkus tool capability | Critical |
+| 4 | 4.1-4.4 | Start and register Quarkus tool capability | Critical |
+| 5 | 5.1-5.5 | Register tool, list via MCP, invoke via MCP, negative param test | Critical |
+| 6 | 6.1-6.4 | Scaffold and build Camel tool capability | High |
+| 7 | 7.1-7.4 | Scaffold and build Quarkus resource provider | High |
+| 8 | 8.1-8.4 | Scaffold and build Camel resource provider | High |
+| 9 | 9.1-9.2 | Negative tests (missing name, invalid type) | High |
+| 10 | 10.1-10.4 | Cleanup (tool, capability, router, temp dir) | Critical |

--- a/tests/plans/cli-capabilities-management.md
+++ b/tests/plans/cli-capabilities-management.md
@@ -1,0 +1,547 @@
+# Test Plan: CLI Capabilities Management
+
+## Overview
+
+This test plan verifies the `wanaku capabilities` CLI commands against a locally running Wanaku instance (no authentication). Capabilities are services (tool providers, resource providers) that register with the router. When started via `wanaku start local` with the HTTP tool distribution, the HTTP tool service automatically registers as a capability.
+
+The plan covers listing, showing details, checking status, and cleaning up capabilities using the CLI.
+
+Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+| `jq` | 1.6+ | `jq --version` |
+
+### Prerequisite check script
+
+```bash
+FAIL=0
+
+for CMD in java mvn jq; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found at $(command -v ${CMD})"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo ""
+  echo "FAIL: one or more prerequisites missing"
+  exit 1
+fi
+
+echo ""
+echo "PASS: all prerequisites met"
+```
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} capabilities list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+```
+
+### Known limitations for local testing
+
+- **Capabilities commands do not use `--no-auth`:** The `capabilities list`, `show`, `status`, and `cleanup` commands use a static service initializer that does not pass the `--no-auth` flag. When running locally with `start local`, the router runs in `noauth` profile so authentication is not enforced. Do not pass `--no-auth` to capabilities commands -- it has no effect.
+- **Only the HTTP tool service is available locally:** The `start local` command only supports tool services. No resource providers register as capabilities locally. The test plan uses the HTTP tool capability as the test subject.
+- **`capabilities show` is interactive when multiple instances exist:** If multiple capability instances share the same service name, `show` presents an interactive selection menu. In local testing only one HTTP instance is expected.
+
+---
+
+## Phase 0: Prerequisites
+
+### Test 0.1: Verify tools table
+
+```bash
+FAIL=0
+
+for CMD in java mvn jq; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo "FAIL: prerequisites not met"
+  exit 1
+fi
+echo "PASS: all prerequisites met"
+```
+
+### Test 0.2: Verify environment variables
+
+```bash
+for VAR_NAME in WANAKU_REPO_ROOT WANAKU_ROUTER_URL; do
+  eval "VAL=\${${VAR_NAME}}"
+  if [ -z "${VAL}" ]; then
+    echo "FAIL: ${VAR_NAME} is not set"
+    exit 1
+  fi
+  echo "PASS: ${VAR_NAME}=${VAL}"
+done
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start the Wanaku local stack with the HTTP tool capability.
+
+After completion, `VERSION`, `CLI_JAR`, `WANAKU_ROUTER_URL`, and `WANAKU_PID` must be set.
+
+### Test 1.1: Verify the HTTP tool capability has registered
+
+After the router is healthy, wait for the HTTP tool capability to register. Capabilities register asynchronously after startup.
+
+```bash
+MAX_RETRIES=12
+RETRY_INTERVAL=5
+for i in $(seq 1 ${MAX_RETRIES}); do
+  OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+  if echo "${OUTPUT}" | grep -q "http"; then
+    echo "PASS: HTTP tool capability registered (attempt ${i})"
+    break
+  fi
+  if [ "${i}" -eq "${MAX_RETRIES}" ]; then
+    echo "FAIL: HTTP tool capability not registered after ${MAX_RETRIES} attempts"
+    echo "${OUTPUT}"
+    exit 1
+  fi
+  echo "Waiting for HTTP capability to register... (attempt ${i})"
+  sleep ${RETRY_INTERVAL}
+done
+```
+
+---
+
+## Phase 2: Capabilities List
+
+### Test 2.1: List capabilities shows at least one registered service
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+LINE_COUNT=$(echo "${OUTPUT}" | wc -l | tr -d ' ')
+if [ "${LINE_COUNT}" -gt 0 ]; then
+  echo "PASS: capabilities list returned ${LINE_COUNT} lines"
+else
+  echo "FAIL: capabilities list returned no output"
+fi
+```
+
+### Test 2.2: Verify the HTTP capability appears in the list
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${OUTPUT}" | grep -q "http" \
+  && echo "PASS: 'http' capability found in list" \
+  || echo "FAIL: 'http' capability not found in list"
+```
+
+### Test 2.3: Verify the list output contains expected columns
+
+The capabilities list displays columns: service, serviceType, host, port, status, lastSeen, labels.
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${OUTPUT}" | grep -qi "service" \
+  && echo "PASS: output contains 'service' column" \
+  || echo "FAIL: output missing 'service' column"
+
+echo "${OUTPUT}" | grep -qi "status" \
+  && echo "PASS: output contains 'status' column" \
+  || echo "FAIL: output missing 'status' column"
+```
+
+### Test 2.4: Verify list with label expression filter (non-matching)
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" -e "nonexistent=true" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: capabilities list with non-matching label expression succeeded (returned empty or filtered)"
+else
+  echo "WARN: capabilities list with non-matching label expression returned exit code ${EXIT_CODE}"
+fi
+```
+
+---
+
+## Phase 3: Capabilities Show
+
+### Test 3.1: Show details for the HTTP capability
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" http --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities show http failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: capabilities show http succeeded"
+echo "${OUTPUT}"
+```
+
+### Test 3.2: Verify show output contains service name
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" http --plain 2>&1)
+
+echo "${OUTPUT}" | grep -qi "http" \
+  && echo "PASS: show output contains service name 'http'" \
+  || echo "FAIL: show output does not contain service name 'http'"
+```
+
+### Test 3.3: Verify show output contains host and port
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" http --plain 2>&1)
+
+echo "${OUTPUT}" | grep -qE "[0-9]+" \
+  && echo "PASS: show output contains numeric data (port)" \
+  || echo "FAIL: show output does not contain expected numeric data"
+```
+
+### Test 3.4: Show a non-existent capability should fail
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" non-existent-service-12345 --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: show non-existent capability failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: show non-existent capability should have returned a non-zero exit code"
+fi
+```
+
+### Test 3.5: Verify non-existent show output contains warning message
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" non-existent-service-12345 --plain 2>&1)
+
+echo "${OUTPUT}" | grep -qi "no capabilities found" \
+  && echo "PASS: warning message present for non-existent capability" \
+  || echo "FAIL: expected 'No capabilities found' warning not present"
+```
+
+---
+
+## Phase 4: Capabilities Status
+
+### Test 4.1: Status shows health summary
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities status failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: capabilities status succeeded"
+echo "${OUTPUT}"
+```
+
+### Test 4.2: Verify status output contains health categories
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${OUTPUT}" | grep -qi "healthy" \
+  && echo "PASS: status output contains 'Healthy' category" \
+  || echo "FAIL: status output missing 'Healthy' category"
+
+echo "${OUTPUT}" | grep -qi "total" \
+  && echo "PASS: status output contains 'Total' category" \
+  || echo "FAIL: status output missing 'Total' category"
+```
+
+### Test 4.3: Verify at least one healthy capability is reported
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+# The Healthy count should be >= 1 since the HTTP capability is running
+HEALTHY_LINE=$(echo "${OUTPUT}" | grep -i "healthy" | head -1)
+if echo "${HEALTHY_LINE}" | grep -qE "[1-9]"; then
+  echo "PASS: at least one healthy capability reported"
+else
+  echo "FAIL: expected at least one healthy capability"
+  echo "Healthy line: ${HEALTHY_LINE}"
+fi
+```
+
+### Test 4.4: Status with --filter healthy shows only healthy capabilities
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --filter healthy --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities status --filter healthy failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "http" \
+  && echo "PASS: HTTP capability shown in healthy filter" \
+  || echo "FAIL: HTTP capability not shown in healthy filter"
+```
+
+### Test 4.5: Status with --filter down shows no capabilities (all should be healthy)
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --filter down --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: capabilities status --filter down succeeded"
+  # Should show the summary but no matching capabilities in the table
+  echo "${OUTPUT}" | grep -qi "no capabilities match" \
+    && echo "PASS: no capabilities match 'down' filter (expected)" \
+    || echo "INFO: output did not explicitly say no match, but command succeeded"
+else
+  echo "FAIL: capabilities status --filter down failed unexpectedly"
+fi
+```
+
+---
+
+## Phase 5: Capabilities Cleanup
+
+### Test 5.1: Cleanup with default max-age finds no stale capabilities
+
+The HTTP tool capability was just started, so it should not be stale (default max-age is 1 day).
+
+```bash
+OUTPUT=$(wanaku capabilities cleanup --host "${WANAKU_ROUTER_URL}" -y --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities cleanup failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -qi "no stale" \
+  && echo "PASS: no stale capabilities found (expected for fresh start)" \
+  || echo "WARN: cleanup output did not contain 'no stale' message"
+
+echo "Cleanup output: ${OUTPUT}"
+```
+
+### Test 5.2: Cleanup does not remove the healthy HTTP capability
+
+```bash
+# Run cleanup
+wanaku capabilities cleanup --host "${WANAKU_ROUTER_URL}" -y --plain 2>&1
+
+# Verify the HTTP capability is still registered
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "http" \
+  && echo "PASS: HTTP capability still registered after cleanup" \
+  || echo "FAIL: HTTP capability was removed by cleanup"
+```
+
+### Test 5.3: Cleanup with --inactive-only and default max-age
+
+```bash
+OUTPUT=$(wanaku capabilities cleanup --host "${WANAKU_ROUTER_URL}" --inactive-only -y --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities cleanup --inactive-only failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: cleanup --inactive-only succeeded"
+echo "${OUTPUT}"
+```
+
+### Test 5.4: Cleanup with custom max-age-days
+
+```bash
+OUTPUT=$(wanaku capabilities cleanup --host "${WANAKU_ROUTER_URL}" --max-age-days 365 -y --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities cleanup --max-age-days 365 failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: cleanup with custom max-age-days succeeded"
+echo "${OUTPUT}"
+```
+
+---
+
+## Phase 6: Negative Tests
+
+### Test 6.1: Show with no service name should fail
+
+```bash
+OUTPUT=$(wanaku capabilities show --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: show without service name failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: show without service name should require a positional parameter"
+fi
+```
+
+### Test 6.2: List against a non-existent host should fail gracefully
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "http://localhost:59999" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: list against non-existent host failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: list against non-existent host should fail"
+fi
+```
+
+### Test 6.3: Status against a non-existent host should fail gracefully
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "http://localhost:59999" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: status against non-existent host failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: status against non-existent host should fail"
+fi
+```
+
+### Test 6.4: Cleanup against a non-existent host should fail gracefully
+
+```bash
+OUTPUT=$(wanaku capabilities cleanup --host "http://localhost:59999" -y --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: cleanup against non-existent host failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: cleanup against non-existent host should fail"
+fi
+```
+
+### Test 6.5: Cleanup with nothing stale is a successful no-op
+
+```bash
+OUTPUT=$(wanaku capabilities cleanup --host "${WANAKU_ROUTER_URL}" -y --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: cleanup with no stale capabilities is a successful no-op"
+else
+  echo "FAIL: cleanup should succeed even when nothing is stale"
+fi
+```
+
+### Test 6.6: Status with invalid filter value
+
+```bash
+OUTPUT=$(wanaku capabilities status --host "${WANAKU_ROUTER_URL}" --filter "invalid-status-value" --plain 2>&1)
+EXIT_CODE=$?
+
+# Should succeed but show no matching capabilities
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: status with invalid filter value succeeded (shows no matches)"
+  echo "${OUTPUT}" | grep -qi "no capabilities match" \
+    && echo "PASS: displayed 'no capabilities match' message" \
+    || echo "INFO: command succeeded but did not show explicit no-match message"
+else
+  echo "INFO: status with invalid filter value returned exit code ${EXIT_CODE}"
+fi
+```
+
+---
+
+## Phase 7: Cleanup
+
+### Step 7.1: Kill the local Wanaku process
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+else
+  echo "WARN: WANAKU_PID not set, nothing to stop"
+fi
+```
+
+### Step 7.2: Verify the process is stopped
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  if kill -0 "${WANAKU_PID}" 2>/dev/null; then
+    echo "FAIL: Wanaku process (PID ${WANAKU_PID}) is still running"
+  else
+    echo "PASS: Wanaku process (PID ${WANAKU_PID}) is no longer running"
+  fi
+else
+  echo "PASS: no process to verify (WANAKU_PID not set)"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1-0.2 | Prerequisites and environment variables | High |
+| 1 | 1.1 | HTTP tool capability registration after startup | Critical |
+| 2 | 2.1-2.4 | Capabilities list, column output, label expression filter | Critical |
+| 3 | 3.1-3.5 | Capabilities show (details, content verification, non-existent) | Critical |
+| 4 | 4.1-4.5 | Capabilities status (summary, health categories, filter) | High |
+| 5 | 5.1-5.4 | Capabilities cleanup (no stale, healthy preserved, inactive-only, custom max-age) | High |
+| 6 | 6.1-6.6 | Negative tests (missing args, bad host, invalid filter, no-op cleanup) | High |
+| 7 | 7.1-7.2 | Process cleanup | Critical |

--- a/tests/plans/cli-forwards-datastores.md
+++ b/tests/plans/cli-forwards-datastores.md
@@ -1,0 +1,651 @@
+# Test Plan: Wanaku CLI Forwards and Data Store Commands
+
+## Overview
+
+This test plan verifies the `wanaku forwards` and `wanaku data-store` CLI commands against a locally running Wanaku instance (no authentication). It covers the full CRUD lifecycle for forward targets and data store entries, including label management and negative tests.
+
+Every step except the initial build is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} forwards list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+```
+
+---
+
+## Phase 0: Manual Prerequisites
+
+Verify all required tools are available:
+
+```bash
+wanaku --version && echo "PASS: wanaku CLI available" || echo "FAIL: wanaku CLI not found"
+jq --version && echo "PASS: jq available" || echo "FAIL: jq not found"
+java -version 2>&1 | head -1 && echo "PASS: java available" || echo "FAIL: java not found"
+```
+
+---
+
+## Phase 1: Start Wanaku Locally
+
+Follow [common/start-local.md](common/start-local.md). After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, and `CLI_JAR` must be set.
+
+Verify the CLI can connect:
+
+```bash
+wanaku forwards list --host "${WANAKU_ROUTER_URL}" --plain
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI can connect to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 2: Forward CRUD
+
+### Test 2.1: Add a forward target
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-forward \
+  --service "http://localhost:9999/mcp/sse" \
+  --namespace public
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: forward 'test-forward' added"
+else
+  echo "FAIL: could not add forward (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 2.2: Verify forward appears in list
+
+```bash
+OUTPUT=$(wanaku forwards list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: forwards list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+elif echo "${OUTPUT}" | grep -q "test-forward"; then
+  echo "PASS: 'test-forward' appears in forwards list"
+else
+  echo "FAIL: 'test-forward' not found in forwards list"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 2.3: Remove the forward target
+
+```bash
+wanaku forwards remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-forward
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: forward 'test-forward' removed"
+else
+  echo "FAIL: could not remove forward (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 2.4: Verify forward is gone from list
+
+```bash
+OUTPUT=$(wanaku forwards list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep -q "test-forward"; then
+  echo "FAIL: 'test-forward' still appears after removal"
+else
+  echo "PASS: 'test-forward' no longer in forwards list"
+fi
+```
+
+---
+
+## Phase 3: Forward Refresh
+
+### Test 3.1: Re-add a forward target for refresh testing
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-forward-refresh \
+  --service "http://localhost:9999/mcp/sse" \
+  --namespace public
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: forward 'test-forward-refresh' added"
+else
+  echo "FAIL: could not add forward (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 3.2: Refresh the forward
+
+The target service may not be reachable -- that is acceptable. The command should still exit without crashing.
+
+```bash
+wanaku forwards refresh \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-forward-refresh 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: forwards refresh completed successfully"
+else
+  echo "WARN: forwards refresh exited with code ${EXIT_CODE} (target may be unreachable, but command should not crash)"
+fi
+```
+
+### Test 3.3: Verify the forward still exists after refresh
+
+```bash
+OUTPUT=$(wanaku forwards list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep -q "test-forward-refresh"; then
+  echo "PASS: forward still present after refresh"
+else
+  echo "FAIL: forward disappeared after refresh"
+fi
+```
+
+### Test 3.4: Clean up refresh test forward
+
+```bash
+wanaku forwards remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-forward-refresh 2>/dev/null || true
+echo "PASS: refresh test forward cleaned up"
+```
+
+---
+
+## Phase 4: Data Store -- Add from File
+
+### Test 4.1: Create a test YAML file
+
+```bash
+cat > /tmp/test-datastore.yaml << 'YAMLEOF'
+name: test-config
+version: 1
+settings:
+  key1: value1
+  key2: value2
+YAMLEOF
+
+if [ -f /tmp/test-datastore.yaml ]; then
+  echo "PASS: test YAML file created"
+else
+  echo "FAIL: could not create test YAML file"
+fi
+```
+
+### Test 4.2: Add data store from file
+
+```bash
+wanaku data-store add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --read-from-file /tmp/test-datastore.yaml \
+  --name test-datastore
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: data store 'test-datastore' added from file"
+else
+  echo "FAIL: could not add data store (exit code ${EXIT_CODE})"
+fi
+```
+
+---
+
+## Phase 5: Data Store -- List and Get
+
+### Test 5.1: List data stores and verify entry appears
+
+```bash
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: data-store list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+elif echo "${OUTPUT}" | grep -q "test-datastore"; then
+  echo "PASS: 'test-datastore' appears in data store list"
+else
+  echo "FAIL: 'test-datastore' not found in data store list"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 5.2: Get data store by name and verify content
+
+The `data-store get` command writes the decoded content to a file. Verify the output matches the original.
+
+```bash
+wanaku data-store get \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-datastore \
+  --output-file /tmp/test-datastore-retrieved.yaml
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: data-store get failed (exit code ${EXIT_CODE})"
+elif diff /tmp/test-datastore.yaml /tmp/test-datastore-retrieved.yaml > /dev/null 2>&1; then
+  echo "PASS: retrieved content matches original file"
+else
+  echo "FAIL: retrieved content does not match original"
+fi
+```
+
+---
+
+## Phase 6: Data Store -- Labels
+
+### Test 6.1: Extract the data store ID
+
+Label commands require `--id`. Extract it from the list output.
+
+```bash
+DS_ID=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1 | grep "test-datastore" | awk '{print $1}')
+if [ -n "${DS_ID}" ]; then
+  echo "PASS: extracted data store ID: ${DS_ID}"
+else
+  echo "FAIL: could not extract data store ID from list output"
+fi
+```
+
+### Test 6.2: Add labels to the data store
+
+```bash
+wanaku data-store label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "${DS_ID}" \
+  --label env=test \
+  --label type=yaml
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: labels added to data store"
+else
+  echo "FAIL: could not add labels (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 6.3: Verify labels appear in list output
+
+```bash
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep "test-datastore" | grep -q "env"; then
+  echo "PASS: label 'env' visible in list output"
+else
+  echo "FAIL: label 'env' not visible in list output"
+fi
+
+if echo "${OUTPUT}" | grep "test-datastore" | grep -q "type"; then
+  echo "PASS: label 'type' visible in list output"
+else
+  echo "FAIL: label 'type' not visible in list output"
+fi
+```
+
+### Test 6.4: Remove a label from the data store
+
+```bash
+wanaku data-store label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "${DS_ID}" \
+  --label type
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: label 'type' removed"
+else
+  echo "FAIL: could not remove label (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 6.5: Verify label was removed
+
+```bash
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep "test-datastore" | grep -q "type=yaml"; then
+  echo "FAIL: label 'type=yaml' still present after removal"
+else
+  echo "PASS: label 'type' no longer present"
+fi
+```
+
+---
+
+## Phase 7: Data Store -- Remove
+
+### Test 7.1: Remove the data store by name
+
+```bash
+wanaku data-store remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-datastore
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: data store 'test-datastore' removed"
+else
+  echo "FAIL: could not remove data store (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 7.2: Verify data store is gone from list
+
+```bash
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep -q "test-datastore"; then
+  echo "FAIL: 'test-datastore' still appears after removal"
+else
+  echo "PASS: 'test-datastore' no longer in data store list"
+fi
+```
+
+---
+
+## Phase 8: Multiple Data Stores with Label Expression
+
+### Test 8.1: Add three data stores with a shared label
+
+```bash
+for i in 1 2 3; do
+  cat > /tmp/test-batch-${i}.yaml << EOF
+batch_item: ${i}
+EOF
+
+  wanaku data-store add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --read-from-file /tmp/test-batch-${i}.yaml \
+    --name "batch-ds-${i}"
+  EXIT_CODE=$?
+  if [ "${EXIT_CODE}" -eq 0 ]; then
+    echo "PASS: batch data store 'batch-ds-${i}' added"
+  else
+    echo "FAIL: could not add 'batch-ds-${i}' (exit code ${EXIT_CODE})"
+  fi
+done
+```
+
+### Test 8.2: Add the `batch=true` label to all three using label expression
+
+First add a `batch=true` label to each data store individually (since we need the IDs):
+
+```bash
+for i in 1 2 3; do
+  DS_ID=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1 | grep "batch-ds-${i}" | awk '{print $1}')
+  if [ -z "${DS_ID}" ]; then
+    echo "FAIL: could not find ID for batch-ds-${i}"
+    continue
+  fi
+
+  wanaku data-store label add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --id "${DS_ID}" \
+    --label batch=true
+  EXIT_CODE=$?
+  if [ "${EXIT_CODE}" -eq 0 ]; then
+    echo "PASS: label 'batch=true' added to batch-ds-${i}"
+  else
+    echo "FAIL: could not add label to batch-ds-${i} (exit code ${EXIT_CODE})"
+  fi
+done
+```
+
+### Test 8.3: List data stores filtered by label expression
+
+```bash
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" -e "batch=true" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: data-store list with expression failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  COUNT=$(echo "${OUTPUT}" | grep -c "batch-ds-")
+  if [ "${COUNT}" -eq 3 ]; then
+    echo "PASS: all 3 batch data stores returned by label expression"
+  else
+    echo "FAIL: expected 3 batch data stores, found ${COUNT}"
+    echo "${OUTPUT}"
+  fi
+fi
+```
+
+### Test 8.4: Remove all batch data stores individually
+
+Note: `data-store remove` does not support `--label-expression`. Remove each entry by name.
+
+```bash
+for i in 1 2 3; do
+  wanaku data-store remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --name "batch-ds-${i}" 2>/dev/null || true
+done
+
+OUTPUT=$(wanaku data-store list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+if echo "${OUTPUT}" | grep -q "batch-ds-"; then
+  echo "FAIL: some batch data stores still present after removal"
+  echo "${OUTPUT}"
+else
+  echo "PASS: all batch data stores removed"
+fi
+```
+
+---
+
+## Phase 9: Negative Tests
+
+### Test 9.1: Add forward with no name should fail
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --service "http://localhost:9999/mcp/sse" \
+  --namespace public 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: forwards add without --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: forwards add without --name should fail"
+fi
+```
+
+### Test 9.2: Add forward with no service URL should fail
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name negative-test-forward \
+  --namespace public 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: forwards add without --service rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: forwards add without --service should fail"
+  # Clean up in case it was created
+  wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name negative-test-forward 2>/dev/null || true
+fi
+```
+
+### Test 9.3: Add forward with no namespace should fail
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name negative-test-forward \
+  --service "http://localhost:9999/mcp/sse" 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: forwards add without --namespace rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: forwards add without --namespace should fail"
+  wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name negative-test-forward 2>/dev/null || true
+fi
+```
+
+### Test 9.4: Remove non-existent forward should fail gracefully
+
+```bash
+OUTPUT=$(wanaku forwards remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "does-not-exist-12345" 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: removing non-existent forward failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: removing non-existent forward should fail"
+fi
+```
+
+### Test 9.5: Add data store with non-existent file should fail
+
+```bash
+wanaku data-store add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --read-from-file /tmp/this-file-does-not-exist-12345.yaml \
+  --name negative-ds 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: data-store add with non-existent file rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: data-store add with non-existent file should fail"
+  wanaku data-store remove --host "${WANAKU_ROUTER_URL}" --name negative-ds 2>/dev/null || true
+fi
+```
+
+### Test 9.6: Get non-existent data store should fail
+
+```bash
+wanaku data-store get \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "does-not-exist-12345" \
+  --output-file /tmp/negative-ds-output.yaml 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: data-store get for non-existent entry failed (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: data-store get for non-existent entry should fail"
+fi
+rm -f /tmp/negative-ds-output.yaml 2>/dev/null || true
+```
+
+### Test 9.7: Data store get without --id or --name should fail
+
+```bash
+wanaku data-store get \
+  --host "${WANAKU_ROUTER_URL}" \
+  --output-file /tmp/negative-ds-output.yaml 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: data-store get without --id or --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: data-store get without --id or --name should fail"
+fi
+rm -f /tmp/negative-ds-output.yaml 2>/dev/null || true
+```
+
+### Test 9.8: Data store remove without --id or --name should fail
+
+```bash
+wanaku data-store remove \
+  --host "${WANAKU_ROUTER_URL}" 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: data-store remove without --id or --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: data-store remove without --id or --name should fail"
+fi
+```
+
+### Test 9.9: Refresh non-existent forward should fail gracefully
+
+```bash
+OUTPUT=$(wanaku forwards refresh \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "does-not-exist-12345" 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: refreshing non-existent forward failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: refreshing non-existent forward should fail"
+fi
+```
+
+---
+
+## Phase 10: Cleanup
+
+### Step 10.1: Remove all test artifacts
+
+```bash
+wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name test-forward 2>/dev/null || true
+wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name test-forward-refresh 2>/dev/null || true
+wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name negative-test-forward 2>/dev/null || true
+
+wanaku data-store remove --host "${WANAKU_ROUTER_URL}" --name test-datastore 2>/dev/null || true
+for i in 1 2 3; do
+  wanaku data-store remove --host "${WANAKU_ROUTER_URL}" --name "batch-ds-${i}" 2>/dev/null || true
+done
+
+echo "PASS: test artifacts cleaned up"
+```
+
+### Step 10.2: Clean up temporary files
+
+```bash
+rm -f /tmp/test-datastore.yaml 2>/dev/null || true
+rm -f /tmp/test-datastore-retrieved.yaml 2>/dev/null || true
+rm -f /tmp/test-batch-1.yaml /tmp/test-batch-2.yaml /tmp/test-batch-3.yaml 2>/dev/null || true
+rm -f /tmp/negative-ds-output.yaml 2>/dev/null || true
+echo "PASS: temporary files cleaned up"
+```
+
+### Step 10.3: Stop the local stack
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+fi
+```
+
+---
+
+## Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Prerequisites check | High |
+| 1 | 1.1 | Start local stack and verify connectivity | Critical |
+| 2 | 2.1-2.4 | Forward add, list, remove, verify gone | Critical |
+| 3 | 3.1-3.4 | Forward refresh lifecycle | High |
+| 4 | 4.1-4.2 | Data store add from file | Critical |
+| 5 | 5.1-5.2 | Data store list and get with content verification | Critical |
+| 6 | 6.1-6.5 | Data store label add, verify, remove, verify | High |
+| 7 | 7.1-7.2 | Data store remove and verify gone | Critical |
+| 8 | 8.1-8.4 | Multiple data stores with label expression filtering | High |
+| 9 | 9.1-9.9 | Negative tests (missing args, non-existent entries) | High |
+| 10 | 10.1-10.3 | Cleanup (artifacts, temp files, process) | Critical |

--- a/tests/plans/cli-namespaces-labels.md
+++ b/tests/plans/cli-namespaces-labels.md
@@ -1,0 +1,1024 @@
+# Test Plan: CLI Namespaces and Labels
+
+## Overview
+
+This test plan verifies namespace management, label operations, and namespace isolation via the Wanaku CLI against a locally running instance (no authentication). It covers the full CRUD lifecycle for namespaces, label add/remove operations on both namespaces and tools, label expression filtering, and namespace-scoped tool isolation.
+
+Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} namespaces list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) --- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+```
+
+---
+
+## Phase 0: Manual Prerequisites
+
+Verify the required tools are installed:
+
+```bash
+wanaku --version && echo "PASS: wanaku CLI available" || echo "FAIL: wanaku CLI not found"
+jq --version && echo "PASS: jq available" || echo "FAIL: jq not found"
+java -version 2>&1 | head -1 && echo "PASS: java available" || echo "FAIL: java not found"
+mvn -version 2>&1 | head -1 && echo "PASS: mvn available" || echo "FAIL: mvn not found"
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start the Wanaku stack locally. After completion, the following variables must be set:
+
+- `VERSION`
+- `CLI_JAR`
+- `WANAKU_ROUTER_URL` (defaults to `http://localhost:8080`)
+- `WANAKU_PID`
+
+---
+
+## Phase 2: Namespace CRUD
+
+### Test 2.1: List namespaces and verify defaults exist
+
+```bash
+OUTPUT=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespaces list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespaces list succeeded"
+echo "${OUTPUT}"
+
+echo "${OUTPUT}" | grep -q "public" \
+  && echo "PASS: 'public' namespace exists" \
+  || echo "FAIL: 'public' namespace not found"
+
+echo "${OUTPUT}" | grep -q "<default>" \
+  && echo "PASS: '<default>' namespace exists" \
+  || echo "FAIL: '<default>' namespace not found"
+```
+
+### Test 2.2: Create a custom namespace
+
+```bash
+OUTPUT=$(wanaku namespaces create \
+  --host "${WANAKU_ROUTER_URL}" \
+  --path "test-ns" \
+  --name "test-namespace" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace create failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespace created"
+echo "${OUTPUT}"
+
+# Extract the namespace ID for subsequent tests
+TEST_NS_ID=$(echo "${OUTPUT}" | grep -i "id" | head -1 | sed 's/.*: *//' | tr -d '[:space:]')
+if [ -z "${TEST_NS_ID}" ]; then
+  echo "WARN: could not extract namespace ID from output, will look up by listing"
+fi
+```
+
+### Test 2.3: Verify created namespace appears in list
+
+```bash
+OUTPUT=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-namespace" \
+  && echo "PASS: created namespace appears in list" \
+  || echo "FAIL: created namespace not found in list"
+```
+
+### Test 2.4: Show namespace details
+
+**Description:** Retrieve details of the created namespace by ID.
+
+```bash
+# If TEST_NS_ID was not captured, look it up from the list output
+if [ -z "${TEST_NS_ID}" ]; then
+  TEST_NS_ID=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1 \
+    | grep "test-namespace" | awk '{print $1}' | head -1)
+fi
+
+if [ -z "${TEST_NS_ID}" ]; then
+  echo "FAIL: could not determine namespace ID"
+  exit 1
+fi
+
+OUTPUT=$(wanaku namespaces show --host "${WANAKU_ROUTER_URL}" "${TEST_NS_ID}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace show failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespace show succeeded"
+echo "${OUTPUT}"
+
+echo "${OUTPUT}" | grep -q "test-namespace" \
+  && echo "PASS: namespace name matches" \
+  || echo "FAIL: namespace name does not match"
+```
+
+### Test 2.5: Update namespace name
+
+```bash
+OUTPUT=$(wanaku namespaces update \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "test-namespace-updated" \
+  "${TEST_NS_ID}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace update failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespace updated"
+
+# Verify the update
+VERIFY=$(wanaku namespaces show --host "${WANAKU_ROUTER_URL}" "${TEST_NS_ID}" --plain 2>&1)
+echo "${VERIFY}" | grep -q "test-namespace-updated" \
+  && echo "PASS: updated name verified" \
+  || echo "FAIL: updated name not found"
+```
+
+### Test 2.6: Delete namespace
+
+```bash
+OUTPUT=$(wanaku namespaces delete --host "${WANAKU_ROUTER_URL}" "${TEST_NS_ID}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace delete failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespace deleted"
+
+# Verify deletion
+VERIFY=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${VERIFY}" | grep -q "test-namespace-updated" \
+  && echo "FAIL: deleted namespace still appears in list" \
+  || echo "PASS: deleted namespace no longer in list"
+```
+
+---
+
+## Phase 3: Namespace Labels
+
+### Test 3.1: Create a namespace for label tests
+
+```bash
+OUTPUT=$(wanaku namespaces create \
+  --host "${WANAKU_ROUTER_URL}" \
+  --path "label-test-ns" \
+  --name "label-test-namespace" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace create for label tests failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: label test namespace created"
+
+# Extract namespace ID
+LABEL_NS_ID=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1 \
+  | grep "label-test-namespace" | awk '{print $1}' | head -1)
+
+if [ -z "${LABEL_NS_ID}" ]; then
+  echo "FAIL: could not determine label test namespace ID"
+  exit 1
+fi
+echo "PASS: label test namespace ID is ${LABEL_NS_ID}"
+```
+
+### Test 3.2: Add a label to the namespace
+
+```bash
+OUTPUT=$(wanaku namespaces label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "${LABEL_NS_ID}" \
+  --label env=test \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace label add failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: label added to namespace"
+
+# Verify the label exists
+VERIFY=$(wanaku namespaces show --host "${WANAKU_ROUTER_URL}" "${LABEL_NS_ID}" --plain 2>&1)
+echo "${VERIFY}" | grep -q "env" \
+  && echo "PASS: label 'env' visible on namespace" \
+  || echo "FAIL: label 'env' not found on namespace"
+```
+
+### Test 3.3: Add multiple labels to the namespace
+
+```bash
+OUTPUT=$(wanaku namespaces label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "${LABEL_NS_ID}" \
+  --label tier=frontend \
+  --label region=us-east \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace multiple label add failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: multiple labels added to namespace"
+
+VERIFY=$(wanaku namespaces show --host "${WANAKU_ROUTER_URL}" "${LABEL_NS_ID}" --plain 2>&1)
+echo "${VERIFY}" | grep -q "tier" \
+  && echo "PASS: label 'tier' visible" \
+  || echo "FAIL: label 'tier' not found"
+echo "${VERIFY}" | grep -q "region" \
+  && echo "PASS: label 'region' visible" \
+  || echo "FAIL: label 'region' not found"
+```
+
+### Test 3.4: Remove a label from the namespace
+
+```bash
+OUTPUT=$(wanaku namespaces label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "${LABEL_NS_ID}" \
+  --label env \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace label remove failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: label removed from namespace"
+
+# Verify the label is gone but others remain
+VERIFY=$(wanaku namespaces show --host "${WANAKU_ROUTER_URL}" "${LABEL_NS_ID}" --plain 2>&1)
+echo "${VERIFY}" | grep -q "env=test" \
+  && echo "FAIL: label 'env=test' still present after removal" \
+  || echo "PASS: label 'env=test' removed"
+echo "${VERIFY}" | grep -q "tier" \
+  && echo "PASS: label 'tier' still present (not removed)" \
+  || echo "FAIL: label 'tier' was incorrectly removed"
+```
+
+### Test 3.5: Filter namespaces by label expression
+
+```bash
+OUTPUT=$(wanaku namespaces list \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "tier=frontend" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace list with label expression failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "label-test-namespace" \
+  && echo "PASS: label-test-namespace found with tier=frontend filter" \
+  || echo "FAIL: label-test-namespace not returned by tier=frontend filter"
+```
+
+### Test 3.6: Clean up label test namespace
+
+```bash
+wanaku namespaces delete --host "${WANAKU_ROUTER_URL}" "${LABEL_NS_ID}" 2>/dev/null || true
+echo "PASS: label test namespace cleanup done"
+```
+
+---
+
+## Phase 4: Namespace Isolation
+
+### Test 4.1: Register a tool in namespace ns-0
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name ns0-tool \
+  --namespace ns-0 \
+  --description "Tool in namespace ns-0 for isolation testing" \
+  --uri "https://example.com/ns0" \
+  --type http \
+  --property "input:string,An input parameter" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not register ns0-tool (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: ns0-tool registered in namespace ns-0"
+```
+
+### Test 4.2: Register a tool in namespace ns-1
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name ns1-tool \
+  --namespace ns-1 \
+  --description "Tool in namespace ns-1 for isolation testing" \
+  --uri "https://example.com/ns1" \
+  --type http \
+  --property "input:string,An input parameter" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not register ns1-tool (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: ns1-tool registered in namespace ns-1"
+```
+
+### Test 4.3: Verify both tools are visible in the global tool list
+
+```bash
+TOOLS_OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${TOOLS_OUTPUT}" | grep -q "ns0-tool" \
+  && echo "PASS: ns0-tool visible in global list" \
+  || echo "FAIL: ns0-tool not found in global list"
+
+echo "${TOOLS_OUTPUT}" | grep -q "ns1-tool" \
+  && echo "PASS: ns1-tool visible in global list" \
+  || echo "FAIL: ns1-tool not found in global list"
+```
+
+### Test 4.4: Verify tools show correct namespace assignment
+
+```bash
+TOOLS_OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${TOOLS_OUTPUT}" | grep "ns0-tool" | grep -q "ns-0" \
+  && echo "PASS: ns0-tool shows namespace ns-0" \
+  || echo "FAIL: ns0-tool does not show namespace ns-0"
+
+echo "${TOOLS_OUTPUT}" | grep "ns1-tool" | grep -q "ns-1" \
+  && echo "PASS: ns1-tool shows namespace ns-1" \
+  || echo "FAIL: ns1-tool does not show namespace ns-1"
+```
+
+### Test 4.5: Verify tool details include namespace
+
+```bash
+OUTPUT=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" ns0-tool --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools show for ns0-tool failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "ns-0" \
+  && echo "PASS: ns0-tool detail shows namespace ns-0" \
+  || echo "FAIL: ns0-tool detail does not show namespace ns-0"
+```
+
+---
+
+## Phase 5: Label Expression Routing
+
+### Test 5.1: Register tool-a with labels env=prod and tier=frontend
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name tool-a \
+  --namespace public \
+  --description "Label test tool A" \
+  --uri "https://example.com/tool-a" \
+  --type http \
+  --property "input:string,An input" \
+  --label env=prod \
+  --label tier=frontend \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not register tool-a (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: tool-a registered with labels env=prod, tier=frontend"
+```
+
+### Test 5.2: Register tool-b with labels env=prod and tier=backend
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name tool-b \
+  --namespace public \
+  --description "Label test tool B" \
+  --uri "https://example.com/tool-b" \
+  --type http \
+  --property "input:string,An input" \
+  --label env=prod \
+  --label tier=backend \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not register tool-b (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: tool-b registered with labels env=prod, tier=backend"
+```
+
+### Test 5.3: Register tool-c with labels env=staging and tier=frontend
+
+```bash
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name tool-c \
+  --namespace public \
+  --description "Label test tool C" \
+  --uri "https://example.com/tool-c" \
+  --type http \
+  --property "input:string,An input" \
+  --label env=staging \
+  --label tier=frontend \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not register tool-c (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: tool-c registered with labels env=staging, tier=frontend"
+```
+
+### Test 5.4: Filter tools by env=prod
+
+```bash
+OUTPUT=$(wanaku tools list \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "env=prod" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list with label expression failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "tool-a" \
+  && echo "PASS: tool-a returned for env=prod" \
+  || echo "FAIL: tool-a not returned for env=prod"
+
+echo "${OUTPUT}" | grep -q "tool-b" \
+  && echo "PASS: tool-b returned for env=prod" \
+  || echo "FAIL: tool-b not returned for env=prod"
+
+echo "${OUTPUT}" | grep -q "tool-c" \
+  && echo "FAIL: tool-c should NOT be returned for env=prod" \
+  || echo "PASS: tool-c correctly excluded from env=prod"
+```
+
+### Test 5.5: Filter tools by tier=frontend
+
+```bash
+OUTPUT=$(wanaku tools list \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "tier=frontend" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list with tier=frontend failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "tool-a" \
+  && echo "PASS: tool-a returned for tier=frontend" \
+  || echo "FAIL: tool-a not returned for tier=frontend"
+
+echo "${OUTPUT}" | grep -q "tool-c" \
+  && echo "PASS: tool-c returned for tier=frontend" \
+  || echo "FAIL: tool-c not returned for tier=frontend"
+
+echo "${OUTPUT}" | grep -q "tool-b" \
+  && echo "FAIL: tool-b should NOT be returned for tier=frontend" \
+  || echo "PASS: tool-b correctly excluded from tier=frontend"
+```
+
+### Test 5.6: Filter tools by compound expression (env=prod AND tier=frontend)
+
+**Description:** Verify that AND logic in label expressions correctly narrows results. See `wanaku man label-expression` for supported syntax.
+
+```bash
+OUTPUT=$(wanaku tools list \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "env=prod AND tier=frontend" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list with compound expression failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "tool-a" \
+  && echo "PASS: tool-a returned for compound expression" \
+  || echo "FAIL: tool-a not returned for compound expression"
+
+echo "${OUTPUT}" | grep -q "tool-b" \
+  && echo "FAIL: tool-b should NOT match (tier=backend, not frontend)" \
+  || echo "PASS: tool-b correctly excluded"
+
+echo "${OUTPUT}" | grep -q "tool-c" \
+  && echo "FAIL: tool-c should NOT match (env=staging, not prod)" \
+  || echo "PASS: tool-c correctly excluded"
+```
+
+### Test 5.7: Add labels to a tool post-registration
+
+```bash
+OUTPUT=$(wanaku tools label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name tool-c \
+  --label priority=low \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools label add failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: label 'priority=low' added to tool-c"
+
+VERIFY=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" tool-c --plain 2>&1)
+echo "${VERIFY}" | grep -q "priority" \
+  && echo "PASS: label 'priority' visible on tool-c" \
+  || echo "FAIL: label 'priority' not found on tool-c"
+```
+
+### Test 5.8: Remove a label from a tool
+
+```bash
+OUTPUT=$(wanaku tools label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name tool-c \
+  --label priority \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools label remove failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: label 'priority' removed from tool-c"
+
+VERIFY=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" tool-c --plain 2>&1)
+echo "${VERIFY}" | grep -q "priority" \
+  && echo "FAIL: label 'priority' still present after removal" \
+  || echo "PASS: label 'priority' confirmed removed"
+```
+
+### Test 5.9: Batch remove tools by label expression
+
+**Description:** Remove all tools matching `env=staging` and verify only tool-c is removed.
+
+```bash
+OUTPUT=$(wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "env=staging" \
+  -y \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools remove by label expression failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: batch remove by label expression completed"
+
+# Verify tool-c is gone, tool-a and tool-b remain
+VERIFY=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${VERIFY}" | grep -q "tool-c" \
+  && echo "FAIL: tool-c should have been removed" \
+  || echo "PASS: tool-c removed as expected"
+
+echo "${VERIFY}" | grep -q "tool-a" \
+  && echo "PASS: tool-a still present (not affected)" \
+  || echo "FAIL: tool-a was incorrectly removed"
+
+echo "${VERIFY}" | grep -q "tool-b" \
+  && echo "PASS: tool-b still present (not affected)" \
+  || echo "FAIL: tool-b was incorrectly removed"
+```
+
+---
+
+## Phase 6: Namespace Cleanup
+
+### Test 6.1: Run namespace cleanup (dry run)
+
+**Description:** Verify that the cleanup command runs without error. Uses `--assume-yes` to avoid interactive prompts and a short max-age to reduce scope.
+
+```bash
+OUTPUT=$(wanaku namespaces cleanup \
+  --host "${WANAKU_ROUTER_URL}" \
+  --max-age-days 0 \
+  --assume-yes \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace cleanup failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: namespace cleanup completed without error"
+echo "${OUTPUT}"
+```
+
+### Test 6.2: Create a pre-allocated namespace and verify cleanup targets it
+
+**Description:** Pre-allocated namespaces (no name) should be eligible for cleanup.
+
+```bash
+# Create a pre-allocated namespace (no --name)
+OUTPUT=$(wanaku namespaces create \
+  --host "${WANAKU_ROUTER_URL}" \
+  --path "cleanup-target" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: pre-allocated namespace create failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: pre-allocated namespace created"
+
+# Run cleanup with max-age-days 0 to catch newly created pre-allocated namespaces
+OUTPUT=$(wanaku namespaces cleanup \
+  --host "${WANAKU_ROUTER_URL}" \
+  --max-age-days 0 \
+  --assume-yes \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: namespace cleanup after pre-allocation failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "PASS: namespace cleanup ran after pre-allocation"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 7: Negative Tests
+
+### Test 7.1: Delete a non-existent namespace
+
+```bash
+OUTPUT=$(wanaku namespaces delete \
+  --host "${WANAKU_ROUTER_URL}" \
+  "non-existent-id-12345" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: deleting non-existent namespace failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: deleting non-existent namespace should have failed"
+fi
+```
+
+### Test 7.2: Show a non-existent namespace
+
+```bash
+OUTPUT=$(wanaku namespaces show \
+  --host "${WANAKU_ROUTER_URL}" \
+  "non-existent-id-12345" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: showing non-existent namespace failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: showing non-existent namespace should have failed"
+fi
+```
+
+### Test 7.3: Update a non-existent namespace
+
+```bash
+OUTPUT=$(wanaku namespaces update \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "ghost" \
+  "non-existent-id-12345" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: updating non-existent namespace failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: updating non-existent namespace should have failed"
+fi
+```
+
+### Test 7.4: Add label to a non-existent namespace
+
+```bash
+OUTPUT=$(wanaku namespaces label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "non-existent-id-12345" \
+  --label env=test \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: adding label to non-existent namespace failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: adding label to non-existent namespace should have failed"
+fi
+```
+
+### Test 7.5: Remove label from a non-existent namespace
+
+```bash
+OUTPUT=$(wanaku namespaces label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "non-existent-id-12345" \
+  --label env \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: removing label from non-existent namespace failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: removing label from non-existent namespace should have failed"
+fi
+```
+
+### Test 7.6: Create namespace without required --path option
+
+```bash
+OUTPUT=$(wanaku namespaces create \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "missing-path" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: create namespace without --path rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: create namespace without --path should have failed"
+fi
+```
+
+### Test 7.7: Update namespace with no update fields
+
+```bash
+# First create a temporary namespace for this test
+TEMP_OUTPUT=$(wanaku namespaces create \
+  --host "${WANAKU_ROUTER_URL}" \
+  --path "negative-test-ns" \
+  --name "negative-test" \
+  --plain 2>&1)
+
+TEMP_NS_ID=$(wanaku namespaces list --host "${WANAKU_ROUTER_URL}" --plain 2>&1 \
+  | grep "negative-test" | awk '{print $1}' | head -1)
+
+if [ -n "${TEMP_NS_ID}" ]; then
+  OUTPUT=$(wanaku namespaces update \
+    --host "${WANAKU_ROUTER_URL}" \
+    "${TEMP_NS_ID}" \
+    --plain 2>&1)
+  EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "PASS: update with no fields rejected (exit code ${EXIT_CODE})"
+  else
+    echo "FAIL: update with no fields should have been rejected"
+  fi
+
+  # Clean up
+  wanaku namespaces delete --host "${WANAKU_ROUTER_URL}" "${TEMP_NS_ID}" 2>/dev/null || true
+else
+  echo "SKIP: could not create temporary namespace for this test"
+fi
+```
+
+### Test 7.8: Namespace label add with both --id and --label-expression (mutual exclusion)
+
+```bash
+OUTPUT=$(wanaku namespaces label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --id "some-id" \
+  --label-expression "env=test" \
+  --label env=test \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: specifying both --id and --label-expression rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: specifying both --id and --label-expression should have been rejected"
+fi
+```
+
+### Test 7.9: Tools remove with both --name and --label-expression (mutual exclusion)
+
+```bash
+OUTPUT=$(wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "some-tool" \
+  --label-expression "env=test" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: specifying both --name and --label-expression rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: specifying both --name and --label-expression should have been rejected"
+fi
+```
+
+### Test 7.10: Add label to a non-existent tool
+
+```bash
+OUTPUT=$(wanaku tools label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "non-existent-tool-12345" \
+  --label env=test \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: adding label to non-existent tool failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: adding label to non-existent tool should have failed"
+fi
+```
+
+---
+
+## Phase 8: Cleanup
+
+### Step 8.1: Remove test tools
+
+```bash
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name ns0-tool 2>/dev/null || true
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name ns1-tool 2>/dev/null || true
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name tool-a 2>/dev/null || true
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name tool-b 2>/dev/null || true
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name tool-c 2>/dev/null || true
+echo "PASS: test tools removed"
+```
+
+### Step 8.2: Verify tools are cleaned up
+
+```bash
+REMAINING=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+for TOOL in ns0-tool ns1-tool tool-a tool-b tool-c; do
+  echo "${REMAINING}" | grep -q "${TOOL}" \
+    && echo "WARN: ${TOOL} still present after cleanup" \
+    || echo "PASS: ${TOOL} confirmed removed"
+done
+```
+
+### Step 8.3: Stop the Wanaku process
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+else
+  echo "WARN: WANAKU_PID not set, process may still be running"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0 | Manual prerequisites | Medium |
+| 1 | 1 | Start local stack | Critical |
+| 2 | 2.1 | List namespaces, verify defaults | Critical |
+| 2 | 2.2 | Create a custom namespace | Critical |
+| 2 | 2.3 | Verify created namespace in list | Critical |
+| 2 | 2.4 | Show namespace details | High |
+| 2 | 2.5 | Update namespace name | High |
+| 2 | 2.6 | Delete namespace | Critical |
+| 3 | 3.1 | Create namespace for label tests | High |
+| 3 | 3.2 | Add single label to namespace | Critical |
+| 3 | 3.3 | Add multiple labels to namespace | High |
+| 3 | 3.4 | Remove label from namespace | Critical |
+| 3 | 3.5 | Filter namespaces by label expression | High |
+| 3 | 3.6 | Clean up label test namespace | Medium |
+| 4 | 4.1 | Register tool in namespace ns-0 | Critical |
+| 4 | 4.2 | Register tool in namespace ns-1 | Critical |
+| 4 | 4.3 | Verify both tools in global list | Critical |
+| 4 | 4.4 | Verify namespace assignment in list | High |
+| 4 | 4.5 | Verify tool details include namespace | High |
+| 5 | 5.1 | Register tool-a (env=prod, tier=frontend) | Critical |
+| 5 | 5.2 | Register tool-b (env=prod, tier=backend) | Critical |
+| 5 | 5.3 | Register tool-c (env=staging, tier=frontend) | Critical |
+| 5 | 5.4 | Filter tools by env=prod | Critical |
+| 5 | 5.5 | Filter tools by tier=frontend | Critical |
+| 5 | 5.6 | Filter tools by compound AND expression | Critical |
+| 5 | 5.7 | Add label to tool post-registration | High |
+| 5 | 5.8 | Remove label from tool | High |
+| 5 | 5.9 | Batch remove tools by label expression | Critical |
+| 6 | 6.1 | Run namespace cleanup | High |
+| 6 | 6.2 | Pre-allocated namespace cleanup | High |
+| 7 | 7.1 | Delete non-existent namespace | High |
+| 7 | 7.2 | Show non-existent namespace | High |
+| 7 | 7.3 | Update non-existent namespace | High |
+| 7 | 7.4 | Add label to non-existent namespace | High |
+| 7 | 7.5 | Remove label from non-existent namespace | High |
+| 7 | 7.6 | Create namespace without required path | High |
+| 7 | 7.7 | Update namespace with no fields | Medium |
+| 7 | 7.8 | Namespace label add mutual exclusion (--id + --label-expression) | High |
+| 7 | 7.9 | Tools remove mutual exclusion (--name + --label-expression) | High |
+| 7 | 7.10 | Add label to non-existent tool | High |
+| 8 | 8.1-8.3 | Cleanup (tools, namespaces, process) | Critical |

--- a/tests/plans/cli-negative-tests.md
+++ b/tests/plans/cli-negative-tests.md
@@ -1,0 +1,889 @@
+# Test Plan: CLI Negative / Error Path Tests
+
+## Overview
+
+This test plan exercises negative and error paths across all major Wanaku CLI command groups against a locally running instance (no auth). Every step verifies that the command **fails with a non-zero exit code** and **fails gracefully** (no stack trace, meaningful error message).
+
+All steps are idempotent, POSIX-compatible, and fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} tools list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export WANAKU_UNREACHABLE_HOST="${WANAKU_UNREACHABLE_HOST:-http://localhost:59999}"
+```
+
+### Helper: assert failure
+
+Reusable function to verify a command fails gracefully. Checks non-zero exit code and absence of Java stack traces.
+
+```bash
+assert_failure() {
+  local TEST_ID="$1"
+  local DESCRIPTION="$2"
+  shift 2
+  OUTPUT=$("$@" 2>&1)
+  EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "PASS [${TEST_ID}]: ${DESCRIPTION} (exit code ${EXIT_CODE})"
+  else
+    echo "FAIL [${TEST_ID}]: expected non-zero exit code, got 0"
+    echo "  Output: ${OUTPUT}"
+    return 1
+  fi
+
+  # Verify no Java stack trace leaked to the user
+  if echo "${OUTPUT}" | grep -q "at .*(.*\.java:"; then
+    echo "FAIL [${TEST_ID}]: stack trace detected in output"
+    echo "  Output: ${OUTPUT}"
+    return 1
+  fi
+
+  return 0
+}
+```
+
+### Helper: assert graceful failure (may succeed)
+
+Reusable function for "remove non-existent" cases where the CLI may exit 0 with a warning or exit non-zero. Either is acceptable as long as no stack trace appears.
+
+```bash
+assert_graceful() {
+  local TEST_ID="$1"
+  local DESCRIPTION="$2"
+  shift 2
+  OUTPUT=$("$@" 2>&1)
+  EXIT_CODE=$?
+
+  # Check no stack trace
+  if echo "${OUTPUT}" | grep -q "at .*(.*\.java:"; then
+    echo "FAIL [${TEST_ID}]: stack trace detected in output"
+    echo "  Output: ${OUTPUT}"
+    return 1
+  fi
+
+  echo "PASS [${TEST_ID}]: ${DESCRIPTION} (exit code ${EXIT_CODE})"
+  return 0
+}
+```
+
+---
+
+## Phase 0: Prerequisites Verification
+
+### Test 0.1: Verify required tools
+
+```bash
+for CMD in wanaku jq java mvn; do
+  if command -v "${CMD}" > /dev/null 2>&1; then
+    echo "PASS [0.1]: ${CMD} is available"
+  else
+    echo "FAIL [0.1]: ${CMD} not found in PATH"
+  fi
+done
+```
+
+### Test 0.2: Verify environment variables
+
+```bash
+for VAR_NAME in WANAKU_ROUTER_URL WANAKU_UNREACHABLE_HOST; do
+  eval "VAL=\${${VAR_NAME}}"
+  if [ -z "${VAL}" ]; then
+    echo "FAIL [0.2]: ${VAR_NAME} is not set"
+  else
+    echo "PASS [0.2]: ${VAR_NAME}=${VAL}"
+  fi
+done
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start a local Wanaku stack.
+
+After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, and `CLI_JAR` must be set.
+
+Verify router health (curl is used here specifically to test HTTP-level readiness):
+
+```bash
+curl -sf "${WANAKU_ROUTER_URL}/q/health/ready" > /dev/null && echo "PASS [1.0]: router is healthy" || echo "FAIL [1.0]: router not healthy"
+```
+
+---
+
+## Phase 2: Tools -- Error Cases
+
+### Test 2.1: Add tool with no name
+
+The `--name` option is required by `tools add`.
+
+```bash
+assert_failure "2.1" "tools add with no name rejected" \
+  wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --namespace public \
+    --description "test tool" \
+    --uri "http://example.com" \
+    --type http
+```
+
+### Test 2.2: Add tool with no URI
+
+The `--uri` option is required by `tools add`.
+
+```bash
+assert_failure "2.2" "tools add with no URI rejected" \
+  wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-uri" \
+    --namespace public \
+    --description "test tool" \
+    --type http
+```
+
+### Test 2.3: Add tool with no type
+
+The `--type` option is required by `tools add`.
+
+```bash
+assert_failure "2.3" "tools add with no type rejected" \
+  wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-type" \
+    --namespace public \
+    --description "test tool" \
+    --uri "http://example.com"
+```
+
+### Test 2.4: Add tool with invalid type
+
+A type that has no registered downstream service should be rejected.
+
+```bash
+assert_failure "2.4" "tools add with invalid type rejected" \
+  wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-bad-type" \
+    --namespace public \
+    --description "test tool" \
+    --uri "http://example.com" \
+    --type "nonexistent-type-12345"
+```
+
+### Test 2.5: Add duplicate tool name
+
+First register a tool, then try to add another with the same name.
+
+```bash
+# Setup: register a tool
+wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name "neg-test-duplicate" \
+  --namespace public \
+  --description "first tool" \
+  --uri "http://example.com/first" \
+  --type http 2>&1
+SETUP_EXIT=$?
+
+if [ "${SETUP_EXIT}" -ne 0 ]; then
+  echo "SKIP [2.5]: could not register setup tool (no http capability?)"
+else
+  # Attempt to add duplicate
+  OUTPUT=$(wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-duplicate" \
+    --namespace public \
+    --description "second tool" \
+    --uri "http://example.com/second" \
+    --type http 2>&1)
+  EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "PASS [2.5]: duplicate tool name rejected (exit code ${EXIT_CODE})"
+  else
+    echo "WARN [2.5]: duplicate tool was accepted -- server may allow overwrite"
+  fi
+
+  # Cleanup
+  wanaku tools remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "neg-test-duplicate" 2>/dev/null || true
+fi
+```
+
+### Test 2.6: Show non-existent tool
+
+The `tools show` command takes the tool name as a positional parameter.
+
+```bash
+assert_failure "2.6" "show non-existent tool rejected" \
+  wanaku tools show \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    "nonexistent-tool-12345"
+```
+
+### Test 2.7: Edit non-existent tool
+
+The `tools edit` command takes the tool name as a positional parameter.
+
+```bash
+assert_failure "2.7" "edit non-existent tool rejected" \
+  wanaku tools edit \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    "nonexistent-tool-12345"
+```
+
+### Test 2.8: Remove non-existent tool
+
+```bash
+assert_graceful "2.8" "remove non-existent tool handled gracefully" \
+  wanaku tools remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-tool-12345"
+```
+
+### Test 2.9: Label add on non-existent tool
+
+The `tools label add` command requires `--name` and `--label`.
+
+```bash
+assert_failure "2.9" "label add on non-existent tool rejected" \
+  wanaku tools label add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-tool-12345" \
+    --label "env=test"
+```
+
+### Test 2.10: Generate from non-existent OpenAPI file
+
+The `tools generate` command takes the spec location as a positional parameter.
+
+```bash
+assert_failure "2.10" "generate from non-existent file rejected" \
+  wanaku tools generate /tmp/nonexistent-openapi-spec-12345.yaml
+```
+
+---
+
+## Phase 3: Resources -- Error Cases
+
+### Test 3.1: Expose resource with no name
+
+The `--name` option is required by `resources expose`.
+
+```bash
+assert_failure "3.1" "resources expose with no name rejected" \
+  wanaku resources expose \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --namespace public \
+    --description "test resource" \
+    --location "http://example.com/data" \
+    --type http
+```
+
+### Test 3.2: Expose resource with no location
+
+The `--location` option is required by `resources expose`.
+
+```bash
+assert_failure "3.2" "resources expose with no location rejected" \
+  wanaku resources expose \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-location" \
+    --namespace public \
+    --description "test resource" \
+    --type http
+```
+
+### Test 3.3: Expose resource with no type
+
+The `--type` option is required by `resources expose`.
+
+```bash
+assert_failure "3.3" "resources expose with no type rejected" \
+  wanaku resources expose \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-type" \
+    --namespace public \
+    --description "test resource" \
+    --location "http://example.com/data"
+```
+
+### Test 3.4: Expose resource with duplicate name
+
+First register a resource, then try to add another with the same name.
+
+```bash
+# Setup: register a resource (type must match a running provider)
+wanaku resources expose \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name "neg-test-dup-resource" \
+  --namespace public \
+  --description "first resource" \
+  --location "http://example.com/data" \
+  --type http 2>&1
+SETUP_EXIT=$?
+
+if [ "${SETUP_EXIT}" -ne 0 ]; then
+  echo "SKIP [3.4]: could not register setup resource (no matching provider?)"
+else
+  OUTPUT=$(wanaku resources expose \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-dup-resource" \
+    --namespace public \
+    --description "second resource" \
+    --location "http://example.com/other" \
+    --type http 2>&1)
+  EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "PASS [3.4]: duplicate resource name rejected (exit code ${EXIT_CODE})"
+  else
+    echo "WARN [3.4]: duplicate resource was accepted -- server may allow overwrite"
+  fi
+
+  # Cleanup
+  wanaku resources remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "neg-test-dup-resource" 2>/dev/null || true
+fi
+```
+
+### Test 3.5: Show non-existent resource
+
+The `resources show` command takes the resource name as a positional parameter.
+
+```bash
+assert_failure "3.5" "show non-existent resource rejected" \
+  wanaku resources show \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    "nonexistent-resource-12345"
+```
+
+### Test 3.6: Remove non-existent resource
+
+```bash
+assert_graceful "3.6" "remove non-existent resource handled gracefully" \
+  wanaku resources remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-resource-12345"
+```
+
+---
+
+## Phase 4: Prompts -- Error Cases
+
+### Test 4.1: Add prompt with no name
+
+The `--name` option is required by `prompts add`.
+
+```bash
+assert_failure "4.1" "prompts add with no name rejected" \
+  wanaku prompts add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --namespace public \
+    --description "test prompt" \
+    --message "user:text:Hello"
+```
+
+### Test 4.2: Add prompt with no description
+
+The `--description` option is required by `prompts add`.
+
+```bash
+assert_failure "4.2" "prompts add with no description rejected" \
+  wanaku prompts add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-desc" \
+    --namespace public \
+    --message "user:text:Hello"
+```
+
+### Test 4.3: Edit non-existent prompt
+
+The `--name` option is required by `prompts edit` and the prompt must exist.
+
+```bash
+assert_failure "4.3" "edit non-existent prompt rejected" \
+  wanaku prompts edit \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-prompt-12345" \
+    --description "updated description"
+```
+
+### Test 4.4: Remove non-existent prompt
+
+```bash
+assert_graceful "4.4" "remove non-existent prompt handled gracefully" \
+  wanaku prompts remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-prompt-12345"
+```
+
+---
+
+## Phase 5: Forwards -- Error Cases
+
+### Test 5.1: Add forward with no name
+
+The `--name` option is required by `forwards add`.
+
+```bash
+assert_failure "5.1" "forwards add with no name rejected" \
+  wanaku forwards add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --service "http://example.com:8080"
+```
+
+### Test 5.2: Add forward with no service
+
+The `--service` option is required by `forwards add`.
+
+```bash
+assert_failure "5.2" "forwards add with no service rejected" \
+  wanaku forwards add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-no-service"
+```
+
+### Test 5.3: Add duplicate forward name
+
+First register a forward, then try to add another with the same name.
+
+```bash
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name "neg-test-dup-forward" \
+  --service "http://example.com:8080" 2>&1
+SETUP_EXIT=$?
+
+if [ "${SETUP_EXIT}" -ne 0 ]; then
+  echo "SKIP [5.3]: could not register setup forward"
+else
+  OUTPUT=$(wanaku forwards add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-dup-forward" \
+    --service "http://other.example.com:8080" 2>&1)
+  EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" -ne 0 ]; then
+    echo "PASS [5.3]: duplicate forward name rejected (exit code ${EXIT_CODE})"
+  else
+    echo "WARN [5.3]: duplicate forward was accepted -- server may allow overwrite"
+  fi
+
+  # Cleanup
+  wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "neg-test-dup-forward" 2>/dev/null || true
+fi
+```
+
+### Test 5.4: Remove non-existent forward
+
+```bash
+assert_graceful "5.4" "remove non-existent forward handled gracefully" \
+  wanaku forwards remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-forward-12345"
+```
+
+### Test 5.5: Refresh non-existent forward
+
+```bash
+assert_failure "5.5" "refresh non-existent forward rejected" \
+  wanaku forwards refresh \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-forward-12345"
+```
+
+---
+
+## Phase 6: Data Store -- Error Cases
+
+### Test 6.1: Add with non-existent file
+
+The `--read-from-file` option is required by `datastores add`.
+
+```bash
+assert_failure "6.1" "datastores add with non-existent file rejected" \
+  wanaku datastores add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --read-from-file "/tmp/nonexistent-datastore-file-12345.bin"
+```
+
+### Test 6.2: Get non-existent data store by name
+
+The `datastores get` command requires either `--id` or `--name`.
+
+```bash
+assert_failure "6.2" "datastores get non-existent name rejected" \
+  wanaku datastores get \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-datastore-12345"
+```
+
+### Test 6.3: Get with neither id nor name
+
+```bash
+assert_failure "6.3" "datastores get with no id or name rejected" \
+  wanaku datastores get \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth
+```
+
+### Test 6.4: Remove non-existent data store
+
+```bash
+assert_graceful "6.4" "remove non-existent datastore handled gracefully" \
+  wanaku datastores remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "nonexistent-datastore-12345"
+```
+
+### Test 6.5: Remove with neither id nor name
+
+```bash
+assert_failure "6.5" "datastores remove with no id or name rejected" \
+  wanaku datastores remove \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth
+```
+
+---
+
+## Phase 7: Namespaces -- Error Cases
+
+### Test 7.1: Delete non-existent namespace
+
+The `namespaces delete` command takes the namespace ID as a positional parameter.
+
+```bash
+assert_graceful "7.1" "delete non-existent namespace handled gracefully" \
+  wanaku namespaces delete \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    "nonexistent-namespace-id-12345"
+```
+
+### Test 7.2: Create namespace with no path
+
+The `--path` option is required by `namespaces create`.
+
+```bash
+assert_failure "7.2" "namespaces create with no path rejected" \
+  wanaku namespaces create \
+    --host "${WANAKU_ROUTER_URL}" \
+    --no-auth \
+    --name "neg-test-ns"
+```
+
+---
+
+## Phase 8: Service -- Error Cases
+
+### Test 8.1: Service init with no name
+
+The `--name` option is required by `service init`.
+
+```bash
+assert_failure "8.1" "service init with no name rejected" \
+  wanaku service init \
+    --services "system1"
+```
+
+### Test 8.2: Service init with no services
+
+The `--services` option is required by `service init`.
+
+```bash
+assert_failure "8.2" "service init with no services rejected" \
+  wanaku service init \
+    --name "neg-test-init"
+```
+
+### Test 8.3: Service expose with invalid path (no index.properties)
+
+```bash
+assert_failure "8.3" "service expose with invalid path rejected" \
+  wanaku service expose \
+    --path "/tmp/nonexistent-service-catalog-12345"
+```
+
+### Test 8.4: Service package with non-existent path
+
+```bash
+assert_failure "8.4" "service package with non-existent path rejected" \
+  wanaku service package \
+    --path "/tmp/nonexistent-service-catalog-12345"
+```
+
+### Test 8.5: Service deploy with non-existent path
+
+```bash
+assert_failure "8.5" "service deploy with non-existent path rejected" \
+  wanaku service deploy \
+    --path "/tmp/nonexistent-service-catalog-12345" \
+    --host "${WANAKU_ROUTER_URL}"
+```
+
+### Test 8.6: Service deploy with unreachable host
+
+Create a minimal valid service catalog, then try to deploy to an unreachable host.
+
+```bash
+NEG_TEST_DIR=$(mktemp -d)
+wanaku service init --name "${NEG_TEST_DIR}/neg-svc" --services "testsys" 2>/dev/null || true
+
+# Only run if init succeeded
+if [ -f "${NEG_TEST_DIR}/neg-svc/index.properties" ]; then
+  # Generate rules so the catalog is complete
+  wanaku service expose --path "${NEG_TEST_DIR}/neg-svc" 2>/dev/null || true
+
+  assert_failure "8.6" "service deploy to unreachable host rejected" \
+    wanaku service deploy \
+      --path "${NEG_TEST_DIR}/neg-svc" \
+      --host "${WANAKU_UNREACHABLE_HOST}"
+else
+  echo "SKIP [8.6]: service init did not produce expected files"
+fi
+
+# Cleanup
+rm -rf "${NEG_TEST_DIR}" 2>/dev/null || true
+```
+
+### Test 8.7: Service init with already existing directory
+
+```bash
+NEG_TEST_DIR=$(mktemp -d)
+mkdir -p "${NEG_TEST_DIR}/neg-existing"
+
+OUTPUT=$(wanaku service init --name "${NEG_TEST_DIR}/neg-existing" --services "sys1" 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS [8.7]: service init with existing directory rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL [8.7]: service init should reject existing directory"
+fi
+
+# Cleanup
+rm -rf "${NEG_TEST_DIR}" 2>/dev/null || true
+```
+
+---
+
+## Phase 9: Connection Errors
+
+All commands pointing to an unreachable host should fail gracefully with a clear error message and no stack trace.
+
+### Test 9.1: Tools list with unreachable host
+
+```bash
+assert_failure "9.1" "tools list with unreachable host fails gracefully" \
+  wanaku tools list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.2: Resources list with unreachable host
+
+```bash
+assert_failure "9.2" "resources list with unreachable host fails gracefully" \
+  wanaku resources list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.3: Prompts list with unreachable host
+
+```bash
+assert_failure "9.3" "prompts list with unreachable host fails gracefully" \
+  wanaku prompts list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.4: Forwards list with unreachable host
+
+```bash
+assert_failure "9.4" "forwards list with unreachable host fails gracefully" \
+  wanaku forwards list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.5: Datastores list with unreachable host
+
+```bash
+assert_failure "9.5" "datastores list with unreachable host fails gracefully" \
+  wanaku datastores list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.6: Namespaces list with unreachable host
+
+```bash
+assert_failure "9.6" "namespaces list with unreachable host fails gracefully" \
+  wanaku namespaces list \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --plain
+```
+
+### Test 9.7: Tools add with unreachable host
+
+```bash
+assert_failure "9.7" "tools add with unreachable host fails gracefully" \
+  wanaku tools add \
+    --host "${WANAKU_UNREACHABLE_HOST}" \
+    --no-auth \
+    --name "neg-test-unreachable" \
+    --namespace public \
+    --description "test" \
+    --uri "http://example.com" \
+    --type http
+```
+
+---
+
+## Phase 10: Cleanup
+
+### Step 10.1: Remove any leftover test data
+
+```bash
+for TOOL_NAME in neg-test-duplicate neg-test-no-uri neg-test-no-type neg-test-bad-type neg-test-unreachable; do
+  wanaku tools remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "${TOOL_NAME}" 2>/dev/null || true
+done
+
+for RESOURCE_NAME in neg-test-dup-resource neg-test-no-location neg-test-no-type; do
+  wanaku resources remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "${RESOURCE_NAME}" 2>/dev/null || true
+done
+
+wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --no-auth --name "neg-test-dup-forward" 2>/dev/null || true
+
+echo "PASS [10.1]: test data cleaned up"
+```
+
+### Step 10.2: Stop the local stack
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS [10.2]: Wanaku process stopped"
+else
+  echo "SKIP [10.2]: WANAKU_PID not set"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority | Category |
+|-------|---------|-----------|----------|----------|
+| 0 | 0.1-0.2 | Prerequisites verification | Critical | Setup |
+| 1 | 1.0 | Router health check | Critical | Setup |
+| 2 | 2.1 | Tool add: missing --name | High | Validation |
+| 2 | 2.2 | Tool add: missing --uri | High | Validation |
+| 2 | 2.3 | Tool add: missing --type | High | Validation |
+| 2 | 2.4 | Tool add: invalid type | High | Validation |
+| 2 | 2.5 | Tool add: duplicate name | Medium | Validation |
+| 2 | 2.6 | Tool show: non-existent | High | Error handling |
+| 2 | 2.7 | Tool edit: non-existent | High | Error handling |
+| 2 | 2.8 | Tool remove: non-existent | Medium | Error handling |
+| 2 | 2.9 | Tool label add: non-existent | High | Error handling |
+| 2 | 2.10 | Tool generate: non-existent OpenAPI | High | Error handling |
+| 3 | 3.1 | Resource expose: missing --name | High | Validation |
+| 3 | 3.2 | Resource expose: missing --location | High | Validation |
+| 3 | 3.3 | Resource expose: missing --type | High | Validation |
+| 3 | 3.4 | Resource expose: duplicate name | Medium | Validation |
+| 3 | 3.5 | Resource show: non-existent | High | Error handling |
+| 3 | 3.6 | Resource remove: non-existent | Medium | Error handling |
+| 4 | 4.1 | Prompt add: missing --name | High | Validation |
+| 4 | 4.2 | Prompt add: missing --description | High | Validation |
+| 4 | 4.3 | Prompt edit: non-existent | High | Error handling |
+| 4 | 4.4 | Prompt remove: non-existent | Medium | Error handling |
+| 5 | 5.1 | Forward add: missing --name | High | Validation |
+| 5 | 5.2 | Forward add: missing --service | High | Validation |
+| 5 | 5.3 | Forward add: duplicate name | Medium | Validation |
+| 5 | 5.4 | Forward remove: non-existent | Medium | Error handling |
+| 5 | 5.5 | Forward refresh: non-existent | High | Error handling |
+| 6 | 6.1 | Datastore add: non-existent file | High | Validation |
+| 6 | 6.2 | Datastore get: non-existent name | High | Error handling |
+| 6 | 6.3 | Datastore get: no id or name | High | Validation |
+| 6 | 6.4 | Datastore remove: non-existent | Medium | Error handling |
+| 6 | 6.5 | Datastore remove: no id or name | High | Validation |
+| 7 | 7.1 | Namespace delete: non-existent | Medium | Error handling |
+| 7 | 7.2 | Namespace create: missing --path | High | Validation |
+| 8 | 8.1 | Service init: missing --name | High | Validation |
+| 8 | 8.2 | Service init: missing --services | High | Validation |
+| 8 | 8.3 | Service expose: invalid path | High | Error handling |
+| 8 | 8.4 | Service package: non-existent path | High | Error handling |
+| 8 | 8.5 | Service deploy: non-existent path | High | Error handling |
+| 8 | 8.6 | Service deploy: unreachable host | High | Connection |
+| 8 | 8.7 | Service init: existing directory | High | Error handling |
+| 9 | 9.1 | Tools list: unreachable host | Critical | Connection |
+| 9 | 9.2 | Resources list: unreachable host | Critical | Connection |
+| 9 | 9.3 | Prompts list: unreachable host | Critical | Connection |
+| 9 | 9.4 | Forwards list: unreachable host | Critical | Connection |
+| 9 | 9.5 | Datastores list: unreachable host | Critical | Connection |
+| 9 | 9.6 | Namespaces list: unreachable host | Critical | Connection |
+| 9 | 9.7 | Tools add: unreachable host | Critical | Connection |
+| 10 | 10.1-10.2 | Cleanup | Critical | Teardown |

--- a/tests/plans/cli-service-catalog-lifecycle.md
+++ b/tests/plans/cli-service-catalog-lifecycle.md
@@ -1,0 +1,706 @@
+# Test Plan: CLI Service Catalog and Service Template Lifecycle
+
+## Overview
+
+This test plan verifies the full lifecycle of service catalogs and service templates via the `wanaku` CLI against a locally running Wanaku instance (no authentication). It covers initialization, route authoring, expose, package, deploy, listing, template operations, deployment instructions, negative tests, and cleanup.
+
+Every step except the initial build is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `curl` | any | `curl --version` |
+| `base64` | any (coreutils) | `base64 --version 2>/dev/null \|\| echo "available"` |
+
+### Prerequisite check script
+
+```bash
+FAIL=0
+
+for CMD in wanaku jq curl base64; do
+  if ! command -v "${CMD}" > /dev/null 2>&1; then
+    echo "FAIL: ${CMD} is not installed"
+    FAIL=1
+  else
+    echo "PASS: ${CMD} found at $(command -v ${CMD})"
+  fi
+done
+
+if [ "${FAIL}" -ne 0 ]; then
+  echo ""
+  echo "FAIL: one or more prerequisites missing"
+  exit 1
+fi
+
+echo ""
+echo "PASS: all prerequisites met"
+```
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} service init --name ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export TEST_CATALOG_NAME="${TEST_CATALOG_NAME:-test-catalog}"
+export TEST_CATALOG_DIR="${TEST_CATALOG_DIR:-/tmp/wanaku-test-catalog}"
+export TEST_PACKAGE_OUTPUT="${TEST_PACKAGE_OUTPUT:-/tmp/test-catalog.b64}"
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start a local Wanaku stack. After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, and `CLI_JAR` must be set.
+
+---
+
+## Phase 2: Service Catalog -- Init
+
+### Test 2.1: Initialize a new service catalog
+
+```bash
+cd "${TEST_CATALOG_DIR%/*}"
+rm -rf "${TEST_CATALOG_DIR}" 2>/dev/null || true
+
+wanaku service init --name="${TEST_CATALOG_NAME}" --services=system-a,system-b
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: service init succeeded"
+else
+  echo "FAIL: service init failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 2.2: Verify root directory and index.properties exist
+
+```bash
+CATALOG_DIR="${TEST_CATALOG_NAME}"
+
+if [ ! -d "${CATALOG_DIR}" ]; then
+  echo "FAIL: catalog directory '${CATALOG_DIR}' not created"
+  exit 1
+fi
+echo "PASS: catalog directory exists"
+
+if [ ! -f "${CATALOG_DIR}/index.properties" ]; then
+  echo "FAIL: index.properties not found"
+  exit 1
+fi
+echo "PASS: index.properties exists"
+```
+
+### Test 2.3: Verify service subdirectories were created
+
+```bash
+for SVC in system-a system-b; do
+  if [ ! -d "${CATALOG_DIR}/${SVC}" ]; then
+    echo "FAIL: service directory '${SVC}' not created"
+    exit 1
+  fi
+  echo "PASS: ${SVC}/ directory exists"
+
+  for EXT in camel.yaml wanaku-rules.yaml dependencies.txt; do
+    FILE="${CATALOG_DIR}/${SVC}/${SVC}.${EXT}"
+    if [ ! -f "${FILE}" ]; then
+      echo "FAIL: ${FILE} not found"
+    else
+      echo "PASS: ${FILE} exists"
+    fi
+  done
+done
+```
+
+### Test 2.4: Verify index.properties contains correct entries
+
+```bash
+INDEX="${CATALOG_DIR}/index.properties"
+
+grep -q "catalog.name=${TEST_CATALOG_NAME}" "${INDEX}" \
+  && echo "PASS: catalog.name is set" \
+  || echo "FAIL: catalog.name not found or incorrect"
+
+grep -q "catalog.services=" "${INDEX}" \
+  && echo "PASS: catalog.services is set" \
+  || echo "FAIL: catalog.services not found"
+
+for SVC in system-a system-b; do
+  grep -q "catalog.routes.${SVC}=" "${INDEX}" \
+    && echo "PASS: catalog.routes.${SVC} is set" \
+    || echo "FAIL: catalog.routes.${SVC} not found"
+
+  grep -q "catalog.rules.${SVC}=" "${INDEX}" \
+    && echo "PASS: catalog.rules.${SVC} is set" \
+    || echo "FAIL: catalog.rules.${SVC} not found"
+done
+```
+
+---
+
+## Phase 3: Service Catalog -- Create Route Files
+
+### Test 3.1: Write a Camel route into system-a
+
+**Description:** Replace the skeleton route with a minimal route containing a known route ID.
+
+```bash
+cat > "${CATALOG_DIR}/system-a/system-a.camel.yaml" <<'ROUTE_EOF'
+- route:
+    id: get-system-a-data
+    description: Retrieve data from system A
+    from:
+      uri: direct:get-system-a-data
+      steps:
+        - log:
+            message: "Processing system-a request"
+ROUTE_EOF
+
+if [ -s "${CATALOG_DIR}/system-a/system-a.camel.yaml" ]; then
+  echo "PASS: system-a route file written"
+else
+  echo "FAIL: system-a route file is empty or missing"
+fi
+```
+
+### Test 3.2: Verify the route ID is present
+
+```bash
+grep -q "id: get-system-a-data" "${CATALOG_DIR}/system-a/system-a.camel.yaml" \
+  && echo "PASS: route ID 'get-system-a-data' found in route file" \
+  || echo "FAIL: route ID 'get-system-a-data' not found"
+```
+
+### Test 3.3: Write a Camel route into system-b
+
+```bash
+cat > "${CATALOG_DIR}/system-b/system-b.camel.yaml" <<'ROUTE_EOF'
+- route:
+    id: get-system-b-data
+    description: Retrieve data from system B
+    from:
+      uri: direct:get-system-b-data
+      steps:
+        - log:
+            message: "Processing system-b request"
+ROUTE_EOF
+
+if [ -s "${CATALOG_DIR}/system-b/system-b.camel.yaml" ]; then
+  echo "PASS: system-b route file written"
+else
+  echo "FAIL: system-b route file is empty or missing"
+fi
+```
+
+---
+
+## Phase 4: Service Catalog -- Expose
+
+### Test 4.1: Generate Wanaku rules from Camel routes
+
+```bash
+wanaku service expose --path="${CATALOG_DIR}" --namespace=default
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: service expose succeeded"
+else
+  echo "FAIL: service expose failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 4.2: Verify rules file was generated for system-a
+
+```bash
+RULES_FILE="${CATALOG_DIR}/system-a/system-a.wanaku-rules.yaml"
+
+if [ ! -f "${RULES_FILE}" ]; then
+  echo "FAIL: rules file not found: ${RULES_FILE}"
+  exit 1
+fi
+
+grep -q "get-system-a-data" "${RULES_FILE}" \
+  && echo "PASS: route ID 'get-system-a-data' present in rules file" \
+  || echo "FAIL: route ID 'get-system-a-data' not found in rules file"
+
+grep -q "namespace" "${RULES_FILE}" \
+  && echo "PASS: namespace entry present in rules file" \
+  || echo "FAIL: namespace entry not found in rules file"
+```
+
+### Test 4.3: Verify rules file was generated for system-b
+
+```bash
+RULES_FILE="${CATALOG_DIR}/system-b/system-b.wanaku-rules.yaml"
+
+if [ ! -f "${RULES_FILE}" ]; then
+  echo "FAIL: rules file not found: ${RULES_FILE}"
+  exit 1
+fi
+
+grep -q "get-system-b-data" "${RULES_FILE}" \
+  && echo "PASS: route ID 'get-system-b-data' present in rules file" \
+  || echo "FAIL: route ID 'get-system-b-data' not found in rules file"
+```
+
+---
+
+## Phase 5: Service Catalog -- Package
+
+### Test 5.1: Package the service catalog
+
+```bash
+wanaku service package --path="${CATALOG_DIR}" -o "${TEST_PACKAGE_OUTPUT}"
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: service package succeeded"
+else
+  echo "FAIL: service package failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 5.2: Verify package output file exists and is non-empty
+
+```bash
+if [ ! -f "${TEST_PACKAGE_OUTPUT}" ]; then
+  echo "FAIL: package output file not found: ${TEST_PACKAGE_OUTPUT}"
+  exit 1
+fi
+echo "PASS: package output file exists"
+
+FILE_SIZE=$(wc -c < "${TEST_PACKAGE_OUTPUT}" | tr -d ' ')
+if [ "${FILE_SIZE}" -gt 0 ]; then
+  echo "PASS: package output file is non-empty (${FILE_SIZE} bytes)"
+else
+  echo "FAIL: package output file is empty"
+fi
+```
+
+### Test 5.3: Verify the output is valid Base64
+
+```bash
+base64 -d < "${TEST_PACKAGE_OUTPUT}" > /dev/null 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: package output is valid Base64"
+else
+  echo "FAIL: package output is not valid Base64 (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 5.4: Verify decoded content is a valid ZIP
+
+```bash
+base64 -d < "${TEST_PACKAGE_OUTPUT}" > /tmp/test-catalog-verify.zip 2>/dev/null
+file /tmp/test-catalog-verify.zip | grep -qi "zip" \
+  && echo "PASS: decoded content is a ZIP archive" \
+  || echo "FAIL: decoded content is not a ZIP archive"
+rm -f /tmp/test-catalog-verify.zip
+```
+
+---
+
+## Phase 6: Service Catalog -- Deploy
+
+### Test 6.1: Deploy the service catalog to the router
+
+```bash
+wanaku service deploy --path="${CATALOG_DIR}" --host="${WANAKU_ROUTER_URL}"
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: service deploy succeeded"
+else
+  echo "FAIL: service deploy failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 7: Service Catalog -- List and Verify
+
+### Test 7.1: List deployed service catalogs
+
+```bash
+OUTPUT=$(wanaku service catalog list --host="${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: service catalog list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+echo "PASS: service catalog list succeeded"
+```
+
+### Test 7.2: Verify the test catalog appears in the list
+
+```bash
+echo "${OUTPUT}" | grep -q "${TEST_CATALOG_NAME}" \
+  && echo "PASS: '${TEST_CATALOG_NAME}' found in catalog list" \
+  || echo "FAIL: '${TEST_CATALOG_NAME}' not found in catalog list"
+```
+
+---
+
+## Phase 8: Service Template -- List
+
+### Test 8.1: List all available service templates
+
+```bash
+OUTPUT=$(wanaku service template list --host="${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: service template list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+echo "PASS: service template list succeeded"
+echo "${OUTPUT}"
+```
+
+### Test 8.2: Verify at least one built-in template is listed
+
+```bash
+FOUND_TEMPLATE=0
+for TEMPLATE in activemq6-tool kafka-tool sql-tool github-pullrequest-source-tool; do
+  if echo "${OUTPUT}" | grep -q "${TEMPLATE}"; then
+    echo "PASS: built-in template '${TEMPLATE}' found"
+    FOUND_TEMPLATE=1
+  fi
+done
+
+if [ "${FOUND_TEMPLATE}" -eq 0 ]; then
+  echo "FAIL: no built-in templates found in template list"
+fi
+```
+
+### Test 8.3: List templates with search filter
+
+```bash
+FILTERED=$(wanaku service template list --host="${WANAKU_ROUTER_URL}" --search activemq --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: filtered template list failed (exit code ${EXIT_CODE})"
+  echo "${FILTERED}"
+  exit 1
+fi
+echo "PASS: filtered template list succeeded"
+
+echo "${FILTERED}" | grep -q "activemq" \
+  && echo "PASS: filtered results contain 'activemq'" \
+  || echo "FAIL: filtered results do not contain 'activemq'"
+```
+
+---
+
+## Phase 9: Service Template -- Instantiate
+
+### Test 9.1: Instantiate a template with properties
+
+**Description:** Instantiate the `activemq6-tool` template with test property values. This creates and deploys a service catalog from the template.
+
+```bash
+OUTPUT=$(wanaku service template instantiate \
+  --host="${WANAKU_ROUTER_URL}" \
+  --name activemq6-tool \
+  --property broker.url=tcp://localhost:61616 \
+  --property broker.username=admin \
+  --property broker.password=admin \
+  --property queue.name=test.queue 2>&1)
+EXIT_CODE=$?
+
+echo "${OUTPUT}"
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: template instantiate succeeded"
+else
+  echo "FAIL: template instantiate failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 9.2: Verify instantiated catalog appears in catalog list
+
+```bash
+CATALOG_OUTPUT=$(wanaku service catalog list --host="${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${CATALOG_OUTPUT}" | grep -qi "activemq" \
+  && echo "PASS: instantiated activemq catalog found in catalog list" \
+  || echo "WARN: instantiated activemq catalog not found in catalog list (may use a different name)"
+```
+
+---
+
+## Phase 10: Service Catalog -- Deployment Instructions
+
+### Test 10.1: Get local deployment instructions for the test catalog
+
+```bash
+OUTPUT=$(wanaku service instructions \
+  --host="${WANAKU_ROUTER_URL}" \
+  --name="${TEST_CATALOG_NAME}" \
+  --model=local 2>&1)
+EXIT_CODE=$?
+
+echo "${OUTPUT}"
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: deployment instructions returned"
+else
+  echo "FAIL: deployment instructions failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 10.2: Verify instructions contain meaningful content
+
+```bash
+if [ -n "${OUTPUT}" ]; then
+  echo "PASS: instructions output is non-empty"
+else
+  echo "FAIL: instructions output is empty"
+fi
+```
+
+### Test 10.3: Get Kubernetes deployment instructions
+
+```bash
+K8S_OUTPUT=$(wanaku service instructions \
+  --host="${WANAKU_ROUTER_URL}" \
+  --name="${TEST_CATALOG_NAME}" \
+  --model=kubernetes 2>&1)
+EXIT_CODE=$?
+
+echo "${K8S_OUTPUT}"
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: kubernetes deployment instructions returned"
+else
+  echo "FAIL: kubernetes deployment instructions failed (exit code ${EXIT_CODE})"
+fi
+```
+
+---
+
+## Phase 11: Negative Tests
+
+### Test 11.1: Init with missing --name should fail
+
+```bash
+wanaku service init --services=a,b 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: init without --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: init without --name should fail"
+  rm -rf a b 2>/dev/null || true
+fi
+```
+
+### Test 11.2: Init with missing --services should fail
+
+```bash
+wanaku service init --name=should-fail 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: init without --services rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: init without --services should fail"
+  rm -rf should-fail 2>/dev/null || true
+fi
+```
+
+### Test 11.3: Init when directory already exists should fail
+
+```bash
+wanaku service init --name="${TEST_CATALOG_NAME}" --services=x 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: init with existing directory rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: init with existing directory should fail"
+fi
+```
+
+### Test 11.4: Expose with invalid path should fail
+
+```bash
+wanaku service expose --path=/tmp/nonexistent-catalog-99999 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: expose with invalid path rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: expose with invalid path should fail"
+fi
+```
+
+### Test 11.5: Package with non-existent path should fail
+
+```bash
+wanaku service package --path=/tmp/nonexistent-catalog-99999 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: package with non-existent path rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: package with non-existent path should fail"
+fi
+```
+
+### Test 11.6: Deploy with unreachable host should fail
+
+```bash
+wanaku service deploy --path="${CATALOG_DIR}" --host="http://localhost:59999" 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: deploy with unreachable host rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: deploy with unreachable host should fail"
+fi
+```
+
+### Test 11.7: Template instantiate with non-existent template should fail
+
+```bash
+wanaku service template instantiate \
+  --host="${WANAKU_ROUTER_URL}" \
+  --name="nonexistent-template-99999" \
+  --property key=value 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: instantiate non-existent template rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: instantiate non-existent template should fail"
+fi
+```
+
+### Test 11.8: Catalog list with unreachable host should fail
+
+```bash
+wanaku service catalog list --host="http://localhost:59999" 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: catalog list with unreachable host rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: catalog list with unreachable host should fail"
+fi
+```
+
+### Test 11.9: Instructions with missing --name should fail
+
+```bash
+wanaku service instructions --host="${WANAKU_ROUTER_URL}" --model=local 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: instructions without --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: instructions without --name should fail"
+fi
+```
+
+### Test 11.10: Instructions with missing --model should fail
+
+```bash
+wanaku service instructions --host="${WANAKU_ROUTER_URL}" --name="${TEST_CATALOG_NAME}" 2>&1
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: instructions without --model rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: instructions without --model should fail"
+fi
+```
+
+---
+
+## Phase 12: Cleanup
+
+### Step 12.1: Remove deployed catalogs via REST API
+
+There is no CLI command for removing catalogs. Use curl to call the REST API directly (acceptable per guidelines for HTTP-level cleanup operations).
+
+```bash
+# Remove the test catalog
+curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE "${WANAKU_ROUTER_URL}/api/v1/service-catalog/${TEST_CATALOG_NAME}" 2>/dev/null || true
+echo "Removed catalog: ${TEST_CATALOG_NAME}"
+
+# Remove the instantiated activemq catalog (name may vary)
+curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE "${WANAKU_ROUTER_URL}/api/v1/service-catalog/activemq6-tool" 2>/dev/null || true
+echo "Removed catalog: activemq6-tool (if present)"
+
+echo "PASS: catalog cleanup complete"
+```
+
+### Step 12.2: Remove temporary files and directories
+
+```bash
+rm -rf "${TEST_CATALOG_DIR}" 2>/dev/null || true
+rm -rf "${TEST_CATALOG_NAME}" 2>/dev/null || true
+rm -f "${TEST_PACKAGE_OUTPUT}" 2>/dev/null || true
+rm -rf should-fail 2>/dev/null || true
+
+echo "PASS: temporary files removed"
+```
+
+### Step 12.3: Stop the local Wanaku instance
+
+Follow the shutdown steps in [common/start-local.md](common/start-local.md):
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+fi
+```
+
+---
+
+## Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 1 | -- | Setup (build and start local) | Critical |
+| 2 | 2.1-2.4 | Service catalog init and structure verification | Critical |
+| 3 | 3.1-3.3 | Create Camel route files for services | Critical |
+| 4 | 4.1-4.3 | Expose routes and generate rules | Critical |
+| 5 | 5.1-5.4 | Package into Base64-encoded ZIP | High |
+| 6 | 6.1 | Deploy to running router | Critical |
+| 7 | 7.1-7.2 | List and verify deployed catalog | Critical |
+| 8 | 8.1-8.3 | List and filter service templates | High |
+| 9 | 9.1-9.2 | Instantiate template into catalog | High |
+| 10 | 10.1-10.3 | Deployment instructions (local and Kubernetes) | Medium |
+| 11 | 11.1-11.10 | Negative tests (missing args, bad paths, unreachable host) | High |
+| 12 | 12.1-12.3 | Cleanup (catalogs, temp files, process) | Critical |

--- a/tests/plans/cli-start-local-smoke.md
+++ b/tests/plans/cli-start-local-smoke.md
@@ -1,0 +1,511 @@
+# Test Plan: CLI Start Local Smoke Test
+
+## Overview
+
+This test plan verifies that `wanaku start local` works end-to-end: build the project, start the local stack, confirm health, register a tool, invoke it via MCP, manage prompts, verify the admin UI is reachable, then shut down cleanly.
+
+This runs locally with **no authentication** (`start local` is always noauth). Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn -version` |
+| `jq` | 1.6+ | `jq --version` |
+| `curl` | any | `curl --version` |
+
+### Prerequisite check
+
+```bash
+java -version 2>&1 || { echo "FAIL: java not found"; exit 1; }
+mvn -version 2>&1 || { echo "FAIL: mvn not found"; exit 1; }
+jq --version 2>&1 || { echo "FAIL: jq not found"; exit 1; }
+curl --version > /dev/null 2>&1 || { echo "FAIL: curl not found"; exit 1; }
+echo "PASS: all prerequisites met"
+```
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} tools list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/public/mcp/sse}"
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WANAKU_REPO_ROOT` | `.` | Path to the Wanaku repository root |
+| `WANAKU_ROUTER_URL` | `http://localhost:8080` | Router base URL (no trailing slash) |
+| `MCP_SERVER_URI` | `http://localhost:8080/public/mcp/sse` | MCP SSE endpoint for direct MCP commands |
+
+### Known limitations for local testing
+
+- **No resource providers in `wanaku start local`:** The local start command only supports tool services (`service-http`). Resource providers are not available locally. Resource tests are limited to verifying the list command returns successfully.
+- **Prompts are not backed by providers:** Prompts are stored in the router and do not require a downstream provider. They can be added, listed, and removed locally.
+- **MCP SSE path:** The public MCP endpoint is `/public/mcp/sse` (not `/mcp`). Using a wrong path will return connection errors.
+
+---
+
+## Phase 0: Prerequisites
+
+Verify all required tools are present and environment variables are set.
+
+### Test 0.1: Verify required tools
+
+```bash
+java -version 2>&1 | head -1
+JAVA_EXIT=$?
+
+mvn -version 2>&1 | head -1
+MVN_EXIT=$?
+
+jq --version 2>&1
+JQ_EXIT=$?
+
+if [ "${JAVA_EXIT}" -eq 0 ] && [ "${MVN_EXIT}" -eq 0 ] && [ "${JQ_EXIT}" -eq 0 ]; then
+  echo "PASS: all required tools present"
+else
+  echo "FAIL: one or more tools missing (java=${JAVA_EXIT}, mvn=${MVN_EXIT}, jq=${JQ_EXIT})"
+  exit 1
+fi
+```
+
+### Test 0.2: Verify Java version is 21+
+
+```bash
+JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*"\([0-9]*\).*/\1/')
+if [ "${JAVA_VERSION}" -ge 21 ]; then
+  echo "PASS: Java version ${JAVA_VERSION} >= 21"
+else
+  echo "FAIL: Java version ${JAVA_VERSION} < 21"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Build and Start
+
+Follow [common/start-local.md](common/start-local.md) to build the project, start the local stack, and wait for health.
+
+After completion, the following variables must be set:
+
+- `VERSION` -- Wanaku version string
+- `CLI_JAR` -- path to the CLI JAR
+- `WANAKU_ROUTER_URL` -- router base URL (`http://localhost:8080`)
+- `WANAKU_PID` -- PID of the background Wanaku process
+
+### Test 1.1: Verify CLI JAR exists
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+if [ -f "${CLI_JAR}" ]; then
+  echo "PASS: CLI JAR exists at ${CLI_JAR}"
+else
+  echo "FAIL: CLI JAR not found at ${CLI_JAR}"
+  exit 1
+fi
+```
+
+### Test 1.2: Verify router is healthy
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready" 2>/dev/null || echo "000")
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: router is healthy"
+else
+  echo "FAIL: router not healthy (HTTP ${HTTP_CODE})"
+  exit 1
+fi
+```
+
+### Test 1.3: Verify CLI can connect to router
+
+```bash
+java -jar ${CLI_JAR} tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI can connect to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 2: Smoke Test -- Tools
+
+### Test 2.1: Register an HTTP tool
+
+```bash
+java -jar ${CLI_JAR} tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name smoke-test-tool \
+  --namespace public \
+  --description "Smoke test tool for local validation" \
+  --uri "https://httpbin.org/get?param={value}" \
+  --type http \
+  --property "value:string,A test value" \
+  --required value
+
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: smoke-test-tool registered"
+else
+  echo "FAIL: could not register smoke-test-tool (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 2.2: List tools and verify smoke-test-tool appears
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list command failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "smoke-test-tool" \
+  && echo "PASS: smoke-test-tool is listed" \
+  || echo "FAIL: smoke-test-tool not found in tools list"
+```
+
+### Test 2.3: Show tool details
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} tools show --host "${WANAKU_ROUTER_URL}" --plain smoke-test-tool 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools show command failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "smoke-test-tool" \
+  && echo "PASS: tool details contain tool name" \
+  || echo "FAIL: tool details do not contain tool name"
+
+echo "${OUTPUT}" | grep -q "httpbin" \
+  && echo "PASS: tool details contain URI" \
+  || echo "FAIL: tool details do not contain URI"
+```
+
+### Test 2.4: Call the tool via MCP
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} mcp tool \
+  --uri "${MCP_SERVER_URI}" \
+  --name smoke-test-tool \
+  --param value=hello \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+echo "Exit code: ${EXIT_CODE}"
+echo "Output: ${OUTPUT}"
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: MCP tool call failed (exit code ${EXIT_CODE})"
+  exit 1
+fi
+
+if [ -n "${OUTPUT}" ]; then
+  echo "PASS: MCP tool call returned non-empty response"
+else
+  echo "FAIL: MCP tool call returned empty response"
+fi
+```
+
+### Test 2.5: List tools via MCP and verify smoke-test-tool appears
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} mcp tool list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: MCP tool list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "smoke-test-tool" \
+  && echo "PASS: smoke-test-tool visible via MCP" \
+  || echo "FAIL: smoke-test-tool not visible via MCP"
+```
+
+### Test 2.6: Call a non-existent tool should fail
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} mcp tool \
+  --uri "${MCP_SERVER_URI}" \
+  --name "nonexistent-tool-12345" \
+  --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: non-existent tool call failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: non-existent tool call should have failed"
+fi
+```
+
+---
+
+## Phase 3: Smoke Test -- Resources
+
+No resource providers ship with `start local` by default. This phase verifies the resources commands function correctly against the router even without providers.
+
+### Test 3.1: List resources returns successfully
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} resources list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resources list returned successfully (empty is expected)"
+else
+  echo "FAIL: resources list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 3.2: List resources via MCP returns successfully
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} mcp resource list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: MCP resource list returned successfully"
+else
+  echo "FAIL: MCP resource list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 4: Smoke Test -- Prompts
+
+### Test 4.1: Add a prompt
+
+```bash
+java -jar ${CLI_JAR} prompts add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name smoke-test-prompt \
+  --namespace public \
+  --description "Smoke prompt for local validation" \
+  --message "user:text:Hello {{name}}" \
+  --argument "name:The name to greet:true"
+
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: smoke-test-prompt added"
+else
+  echo "FAIL: could not add smoke-test-prompt (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+### Test 4.2: List prompts and verify smoke-test-prompt appears
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} prompts list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: prompts list command failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "smoke-test-prompt" \
+  && echo "PASS: smoke-test-prompt is listed" \
+  || echo "FAIL: smoke-test-prompt not found in prompts list"
+```
+
+### Test 4.3: List prompts via MCP and verify smoke-test-prompt appears
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} mcp prompt list --uri "${MCP_SERVER_URI}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: MCP prompt list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "${OUTPUT}" | grep -q "smoke-test-prompt" \
+  && echo "PASS: smoke-test-prompt visible via MCP" \
+  || echo "FAIL: smoke-test-prompt not visible via MCP"
+```
+
+### Test 4.4: Remove the prompt
+
+```bash
+java -jar ${CLI_JAR} prompts remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name smoke-test-prompt
+
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: smoke-test-prompt removed"
+else
+  echo "FAIL: could not remove smoke-test-prompt (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 4.5: Verify prompt is no longer listed
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} prompts list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+
+echo "${OUTPUT}" | grep -q "smoke-test-prompt"
+if [ $? -ne 0 ]; then
+  echo "PASS: smoke-test-prompt no longer listed after removal"
+else
+  echo "FAIL: smoke-test-prompt still appears after removal"
+fi
+```
+
+### Test 4.6: Remove a non-existent prompt should fail
+
+```bash
+OUTPUT=$(java -jar ${CLI_JAR} prompts remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "nonexistent-prompt-12345" 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: removing non-existent prompt failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: removing non-existent prompt should have failed"
+fi
+```
+
+---
+
+## Phase 5: Smoke Test -- Admin UI
+
+Curl is used here specifically to test HTTP-level reachability of the admin UI static assets.
+
+### Test 5.1: Verify admin UI returns HTTP 200
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/admin/" 2>/dev/null || echo "000")
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: admin UI accessible at /admin/ (HTTP 200)"
+else
+  echo "FAIL: admin UI not accessible (HTTP ${HTTP_CODE})"
+fi
+```
+
+### Test 5.2: Verify admin UI serves HTML content
+
+```bash
+CONTENT_TYPE=$(curl -s -o /dev/null -w "%{content_type}" "${WANAKU_ROUTER_URL}/admin/" 2>/dev/null || echo "")
+echo "${CONTENT_TYPE}" | grep -qi "text/html" \
+  && echo "PASS: admin UI serves HTML content" \
+  || echo "FAIL: admin UI content-type is not HTML (got: ${CONTENT_TYPE})"
+```
+
+---
+
+## Phase 6: Cleanup
+
+### Step 6.1: Remove registered tools
+
+```bash
+java -jar ${CLI_JAR} tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name smoke-test-tool 2>/dev/null || true
+echo "PASS: smoke-test-tool removed (or already absent)"
+```
+
+### Step 6.2: Remove registered prompts (idempotent)
+
+```bash
+java -jar ${CLI_JAR} prompts remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name smoke-test-prompt 2>/dev/null || true
+echo "PASS: smoke-test-prompt removed (or already absent)"
+```
+
+### Step 6.3: Kill the Wanaku process
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process ${WANAKU_PID} stopped"
+else
+  echo "PASS: no WANAKU_PID set, nothing to stop"
+fi
+```
+
+### Step 6.4: Verify process is gone
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill -0 "${WANAKU_PID}" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo "PASS: Wanaku process ${WANAKU_PID} is no longer running"
+  else
+    echo "FAIL: Wanaku process ${WANAKU_PID} is still running"
+  fi
+else
+  echo "PASS: no WANAKU_PID set, nothing to verify"
+fi
+```
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | Critical |
+| 0 | 0.2 | Verify Java version >= 21 | Critical |
+| 1 | 1.1 | Verify CLI JAR exists | Critical |
+| 1 | 1.2 | Verify router is healthy | Critical |
+| 1 | 1.3 | Verify CLI can connect to router | Critical |
+| 2 | 2.1 | Register an HTTP tool | Critical |
+| 2 | 2.2 | List tools and verify registration | Critical |
+| 2 | 2.3 | Show tool details | High |
+| 2 | 2.4 | Call tool via MCP | Critical |
+| 2 | 2.5 | List tools via MCP | High |
+| 2 | 2.6 | Call non-existent tool (negative) | High |
+| 3 | 3.1 | List resources returns successfully | Medium |
+| 3 | 3.2 | List resources via MCP returns successfully | Medium |
+| 4 | 4.1 | Add a prompt | Critical |
+| 4 | 4.2 | List prompts and verify registration | Critical |
+| 4 | 4.3 | List prompts via MCP | High |
+| 4 | 4.4 | Remove the prompt | Critical |
+| 4 | 4.5 | Verify prompt removed from list | High |
+| 4 | 4.6 | Remove non-existent prompt (negative) | High |
+| 5 | 5.1 | Admin UI returns HTTP 200 | High |
+| 5 | 5.2 | Admin UI serves HTML content | Medium |
+| 6 | 6.1 | Remove registered tools | Critical |
+| 6 | 6.2 | Remove registered prompts | Critical |
+| 6 | 6.3 | Kill the Wanaku process | Critical |
+| 6 | 6.4 | Verify process is gone | High |

--- a/tests/plans/cli-tools-resources-prompts-local.md
+++ b/tests/plans/cli-tools-resources-prompts-local.md
@@ -1,0 +1,840 @@
+# Test Plan: CLI Tools, Resources, and Prompts CRUD (Local)
+
+## Overview
+
+This test plan exercises the full CRUD lifecycle for tools, resources, and prompts via the `wanaku` CLI against a locally running Wanaku instance without authentication. It covers add, list, show, edit, label, generate, import, batch removal, and negative tests.
+
+Every step uses the Wanaku CLI. No `curl` or other HTTP clients are used except for the health check (which tests HTTP-level readiness).
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `java` | 21+ | `java -version` |
+| `mvn` | 3.9+ | `mvn --version` |
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} tools list --host "${WANAKU_ROUTER_URL}" --plain
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) -- zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+### Environment variables
+
+```bash
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+```
+
+---
+
+## Phase 0: Manual Prerequisites
+
+### Step 0.1: Verify required tools are installed
+
+```bash
+MISSING=""
+for CMD in wanaku jq java mvn; do
+  command -v "${CMD}" > /dev/null 2>&1 || MISSING="${MISSING} ${CMD}"
+done
+
+if [ -z "${MISSING}" ]; then
+  echo "PASS: all required tools are installed"
+else
+  echo "FAIL: missing tools:${MISSING}"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md). After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, `CLI_JAR`, and `VERSION` must be set.
+
+### Step 1.1: Verify CLI can connect to router
+
+```bash
+wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI connected to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+---
+
+## Phase 2: Tool CRUD
+
+### Test 2.1: Add a tool
+
+```bash
+wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-http-tool \
+  --description "Test tool for E2E verification" \
+  --uri "https://httpbin.org/get?q={query}" \
+  --type http \
+  --property "query:string,Search query" \
+  --required query
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool 'test-http-tool' added"
+else
+  echo "FAIL: could not add tool (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 2.2: Verify tool appears in list
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-http-tool" \
+  && echo "PASS: 'test-http-tool' appears in tools list" \
+  || echo "FAIL: 'test-http-tool' not found in tools list"
+```
+
+### Test 2.3: Show tool details
+
+```bash
+OUTPUT=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" test-http-tool 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools show failed (exit code ${EXIT_CODE})"
+else
+  echo "${OUTPUT}" | grep -q "test-http-tool" \
+    && echo "PASS: show displays tool name" \
+    || echo "FAIL: tool name not in show output"
+  echo "${OUTPUT}" | grep -q "Test tool for E2E verification" \
+    && echo "PASS: show displays description" \
+    || echo "FAIL: description not in show output"
+  echo "${OUTPUT}" | grep -q "httpbin.org" \
+    && echo "PASS: show displays URI" \
+    || echo "FAIL: URI not in show output"
+  echo "${OUTPUT}" | grep -qi "http" \
+    && echo "PASS: show displays type" \
+    || echo "FAIL: type not in show output"
+fi
+```
+
+### Test 2.4: Edit tool (interactive editor)
+
+**Note:** The `tools edit` command opens a Nano editor for interactive modification. In an automated test environment this requires a wrapper or a direct API update. For manual execution:
+
+```bash
+wanaku tools edit --host "${WANAKU_ROUTER_URL}" test-http-tool
+```
+
+**Manual verification:** Change the description to "Updated description" in the editor, save and confirm.
+
+```bash
+OUTPUT=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" test-http-tool 2>&1)
+echo "${OUTPUT}" | grep -q "Updated description" \
+  && echo "PASS: description was updated via edit" \
+  || echo "FAIL: description was not updated"
+```
+
+### Test 2.5: Add labels to tool
+
+```bash
+wanaku tools label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-http-tool \
+  --label env=test \
+  --label tier=smoke
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: labels added to tool"
+else
+  echo "FAIL: could not add labels (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 2.6: Verify labels appear in list
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep "test-http-tool" | grep -q "env=test" \
+  && echo "PASS: label 'env=test' visible in list" \
+  || echo "FAIL: label 'env=test' not visible in list"
+echo "${OUTPUT}" | grep "test-http-tool" | grep -q "tier=smoke" \
+  && echo "PASS: label 'tier=smoke' visible in list" \
+  || echo "FAIL: label 'tier=smoke' not visible in list"
+```
+
+### Test 2.7: Remove a label from tool
+
+```bash
+wanaku tools label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-http-tool \
+  --label env
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: label 'env' removed"
+else
+  echo "FAIL: could not remove label (exit code ${EXIT_CODE})"
+fi
+
+# Verify env label is gone but tier remains
+OUTPUT=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" test-http-tool 2>&1)
+echo "${OUTPUT}" | grep -q "env=test" \
+  && echo "FAIL: label 'env=test' still present after removal" \
+  || echo "PASS: label 'env=test' confirmed removed"
+echo "${OUTPUT}" | grep -q "tier=smoke" \
+  && echo "PASS: label 'tier=smoke' still present" \
+  || echo "FAIL: label 'tier=smoke' unexpectedly removed"
+```
+
+### Test 2.8: Remove tool
+
+```bash
+wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-http-tool
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tool 'test-http-tool' removed"
+else
+  echo "FAIL: could not remove tool (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 2.9: Verify tool is gone
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-http-tool" \
+  && echo "FAIL: 'test-http-tool' still in list after removal" \
+  || echo "PASS: 'test-http-tool' confirmed removed from list"
+```
+
+---
+
+## Phase 3: Tool OpenAPI Generation
+
+### Test 3.1: Create a minimal OpenAPI spec file
+
+```bash
+cat > /tmp/wanaku-test-openapi.json <<'SPEC_EOF'
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/get": {
+      "get": {
+        "operationId": "getRequest",
+        "summary": "Returns GET data",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A query parameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    },
+    "/post": {
+      "post": {
+        "operationId": "postRequest",
+        "summary": "Returns POST data",
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}
+SPEC_EOF
+
+if [ -f /tmp/wanaku-test-openapi.json ]; then
+  echo "PASS: OpenAPI spec file created"
+else
+  echo "FAIL: could not create OpenAPI spec file"
+fi
+```
+
+### Test 3.2: Generate tools from OpenAPI spec
+
+```bash
+wanaku tools generate \
+  --output-file /tmp/wanaku-test-toolset.json \
+  /tmp/wanaku-test-openapi.json
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: tools generated from OpenAPI spec"
+else
+  echo "FAIL: tools generate failed (exit code ${EXIT_CODE})"
+fi
+
+if [ -f /tmp/wanaku-test-toolset.json ]; then
+  echo "PASS: generated toolset file exists"
+else
+  echo "FAIL: generated toolset file not found"
+fi
+```
+
+### Test 3.3: Import generated tools
+
+```bash
+wanaku tools import \
+  --host "${WANAKU_ROUTER_URL}" \
+  /tmp/wanaku-test-toolset.json
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset imported"
+else
+  echo "FAIL: tools import failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 3.4: Verify imported tools appear in list
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -qi "getRequest\|get-request\|get_request\|get" \
+  && echo "PASS: at least one generated tool visible in list" \
+  || echo "FAIL: no generated tools found in list"
+```
+
+### Test 3.5: Cleanup generated tools
+
+Remove tools that were imported from the generated toolset. Identify them by listing and filtering:
+
+```bash
+# Get tool names from the generated file
+GENERATED_TOOLS=$(jq -r '.[].name // empty' /tmp/wanaku-test-toolset.json 2>/dev/null)
+if [ -z "${GENERATED_TOOLS}" ]; then
+  # Alternate structure: may be a single object or different key
+  GENERATED_TOOLS=$(jq -r '.name // empty' /tmp/wanaku-test-toolset.json 2>/dev/null)
+fi
+
+for TOOL_NAME in ${GENERATED_TOOLS}; do
+  wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name "${TOOL_NAME}" 2>/dev/null || true
+done
+echo "PASS: generated tools cleaned up"
+
+rm -f /tmp/wanaku-test-openapi.json /tmp/wanaku-test-toolset.json
+```
+
+---
+
+## Phase 4: Resource CRUD
+
+### Test 4.1: Expose a resource
+
+```bash
+wanaku resources expose \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-resource \
+  --location "file:///tmp/test-resource.txt" \
+  --type file \
+  --mimeType text/plain \
+  --description "Test resource for E2E verification"
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource 'test-resource' exposed"
+else
+  echo "FAIL: could not expose resource (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 4.2: Verify resource appears in list
+
+```bash
+OUTPUT=$(wanaku resources list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-resource" \
+  && echo "PASS: 'test-resource' appears in resources list" \
+  || echo "FAIL: 'test-resource' not found in resources list"
+```
+
+### Test 4.3: Show resource details
+
+```bash
+OUTPUT=$(wanaku resources show --host "${WANAKU_ROUTER_URL}" test-resource 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: resources show failed (exit code ${EXIT_CODE})"
+else
+  echo "${OUTPUT}" | grep -q "test-resource" \
+    && echo "PASS: show displays resource name" \
+    || echo "FAIL: resource name not in show output"
+  echo "${OUTPUT}" | grep -q "Test resource for E2E verification" \
+    && echo "PASS: show displays description" \
+    || echo "FAIL: description not in show output"
+  echo "${OUTPUT}" | grep -q "file:///tmp/test-resource.txt" \
+    && echo "PASS: show displays location" \
+    || echo "FAIL: location not in show output"
+  echo "${OUTPUT}" | grep -q "text/plain" \
+    && echo "PASS: show displays mimeType" \
+    || echo "FAIL: mimeType not in show output"
+fi
+```
+
+### Test 4.4: Add labels to resource
+
+```bash
+wanaku resources label add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-resource \
+  --label env=test
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: label added to resource"
+else
+  echo "FAIL: could not add label to resource (exit code ${EXIT_CODE})"
+fi
+
+OUTPUT=$(wanaku resources show --host "${WANAKU_ROUTER_URL}" test-resource 2>&1)
+echo "${OUTPUT}" | grep -q "env=test" \
+  && echo "PASS: label 'env=test' visible in resource details" \
+  || echo "FAIL: label 'env=test' not visible in resource details"
+```
+
+### Test 4.5: Remove label from resource
+
+```bash
+wanaku resources label remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-resource \
+  --label env
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: label removed from resource"
+else
+  echo "FAIL: could not remove label from resource (exit code ${EXIT_CODE})"
+fi
+
+OUTPUT=$(wanaku resources show --host "${WANAKU_ROUTER_URL}" test-resource 2>&1)
+echo "${OUTPUT}" | grep -q "env=test" \
+  && echo "FAIL: label 'env=test' still present after removal" \
+  || echo "PASS: label 'env=test' confirmed removed"
+```
+
+### Test 4.6: Remove resource
+
+```bash
+wanaku resources remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-resource
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: resource 'test-resource' removed"
+else
+  echo "FAIL: could not remove resource (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 4.7: Verify resource is gone
+
+```bash
+OUTPUT=$(wanaku resources list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-resource" \
+  && echo "FAIL: 'test-resource' still in list after removal" \
+  || echo "PASS: 'test-resource' confirmed removed from list"
+```
+
+---
+
+## Phase 5: Prompt CRUD
+
+### Test 5.1: Add a prompt
+
+```bash
+wanaku prompts add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-prompt \
+  --description "Test prompt for E2E verification" \
+  --message "user:text:Review this code: {{code}}" \
+  --argument "code:The code to review:true"
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: prompt 'test-prompt' added"
+else
+  echo "FAIL: could not add prompt (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 5.2: Verify prompt appears in list
+
+```bash
+OUTPUT=$(wanaku prompts list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-prompt" \
+  && echo "PASS: 'test-prompt' appears in prompts list" \
+  || echo "FAIL: 'test-prompt' not found in prompts list"
+```
+
+### Test 5.3: Edit prompt description
+
+```bash
+wanaku prompts edit \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-prompt \
+  --description "Updated prompt description"
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: prompt edit succeeded"
+else
+  echo "FAIL: prompt edit failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 5.4: Verify prompt description was updated
+
+```bash
+OUTPUT=$(wanaku prompts list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "Updated prompt description" \
+  && echo "PASS: prompt description updated" \
+  || echo "FAIL: prompt description not updated in list output"
+```
+
+### Test 5.5: Remove prompt
+
+```bash
+wanaku prompts remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name test-prompt
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: prompt 'test-prompt' removed"
+else
+  echo "FAIL: could not remove prompt (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 5.6: Verify prompt is gone
+
+```bash
+OUTPUT=$(wanaku prompts list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-prompt" \
+  && echo "FAIL: 'test-prompt' still in list after removal" \
+  || echo "PASS: 'test-prompt' confirmed removed from list"
+```
+
+---
+
+## Phase 6: Batch Operations
+
+### Test 6.1: Register 3 tools with the same label
+
+```bash
+for i in 1 2 3; do
+  wanaku tools add \
+    --host "${WANAKU_ROUTER_URL}" \
+    --name "batch-tool-${i}" \
+    --description "Batch test tool ${i}" \
+    --uri "https://httpbin.org/get?id=${i}" \
+    --type http \
+    --label env=batch-test
+  EXIT_CODE=$?
+  if [ "${EXIT_CODE}" -eq 0 ]; then
+    echo "PASS: batch-tool-${i} added"
+  else
+    echo "FAIL: could not add batch-tool-${i} (exit code ${EXIT_CODE})"
+  fi
+done
+```
+
+### Test 6.2: Verify all 3 tools are listed
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+COUNT=0
+for i in 1 2 3; do
+  echo "${OUTPUT}" | grep -q "batch-tool-${i}" && COUNT=$((COUNT + 1))
+done
+if [ "${COUNT}" -eq 3 ]; then
+  echo "PASS: all 3 batch tools are listed"
+else
+  echo "FAIL: only ${COUNT}/3 batch tools found in list"
+fi
+```
+
+### Test 6.3: Batch remove tools by label expression
+
+```bash
+wanaku tools remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  -e "env=batch-test" \
+  -y
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: batch remove by label expression succeeded"
+else
+  echo "FAIL: batch remove failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 6.4: Verify all 3 tools are removed
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+REMAINING=0
+for i in 1 2 3; do
+  echo "${OUTPUT}" | grep -q "batch-tool-${i}" && REMAINING=$((REMAINING + 1))
+done
+if [ "${REMAINING}" -eq 0 ]; then
+  echo "PASS: all batch tools removed"
+else
+  echo "FAIL: ${REMAINING} batch tool(s) still present after removal"
+fi
+```
+
+---
+
+## Phase 7: Negative Tests
+
+### Test 7.1: Add tool with duplicate name should fail
+
+```bash
+# First, add a tool
+wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name duplicate-tool \
+  --description "First instance" \
+  --uri "https://httpbin.org/get" \
+  --type http
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: could not add initial tool for duplicate test"
+fi
+
+# Attempt to add a tool with the same name
+OUTPUT=$(wanaku tools add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name duplicate-tool \
+  --description "Duplicate instance" \
+  --uri "https://httpbin.org/post" \
+  --type http 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: duplicate tool name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: duplicate tool name was accepted -- expected rejection"
+fi
+
+# Cleanup
+wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name duplicate-tool 2>/dev/null || true
+```
+
+### Test 7.2: Show non-existent tool should fail
+
+```bash
+OUTPUT=$(wanaku tools show --host "${WANAKU_ROUTER_URL}" non-existent-tool-99999 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: show non-existent tool failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "${OUTPUT}" | grep -qi "not found\|warning" \
+    && echo "PASS: show non-existent tool returned not-found message" \
+    || echo "FAIL: show non-existent tool did not fail or indicate not-found"
+fi
+```
+
+### Test 7.3: Remove non-existent tool should fail gracefully
+
+```bash
+OUTPUT=$(wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name non-existent-tool-99999 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: remove non-existent tool failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: remove non-existent tool should have returned a non-zero exit code"
+fi
+```
+
+### Test 7.4: Expose resource with missing required fields should fail
+
+The `--location`, `--type`, `--name`, and `--description` options are required. Omitting `--name` should cause a CLI error.
+
+```bash
+OUTPUT=$(wanaku resources expose \
+  --host "${WANAKU_ROUTER_URL}" \
+  --location "file:///tmp/test.txt" \
+  --type file \
+  --description "Missing name field" 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: resource with missing required field rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: resource with missing required field was accepted"
+fi
+```
+
+### Test 7.5: Add prompt with no messages
+
+```bash
+OUTPUT=$(wanaku prompts add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name empty-prompt \
+  --description "Prompt with no messages" 2>&1)
+EXIT_CODE=$?
+# A prompt with no messages may be accepted or rejected depending on implementation.
+# Record the outcome for analysis.
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: prompt with no messages rejected (exit code ${EXIT_CODE})"
+else
+  echo "WARN: prompt with no messages was accepted -- verify if this is intended behavior"
+  # Cleanup
+  wanaku prompts remove --host "${WANAKU_ROUTER_URL}" --name empty-prompt 2>/dev/null || true
+fi
+```
+
+### Test 7.6: Remove non-existent prompt should fail gracefully
+
+```bash
+OUTPUT=$(wanaku prompts remove --host "${WANAKU_ROUTER_URL}" --name non-existent-prompt-99999 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: remove non-existent prompt failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: remove non-existent prompt should have returned a non-zero exit code"
+fi
+```
+
+### Test 7.7: Show non-existent resource should fail
+
+```bash
+OUTPUT=$(wanaku resources show --host "${WANAKU_ROUTER_URL}" non-existent-resource-99999 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: show non-existent resource failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "${OUTPUT}" | grep -qi "not found\|warning" \
+    && echo "PASS: show non-existent resource returned not-found message" \
+    || echo "FAIL: show non-existent resource did not fail or indicate not-found"
+fi
+```
+
+### Test 7.8: Remove non-existent resource should fail gracefully
+
+```bash
+OUTPUT=$(wanaku resources remove --host "${WANAKU_ROUTER_URL}" --name non-existent-resource-99999 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: remove non-existent resource failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: remove non-existent resource should have returned a non-zero exit code"
+fi
+```
+
+---
+
+## Phase 8: Cleanup
+
+All cleanup steps are idempotent and safe to re-run.
+
+### Step 8.1: Remove any remaining test artifacts
+
+```bash
+for TOOL in test-http-tool duplicate-tool batch-tool-1 batch-tool-2 batch-tool-3; do
+  wanaku tools remove --host "${WANAKU_ROUTER_URL}" --name "${TOOL}" 2>/dev/null || true
+done
+
+wanaku resources remove --host "${WANAKU_ROUTER_URL}" --name test-resource 2>/dev/null || true
+
+for PROMPT in test-prompt empty-prompt; do
+  wanaku prompts remove --host "${WANAKU_ROUTER_URL}" --name "${PROMPT}" 2>/dev/null || true
+done
+
+echo "PASS: test artifacts cleaned up"
+```
+
+### Step 8.2: Remove temporary files
+
+```bash
+rm -f /tmp/wanaku-test-openapi.json /tmp/wanaku-test-toolset.json
+echo "PASS: temporary files removed"
+```
+
+### Step 8.3: Stop the local Wanaku process
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+else
+  echo "PASS: no Wanaku PID to stop (may have been started externally)"
+fi
+```
+
+---
+
+## Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Verify required tools | High |
+| 1 | 1.1 | CLI connects to router | Critical |
+| 2 | 2.1 | Add a tool | Critical |
+| 2 | 2.2 | Tool appears in list | Critical |
+| 2 | 2.3 | Show tool details | Critical |
+| 2 | 2.4 | Edit tool (interactive) | Medium |
+| 2 | 2.5 | Add labels to tool | High |
+| 2 | 2.6 | Labels visible in list | High |
+| 2 | 2.7 | Remove a label from tool | High |
+| 2 | 2.8 | Remove tool | Critical |
+| 2 | 2.9 | Tool gone after removal | Critical |
+| 3 | 3.1 | Create OpenAPI spec file | High |
+| 3 | 3.2 | Generate tools from OpenAPI | High |
+| 3 | 3.3 | Import generated tools | High |
+| 3 | 3.4 | Imported tools in list | High |
+| 3 | 3.5 | Cleanup generated tools | Medium |
+| 4 | 4.1 | Expose a resource | Critical |
+| 4 | 4.2 | Resource appears in list | Critical |
+| 4 | 4.3 | Show resource details | Critical |
+| 4 | 4.4 | Add labels to resource | High |
+| 4 | 4.5 | Remove label from resource | High |
+| 4 | 4.6 | Remove resource | Critical |
+| 4 | 4.7 | Resource gone after removal | Critical |
+| 5 | 5.1 | Add a prompt | Critical |
+| 5 | 5.2 | Prompt appears in list | Critical |
+| 5 | 5.3 | Edit prompt description | High |
+| 5 | 5.4 | Prompt description updated | High |
+| 5 | 5.5 | Remove prompt | Critical |
+| 5 | 5.6 | Prompt gone after removal | Critical |
+| 6 | 6.1 | Register 3 batch tools | High |
+| 6 | 6.2 | All batch tools listed | High |
+| 6 | 6.3 | Batch remove by label | High |
+| 6 | 6.4 | All batch tools removed | High |
+| 7 | 7.1 | Duplicate tool name rejected | High |
+| 7 | 7.2 | Show non-existent tool fails | Medium |
+| 7 | 7.3 | Remove non-existent tool fails | Medium |
+| 7 | 7.4 | Resource missing required field | Medium |
+| 7 | 7.5 | Prompt with no messages | Medium |
+| 7 | 7.6 | Remove non-existent prompt fails | Medium |
+| 7 | 7.7 | Show non-existent resource fails | Medium |
+| 7 | 7.8 | Remove non-existent resource fails | Medium |
+| 8 | 8.1-8.3 | Cleanup | Critical |

--- a/tests/plans/cli-toolset-repos.md
+++ b/tests/plans/cli-toolset-repos.md
@@ -1,0 +1,462 @@
+# Test Plan: CLI Toolset Repository Commands
+
+## Overview
+
+This test plan verifies the `wanaku toolset repo` CLI commands for managing toolset repositories
+against a locally running Wanaku instance (no authentication). It covers adding, listing, browsing,
+and removing toolset repositories, as well as importing tools from a toolset file via `wanaku tools import`.
+
+Every step is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `jq` | 1.6+ | `jq --version` |
+| `curl` | any | `curl --version` |
+
+### Environment variables
+
+```bash
+export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+export TOOLSET_REPO_URL="${TOOLSET_REPO_URL:-https://github.com/wanaku-ai/wanaku-toolsets}"
+export TOOLSET_REPO_NAME="${TOOLSET_REPO_NAME:-test-repo}"
+export TOOLSET_IMPORT_URL="${TOOLSET_IMPORT_URL:-https://raw.githubusercontent.com/wanaku-ai/wanaku-toolsets/refs/heads/main/toolsets/currency.json}"
+```
+
+### CLI invocation
+
+When using the CLI from a local build (not installed), use `java -jar` directly:
+
+```bash
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+java -jar ${CLI_JAR} toolset repo list --host ...
+```
+
+Do **not** assign the full command to a single variable (e.g., `WANAKU_CLI="java -jar path/to/jar"`) — zsh treats it as a single token. Use `CLI_JAR` for the path and call `java -jar ${CLI_JAR}` explicitly.
+
+---
+
+## Phase 0: Prerequisites Verification
+
+### Test 0.1: Verify required tools are available
+
+```bash
+wanaku --version > /dev/null 2>&1 && echo "PASS: wanaku CLI available" || echo "FAIL: wanaku CLI not found"
+jq --version > /dev/null 2>&1 && echo "PASS: jq available" || echo "FAIL: jq not found"
+curl --version > /dev/null 2>&1 && echo "PASS: curl available" || echo "FAIL: curl not found"
+```
+
+### Test 0.2: Verify environment variables are set
+
+```bash
+for VAR_NAME in WANAKU_ROUTER_URL TOOLSET_REPO_URL TOOLSET_REPO_NAME TOOLSET_IMPORT_URL; do
+  eval "VAL=\${${VAR_NAME}}"
+  if [ -z "${VAL}" ]; then
+    echo "FAIL: ${VAR_NAME} is not set"
+  else
+    echo "PASS: ${VAR_NAME}=${VAL}"
+  fi
+done
+```
+
+---
+
+## Phase 1: Setup
+
+Follow [common/start-local.md](common/start-local.md) to build and start the local Wanaku stack.
+
+After completion, `WANAKU_ROUTER_URL`, `WANAKU_PID`, and `CLI_JAR` must be set.
+
+### Test 1.1: Verify router is healthy
+
+```bash
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready" 2>/dev/null || echo "000")
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "PASS: router is healthy"
+else
+  echo "FAIL: router not healthy (HTTP ${HTTP_CODE})"
+fi
+```
+
+### Test 1.2: Verify CLI can connect
+
+```bash
+wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI can connect to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+fi
+```
+
+---
+
+## Phase 2: Help and Usage
+
+### Test 2.1: Verify `wanaku toolset` shows subcommands
+
+```bash
+OUTPUT=$(wanaku toolset 2>&1)
+echo "${OUTPUT}" | grep -q "repo" && echo "PASS: 'repo' subcommand listed" || echo "FAIL: 'repo' not in usage"
+echo "${OUTPUT}" | grep -q "add" && echo "PASS: 'add' subcommand listed" || echo "FAIL: 'add' not in usage"
+```
+
+### Test 2.2: Verify `wanaku toolset repo` shows subcommands
+
+```bash
+OUTPUT=$(wanaku toolset repo 2>&1)
+echo "${OUTPUT}" | grep -q "add" && echo "PASS: 'add' subcommand listed" || echo "FAIL: 'add' not in usage"
+echo "${OUTPUT}" | grep -q "list" && echo "PASS: 'list' subcommand listed" || echo "FAIL: 'list' not in usage"
+echo "${OUTPUT}" | grep -q "remove" && echo "PASS: 'remove' subcommand listed" || echo "FAIL: 'remove' not in usage"
+echo "${OUTPUT}" | grep -q "browse" && echo "PASS: 'browse' subcommand listed" || echo "FAIL: 'browse' not in usage"
+```
+
+### Test 2.3: Verify `wanaku toolset repo add --help` shows required options
+
+```bash
+OUTPUT=$(wanaku toolset repo add --help 2>&1)
+echo "${OUTPUT}" | grep -q "\-\-name" && echo "PASS: --name option listed" || echo "FAIL: --name not in help"
+echo "${OUTPUT}" | grep -q "\-\-url" && echo "PASS: --url option listed" || echo "FAIL: --url not in help"
+echo "${OUTPUT}" | grep -q "\-\-host" && echo "PASS: --host option listed" || echo "FAIL: --host not in help"
+echo "${OUTPUT}" | grep -q "\-\-branch" && echo "PASS: --branch option listed" || echo "FAIL: --branch not in help"
+```
+
+---
+
+## Phase 3: Toolset Repo -- Add
+
+### Test 3.1: Add a toolset repository
+
+```bash
+wanaku toolset repo add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "${TOOLSET_REPO_NAME}" \
+  --url "${TOOLSET_REPO_URL}" \
+  --description "Test toolset repository" \
+  --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset repository '${TOOLSET_REPO_NAME}' added successfully"
+else
+  echo "FAIL: failed to add toolset repository (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 3.2: Add a second toolset repository with a custom branch
+
+```bash
+wanaku toolset repo add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "test-repo-branch" \
+  --url "${TOOLSET_REPO_URL}" \
+  --branch "main" \
+  --description "Test repo with explicit branch" \
+  --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset repository 'test-repo-branch' added with explicit branch"
+else
+  echo "FAIL: failed to add toolset repository with branch (exit code ${EXIT_CODE})"
+fi
+```
+
+---
+
+## Phase 4: Toolset Repo -- List
+
+### Test 4.1: List toolset repositories and verify test-repo appears
+
+```bash
+OUTPUT=$(wanaku toolset repo list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: toolset repo list failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "${OUTPUT}" | grep -q "${TOOLSET_REPO_NAME}" \
+    && echo "PASS: '${TOOLSET_REPO_NAME}' appears in repo list" \
+    || echo "FAIL: '${TOOLSET_REPO_NAME}' not found in repo list"
+
+  echo "${OUTPUT}" | grep -q "test-repo-branch" \
+    && echo "PASS: 'test-repo-branch' appears in repo list" \
+    || echo "FAIL: 'test-repo-branch' not found in repo list"
+fi
+```
+
+### Test 4.2: List output contains the repository URL
+
+```bash
+OUTPUT=$(wanaku toolset repo list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "${TOOLSET_REPO_URL}" \
+  && echo "PASS: repository URL appears in list output" \
+  || echo "FAIL: repository URL not found in list output"
+```
+
+---
+
+## Phase 5: Toolset Repo -- Browse
+
+### Test 5.1: Browse the test repository catalog
+
+**Note:** The `browse` command takes the repository name as a positional argument, not `--name`.
+
+```bash
+OUTPUT=$(wanaku toolset repo browse --host "${WANAKU_ROUTER_URL}" "${TOOLSET_REPO_NAME}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: toolset repo browse failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+else
+  echo "PASS: toolset repo browse succeeded"
+  echo "Catalog contents:"
+  echo "${OUTPUT}"
+fi
+```
+
+### Test 5.2: Browse output contains repository metadata
+
+```bash
+OUTPUT=$(wanaku toolset repo browse --host "${WANAKU_ROUTER_URL}" "${TOOLSET_REPO_NAME}" --plain 2>&1)
+echo "${OUTPUT}" | grep -qi "toolset" \
+  && echo "PASS: browse output contains toolset entries" \
+  || echo "FAIL: browse output does not contain toolset entries"
+```
+
+---
+
+## Phase 6: Toolset Repo -- Remove
+
+### Test 6.1: Remove the second test repository
+
+**Note:** The `remove` command takes the repository name as a positional argument, not `--name`.
+
+```bash
+wanaku toolset repo remove --host "${WANAKU_ROUTER_URL}" "test-repo-branch" --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset repository 'test-repo-branch' removed"
+else
+  echo "FAIL: failed to remove toolset repository (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 6.2: Verify the removed repository no longer appears in list
+
+```bash
+OUTPUT=$(wanaku toolset repo list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "test-repo-branch" \
+  && echo "FAIL: 'test-repo-branch' still appears after removal" \
+  || echo "PASS: 'test-repo-branch' no longer in list"
+```
+
+### Test 6.3: Remove the primary test repository
+
+```bash
+wanaku toolset repo remove --host "${WANAKU_ROUTER_URL}" "${TOOLSET_REPO_NAME}" --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset repository '${TOOLSET_REPO_NAME}' removed"
+else
+  echo "FAIL: failed to remove toolset repository (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 6.4: Verify list is empty (or no longer contains test-repo)
+
+```bash
+OUTPUT=$(wanaku toolset repo list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+echo "${OUTPUT}" | grep -q "${TOOLSET_REPO_NAME}" \
+  && echo "FAIL: '${TOOLSET_REPO_NAME}' still appears after removal" \
+  || echo "PASS: '${TOOLSET_REPO_NAME}' no longer in list"
+```
+
+---
+
+## Phase 7: Tools Import from Toolset
+
+### Test 7.1: Import tools from a remote toolset URL
+
+```bash
+wanaku tools import --host "${WANAKU_ROUTER_URL}" "${TOOLSET_IMPORT_URL}" --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset imported from URL"
+else
+  echo "FAIL: toolset import failed (exit code ${EXIT_CODE})"
+fi
+```
+
+### Test 7.2: Verify imported tools appear in tools list
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list failed (exit code ${EXIT_CODE})"
+else
+  # The currency toolset should contain at least one tool
+  if [ -n "${OUTPUT}" ]; then
+    echo "PASS: tools list returned data after import"
+    echo "${OUTPUT}"
+  else
+    echo "FAIL: tools list is empty after import"
+  fi
+fi
+```
+
+### Test 7.3: Import with a default namespace
+
+```bash
+wanaku tools import \
+  --host "${WANAKU_ROUTER_URL}" \
+  --namespace "test-ns" \
+  "${TOOLSET_IMPORT_URL}" \
+  --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: toolset imported with namespace override"
+else
+  echo "FAIL: toolset import with namespace failed (exit code ${EXIT_CODE})"
+fi
+```
+
+---
+
+## Phase 8: Negative Tests
+
+### Test 8.1: Add repo without required --name should fail
+
+```bash
+wanaku toolset repo add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --url "${TOOLSET_REPO_URL}" \
+  --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --name should have failed"
+fi
+```
+
+### Test 8.2: Add repo without required --url should fail
+
+```bash
+wanaku toolset repo add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name "no-url-repo" \
+  --plain 2>&1
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: missing --url rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: missing --url should have failed"
+fi
+```
+
+### Test 8.3: Browse a non-existent repository should fail
+
+```bash
+OUTPUT=$(wanaku toolset repo browse --host "${WANAKU_ROUTER_URL}" "non-existent-repo-12345" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: browse non-existent repo failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: browse non-existent repo should have failed"
+fi
+```
+
+### Test 8.4: Remove a non-existent repository should fail gracefully
+
+```bash
+OUTPUT=$(wanaku toolset repo remove --host "${WANAKU_ROUTER_URL}" "non-existent-repo-12345" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: remove non-existent repo failed gracefully (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}" | grep -qi "not found" \
+    && echo "PASS: error message mentions 'not found'" \
+    || echo "WARN: error message does not mention 'not found'"
+else
+  echo "FAIL: remove non-existent repo should have failed"
+fi
+```
+
+### Test 8.5: Import from an invalid URL should fail
+
+```bash
+OUTPUT=$(wanaku tools import --host "${WANAKU_ROUTER_URL}" "https://invalid.example.com/does-not-exist.json" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: import from invalid URL failed as expected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: import from invalid URL should have failed"
+fi
+```
+
+### Test 8.6: Connecting to a non-existent host should fail gracefully
+
+```bash
+OUTPUT=$(wanaku toolset repo list --host "http://localhost:59999" --plain 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: connection to non-existent host failed gracefully (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: connection to non-existent host should have failed"
+fi
+```
+
+---
+
+## Phase 9: Cleanup
+
+### Step 9.1: Remove any remaining test repositories
+
+```bash
+wanaku toolset repo remove --host "${WANAKU_ROUTER_URL}" "${TOOLSET_REPO_NAME}" --plain 2>/dev/null || true
+wanaku toolset repo remove --host "${WANAKU_ROUTER_URL}" "test-repo-branch" --plain 2>/dev/null || true
+echo "PASS: test repositories cleaned up"
+```
+
+### Step 9.2: Remove any imported tools
+
+```bash
+# List and remove tools that were imported during this test
+TOOLS_OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
+# Remove tools by name if they were imported from the currency toolset
+# This is best-effort; specific tool names depend on the toolset contents
+echo "INFO: review tools list for any test artifacts to remove manually"
+echo "${TOOLS_OUTPUT}"
+```
+
+### Step 9.3: Stop the local Wanaku process
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+fi
+```
+
+---
+
+## Test Summary Matrix
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1-0.2 | Prerequisites verification | Critical |
+| 1 | 1.1-1.2 | Local setup and health check | Critical |
+| 2 | 2.1-2.3 | Help and usage output | Medium |
+| 3 | 3.1-3.2 | Add toolset repositories | Critical |
+| 4 | 4.1-4.2 | List toolset repositories | Critical |
+| 5 | 5.1-5.2 | Browse toolset repository catalog | Critical |
+| 6 | 6.1-6.4 | Remove toolset repositories | Critical |
+| 7 | 7.1-7.3 | Import tools from toolset URL | High |
+| 8 | 8.1-8.6 | Negative tests (missing args, non-existent repos, bad URLs) | High |
+| 9 | 9.1-9.3 | Cleanup | Critical |

--- a/tests/plans/common/start-local.md
+++ b/tests/plans/common/start-local.md
@@ -1,0 +1,105 @@
+# Common: Start Wanaku Locally
+
+Reusable steps for building and starting a Wanaku stack locally (no authentication, no Kubernetes).
+
+## Prerequisites
+
+- Java 21+
+- Maven 3.9+
+- The Wanaku repository checked out and at the repo root
+
+## Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `WANAKU_REPO_ROOT` | Path to the Wanaku repository root | `.` |
+
+## Output variables
+
+| Variable | Description |
+|----------|-------------|
+| `VERSION` | Wanaku version string from the build |
+| `CLI_JAR` | Path to the CLI JAR |
+| `WANAKU_ROUTER_URL` | Router base URL (`http://localhost:8080`) |
+| `WANAKU_PID` | PID of the background Wanaku process |
+
+## Steps
+
+### 1. Build the distribution
+
+```bash
+cd "${WANAKU_REPO_ROOT:-.}"
+mvn -DskipTests -Pdist clean package
+```
+
+**Verification:**
+
+```bash
+VERSION=$(cat core/core-util/target/classes/version.txt)
+CLI_JAR="apps/wanaku-cli/target/quarkus-app/quarkus-run.jar"
+ROUTER_DIST="apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${VERSION}.zip"
+HTTP_TOOL_DIST="capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${VERSION}.zip"
+
+for FILE in "${CLI_JAR}" "${ROUTER_DIST}" "${HTTP_TOOL_DIST}"; do
+  if [ ! -f "${FILE}" ]; then
+    echo "FAIL: ${FILE} not found"
+    exit 1
+  fi
+  echo "PASS: ${FILE} exists"
+done
+```
+
+### 2. Start the local stack
+
+```bash
+java -jar "${CLI_JAR}" start local \
+  --local-dist "${ROUTER_DIST}" \
+  --local-dist "${HTTP_TOOL_DIST}" &
+WANAKU_PID=$!
+echo "Wanaku started with PID ${WANAKU_PID}"
+```
+
+### 3. Wait for health
+
+```bash
+export WANAKU_ROUTER_URL="http://localhost:8080"
+
+MAX_RETRIES=30
+RETRY_INTERVAL=5
+for i in $(seq 1 ${MAX_RETRIES}); do
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready" 2>/dev/null || echo "000")
+  if [ "${HTTP_CODE}" = "200" ]; then
+    echo "PASS: router is healthy (attempt ${i})"
+    break
+  fi
+  if [ "${i}" -eq "${MAX_RETRIES}" ]; then
+    echo "FAIL: router not healthy after ${MAX_RETRIES} attempts (last HTTP ${HTTP_CODE})"
+    kill "${WANAKU_PID}" 2>/dev/null || true
+    exit 1
+  fi
+  sleep ${RETRY_INTERVAL}
+done
+```
+
+### 4. Verify the CLI can connect
+
+```bash
+wanaku tools list --host "${WANAKU_ROUTER_URL}" --plain
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: CLI can connect to router"
+else
+  echo "FAIL: CLI cannot connect to router (exit code ${EXIT_CODE})"
+  exit 1
+fi
+```
+
+## Shutdown
+
+```bash
+if [ -n "${WANAKU_PID}" ]; then
+  kill "${WANAKU_PID}" 2>/dev/null || true
+  wait "${WANAKU_PID}" 2>/dev/null || true
+  echo "PASS: Wanaku process stopped"
+fi
+```

--- a/tests/plans/ui-extended-pages.md
+++ b/tests/plans/ui-extended-pages.md
@@ -1,0 +1,664 @@
+# Test Plan: Extended UI Page Tests
+
+## Overview
+
+This test plan describes Playwright e2e tests for Wanaku admin UI pages that are not covered by the basic UI test suite. It targets: Forwards, Data Stores, Namespaces, Service Catalog, Targets (Capabilities), Tool Call Debugger, and cross-page Navigation.
+
+The basic UI tests (`basic-ui-test.md`) cover Dashboard, Tools, Resources, and Prompts. This plan extends coverage to the remaining pages.
+
+Every scenario is described in Playwright terms (navigate, click, fill, assert) and is fully automatable.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Verify command |
+|------|-----------------|----------------|
+| `node` | 18+ | `node --version` |
+| `yarn` | 1.22+ | `yarn --version` |
+| `npx` | any | `npx --version` |
+| `curl` | any | `curl --version` |
+
+### Prerequisite check
+
+```bash
+node --version || { echo "FAIL: node not found"; exit 1; }
+yarn --version || { echo "FAIL: yarn not found"; exit 1; }
+npx --version || { echo "FAIL: npx not found"; exit 1; }
+curl --version > /dev/null || { echo "FAIL: curl not found"; exit 1; }
+echo "PASS: all prerequisites met"
+```
+
+### Environment variables
+
+```bash
+export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WANAKU_ROUTER_URL` | `http://localhost:8080` | Base URL of the Wanaku router (no trailing slash) |
+
+### Remote instance requirements
+
+The router at `WANAKU_ROUTER_URL` must:
+- Be running and healthy (`/q/health/ready` returns 200)
+- Have auth disabled (`WANAKU_HTTP_AUTH=none`) or the test user must be authenticated
+- Serve the admin UI at `/admin/`
+
+---
+
+## Phase 0: Verify Router Connectivity
+
+### Test 0.1: Router health check
+
+```bash
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${WANAKU_ROUTER_URL}/q/health/ready")
+if [ "${HTTP_STATUS}" -eq 200 ]; then
+  echo "PASS: router healthy at ${WANAKU_ROUTER_URL}"
+else
+  echo "FAIL: router not reachable (HTTP ${HTTP_STATUS})"
+  exit 1
+fi
+```
+
+### Test 0.2: Install dependencies and Playwright browser
+
+```bash
+cd tests/e2e/ui
+yarn install && npx playwright install chromium
+if [ $? -eq 0 ]; then
+  echo "PASS: dependencies and browser installed"
+else
+  echo "FAIL: installation failed"
+  exit 1
+fi
+```
+
+---
+
+## Phase 1: Forwards Page
+
+**Route:** `#/forwards`
+**Page title:** "Forwards"
+**Page description contains:** "A list of forwards registered in the system"
+
+### Test 1.1: Forwards page loads with title and description
+
+**Spec file:** `forwards.spec.ts`
+
+1. Navigate to `#/forwards` via `BasePage.navigateTo('/forwards')`.
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` text is `"Forwards"`.
+4. Assert `p.description` text contains `"forwards registered"`.
+5. Assert the DataTable container is visible.
+
+### Test 1.2: Empty state is displayed when no forwards exist
+
+1. Navigate to `#/forwards`.
+2. If no forwards exist, assert empty state text `"Start by adding forwards"` is visible in the table body.
+
+### Test 1.3: Add a forward via modal
+
+1. Navigate to `#/forwards`.
+2. Click the `"Add Forward"` toolbar button.
+3. Assert modal opens with heading `"Add a Forward"`.
+4. Fill `#forward-name` with a unique name (e.g., `e2e-forward-<timestamp>`).
+5. Fill `#forward-address` with `http://localhost:9090`.
+6. Optionally select a namespace from the `NamespaceSelect` dropdown.
+7. Assert primary button (`"Add"`) is enabled.
+8. Click the primary button to submit.
+9. Assert modal closes.
+10. Assert a table row containing the forward name appears.
+
+### Test 1.4: Edit a forward via modal
+
+1. Seed a forward via API (`POST /api/v1/forwards`).
+2. Navigate to `#/forwards`.
+3. Locate the row with the seeded forward name.
+4. Click the `"Edit"` icon button (ghost button with Edit icon) in that row.
+5. Assert modal opens with heading `"Edit forward"`.
+6. Assert `#forward-name` is pre-filled with the existing name.
+7. Assert `#forward-address` is pre-filled with the existing address.
+8. Change `#forward-address` to `http://localhost:9999`.
+9. Click the `"Save"` primary button.
+10. Assert modal closes.
+11. Assert the row now shows the updated address.
+
+### Test 1.5: Delete a forward
+
+1. Seed a forward via API.
+2. Navigate to `#/forwards`.
+3. Locate the row with the seeded forward name.
+4. Click the `"Delete"` icon button (ghost button with TrashCan icon) in that row.
+5. Assert the row with that forward name disappears from the table.
+
+### Test 1.6: Refresh a forward
+
+1. Seed a forward via API.
+2. Navigate to `#/forwards`.
+3. Locate the row with the seeded forward name.
+4. Click the `"Refresh"` icon button (ghost button with Renew icon) in that row.
+5. Assert no error notification appears.
+6. Assert the row is still present.
+
+### Test 1.7: Primary button is disabled when required fields are empty
+
+1. Navigate to `#/forwards`.
+2. Click `"Add Forward"`.
+3. Assert the primary button (`"Add"`) is disabled.
+4. Fill only `#forward-name` -- assert primary button is still disabled.
+5. Clear `#forward-name`, fill only `#forward-address` -- assert primary button is still disabled.
+6. Fill both fields -- assert primary button is enabled.
+7. Cancel the modal.
+
+**Cleanup:** Each test must delete any forwards it created, either via `afterEach` API cleanup or inline deletion.
+
+---
+
+## Phase 2: Data Stores Page
+
+**Route:** `#/data-stores`
+**Page title:** "Data Stores"
+**Page description contains:** "Manage stored data files"
+
+### Test 2.1: Data Stores page loads with title and description
+
+**Spec file:** `data-stores.spec.ts`
+
+1. Navigate to `#/data-stores`.
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` text is `"Data Stores"`.
+4. Assert `p.description` text contains `"Manage stored data files"`.
+
+### Test 2.2: Empty state message when no data stores exist
+
+1. Navigate to `#/data-stores`.
+2. If no data stores exist, assert the table body shows `"No data stores found"`.
+
+### Test 2.3: Add a data store via file upload modal
+
+1. Navigate to `#/data-stores`.
+2. Click the `"Add Data Store"` toolbar button.
+3. Assert modal opens with heading `"Add Data Store"`.
+4. Assert `#datastore-name` input is present with placeholder `"e.g. config.yaml"`.
+5. Assert the file input (`#file-input`) is present.
+6. Use Playwright's `setInputFiles` on the file input to upload a small test file (e.g., a text file with content `"e2e-test-data"`).
+7. Assert the `"Selected: ..."` indicator appears showing the file name and size.
+8. Assert the name field auto-fills with the file name (if it was empty).
+9. Click `"Upload"` primary button.
+10. Assert modal closes.
+11. Assert a table row appears with the data store name.
+12. Assert the row shows columns: ID, Name, Data (Base64 truncated).
+
+### Test 2.4: View a data store via modal
+
+1. Seed a data store via API.
+2. Navigate to `#/data-stores`.
+3. Click the `"View"` icon button for the seeded data store.
+4. Assert a passive modal opens with heading containing `"View Data Store:"` and the data store name.
+5. Assert the modal displays `ID`, `Name`, and `Contents` sections.
+6. Assert the decoded content is visible in a `<pre>` block.
+7. Close the modal.
+
+### Test 2.5: Delete a data store
+
+1. Seed a data store via API.
+2. Navigate to `#/data-stores`.
+3. Click the `"Delete"` icon button for the seeded data store.
+4. Assert the row disappears from the table.
+
+### Test 2.6: Submit without selecting a file shows error
+
+1. Navigate to `#/data-stores`.
+2. Click `"Add Data Store"`.
+3. Click `"Upload"` without selecting a file.
+4. Assert the error text `"Please select a file to upload"` appears inside the modal.
+5. Cancel the modal.
+
+**Cleanup:** Each test must delete any data stores it created via API in `afterEach`.
+
+---
+
+## Phase 3: Namespaces Page
+
+**Route:** `#/namespaces`
+**Page title:** "Namespaces"
+**Page description contains:** "Namespaces help organize and isolate tools and resources"
+
+### Test 3.1: Namespaces page loads with title and description
+
+**Spec file:** `namespaces.spec.ts`
+
+1. Navigate to `#/namespaces`.
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` text is `"Namespaces"`.
+4. Assert `p.description` text contains `"Namespaces help organize"`.
+
+### Test 3.2: Default namespaces are present
+
+1. Navigate to `#/namespaces`.
+2. Assert the table has columns: ID, Name, Path, Status, Actions.
+3. Assert at least one row with path `"default"` exists.
+4. Assert rows with protected paths (`"default"`, `"public"`, `"wanaku-internal"`) have disabled Edit and Delete buttons.
+
+### Test 3.3: Create a namespace via modal
+
+1. Navigate to `#/namespaces`.
+2. Click the `"Create Namespace"` toolbar button.
+3. Assert modal opens with heading `"Create Namespace"`.
+4. Fill `#namespace-name` with a unique name (e.g., `e2e-ns-<timestamp>`).
+5. Fill `#namespace-path` with a unique path (e.g., `ns-e2e-<timestamp>`).
+6. Assert primary button (`"Create"`) is enabled.
+7. Click `"Create"`.
+8. Assert modal closes.
+9. Assert a table row with the namespace name and path appears.
+10. Assert the status column shows `"Allocated"` for the new namespace.
+
+### Test 3.4: Edit a namespace via modal
+
+1. Create a namespace via API or via the UI (from Test 3.3).
+2. Navigate to `#/namespaces`.
+3. Click the `"Edit"` icon button for the created namespace.
+4. Assert modal opens with heading `"Edit Namespace"`.
+5. Assert `#namespace-path` is disabled (path cannot be changed after creation).
+6. Change `#namespace-name` to a new value.
+7. Click `"Save"`.
+8. Assert modal closes.
+9. Assert the row now shows the updated name.
+
+### Test 3.5: Delete a namespace
+
+1. Create a namespace (non-protected).
+2. Navigate to `#/namespaces`.
+3. Click the `"Delete"` icon button for the created namespace.
+4. Assert the row disappears or reverts to `"Available"` status.
+
+### Test 3.6: Duplicate name validation
+
+1. Navigate to `#/namespaces`.
+2. Note the name of an existing allocated namespace.
+3. Click `"Create Namespace"`.
+4. Type the existing namespace name into `#namespace-name`.
+5. Assert the field shows invalid state with text containing `"already in use"`.
+6. Assert the primary button is disabled.
+7. Cancel the modal.
+
+### Test 3.7: Duplicate path validation
+
+1. Navigate to `#/namespaces`.
+2. Click `"Create Namespace"`.
+3. Type an existing path (e.g., `"default"`) into `#namespace-path`.
+4. Assert the field shows invalid state with text containing `"already in use"`.
+5. Assert the primary button is disabled.
+6. Cancel the modal.
+
+### Test 3.8: Expandable row shows labels
+
+1. If a namespace has labels, assert the expand chevron is present.
+2. Click the expand button.
+3. Assert the expanded row shows a `"Labels:"` heading and `<li>` items.
+
+**Cleanup:** Each test must delete any namespaces it created via API in `afterEach`.
+
+---
+
+## Phase 4: Service Catalog Page
+
+**Route:** `#/service-catalog`
+**Page title:** "Service Catalog"
+**Page description contains:** "View and manage deployed service catalogs"
+
+### Test 4.1: Service Catalog page loads with tabs
+
+**Spec file:** `service-catalog.spec.ts`
+
+1. Navigate to `#/service-catalog`.
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` text is `"Service Catalog"`.
+4. Assert `p.description` text contains `"View and manage"`.
+5. Assert three tabs are visible: `"Service Catalogs"`, `"Service Templates"`, `"Toolset Repositories"`.
+6. Assert the `"Service Catalogs"` tab is active by default.
+
+### Test 4.2: Service Catalogs tab -- empty state
+
+1. Navigate to `#/service-catalog`.
+2. If no catalogs exist, assert the empty tile displays `"No service catalogs found"`.
+3. Assert the CLI hint `"wanaku service init"` is shown.
+
+### Test 4.3: Service Catalogs tab -- search bar present
+
+1. Navigate to `#/service-catalog`.
+2. Assert the search input with placeholder `"Search service catalogs..."` is visible.
+
+### Test 4.4: Service Catalogs tab -- catalog card structure (if catalogs exist)
+
+1. Navigate to `#/service-catalog`.
+2. If catalogs exist, assert each card tile shows:
+   - Catalog name in an `h4`.
+   - Description text.
+   - Service tags (blue `Tag` components).
+   - A `"Deploy"` button.
+   - A `"View details"` / `"Hide details"` toggle button.
+   - A delete icon button.
+
+### Test 4.5: Service Catalogs tab -- expand card details
+
+1. If a catalog exists, click `"View details"` on the first card.
+2. Assert the expanded section shows system details with routes and rules file names.
+3. Click `"Hide details"`.
+4. Assert the details section is hidden.
+
+### Test 4.6: Service Catalogs tab -- delete confirmation modal
+
+1. If a catalog exists, click the delete icon button on a card.
+2. Assert a danger modal opens with heading `"Delete Service Catalog"`.
+3. Assert the modal body contains the catalog name and `"cannot be undone"`.
+4. Click `"Cancel"`.
+5. Assert the modal closes and the card is still present.
+
+### Test 4.7: Service Catalogs tab -- deploy wizard
+
+1. If a catalog exists, click `"Deploy"` on a card.
+2. Assert the `ComposedModal` wizard opens with title containing `"Deploy:"`.
+3. Assert a `ProgressIndicator` shows two steps: `"Deployment Model"` and `"Instructions"`.
+4. Assert three radio buttons are shown: `"Local (java -jar)"`, `"Docker / Podman"`, `"Kubernetes / OpenShift"`.
+5. Assert `"Local (java -jar)"` is selected by default.
+6. Click `"Next"`.
+7. Wait for loading to finish.
+8. Assert step 2 shows deployment instructions with a `CodeSnippet`.
+9. Click `"Back"` and assert step 1 is shown again.
+10. Click `"Next"` again, then `"Done"`.
+11. Assert the wizard closes.
+
+### Test 4.8: Service Templates tab -- loads
+
+1. Navigate to `#/service-catalog`.
+2. Click the `"Service Templates"` tab.
+3. Wait for `Loading...` to disappear.
+4. Assert either template cards are visible or the empty tile shows `"No service templates found"`.
+
+### Test 4.9: Service Templates tab -- search bar present
+
+1. Click the `"Service Templates"` tab.
+2. Assert the search input with placeholder `"Search service templates..."` is visible.
+
+### Test 4.10: Service Templates tab -- template card structure (if templates exist)
+
+1. If templates exist, assert each card shows:
+   - Template name in an `h4`.
+   - Description text.
+   - Service tags (purple `Tag` components).
+   - A `"Parameterized"` green tag if `hasProperties` is true.
+   - A `"Create Service Catalog"` button.
+   - A `"View details"` toggle button.
+
+### Test 4.11: Service Templates tab -- instantiate wizard
+
+1. If a template exists, click `"Create Service Catalog"` on a card.
+2. Assert the `ComposedModal` wizard opens with title containing `"Create Service Catalog from Template"`.
+3. Assert `#service-name` and `#service-system` text inputs are present.
+4. If the template has properties, assert property input fields are rendered with labels.
+5. Click `"Cancel"`.
+6. Assert the wizard closes.
+
+### Test 4.12: Toolset Repositories tab -- loads
+
+1. Navigate to `#/service-catalog`.
+2. Click the `"Toolset Repositories"` tab.
+3. Wait for loading to finish.
+4. Assert either repository cards are visible or the empty tile shows `"No toolset repositories registered"`.
+
+### Test 4.13: Toolset Repositories tab -- add repository modal
+
+1. Click the `"Toolset Repositories"` tab.
+2. Click `"Add Repository"`.
+3. Assert modal opens with heading `"Add Toolset Repository"`.
+4. Assert inputs: `#repo-name`, `#repo-url`, `#repo-branch`, `#repo-description` are present.
+5. Assert primary button is disabled when name or URL is empty.
+6. Fill `#repo-name` with `e2e-repo-<timestamp>`.
+7. Fill `#repo-url` with `https://github.com/example/repo`.
+8. Assert primary button is enabled.
+9. Click `"Cancel"`.
+10. Assert modal closes.
+
+### Test 4.14: Toolset Repositories tab -- delete confirmation
+
+1. If a repository exists, click the delete icon button.
+2. Assert a danger modal opens with heading `"Delete Toolset Repository"`.
+3. Assert the body mentions the repository name and notes that previously imported tools are not removed.
+4. Click `"Cancel"`.
+5. Assert the modal closes.
+
+**Note:** Tests 4.4-4.7 and 4.10-4.11 require pre-existing catalogs or templates. If the router has none, these tests should be skipped gracefully using `test.skip()` with a descriptive message.
+
+---
+
+## Phase 5: Targets (Capabilities) Page
+
+**Route:** `#/capabilities`
+**Page title:** "Capabilities"
+**Page description contains:** "connected to Wanaku"
+
+### Test 5.1: Targets page loads with title and description
+
+**Spec file:** `targets.spec.ts`
+
+1. Navigate to `#/capabilities`.
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` text is `"Capabilities"`.
+4. Assert `p.description` text contains `"connected to Wanaku"`.
+
+### Test 5.2: Table structure is correct
+
+1. Navigate to `#/capabilities`.
+2. Assert the DataTable has headers: `"Service"`, `"Service Type"`, `"Host"`, `"Port"`, `"Status"`, `"Last Seen"`, `"Reason"`.
+3. Assert the table has the correct `aria-label` of `"Targets table"`.
+
+### Test 5.3: Empty state when no capabilities are registered
+
+1. If no capability services are running, assert the empty state component is visible in the table body.
+
+### Test 5.4: Capability rows display status (if capabilities exist)
+
+1. If capabilities are registered, assert each row shows:
+   - A service name.
+   - A service type value.
+   - A host value.
+   - A port value.
+   - A status value (one of: `"Healthy"`, `"Down"`, `"Pending"`, or similar capitalized format).
+   - A last-seen timestamp.
+
+### Test 5.5: No error notification on page load
+
+1. Navigate to `#/capabilities`.
+2. Assert no error toast notification (`.cds--toast-notification--error`) is visible.
+
+**Note:** The Targets page is read-only -- there are no add/edit/delete operations. SSE connectivity is tested implicitly: if the page loads and shows status values, SSE was established. Explicit SSE testing (mocking EventSource events) is out of scope for this plan but could be added as a follow-up.
+
+---
+
+## Phase 6: Tool Call Debugger Page
+
+**Route:** `#/tool-calls`
+**Page title:** "Tool Call Debugger"
+**Page description contains:** "Real-time monitoring and debugging"
+
+### Test 6.1: Tool Call Debugger page loads with title and description
+
+**Spec file:** `tool-calls.spec.ts`
+
+1. Navigate to `#/tool-calls`.
+2. Assert `h1.title` text is `"Tool Call Debugger"`.
+3. Assert `p.description` text contains `"Real-time monitoring and debugging"`.
+
+### Test 6.2: Filter controls are present
+
+1. Navigate to `#/tool-calls`.
+2. Assert two `Search` inputs are visible:
+   - One with placeholder `"Filter by Connection ID"`.
+   - One with placeholder `"Filter by Tool Name"`.
+3. Assert a `<select>` dropdown for error category filtering is present with option `"All Error Categories"`.
+
+### Test 6.3: Action buttons are present
+
+1. Navigate to `#/tool-calls`.
+2. Assert the `"Clear Events"` button (danger style with TrashCan icon) is visible.
+3. Assert the `"Export to JSON"` button (tertiary style with Download icon) is visible.
+4. Assert the auto-scroll toggle is visible with label `"Auto-scroll to latest"`.
+
+### Test 6.4: Empty state when no events exist
+
+1. Navigate to `#/tool-calls`.
+2. Assert the empty message `"No tool call events yet"` is visible.
+3. Assert the event count text shows `"Showing 0 of 0 events"`.
+
+### Test 6.5: Clear events button works
+
+1. Navigate to `#/tool-calls`.
+2. Click `"Clear Events"`.
+3. Assert the empty state message is still visible (no crash, no error).
+
+### Test 6.6: Auto-scroll toggle works
+
+1. Navigate to `#/tool-calls`.
+2. Locate the toggle `#auto-scroll-toggle`.
+3. Assert it is toggled on by default.
+4. Click the toggle to turn it off.
+5. Assert it is now toggled off.
+6. Click again to re-enable.
+7. Assert it is toggled on.
+
+**Note:** Testing actual SSE event rendering requires a running tool invocation or SSE mock. This is out of scope for this plan. If SSE events are present, the accordion-based event detail view should be verified as a follow-up.
+
+---
+
+## Phase 7: Navigation
+
+### Test 7.1: Sidebar links navigate to correct pages
+
+**Spec file:** `navigation.spec.ts`
+
+For each sidebar link, click it and verify the correct page loads:
+
+| Sidebar Label | Expected Route | Expected Page Title |
+|---------------|----------------|---------------------|
+| Home | `#/` | `Dashboard` |
+| Tools | `#/tools` | `Tools` |
+| Resources | `#/resources` | `Resources` |
+| Prompts | `#/prompts` | `Prompts` |
+| Capabilities | `#/capabilities` | `Capabilities` |
+| Namespaces | `#/namespaces` | `Namespaces` |
+| Forwards | `#/forwards` | `Forwards` |
+| Service Catalog | `#/service-catalog` | `Service Catalog` |
+
+Developer submenu items (require expanding the `"Developer"` menu first):
+
+| Sidebar Label | Expected Route | Expected Page Title |
+|---------------|----------------|---------------------|
+| Tool Call Debugger | `#/tool-calls` | `Tool Call Debugger` |
+| Data Stores | `#/data-stores` | `Data Stores` |
+
+1. For each entry above, click the sidebar link (expanding the Developer menu if needed).
+2. Wait for `Loading...` to disappear.
+3. Assert `h1.title` matches the expected page title.
+4. Assert the URL hash matches the expected route.
+
+### Test 7.2: Developer submenu expands and collapses
+
+1. Locate the `"Developer"` SideNavMenu item.
+2. Click to expand it.
+3. Assert subitems `"LLMChat"`, `"Code Execution"`, `"Tool Call Debugger"`, `"Data Stores"` are visible.
+4. Click to collapse it.
+5. Assert subitems are hidden.
+
+---
+
+## Page Object and Helper Guidance
+
+### New page objects to create
+
+| Page Object | File | Base Class |
+|-------------|------|------------|
+| `ForwardsPage` | `pages/forwards.page.ts` | `BasePage` |
+| `DataStoresPage` | `pages/data-stores.page.ts` | `BasePage` |
+| `NamespacesPage` | `pages/namespaces.page.ts` | `BasePage` |
+| `ServiceCatalogPage` | `pages/service-catalog.page.ts` | `BasePage` |
+| `TargetsPage` | `pages/targets.page.ts` | `BasePage` |
+| `ToolCallsPage` | `pages/tool-calls.page.ts` | `BasePage` |
+
+### New API helpers to add
+
+Extend `ApiHelper` in `helpers/api-helpers.ts` with:
+
+- `addForward(forward)` -- `POST /api/v1/forwards`
+- `deleteForward(name)` -- `DELETE /api/v1/forwards/{name}`
+- `addDataStore(dataStore)` -- `POST /api/v1/data-stores`
+- `deleteDataStore(id)` -- `DELETE /api/v1/data-stores/{id}`
+- `createNamespace(namespace)` -- `POST /api/v1/namespaces`
+- `deleteNamespace(id)` -- `DELETE /api/v1/namespaces/{id}`
+
+### New test data helpers to add
+
+Extend `helpers/test-data.ts` with:
+
+- `forwardData()` -- returns `{ name, address }` with unique suffix
+- `dataStoreData()` -- returns `{ name }` with unique suffix
+- `namespaceData()` -- returns `{ name, path }` with unique suffix
+
+---
+
+## Test Summary
+
+| Phase | Test ID | Test Name | Priority |
+|-------|---------|-----------|----------|
+| 0 | 0.1 | Router health check | Critical |
+| 0 | 0.2 | Install dependencies and browser | Critical |
+| 1 | 1.1 | Forwards page loads with title and description | High |
+| 1 | 1.2 | Empty state when no forwards exist | Medium |
+| 1 | 1.3 | Add a forward via modal | Critical |
+| 1 | 1.4 | Edit a forward via modal | Critical |
+| 1 | 1.5 | Delete a forward | Critical |
+| 1 | 1.6 | Refresh a forward | Medium |
+| 1 | 1.7 | Primary button disabled when fields empty | Medium |
+| 2 | 2.1 | Data Stores page loads with title and description | High |
+| 2 | 2.2 | Empty state when no data stores exist | Medium |
+| 2 | 2.3 | Add a data store via file upload | Critical |
+| 2 | 2.4 | View a data store via modal | High |
+| 2 | 2.5 | Delete a data store | Critical |
+| 2 | 2.6 | Submit without file shows error | Medium |
+| 3 | 3.1 | Namespaces page loads with title and description | High |
+| 3 | 3.2 | Default namespaces are present | High |
+| 3 | 3.3 | Create a namespace via modal | Critical |
+| 3 | 3.4 | Edit a namespace via modal | Critical |
+| 3 | 3.5 | Delete a namespace | Critical |
+| 3 | 3.6 | Duplicate name validation | Medium |
+| 3 | 3.7 | Duplicate path validation | Medium |
+| 3 | 3.8 | Expandable row shows labels | Medium |
+| 4 | 4.1 | Service Catalog page loads with tabs | High |
+| 4 | 4.2 | Service Catalogs tab -- empty state | Medium |
+| 4 | 4.3 | Service Catalogs tab -- search bar | Medium |
+| 4 | 4.4 | Service Catalogs tab -- card structure | High |
+| 4 | 4.5 | Service Catalogs tab -- expand details | Medium |
+| 4 | 4.6 | Service Catalogs tab -- delete confirmation | High |
+| 4 | 4.7 | Service Catalogs tab -- deploy wizard | High |
+| 4 | 4.8 | Service Templates tab -- loads | High |
+| 4 | 4.9 | Service Templates tab -- search bar | Medium |
+| 4 | 4.10 | Service Templates tab -- card structure | High |
+| 4 | 4.11 | Service Templates tab -- instantiate wizard | High |
+| 4 | 4.12 | Toolset Repositories tab -- loads | High |
+| 4 | 4.13 | Toolset Repositories tab -- add modal | High |
+| 4 | 4.14 | Toolset Repositories tab -- delete confirmation | Medium |
+| 5 | 5.1 | Targets page loads with title and description | High |
+| 5 | 5.2 | Table structure is correct | High |
+| 5 | 5.3 | Empty state when no capabilities | Medium |
+| 5 | 5.4 | Capability rows display status | High |
+| 5 | 5.5 | No error notification on load | Medium |
+| 6 | 6.1 | Tool Call Debugger loads with title and description | High |
+| 6 | 6.2 | Filter controls are present | High |
+| 6 | 6.3 | Action buttons are present | Medium |
+| 6 | 6.4 | Empty state when no events | Medium |
+| 6 | 6.5 | Clear events button works | Medium |
+| 6 | 6.6 | Auto-scroll toggle works | Medium |
+| 7 | 7.1 | Sidebar links navigate to correct pages | Critical |
+| 7 | 7.2 | Developer submenu expands and collapses | Medium |


### PR DESCRIPTION
## Summary

- Adds 11 new E2E test plans and 1 common reusable step covering local (noauth) scenarios
- Closes the gap analysis that identified 47 untested end-to-end workflows
- All plans follow the conventions in `docs/contributing-test-plans.md`
- Each plan was verified against the CLI source code for exact command syntax

## New test plans

| Plan | Tests | Coverage |
|---|---|---|
| `common/start-local.md` | — | Reusable build/start/health setup |
| `cli-start-local-smoke.md` | 25 | Start local, tools, resources, prompts, admin UI |
| `cli-tools-resources-prompts-local.md` | 38 | Full CRUD + OpenAPI generation + batch label removal |
| `cli-service-catalog-lifecycle.md` | 30 | init→expose→package→deploy→list + templates |
| `cli-forwards-datastores.md` | ~30 | Forward CRUD + data store CRUD with labels |
| `cli-namespaces-labels.md` | 35 | Namespace CRUD + isolation + label expressions |
| `cli-capabilities-management.md` | 27 | list/show/status/cleanup |
| `cli-toolset-repos.md` | ~20 | Repo add/browse/remove + tools import |
| `ui-extended-pages.md` | 40 | Playwright specs for 6 uncovered admin UI pages |
| `archetype-full-lifecycle.md` | ~25 | Scaffold→build→start→register→invoke |
| `cli-negative-tests.md` | 40 | Error paths across all CLI command groups |
| `api-v2-features.md` | 20 | Tool call history, SSE notifications, code execution |

## Bugs found during test execution

- #1436 — `prompts add` returns 500 "Generic error"
- #1437 — `tools add` via CLI fails: HTTP capability gRPC provisioner returns 404
- #1438 — HTTP capability goes "down" immediately after `start local`

## Test plan

- [x] Verified test plans follow `contributing-test-plans.md` conventions
- [x] CLI command syntax verified against Java source code
- [x] Executed against live `wanaku start local` instance (27/33 passed, 6 failed due to bugs above)