### PR TITLE
Fix #1446: source OIDC client secret from K8s Secret in operator Helm chart

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
@@ -32,6 +32,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: WANAKU_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: client-secret
+                  name: {{ .Values.app.oidc.secretName }}
+                  optional: true
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES
               value: {{ .Values.app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES | quote }}
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAMEL_ROUTE_NAMESPACES

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
@@ -11,6 +11,8 @@ app:
     QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_ROUTER_NAMESPACES: JOSDK_WATCH_CURRENT
     QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_SERVICE_CATALOG_NAMESPACES: JOSDK_WATCH_CURRENT
   image: quay.io/wanaku/wanaku-operator:latest
+  oidc:
+    secretName: wanaku-oidc
   imagePullPolicy: IfNotPresent
   livenessProbe:
     failureThreshold: 3

--- a/apps/wanaku-operator/src/main/helm/values.yaml
+++ b/apps/wanaku-operator/src/main/helm/values.yaml
@@ -8,3 +8,5 @@ app:
     capabilities:
       drop:
         - ALL
+  oidc:
+    secretName: wanaku-oidc

--- a/apps/wanaku-operator/src/main/resources/application.properties
+++ b/apps/wanaku-operator/src/main/resources/application.properties
@@ -64,3 +64,11 @@ quarkus.helm.values."app.imagePullPolicy".paths=(kind == Deployment).spec.templa
 quarkus.kubernetes.security-context.run-as-non-root=true
 quarkus.helm.values."podSecurityContext.runAsNonRoot".paths=(kind == Deployment).spec.template.spec.securityContext.runAsNonRoot
 quarkus.helm.values."podSecurityContext.runAsNonRoot".description=Require the pod to run as a non-root user.
+
+# OIDC client secret sourced from a Kubernetes Secret
+quarkus.kubernetes.env.mapping.wanaku-oidc-client-secret.from-secret=wanaku-oidc
+quarkus.kubernetes.env.mapping.wanaku-oidc-client-secret.with-key=client-secret
+
+# Make the OIDC Secret name configurable via Helm values
+quarkus.helm.values."app.oidc.secretName".paths=(kind == Deployment).spec.template.spec.containers.env.(name == WANAKU_OIDC_CLIENT_SECRET).valueFrom.secretKeyRef.name
+quarkus.helm.values."app.oidc.secretName".description=Name of the Kubernetes Secret containing the OIDC client secret.


### PR DESCRIPTION
## Summary

- Add `WANAKU_OIDC_CLIENT_SECRET` env var to the operator Helm chart, sourced from a Kubernetes Secret via `secretKeyRef` with `optional: true`
- The Secret name defaults to `wanaku-oidc` and is configurable via `app.oidc.secretName` in Helm values
- Uses `quarkus.kubernetes.env.mapping` and `quarkus.helm.values` so the env var is auto-generated during chart builds

## Test plan

- [x] `mvn package -pl apps/wanaku-operator -am -DskipTests` — generated chart includes `WANAKU_OIDC_CLIENT_SECRET` with templated secret name
- [x] `mvn test -pl apps/wanaku-operator -am` — all 81 tests pass
- [ ] Deploy operator without OIDC Secret — operator should start normally (`optional: true`)
- [ ] Deploy operator with OIDC Secret (`kubectl create secret generic wanaku-oidc --from-literal=client-secret=<secret>`) — operator should authenticate with OIDC-protected router

## Summary by Sourcery

Source the operator's OIDC client secret from a configurable Kubernetes Secret in the Helm chart and wire it through Quarkus/Helm configuration.

New Features:
- Expose WANAKU_OIDC_CLIENT_SECRET environment variable in the operator Deployment, reading from a Kubernetes Secret via secretKeyRef with optional lookup.
- Add configurable app.oidc.secretName Helm value with a default of wanaku-oidc to control which Secret provides the OIDC client secret.

Enhancements:
- Configure Quarkus kubernetes env mapping and Helm values so the OIDC client secret environment wiring is generated automatically during chart builds.