### PR TITLE
Fix #1437: gRPC provisioner returns 404 in capability services

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -307,6 +307,7 @@ public class LocalRunner {
             LocalRunnerEnvironment environment) {
         File componentDir = quarkusAppDir(componentName);
         String grpcPortOpt = String.format("-Dquarkus.grpc.server.port=%d", grpcPort);
+        String httpPortOpt = String.format("-Dquarkus.http.port=%d", grpcPort);
 
         executorService.submit(() -> {
             try {
@@ -316,6 +317,7 @@ public class LocalRunner {
                         "java",
                         profileOpt,
                         grpcPortOpt,
+                        httpPortOpt,
                         "-jar",
                         "quarkus-run.jar");
             } catch (Exception e) {

--- a/capabilities-quarkus-sdk/wanaku-capabilities-provider/src/main/java/ai/wanaku/core/capabilities/provider/service/ResourceService.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-provider/src/main/java/ai/wanaku/core/capabilities/provider/service/ResourceService.java
@@ -14,15 +14,18 @@ import io.smallrye.mutiny.Uni;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.HealthProbeDelegate;
 import ai.wanaku.core.exchange.ResourceAcquirerDelegate;
+import ai.wanaku.core.exchange.v1.HealthProbe;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.ProvisionReply;
 import ai.wanaku.core.exchange.v1.ProvisionRequest;
+import ai.wanaku.core.exchange.v1.Provisioner;
+import ai.wanaku.core.exchange.v1.ResourceAcquirer;
 import ai.wanaku.core.exchange.v1.ResourceReply;
 import ai.wanaku.core.exchange.v1.ResourceRequest;
 
 @GrpcService
-public class ResourceService {
+public class ResourceService implements ResourceAcquirer, Provisioner, HealthProbe {
     private static final Logger LOG = Logger.getLogger(ResourceService.class);
 
     @Inject

--- a/capabilities-quarkus-sdk/wanaku-capabilities-tools/src/main/java/ai/wanaku/core/capabilities/tool/service/InvocationService.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-tools/src/main/java/ai/wanaku/core/capabilities/tool/service/InvocationService.java
@@ -13,15 +13,18 @@ import io.smallrye.mutiny.Uni;
 import ai.wanaku.core.capabilities.config.WanakuServiceConfig;
 import ai.wanaku.core.exchange.HealthProbeDelegate;
 import ai.wanaku.core.exchange.InvocationDelegate;
+import ai.wanaku.core.exchange.v1.HealthProbe;
 import ai.wanaku.core.exchange.v1.HealthProbeReply;
 import ai.wanaku.core.exchange.v1.HealthProbeRequest;
 import ai.wanaku.core.exchange.v1.ProvisionReply;
 import ai.wanaku.core.exchange.v1.ProvisionRequest;
+import ai.wanaku.core.exchange.v1.Provisioner;
 import ai.wanaku.core.exchange.v1.ToolInvokeReply;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+import ai.wanaku.core.exchange.v1.ToolInvoker;
 
 @GrpcService
-public class InvocationService {
+public class InvocationService implements ToolInvoker, Provisioner, HealthProbe {
     private static final Logger LOG = Logger.getLogger(InvocationService.class);
 
     @Inject


### PR DESCRIPTION
## Summary

- `InvocationService` and `ResourceService` lacked the generated Mutiny gRPC interfaces (`ToolInvoker`, `Provisioner`, `HealthProbe`, `ResourceAcquirer`), so Quarkus never registered any gRPC endpoints on the capability services. The router's provisioning call hit the HTTP server and got a 404 HTML page instead of a gRPC response.
- `LocalRunner.startQuarkusService` only passed `-Dquarkus.grpc.server.port` to capability services, but capabilities use `use-separate-server=false` (gRPC shares the HTTP listener), so this flag was ignored and the services always bound to the hardcoded port in `application.properties`.

## Test plan

- [x] `wanaku tools add` via CLI succeeds (was failing with gRPC 404)
- [x] Tool appears in `tools list` after add
- [x] Labels add/remove work on tools
- [x] Tool remove works
- [x] Batch add/remove by label works (3 tools)
- [x] Negative tests pass (duplicate names, non-existent entities)
- [x] All unit tests pass (`mvn test`)
- [x] Integration test failures are pre-existing (Keycloak not available locally)

## Summary by Sourcery

Ensure capability services expose the correct gRPC endpoints and bind to the expected port when run via the local CLI runner.

Bug Fixes:
- Register the Resource and Invocation capability services as implementations of their generated gRPC interfaces so Quarkus exposes the corresponding endpoints instead of returning HTTP 404s.
- Align capability services’ HTTP listener port with the configured gRPC port in the local runner so they bind to the intended port when gRPC and HTTP share the same server.