### PR TITLE
fix: HTTP capability goes 'down' immediately after start local

### DIFF
--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityChecks.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/CapabilityChecks.java
@@ -18,8 +18,8 @@ class CapabilityChecks {
         HealthCheckResponseBuilder builder = HealthCheckResponse.builder().name(name);
 
         try {
-            int port = grpcServer.getPort();
-            if (port > 0) {
+            int port = getServerPort(grpcServer);
+            if (port > ServicesHelper.PORT_UNAVAILABLE) {
                 builder.up().withData("grpcPort", port);
             } else {
                 builder.down().withData("grpcPort", "not available");
@@ -29,5 +29,9 @@ class CapabilityChecks {
         }
 
         return builder.build();
+    }
+
+    private static int getServerPort(GrpcServer grpcServer) {
+        return ServicesHelper.resolveEffectiveServerPort(grpcServer);
     }
 }

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/DefaultHealthProbeDelegate.java
@@ -19,8 +19,8 @@ public class DefaultHealthProbeDelegate implements HealthProbeDelegate {
     @Override
     public RuntimeStatus getStatus(String id) {
         try {
-            int port = grpcServer.getPort();
-            if (port > 0) {
+            int port = getServerPort();
+            if (port > ServicesHelper.PORT_UNAVAILABLE) {
                 return RuntimeStatus.RUNTIME_STATUS_STARTED;
             }
             return RuntimeStatus.RUNTIME_STATUS_STARTING;
@@ -28,5 +28,9 @@ public class DefaultHealthProbeDelegate implements HealthProbeDelegate {
             LOG.debugf(e, "Health probe check failed for %s: %s", id, e.getMessage());
             return RuntimeStatus.RUNTIME_STATUS_STARTING;
         }
+    }
+
+    private int getServerPort() {
+        return ServicesHelper.resolveEffectiveServerPort(grpcServer);
     }
 }

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/src/main/java/ai/wanaku/core/capabilities/common/ServicesHelper.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.jboss.logging.Logger;
+import io.quarkus.grpc.runtime.GrpcServer;
 import io.quarkus.oidc.client.Tokens;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
@@ -163,24 +164,47 @@ public class ServicesHelper {
     }
 
     static int resolveRegistrationPort() {
+        return resolveServerPort(true);
+    }
+
+    static int resolveServerPortForHealthCheck() {
+        return resolveServerPort(false);
+    }
+
+    private static int resolveServerPort(boolean requireHttpHostEnabled) {
+        return resolveEffectiveServerPort(null, requireHttpHostEnabled);
+    }
+
+    static int resolveEffectiveServerPort(GrpcServer grpcServer) {
+        return resolveEffectiveServerPort(grpcServer, false);
+    }
+
+    static int resolveEffectiveServerPort(GrpcServer grpcServer, boolean requireHttpHostEnabled) {
         Config config = ConfigProvider.getConfig();
         boolean useSeparateServer = config.getOptionalValue("quarkus.grpc.server.use-separate-server", Boolean.class)
                 .orElse(Boolean.TRUE);
 
         if (useSeparateServer) {
-            return config.getValue("quarkus.grpc.server.port", Integer.class);
+            return grpcServer != null
+                    ? grpcServer.getPort()
+                    : config.getValue("quarkus.grpc.server.port", Integer.class);
         }
 
         boolean httpHostEnabled = config.getOptionalValue("quarkus.http.host-enabled", Boolean.class)
                 .orElse(Boolean.TRUE);
         if (!httpHostEnabled) {
-            throw new WanakuException(
-                    "quarkus.grpc.server.use-separate-server=false requires quarkus.http.host-enabled=true "
-                            + "because the gRPC server shares the HTTP listener in that mode");
+            if (requireHttpHostEnabled) {
+                throw new WanakuException(
+                        "quarkus.grpc.server.use-separate-server=false requires quarkus.http.host-enabled=true "
+                                + "because the gRPC server shares the HTTP listener in that mode");
+            }
+            return PORT_UNAVAILABLE;
         }
 
         return config.getValue("quarkus.http.port", Integer.class);
     }
+
+    public static final int PORT_UNAVAILABLE = 0;
 
     private record ServiceClientHeadersFactory(Tokens accessToken) implements ClientHeadersFactory {
 


### PR DESCRIPTION
Closes: #1438

## Summary by Sourcery

Adjust gRPC server port resolution and health checks to correctly handle configurations where the HTTP host is disabled.

Bug Fixes:
- Prevent HTTP capability from being reported as down when the gRPC server shares the HTTP listener and the HTTP host is disabled by returning a non-failing port value in health checks.

Enhancements:
- Introduce shared server port resolution helpers to distinguish between registration-time validation and health-check-time inspection of the HTTP listener port.