### PR TITLE
chore: fix markdown lint errors and improve markdownlint ignores

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,5 +17,10 @@ globs:
 
 ignores:
   - ".oss-ai-helper-rules/**"
+  - ".claude/**"
   - "CLAUDE.md"
-  - "target/**"
+  - "**/node_modules/**"
+  - "**/target/**"
+  - "out/**"
+  - "plan/**"
+  - "working-data/**"

--- a/apps/wanaku-router-backend/README.md
+++ b/apps/wanaku-router-backend/README.md
@@ -7,6 +7,7 @@ The main MCP server engine that receives MCP requests and routes them to appropr
 ## Purpose
 
 The router backend is the central component of Wanaku that:
+
 - Serves MCP protocol requests from AI clients
 - Routes tool invocations to appropriate tool services via gRPC
 - Routes resource read requests to appropriate providers via gRPC
@@ -29,6 +30,7 @@ The router backend is the central component of Wanaku that:
 ## Architecture
 
 Built on:
+
 - **Quarkus**: Modern Java framework for cloud-native applications
 - **Quarkus MCP Server Extension**: MCP protocol implementation
 - **gRPC**: Service communication protocol


### PR DESCRIPTION
## Summary
- Fix MD032 (blanks around lists) and MD047 (trailing newline) violations in `apps/wanaku-router-backend/README.md` introduced by recent commits
- Expand `.markdownlint-cli2.yaml` ignore list to exclude `.claude/`, `**/node_modules/**`, `**/target/**`, `out/`, `plan/`, and `working-data/` directories — drops reported errors from 22k to 149 (remaining are pre-existing)

## Test plan
- [ ] Run `npx markdownlint-cli2 "**/*.md"` and verify no new errors in recently changed files

## Summary by Sourcery

Fix markdown lint issues in the router backend README and broaden markdownlint ignore patterns to reduce noise from generated and dependency directories.

Enhancements:
- Adjust router backend README list formatting and trailing newline to comply with markdown linting rules.
- Expand markdownlint configuration ignores to cover Claude config, node_modules, build artifacts, and working data directories.