### PR TITLE
Fix #1441: use full URL for KC_HOSTNAME in Keycloak setup

### DIFF
--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -163,9 +163,14 @@ they are obtained via the external route or internally. Without this, tokens obt
 (e.g. `http://keycloak-wanaku-test.<cluster>/realms/wanaku`) will have a different issuer than
 what the router expects (`http://keycloak:8080/realms/wanaku`), causing 401 errors.
 
+**Important:** In Keycloak 26+, `KC_HOSTNAME` must be a **full URL** (e.g., `http://hostname`),
+not a bare hostname. A bare hostname causes Keycloak to append the internal HTTP port (8080) to
+the issuer URL, which is unreachable from inside the cluster via the external route and causes
+the Quarkus OIDC tenants to timeout sequentially at startup.
+
 ```bash
 oc set env deployment/keycloak \
-  KC_HOSTNAME="${KEYCLOAK_HOST}" \
+  KC_HOSTNAME="${KEYCLOAK_URL}" \
   KC_HOSTNAME_STRICT=false \
   -n "${WANAKU_NAMESPACE}"
 ```


### PR DESCRIPTION
## Summary
- Fixes the Keycloak hostname configuration in `tests/plans/common/keycloak-setup.md`
- Changes `KC_HOSTNAME="${KEYCLOAK_HOST}"` (bare hostname) to `KC_HOSTNAME="${KEYCLOAK_URL}"` (full URL with scheme)

## Root cause
Keycloak 26+ requires `KC_HOSTNAME` to be a full URL (`http://hostname`). When set to a bare hostname, Keycloak appends the internal HTTP port (8080) to the OIDC issuer URL. This makes the issuer URL unreachable from inside the cluster via the OpenShift route, causing all 12 Quarkus OIDC tenants to timeout sequentially (10s each = ~120s), which triggers the liveness probe to kill the router pod.

## Test plan
- [x] Verified on IBM Cloud OpenShift — router starts cleanly with no OIDC timeout warnings after the fix

## Summary by Sourcery

Document and validate the Camel Integration Capability test flow on OpenShift and correct the Keycloak hostname configuration used in tests.

Documentation:
- Clarify Keycloak 26+ requirement to configure KC_HOSTNAME as a full URL instead of a bare hostname in the common Keycloak setup guide.
- Add a comprehensive, automatable test plan for validating the Camel Integration Capability on OpenShift, including setup, routing, catalog modes, error handling, and cleanup.