### PR TITLE
Fix #1436: fix prompts add 500 Internal Server Error

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/PromptMessageMarshaller.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/marshaller/PromptMessageMarshaller.java
@@ -2,14 +2,13 @@ package ai.wanaku.backend.core.persistence.infinispan.protostream.marshaller;
 
 import java.io.IOException;
 import org.infinispan.protostream.MessageMarshaller;
-import org.infinispan.protostream.WrappedMessage;
+import ai.wanaku.capabilities.sdk.api.types.AudioContent;
+import ai.wanaku.capabilities.sdk.api.types.EmbeddedResource;
+import ai.wanaku.capabilities.sdk.api.types.ImageContent;
 import ai.wanaku.capabilities.sdk.api.types.PromptContent;
 import ai.wanaku.capabilities.sdk.api.types.PromptMessage;
+import ai.wanaku.capabilities.sdk.api.types.TextContent;
 
-/**
- * Protostream marshaller for PromptMessage.
- * Handles the nested PromptContent with oneof by using WrappedMessage.
- */
 public class PromptMessageMarshaller implements MessageMarshaller<PromptMessage> {
 
     @Override
@@ -27,13 +26,24 @@ public class PromptMessageMarshaller implements MessageMarshaller<PromptMessage>
         PromptMessage message = new PromptMessage();
         message.setRole(reader.readString("role"));
 
-        // Read content as WrappedMessage and extract the actual value
-        WrappedMessage wrappedContent = reader.readObject("content", WrappedMessage.class);
-        if (wrappedContent != null) {
-            Object content = wrappedContent.getValue();
-            if (content instanceof PromptContent promptContent) {
-                message.setContent(promptContent);
-            }
+        TextContent text = reader.readObject("text_content", TextContent.class);
+        if (text != null) {
+            message.setContent(text);
+            return message;
+        }
+        ImageContent image = reader.readObject("image_content", ImageContent.class);
+        if (image != null) {
+            message.setContent(image);
+            return message;
+        }
+        AudioContent audio = reader.readObject("audio_content", AudioContent.class);
+        if (audio != null) {
+            message.setContent(audio);
+            return message;
+        }
+        EmbeddedResource embedded = reader.readObject("embedded_resource", EmbeddedResource.class);
+        if (embedded != null) {
+            message.setContent(embedded);
         }
 
         return message;
@@ -43,9 +53,15 @@ public class PromptMessageMarshaller implements MessageMarshaller<PromptMessage>
     public void writeTo(ProtoStreamWriter writer, PromptMessage message) throws IOException {
         writer.writeString("role", message.getRole());
 
-        // Wrap content and write it
-        if (message.getContent() != null) {
-            writer.writeObject("content", new WrappedMessage(message.getContent()), WrappedMessage.class);
+        PromptContent content = message.getContent();
+        if (content instanceof TextContent textContent) {
+            writer.writeObject("text_content", textContent, TextContent.class);
+        } else if (content instanceof ImageContent imageContent) {
+            writer.writeObject("image_content", imageContent, ImageContent.class);
+        } else if (content instanceof AudioContent audioContent) {
+            writer.writeObject("audio_content", audioContent, AudioContent.class);
+        } else if (content instanceof EmbeddedResource embeddedResource) {
+            writer.writeObject("embedded_resource", embeddedResource, EmbeddedResource.class);
         }
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PromptReferenceSchema.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/protostream/schema/PromptReferenceSchema.java
@@ -32,7 +32,6 @@ public class PromptReferenceSchema extends AbstractWanakuSerializationContextIni
     @Override
     public void registerMarshallers(SerializationContext serCtx) {
         contentSchema.registerMarshallers(serCtx);
-        // PromptContent is handled via WrappedMessage in PromptMessageMarshaller
         serCtx.registerMarshaller(new PromptArgumentMarshaller());
         serCtx.registerMarshaller(new PromptMessageMarshaller());
         serCtx.registerMarshaller(new PromptReferenceMarshaller());

--- a/apps/wanaku-router-backend/src/main/resources/proto/prompt_reference.proto
+++ b/apps/wanaku-router-backend/src/main/resources/proto/prompt_reference.proto
@@ -4,9 +4,6 @@ package ai.wanaku.capabilities.sdk.api.types;
 
 import "content.proto";
 
-// Represents a prompt reference in the MCP protocol.
-// Prompts are reusable templates that can leverage multiple tools and provide
-// example interactions for LLMs.
 message PromptReference {
   string id = 1;
   string name = 2;
@@ -17,28 +14,17 @@ message PromptReference {
   string namespace = 7;
   string configuration_uri = 8;
 
-  // Represents a message in an MCP prompt.
-  // Each message has a role and content according to the MCP specification.
   message PromptMessage {
     string role = 1;
-    PromptContent content = 2;
+    TextContent text_content = 2;
+    ImageContent image_content = 3;
+    AudioContent audio_content = 4;
+    EmbeddedResource embedded_resource = 5;
   }
 
-  // Represents an argument/parameter for a prompt.
   message PromptArgument {
     string name = 1;
     string description = 2;
     bool required = 3;
-  }
-}
-
-// Represents content in a prompt message.
-// This is a polymorphic type that can be one of several content types.
-message PromptContent {
-  oneof content {
-    TextContent text_content = 1;
-    ImageContent image_content = 2;
-    AudioContent audio_content = 3;
-    EmbeddedResource embedded_resource = 4;
   }
 }


### PR DESCRIPTION
## Summary

- Fixed `wanaku prompts add` returning HTTP 500 with "Generic error" on local instances
- Root cause: `PromptMessageMarshaller` used `WrappedMessage` to serialize the polymorphic `PromptContent` field, which worked with in-memory Infinispan (test mode, `file-store=false`) but failed at runtime where the persistent file-store requires proper ProtoStream serialization
- Fix: flattened the `PromptContent` oneof directly into `PromptMessage`'s proto schema and handle content type dispatch (TextContent, ImageContent, AudioContent, EmbeddedResource) in the marshaller itself

## Test plan

- [x] `PromptsResourceTest` (6/6 pass) — in-memory mode, no regression
- [x] Runtime test with `start local` — `prompts add`, `list`, `edit`, `remove` all work
- [x] Full `mvn test` passes across all modules

## Summary by Sourcery

Fix persistence serialization of prompt messages to prevent runtime errors when storing prompts in Infinispan with file-store enabled.

Bug Fixes:
- Resolve 500 Internal Server Error when adding prompts by correctly serializing PromptMessage content for ProtoStream persistence storage.

Enhancements:
- Simplify PromptMessage marshalling by explicitly handling each PromptContent variant (text, image, audio, embedded resource) instead of using a generic wrapper.