### PR TITLE
fix: enhance OIDC authentication to support direct Keycloak login with realm option

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -13,7 +13,6 @@ import picocli.CommandLine;
 public class AuthLogin extends BaseCommand {
 
     private static final String DEFAULT_AUTH_SERVER = "http://localhost:8080";
-    private static final String DEFAULT_REALM = "wanaku";
     private static final String DEFAULT_CLIENT_ID = "admin-cli";
     private static final String DEFAULT_AUTH_MODE = "token";
 
@@ -40,8 +39,7 @@ public class AuthLogin extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--realm"},
-            description = "Authentication realm",
-            defaultValue = DEFAULT_REALM)
+            description = "Authentication realm (e.g. 'wanaku'). When omitted, uses the router OIDC proxy.")
     private String realm;
 
     @CommandLine.Option(
@@ -77,13 +75,14 @@ public class AuthLogin extends BaseCommand {
                 config.setClientId(DEFAULT_CLIENT_ID);
                 config.setUsername(username);
                 config.setPassword(password);
-                config.setTokenEndpoint(TokenEndpoint.forDiscovery(serverUrl));
+                config.setTokenEndpoint(TokenEndpoint.forDiscovery(serverUrl, realm));
                 ServiceAuthenticator serviceAuthenticator = new ServiceAuthenticator(config);
 
                 credentialStore.storeApiToken(serviceAuthenticator.currentValidAccessToken());
                 credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
                 credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
                 credentialStore.storeClientId(DEFAULT_CLIENT_ID);
+                credentialStore.storeRealm(realm);
 
                 credentialStore.storeAuthMode("token");
                 credentialStore.storeAuthServerUrl(serverUrl);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -30,6 +30,7 @@ public class AuthCredentialStore {
     private static final String AUTH_SERVER_URL_KEY = "auth.server.url";
     private static final String TOKEN_EXPIRY_KEY = "token.expiry";
     private static final String CLIENT_ID_KEY = "client.id";
+    private static final String REALM_KEY = "auth.realm";
 
     private final URI credentialsUri;
 
@@ -153,6 +154,28 @@ public class AuthCredentialStore {
     }
 
     /**
+     * Stores the Keycloak realm used for OIDC discovery.
+     *
+     * @param realm the realm value, or null to clear
+     */
+    public void storeRealm(String realm) {
+        if (realm != null) {
+            storeCredential(REALM_KEY, realm);
+        } else {
+            clearCredential(REALM_KEY);
+        }
+    }
+
+    /**
+     * Retrieves the stored Keycloak realm, or null if not found.
+     *
+     * @return the realm, or null
+     */
+    public String getRealm() {
+        return get(REALM_KEY);
+    }
+
+    /**
      * Retrieves the OAuth2 client ID.
      *
      * @return the client ID, or null if not found
@@ -204,6 +227,22 @@ public class AuthCredentialStore {
             throw new RuntimeException("Failed to load credentials", e);
         }
         return props;
+    }
+
+    private void clearCredential(String key) {
+        try {
+            Path credentialsPath = Paths.get(credentialsUri);
+            if (!Files.exists(credentialsPath)) {
+                return;
+            }
+            Properties props = loadProperties();
+            props.remove(key);
+            try (OutputStream out = Files.newOutputStream(credentialsPath)) {
+                props.store(out, "Wanaku CLI Authentication Credentials");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to clear credential: " + key, e);
+        }
     }
 
     private void storeCredential(String key, String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -170,8 +170,10 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             clientId = "admin-cli";
         }
 
+        String realm = credentialStore.getRealm();
+
         try {
-            RefreshResult result = tokenRefresher.refresh(refreshToken, authServerUrl, clientId);
+            RefreshResult result = tokenRefresher.refresh(refreshToken, authServerUrl, clientId, realm);
 
             // Store the new tokens
             credentialStore.storeApiToken(result.getAccessToken());

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenEndpoint.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenEndpoint.java
@@ -32,13 +32,19 @@ public final class TokenEndpoint {
     }
 
     /**
-     * Constructs a token endpoint URL by appending the discovery OpenID Connect path to a base URL.
+     * Constructs a discovery URL using the Keycloak-native realm path when a realm is provided,
+     * or falls back to the Quarkus OIDC proxy path otherwise.
      *
      * @param baseUrl The base URL of the authentication server.
-     * @return The complete token endpoint URL.
+     * @param realm   The authentication realm, or {@code null} if not applicable.
+     * @return The complete discovery URL.
      */
-    public static String forDiscovery(String baseUrl) {
-        return stripTrailingSlash(baseUrl) + "/q/oidc/";
+    public static String forDiscovery(String baseUrl, String realm) {
+        String url = stripTrailingSlash(baseUrl);
+        if (realm != null && !realm.isBlank()) {
+            return url + "/realms/" + realm.strip();
+        }
+        return url + "/q/oidc/";
     }
 
     private static String stripTrailingSlash(String url) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
@@ -64,12 +64,13 @@ public class TokenRefresher {
      * @param refreshTokenValue the refresh token value
      * @param authServerUrl the authentication server URL (e.g., http://localhost:8080)
      * @param clientId the OAuth2 client ID
+     * @param realm the authentication realm, or null to use the router OIDC proxy
      * @return the refresh result containing new tokens and expiry
      * @throws TokenRefreshException if the refresh fails
      */
-    public RefreshResult refresh(String refreshTokenValue, String authServerUrl, String clientId) {
+    public RefreshResult refresh(String refreshTokenValue, String authServerUrl, String clientId, String realm) {
         try {
-            URI tokenEndpoint = resolveTokenEndpointUri(authServerUrl);
+            URI tokenEndpoint = resolveTokenEndpointUri(authServerUrl, realm);
             RefreshToken refreshToken = new RefreshToken(refreshTokenValue);
             AuthorizationGrant refreshTokenGrant = new RefreshTokenGrant(refreshToken);
             ClientID clientID = new ClientID(clientId);
@@ -104,8 +105,8 @@ public class TokenRefresher {
         }
     }
 
-    private static Issuer resolveIssuer(String authServerUrl) {
-        String discoveryUrl = authServerUrl + "/q/oidc/";
+    private static Issuer resolveIssuer(String authServerUrl, String realm) {
+        String discoveryUrl = TokenEndpoint.forDiscovery(authServerUrl, realm);
         Issuer issuer = new Issuer(discoveryUrl);
 
         try {
@@ -130,8 +131,8 @@ public class TokenRefresher {
         }
     }
 
-    private static URI resolveTokenEndpointUri(String authServerUrl) {
-        Issuer issuer = new Issuer(resolveIssuer(authServerUrl));
+    private static URI resolveTokenEndpointUri(String authServerUrl, String realm) {
+        Issuer issuer = new Issuer(resolveIssuer(authServerUrl, realm));
 
         try {
             final OIDCProviderMetadata resolvedOp = OIDCProviderMetadata.resolve(issuer);

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
@@ -109,19 +109,52 @@ class AuthenticationInterceptorTest {
         credentialStore.storeRefreshToken(refreshToken);
         credentialStore.storeAuthServerUrl(authServerUrl);
         credentialStore.storeClientId(clientId);
+        credentialStore.storeRealm(null);
         credentialStore.storeAuthMode("token");
         // Token expired 60 seconds ago
         credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
 
         TokenRefresher mockRefresher = mock(TokenRefresher.class);
         long newExpiry = Instant.now().getEpochSecond() + 300;
-        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
 
         AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
         interceptorWithMock.filter(requestContext);
 
-        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId);
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
+        assertEquals("Bearer " + newToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
+        assertEquals(newToken, credentialStore.getApiToken());
+        assertEquals(newExpiry, credentialStore.getTokenExpiry());
+    }
+
+    @Test
+    void shouldRefreshTokenWithRealmWhenExpired() throws Exception {
+        String oldToken = "old-token";
+        String newToken = "new-token";
+        String refreshToken = "refresh-token";
+        String authServerUrl = "http://keycloak-host";
+        String clientId = "admin-cli";
+        String realm = "wanaku";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeRealm(realm);
+        credentialStore.storeAuthMode("token");
+        // Token expired 60 seconds ago
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, realm))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        interceptorWithMock.filter(requestContext);
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, realm);
         assertEquals("Bearer " + newToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
         assertEquals(newToken, credentialStore.getApiToken());
         assertEquals(newExpiry, credentialStore.getTokenExpiry());
@@ -139,7 +172,7 @@ class AuthenticationInterceptorTest {
         AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
         interceptorWithMock.filter(requestContext);
 
-        verify(mockRefresher, never()).refresh(any(), any(), any());
+        verify(mockRefresher, never()).refresh(any(), any(), any(), any());
         assertEquals("Bearer " + token, headers.getFirst(HttpHeaders.AUTHORIZATION));
     }
 
@@ -154,12 +187,13 @@ class AuthenticationInterceptorTest {
         credentialStore.storeRefreshToken(refreshToken);
         credentialStore.storeAuthServerUrl(authServerUrl);
         credentialStore.storeClientId(clientId);
+        credentialStore.storeRealm(null);
         credentialStore.storeAuthMode("token");
         // Token expired
         credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
 
         TokenRefresher mockRefresher = mock(TokenRefresher.class);
-        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenThrow(new TokenRefresher.TokenRefreshException("Refresh failed"));
 
         AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
@@ -180,7 +214,7 @@ class AuthenticationInterceptorTest {
         AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
         interceptorWithMock.filter(requestContext);
 
-        verify(mockRefresher, never()).refresh(any(), any(), any());
+        verify(mockRefresher, never()).refresh(any(), any(), any(), any());
         assertEquals("Bearer " + token, headers.getFirst(HttpHeaders.AUTHORIZATION));
     }
 
@@ -196,19 +230,20 @@ class AuthenticationInterceptorTest {
         credentialStore.storeRefreshToken(refreshToken);
         credentialStore.storeAuthServerUrl(authServerUrl);
         credentialStore.storeClientId(clientId);
+        credentialStore.storeRealm(null);
         credentialStore.storeAuthMode("token");
         // Token expires in 20 seconds (within 30 second buffer)
         credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 20);
 
         TokenRefresher mockRefresher = mock(TokenRefresher.class);
         long newExpiry = Instant.now().getEpochSecond() + 300;
-        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId))
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
 
         AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
         interceptorWithMock.filter(requestContext);
 
-        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId);
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
         assertEquals("Bearer " + newToken, headers.getFirst(HttpHeaders.AUTHORIZATION));
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/TokenEndpointTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/TokenEndpointTest.java
@@ -1,0 +1,40 @@
+package ai.wanaku.cli.main.support;
+
+import ai.wanaku.cli.main.support.security.TokenEndpoint;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TokenEndpointTest {
+
+    private static final String KEYCLOAK_HOST = "http://keycloak-host";
+    private static final String URL_REALMS_WANAKU = "http://keycloak-host/realms/wanaku";
+    private static final String URL_REALMS_MYREALM = "http://keycloak-host/realms/myrealm";
+    private static final String URL_OIDC = "http://localhost:8080/q/oidc/";
+    private static final String URL_LOCALHOST = "http://localhost:8080";
+
+    @Test
+    void forDiscovery_withRealm_returnsKeycloakNativePath() {
+        assertEquals(URL_REALMS_WANAKU, TokenEndpoint.forDiscovery(KEYCLOAK_HOST, "wanaku"));
+    }
+
+    @Test
+    void forDiscovery_withRealm_stripsTrailingSlash() {
+        assertEquals(URL_REALMS_MYREALM, TokenEndpoint.forDiscovery(KEYCLOAK_HOST + "/", "myrealm"));
+    }
+
+    @Test
+    void forDiscovery_withRealm_stripsRealmWhitespace() {
+        assertEquals(URL_REALMS_MYREALM, TokenEndpoint.forDiscovery(KEYCLOAK_HOST, "  myrealm  "));
+    }
+
+    @Test
+    void forDiscovery_nullRealm_fallsBackToProxyPath() {
+        assertEquals(URL_OIDC, TokenEndpoint.forDiscovery(URL_LOCALHOST, null));
+    }
+
+    @Test
+    void forDiscovery_blankRealm_fallsBackToProxyPath() {
+        assertEquals(URL_OIDC, TokenEndpoint.forDiscovery(URL_LOCALHOST, "   "));
+    }
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -86,8 +86,18 @@ When the router has authentication enabled, the CLI requires an active session. 
 **Fix:**
 
 ```shell
-# Log in first
-wanaku auth login --url http://localhost:8080
+# Log in first (through the router OIDC proxy)
+wanaku auth login \
+  --auth-server http://localhost:8080 \
+  --username alice \
+  --password
+
+# Or log in directly against Keycloak (bypasses the router)
+wanaku auth login \
+  --auth-server http://keycloak-host \
+  --realm wanaku \
+  --username alice \
+  --password
 
 # For routers running without authentication, use --no-auth
 wanaku tools list --no-auth

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -829,9 +829,19 @@ wanaku auth login --api-token <your-api-token>
 
 **Options:**
 
-- `--api-token <token>`: API token for authentication (required)
+- `--api-token <token>`: API token for authentication
 - `--auth-server <url>`: Authentication server URL (optional)
+- `--username <username>`: Username for password-based login
+- `--password <password>`: Password for password-based login (interactive)
+- `--realm <realm>`: Keycloak realm for direct Keycloak authentication (optional; when omitted, uses the router OIDC proxy)
+- `--client-id <client-id>`: OAuth2 client ID (default: `admin-cli`)
 - `--mode <mode>`: Authentication mode - `token` or `oauth2` (default: `token`)
+
+**Discovery URL behavior:**
+
+- When `--realm` is provided, the CLI constructs a Keycloak-native OIDC discovery URL: `<auth-server>/realms/<realm>/.well-known/openid-configuration`
+- When `--realm` is omitted (or blank), the CLI falls back to the Wanaku router OIDC proxy path: `<auth-server>/q/oidc/.well-known/openid-configuration`
+- This allows `wanaku auth login` to work directly against a Keycloak instance (e.g. `--auth-server http://keycloak-host --realm wanaku`) as well as through the router's OIDC proxy.
 
 **Example:**
 
@@ -846,6 +856,25 @@ wanaku auth login \
   --api-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... \
   --auth-server https://keycloak.example.com \
   --mode token
+```
+
+With username/password directly against Keycloak:
+
+```shell
+wanaku auth login \
+--auth-server http://keycloak-host \
+--realm wanaku \
+--username alice \
+--password
+```
+
+With username/password through the router's OIDC proxy:
+
+```shell
+wanaku auth login \
+--auth-server http://localhost:8080 \
+--username alice \
+--password
 ```
 
 #### Status

--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -306,11 +306,22 @@ fi
 echo "PASS: test user '${WANAKU_TEST_USER}' created"
 ```
 
-### 11. Verify OIDC login (requires the router)
+### 11. Verify OIDC login
 
-The `wanaku auth login` command authenticates via the router's OIDC proxy endpoint (`/q/oidc/...`), not directly against Keycloak. This means the WanakuRouter must be deployed and healthy before this step can run.
+The `wanaku auth login` command authenticates via the router's OIDC proxy endpoint (`/q/oidc/...`) by default.
+When `--realm <realm>` is provided, it uses Keycloak's native discovery path (`/realms/<realm>`) and does not require the router to be deployed.
 
-Follow [common/oidc-login-verification.md](oidc-login-verification.md) **after the router is created** in the test plan.
+- For standard router-based authentication, follow [common/oidc-login-verification.md](oidc-login-verification.md) **after the router is created**.
+- For direct Keycloak authentication (no router needed):
+
+  ```bash
+  echo "${WANAKU_TEST_PASS}" | ${WANAKU_CLI:-wanaku} auth login \
+    --auth-server "${KEYCLOAK_URL}" \
+    --realm wanaku \
+    --username "${WANAKU_TEST_USER}" \
+    --password \
+    --plain 2>&1
+  ```
 
 ## Output Variables
 

--- a/tests/plans/common/oidc-login-verification.md
+++ b/tests/plans/common/oidc-login-verification.md
@@ -1,8 +1,11 @@
 # Common: OIDC Login Verification
 
-Reusable steps for verifying OIDC authentication via the Wanaku router.
+Reusable steps for verifying OIDC authentication via the Wanaku router or directly against Keycloak.
 
-The `wanaku auth login` command authenticates via the router's OIDC proxy endpoint (`/q/oidc/...`), so the WanakuRouter must be deployed and healthy before running these steps.
+The `wanaku auth login` command authenticates via the router's OIDC proxy endpoint (`/q/oidc/...`) by default.
+When the `--realm` option is provided, it uses Keycloak's native discovery path (`/realms/<realm>`) instead,
+allowing direct authentication against Keycloak without going through the router proxy.
+The default test path below uses the router OIDC proxy; for direct Keycloak authentication, add `--realm <realm>`.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes: #1447

## Summary by Sourcery

Enable the CLI OIDC authentication flow to work either via the router’s OIDC proxy or directly against a Keycloak realm, and document the new login options and behaviors.

New Features:
- Allow specifying a realm to construct a Keycloak-native OIDC discovery URL for direct authentication against Keycloak.
- Support username/password-based OAuth2 login in the CLI alongside token-based authentication.

Enhancements:
- Update the AuthLogin command to use realm-aware discovery URL selection and clarify CLI option semantics.
- Improve user documentation and troubleshooting guides to describe router-based vs direct Keycloak login flows and example commands.
- Extend test plans and add unit tests to validate realm-aware discovery URL construction and fallback behavior.