### PR TITLE
Fix #1451: replace context.getSecondaryResource() with direct kubernetesClient lookups in WanakuRouterReconciler

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.client.dsl.Replaceable;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteIngress;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -134,14 +133,11 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
 
         // Create the internal service (cluster IP)
         final Service desiredExternalService = makeRouterInternalService(resource);
-        Service existingExternalService;
-        try {
-            existingExternalService =
-                    context.getSecondaryResource(Service.class).orElse(null);
-        } catch (IllegalStateException | OperatorException e) {
-            LOG.warnf(e, "There is no existing service");
-            existingExternalService = null;
-        }
+        Service existingExternalService = kubernetesClient
+                .services()
+                .inNamespace(namespace)
+                .withName(desiredExternalService.getMetadata().getName())
+                .get();
         if (!match(desiredExternalService, existingExternalService)) {
             String ns = resource.getMetadata().getNamespace();
             LOG.infof(
@@ -172,13 +168,12 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
         // Create the router deployment
         final Deployment desiredDeployment = makeDesiredRouterBackendDeployment(resource, context, host);
 
-        Deployment existingDeployment;
-        try {
-            existingDeployment = context.getSecondaryResource(Deployment.class).orElse(null);
-        } catch (IllegalStateException | OperatorException e) {
-            LOG.warnf(e, "There is no existing deployment");
-            existingDeployment = null;
-        }
+        Deployment existingDeployment = kubernetesClient
+                .apps()
+                .deployments()
+                .inNamespace(namespace)
+                .withName(desiredDeployment.getMetadata().getName())
+                .get();
 
         if (!match(desiredDeployment, existingDeployment)) {
             String ns = resource.getMetadata().getNamespace();


### PR DESCRIPTION
## Summary

- Replace `context.getSecondaryResource(Service.class)` and `context.getSecondaryResource(Deployment.class)` calls with direct `kubernetesClient` lookups in `WanakuRouterReconciler`
- Aligns with the pattern used by `WanakuCapabilityReconciler` and `WanakuCamelRouteReconciler`, which already use `kubernetesClient` directly
- Removes unused `OperatorException` import

## Root Cause

`WanakuRouterReconciler` called `context.getSecondaryResource()` for `Deployment` and `Service` types, but no JOSDK event source was registered for either (no `@ControllerConfiguration(dependents = ...)` and no `EventSourceInitializer` implementation). This caused `NoEventSourceForClassException` on every reconciliation.

## Test plan

- [ ] Deploy operator via Helm and create a `WanakuRouter` CR
- [ ] Verify no `NoEventSourceForClassException` in operator logs
- [ ] Verify router Deployment and Service are created/updated correctly
- [ ] Verify subsequent reconciliations succeed without errors

## Summary by Sourcery

Use direct Kubernetes client lookups for router Service and Deployment resources in WanakuRouterReconciler to avoid reliance on missing secondary resource event sources.

Bug Fixes:
- Prevent NoEventSourceForClassException during WanakuRouter reconciliation by removing use of context.getSecondaryResource for Service and Deployment.

Enhancements:
- Align WanakuRouterReconciler resource lookup approach with other Wanaku reconcilers that use the Kubernetes client directly.

Chores:
- Remove unused OperatorException import from WanakuRouterReconciler.