### PR TITLE
ci: add INFO-level diagnostic logging for capability health checks (#1457)

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/persistence/infinispan/discovery/InfinispanServiceRegistry.java
@@ -52,6 +52,7 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
     @Override
     public ServiceTarget register(ServiceTarget serviceTarget) {
         ServiceTarget persisted = capabilitiesRepository.persist(serviceTarget);
+        LOG.infof("Registering capability %s with initial health status PENDING", persisted.getId());
         updateHealthStatus(persisted.getId(), HealthStatus.PENDING);
         return persisted;
     }
@@ -139,6 +140,7 @@ public class InfinispanServiceRegistry implements ServiceRegistry {
 
     @Override
     public void updateHealthStatus(String id, HealthStatus healthStatus) {
+        LOG.infof("Updating health status for capability %s to %s", id, healthStatus.asValue());
         activityRecordRepository.update(id, e -> {
             e.setHealthStatus(healthStatus);
             e.setLastSeen(Instant.now());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/HealthProbeClient.java
@@ -37,7 +37,13 @@ class HealthProbeClient {
 
         return transport
                 .probeHealthAsync(request, target)
-                .map(reply -> mapRuntimeStatus(reply.getStatus()))
+                .map(reply -> {
+                    HealthStatus mapped = mapRuntimeStatus(reply.getStatus());
+                    LOG.infof(
+                            "Health probe for %s returned %s (runtime: %s)",
+                            target.toAddress(), mapped.asValue(), reply.getStatus());
+                    return mapped;
+                })
                 .onFailure(ServiceUnavailableException.class)
                 .recoverWithItem(e -> handleServiceUnavailable(target, (ServiceUnavailableException) e))
                 .onFailure()

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -71,7 +71,7 @@ public class PeriodicHealthCheckService {
         }
 
         List<ServiceTarget> entries = serviceRegistry.getEntries();
-        LOG.debugf("Health check sweep: checking %d capabilities", entries.size());
+        LOG.infof("Health check sweep: checking %d registered capabilities", entries.size());
 
         int maxConcurrent = Math.max(0, config.healthCheck().maxConcurrent());
         int budget = maxConcurrent - inProgress.size();
@@ -109,14 +109,14 @@ public class PeriodicHealthCheckService {
         // and will still be probed and marked as DOWN.
         ActivityRecord activityRecord = serviceRegistry.getStates(id);
         if (activityRecord == null) {
-            LOG.debugf(
+            LOG.infof(
                     "Skipping health check for capability without activity record %s (%s)",
                     target.getServiceName(), id);
             return;
         }
 
         if (!activityRecord.isActive()) {
-            LOG.debugf("Skipping health check for deregistered capability %s (%s)", target.getServiceName(), id);
+            LOG.infof("Skipping health check for deregistered capability %s (%s)", target.getServiceName(), id);
             return;
         }
 
@@ -128,7 +128,7 @@ public class PeriodicHealthCheckService {
         }
 
         if (inProgress.putIfAbsent(id, Boolean.TRUE) != null) {
-            LOG.tracef("Health check already in progress for %s, skipping", id);
+            LOG.infof("Health check already in progress for %s, skipping", id);
             return;
         }
 
@@ -142,7 +142,7 @@ public class PeriodicHealthCheckService {
 
     private void completeHealthCheck(ServiceTarget target, String id, HealthStatus status) {
         try {
-            LOG.debugf("Health probe result for %s (%s): %s", target.getServiceName(), id, status.asValue());
+            LOG.infof("Health probe result for %s (%s): %s", target.getServiceName(), id, status.asValue());
             serviceRegistry.updateHealthStatus(id, status);
             emitHealthStatusEvent(id, status);
         } finally {
@@ -152,6 +152,9 @@ public class PeriodicHealthCheckService {
 
     private void failHealthCheck(String id, ActivityRecord activityRecord, Throwable failure) {
         try {
+            LOG.infof(
+                    "Health probe failed for capability %s, current status: %s",
+                    id, activityRecord.getHealthStatus().asValue());
             if (activityRecord.getHealthStatus() == HealthStatus.PENDING) {
                 final Instant lastSeen = activityRecord.getLastSeen();
                 final Duration between = Duration.between(lastSeen, Instant.now());


### PR DESCRIPTION
## Summary
- Adds INFO-level logging to the capability health check system to diagnose #1457
- Capability is stuck as DOWN despite no visible errors at INFO level

## Changes
- `PeriodicHealthCheckService`: sweep count, skip reasons, probe results all at INFO
- `HealthProbeClient`: logs mapped health status from gRPC probe response
- `InfinispanServiceRegistry`: logs registration and health status transitions

## Test plan
- [ ] Deploy to OpenShift and reproduce #1457
- [ ] Read logs to identify why capability stays DOWN

## Summary by Sourcery

Add INFO-level diagnostic logging around capability registration and health check workflows to aid investigation of stuck DOWN states.

Enhancements:
- Increase log level of health check sweep, skip conditions, in-progress checks, and probe results from DEBUG/TRACE to INFO for better observability.
- Log mapped health status and underlying runtime status for gRPC health probe responses.
- Log capability registration with initial PENDING status and subsequent health status updates in the service registry.