### PR TITLE
Fix #1445: set imagePullPolicy=Always in operator test plans

### DIFF
--- a/tests/plans/common/operator-deployment.md
+++ b/tests/plans/common/operator-deployment.md
@@ -43,7 +43,8 @@ echo "PASS: Helm chart found"
 helm install wanaku-operator \
   "${WANAKU_REPO_ROOT}/apps/wanaku-operator/deploy/helm/wanaku-operator" \
   --namespace "${WANAKU_NAMESPACE}" \
-  --set operatorNamespace="${WANAKU_NAMESPACE}"
+  --set operatorNamespace="${WANAKU_NAMESPACE}" \
+  --set app.imagePullPolicy=Always
 ```
 
 **Expected output:** Helm prints a success message containing `STATUS: deployed`.

--- a/tests/plans/operator-helm-clusterrolebinding-naming.md
+++ b/tests/plans/operator-helm-clusterrolebinding-naming.md
@@ -291,7 +291,8 @@ done
 ```bash
 helm install wanaku-operator-a "${WANAKU_CHART_DIR}" \
   --namespace "${WANAKU_NAMESPACE_A}" \
-  --set operatorNamespace="${WANAKU_NAMESPACE_A}"
+  --set operatorNamespace="${WANAKU_NAMESPACE_A}" \
+  --set app.imagePullPolicy=Always
 ```
 
 **Verification:**
@@ -315,7 +316,8 @@ fi
 ```bash
 helm install wanaku-operator-b "${WANAKU_CHART_DIR}" \
   --namespace "${WANAKU_NAMESPACE_B}" \
-  --set operatorNamespace="${WANAKU_NAMESPACE_B}"
+  --set operatorNamespace="${WANAKU_NAMESPACE_B}" \
+  --set app.imagePullPolicy=Always
 
 INSTALL_EXIT=$?
 
@@ -655,7 +657,8 @@ oc delete clusterrolebinding "${WANAKU_NAMESPACE_B}-crd-validating-role-binding"
 # Re-install
 helm install wanaku-operator-b "${WANAKU_CHART_DIR}" \
   --namespace "${WANAKU_NAMESPACE_B}" \
-  --set operatorNamespace="${WANAKU_NAMESPACE_B}"
+  --set operatorNamespace="${WANAKU_NAMESPACE_B}" \
+  --set app.imagePullPolicy=Always
 
 if [ $? -eq 0 ]; then
   echo "PASS: re-installation in ${WANAKU_NAMESPACE_B} succeeded"


### PR DESCRIPTION
## Summary
- Set `imagePullPolicy=Always` in all `helm install` commands across operator test plans
- Prevents stale cached images from masking missing reconcilers (root cause of #1445)
- Updated the shared `operator-deployment.md` and the inline installs in `operator-helm-clusterrolebinding-naming.md`

## Test plan
- [ ] Deploy operator on OpenShift using the updated test plan steps
- [ ] Verify `oc get pod -o jsonpath='{.spec.containers[0].imagePullPolicy}'` returns `Always`
- [ ] Confirm the latest image is pulled on every deployment

## Summary by Sourcery

Tests:
- Update operator test plan Helm install commands to set app.imagePullPolicy=Always when deploying the operator.