### PR TITLE
Fix #1457: protect PENDING capabilities from immediate DOWN transition

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/health/PeriodicHealthCheckService.java
@@ -143,6 +143,20 @@ public class PeriodicHealthCheckService {
     private void completeHealthCheck(ServiceTarget target, String id, HealthStatus status) {
         try {
             LOG.infof("Health probe result for %s (%s): %s", target.getServiceName(), id, status.asValue());
+
+            if (status == HealthStatus.DOWN) {
+                ActivityRecord activityRecord = serviceRegistry.getStates(id);
+                if (activityRecord != null && activityRecord.getHealthStatus() == HealthStatus.PENDING) {
+                    final Duration since = Duration.between(activityRecord.getLastSeen(), Instant.now());
+                    if (since.toMinutes() < ActivityRecord.TIME_TO_LET_GO) {
+                        LOG.infof(
+                                "Keeping capability %s (%s) in PENDING state (registered %d seconds ago, grace period %d minutes)",
+                                target.getServiceName(), id, since.getSeconds(), ActivityRecord.TIME_TO_LET_GO);
+                        return;
+                    }
+                }
+            }
+
             serviceRegistry.updateHealthStatus(id, status);
             emitHealthStatusEvent(id, status);
         } finally {


### PR DESCRIPTION
## Summary
- Fixes #1457: capability stuck as DOWN despite successful gRPC health probes
- Adds INFO-level diagnostic logging to the health check system

## Root cause
When a capability registers, the router immediately probes it via gRPC. If the capability's gRPC server isn't ready yet (race condition), the probe returns `Connection refused` which is mapped to `DOWN` via `completeHealthCheck()`. Once DOWN, `isActive()` returns false and the periodic health sweep permanently skips the capability — it never recovers.

## Fix
In `completeHealthCheck()`, if the probe result is DOWN but the capability is still in PENDING state within the `TIME_TO_LET_GO` grace period, the DOWN result is ignored and the capability stays PENDING. The next periodic sweep (60s) re-probes and transitions to HEALTHY once the gRPC server is ready.

## Verified on OpenShift
- Capability transitions: PENDING → HEALTHY (was PENDING → DOWN → permanently stuck)
- Tool visible via MCP: `sends-greeting`
- Tool invocation returns expected response: `Hello World from route-3104`

## Test plan
- [x] Deploy WanakuCamelRoute CR on OpenShift with OIDC auth
- [x] Verify capability reaches HEALTHY status
- [x] Verify tool listed via `wanaku mcp tool list`
- [x] Verify tool invocation via `wanaku mcp tool --name sends-greeting`

## Summary by Sourcery

Prevent newly registered capabilities from being marked permanently DOWN by health probes and improve observability of capability health lifecycle.

Bug Fixes:
- Ignore initial DOWN health probe results for capabilities that are still PENDING within the grace period so they can transition to HEALTHY once ready.

Enhancements:
- Increase health check and probe logging to INFO level and add structured diagnostics around probe outcomes and capability health state transitions.
- Log capability registration with initial PENDING health status and subsequent health status updates for better traceability.