### PR TITLE
fix #1430: resolve namespace OIDC tenants dynamically to prevent OidcProxy NPE

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -14,8 +14,6 @@ public class AuthConfigSource implements ConfigSource {
 
     private static final String ENV_VAR = "WANAKU_HTTP_AUTH";
 
-    private static final int MAX_NAMESPACES = 10;
-
     private volatile Map<String, String> noauthProperties;
 
     @Override
@@ -74,11 +72,6 @@ public class AuthConfigSource implements ConfigSource {
             props.put("quarkus.oidc.mcp.enabled", "false");
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
             props.put("quarkus.oidc.mcp.resource-metadata.enabled", "false");
-            for (int i = 0; i < MAX_NAMESPACES; i++) {
-                props.put("quarkus.oidc.ns-%d.enabled".formatted(i), "false");
-                props.put("quarkus.oidc.ns-%d.discovery-enabled".formatted(i), "false");
-                props.put("quarkus.oidc.ns-%d.resource-metadata.enabled".formatted(i), "false");
-            }
             props.put("quarkus.oidc-proxy.enabled", "false");
             props.put("quarkus.http.auth.permission.authenticated.policy", "permit");
             props.put("quarkus.http.auth.permission.mcp-authenticated.policy", "permit");

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
@@ -50,8 +50,8 @@ public class NamespaceTenantConfigResolver implements TenantConfigResolver {
         }
 
         String tenantId = "ns-" + nsIndex;
-        String authServerUrl = authServer + "/realms/" + authRealm;
-        String authorizationServer = authProxy + oidcProxyRootPath;
+        String authServerUrl = stripTrailingSlash(authServer) + "/realms/" + authRealm;
+        String authorizationServer = stripTrailingSlash(authProxy) + oidcProxyRootPath;
 
         OidcTenantConfig config = OidcTenantConfig.authServerUrl(authServerUrl)
                 .tenantId(tenantId)
@@ -67,5 +67,12 @@ public class NamespaceTenantConfigResolver implements TenantConfigResolver {
                 .build();
 
         return Uni.createFrom().item(config);
+    }
+
+    private static String stripTrailingSlash(String url) {
+        if (url != null && url.endsWith("/")) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
@@ -1,0 +1,71 @@
+package ai.wanaku.backend.support;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class NamespaceTenantConfigResolver implements TenantConfigResolver {
+
+    static final Pattern NS_PATH_PATTERN = Pattern.compile("^/ns-(\\d+)/.*");
+    static final int MAX_NAMESPACES = 10;
+
+    @ConfigProperty(name = "auth.server")
+    String authServer;
+
+    @ConfigProperty(name = "auth.realm")
+    String authRealm;
+
+    @ConfigProperty(name = "auth.proxy")
+    String authProxy;
+
+    @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    String oidcProxyRootPath;
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+        String path = context.request().path();
+        Matcher matcher = NS_PATH_PATTERN.matcher(path);
+
+        if (!matcher.matches()) {
+            return Uni.createFrom().nullItem();
+        }
+
+        int nsIndex;
+        try {
+            nsIndex = Integer.parseInt(matcher.group(1));
+        } catch (NumberFormatException e) {
+            return Uni.createFrom().nullItem();
+        }
+
+        if (nsIndex < 0 || nsIndex >= MAX_NAMESPACES) {
+            return Uni.createFrom().nullItem();
+        }
+
+        String tenantId = "ns-" + nsIndex;
+        String authServerUrl = authServer + "/realms/" + authRealm;
+        String authorizationServer = authProxy + oidcProxyRootPath;
+
+        OidcTenantConfig config = OidcTenantConfig.authServerUrl(authServerUrl)
+                .tenantId(tenantId)
+                .token()
+                .audience("wanaku-mcp-client")
+                .end()
+                .resourceMetadata()
+                .enabled()
+                .resource(tenantId + "/mcp")
+                .authorizationServer(authorizationServer)
+                .forceHttpsScheme(false)
+                .end()
+                .build();
+
+        return Uni.createFrom().item(config);
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -82,6 +82,7 @@ quarkus.oidc.application-type=hybrid
 # URL path where users can log out from the application (don't change)
 quarkus.oidc.logout.path=/logout
 quarkus.oidc.discovery-enabled=true
+quarkus.oidc.connection-delay=60S
 quarkus.oidc.resource-metadata.enabled=true
 
 # This helps the metadata handler be aware that we are using the OIDC proxy (don't change)
@@ -98,88 +99,11 @@ quarkus.oidc.mcp.token.audience=wanaku-mcp-client
 quarkus.oidc.mcp.resource-metadata.enabled=true
 quarkus.oidc.mcp.resource-metadata.resource=mcp
 quarkus.oidc.mcp.resource-metadata.force-https-scheme=false
+quarkus.oidc.mcp.connection-delay=60S
 
-# Per-namespace OIDC tenant configurations so that each namespace
-# advertises the correct resource metadata URL in WWW-Authenticate headers
-quarkus.oidc.ns-0.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-0.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-0.tenant-paths=/ns-0/*
-quarkus.oidc.ns-0.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-0.resource-metadata.enabled=true
-quarkus.oidc.ns-0.resource-metadata.resource=ns-0/mcp
-quarkus.oidc.ns-0.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-1.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-1.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-1.tenant-paths=/ns-1/*
-quarkus.oidc.ns-1.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-1.resource-metadata.enabled=true
-quarkus.oidc.ns-1.resource-metadata.resource=ns-1/mcp
-quarkus.oidc.ns-1.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-2.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-2.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-2.tenant-paths=/ns-2/*
-quarkus.oidc.ns-2.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-2.resource-metadata.enabled=true
-quarkus.oidc.ns-2.resource-metadata.resource=ns-2/mcp
-quarkus.oidc.ns-2.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-3.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-3.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-3.tenant-paths=/ns-3/*
-quarkus.oidc.ns-3.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-3.resource-metadata.enabled=true
-quarkus.oidc.ns-3.resource-metadata.resource=ns-3/mcp
-quarkus.oidc.ns-3.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-4.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-4.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-4.tenant-paths=/ns-4/*
-quarkus.oidc.ns-4.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-4.resource-metadata.enabled=true
-quarkus.oidc.ns-4.resource-metadata.resource=ns-4/mcp
-quarkus.oidc.ns-4.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-5.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-5.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-5.tenant-paths=/ns-5/*
-quarkus.oidc.ns-5.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-5.resource-metadata.enabled=true
-quarkus.oidc.ns-5.resource-metadata.resource=ns-5/mcp
-quarkus.oidc.ns-5.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-6.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-6.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-6.tenant-paths=/ns-6/*
-quarkus.oidc.ns-6.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-6.resource-metadata.enabled=true
-quarkus.oidc.ns-6.resource-metadata.resource=ns-6/mcp
-quarkus.oidc.ns-6.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-7.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-7.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-7.tenant-paths=/ns-7/*
-quarkus.oidc.ns-7.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-7.resource-metadata.enabled=true
-quarkus.oidc.ns-7.resource-metadata.resource=ns-7/mcp
-quarkus.oidc.ns-7.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-8.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-8.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-8.tenant-paths=/ns-8/*
-quarkus.oidc.ns-8.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-8.resource-metadata.enabled=true
-quarkus.oidc.ns-8.resource-metadata.resource=ns-8/mcp
-quarkus.oidc.ns-8.resource-metadata.force-https-scheme=false
-
-quarkus.oidc.ns-9.resource-metadata.authorization-server=${auth.proxy}/q/oidc
-quarkus.oidc.ns-9.auth-server-url=${auth.server}/realms/${auth.realm}
-quarkus.oidc.ns-9.tenant-paths=/ns-9/*
-quarkus.oidc.ns-9.token.audience=wanaku-mcp-client
-quarkus.oidc.ns-9.resource-metadata.enabled=true
-quarkus.oidc.ns-9.resource-metadata.resource=ns-9/mcp
-quarkus.oidc.ns-9.resource-metadata.force-https-scheme=false
+# Per-namespace OIDC tenant configurations (ns-0 through ns-9) are resolved
+# dynamically by NamespaceTenantConfigResolver to avoid sequential startup
+# discovery delays and OidcProxy NPE when the OIDC server is slow.
 
 quarkus.oidc-proxy.enabled=true
 quarkus.oidc-proxy.root-path=/q/oidc

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -69,11 +69,6 @@ class AuthConfigSourceTest {
         assertEquals("false", props.get("quarkus.oidc.mcp.enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.resource-metadata.enabled"));
-        for (int i = 0; i < 10; i++) {
-            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".enabled"));
-            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".discovery-enabled"));
-            assertEquals("false", props.get("quarkus.oidc.ns-" + i + ".resource-metadata.enabled"));
-        }
         assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.mcp-authenticated.policy"));
         assertEquals("permit", props.get("quarkus.http.auth.permission.web.policy"));
@@ -94,12 +89,6 @@ class AuthConfigSourceTest {
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.resource-metadata.enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.discovery-enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-0.resource-metadata.enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.discovery-enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc.ns-9.resource-metadata.enabled"));
         assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
@@ -99,6 +99,21 @@ class NamespaceTenantConfigResolverTest {
     }
 
     @Test
+    void normalizesTrailingSlashesOnAuthServer() {
+        resolver.authServer = "http://keycloak:8080/";
+        resolver.authProxy = "http://localhost:8080/";
+        RoutingContext ctx = mockContext("/ns-0/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+        assertEquals(
+                "http://keycloak:8080/realms/wanaku", config.authServerUrl().orElse(null));
+        assertEquals(
+                "http://localhost:8080/q/oidc",
+                config.resourceMetadata().authorizationServer().orElse(null));
+    }
+
+    @Test
     void patternDoesNotMatchBareNamespacePath() {
         RoutingContext ctx = mockContext("/ns-0");
         OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
@@ -1,0 +1,115 @@
+package ai.wanaku.backend.support;
+
+import java.util.regex.Matcher;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NamespaceTenantConfigResolverTest {
+
+    private NamespaceTenantConfigResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new NamespaceTenantConfigResolver();
+        resolver.authServer = "http://keycloak:8080";
+        resolver.authRealm = "wanaku";
+        resolver.authProxy = "http://localhost:8080";
+        resolver.oidcProxyRootPath = "/q/oidc";
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/ns-0/mcp/sse", "/ns-5/mcp/message", "/ns-9/something"})
+    void resolvesValidNamespacePaths(String path) {
+        RoutingContext ctx = mockContext(path);
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+
+        Matcher matcher = NamespaceTenantConfigResolver.NS_PATH_PATTERN.matcher(path);
+        assertTrue(matcher.matches());
+        String expectedTenantId = "ns-" + matcher.group(1);
+        assertEquals(expectedTenantId, config.tenantId().orElse(null));
+    }
+
+    @Test
+    void setsCorrectAuthServerUrl() {
+        RoutingContext ctx = mockContext("/ns-3/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+        assertEquals(
+                "http://keycloak:8080/realms/wanaku", config.authServerUrl().orElse(null));
+    }
+
+    @Test
+    void setsCorrectTokenAudience() {
+        RoutingContext ctx = mockContext("/ns-0/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+        assertTrue(config.token().audience().isPresent());
+        assertTrue(config.token().audience().get().contains("wanaku-mcp-client"));
+    }
+
+    @Test
+    void setsCorrectResourceMetadata() {
+        RoutingContext ctx = mockContext("/ns-7/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+        assertTrue(config.resourceMetadata().enabled());
+        assertEquals("ns-7/mcp", config.resourceMetadata().resource().orElse(null));
+        assertEquals(
+                "http://localhost:8080/q/oidc",
+                config.resourceMetadata().authorizationServer().orElse(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/v1/tools", "/mcp/sse", "/admin/dashboard", "/public/mcp", "/"})
+    void returnsNullForNonNamespacePaths(String path) {
+        RoutingContext ctx = mockContext(path);
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+        assertNull(config);
+    }
+
+    @Test
+    void returnsNullForNamespaceExceedingMax() {
+        RoutingContext ctx = mockContext("/ns-10/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+        assertNull(config);
+    }
+
+    @Test
+    void returnsNullForNegativeNamespace() {
+        RoutingContext ctx = mockContext("/ns--1/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+        assertNull(config);
+    }
+
+    @Test
+    void patternDoesNotMatchBareNamespacePath() {
+        RoutingContext ctx = mockContext("/ns-0");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+        assertNull(config);
+    }
+
+    private RoutingContext mockContext(String path) {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(ctx.request()).thenReturn(request);
+        when(request.path()).thenReturn(path);
+        return ctx;
+    }
+}

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -703,7 +703,58 @@ else
 fi
 ```
 
-### Test 7.3: Verify router and capability pods are running
+### Test 7.3: Verify namespace MCP SSE endpoint requires authentication and is reachable
+
+**Description:** The namespace-scoped MCP endpoints (`/ns-{N}/mcp/sse`) use a dynamic OIDC tenant resolver (`NamespaceTenantConfigResolver`). Verify that unauthenticated requests are rejected (HTTP 401) and authenticated requests are accepted. This covers the fix for [#1430](https://github.com/wanaku-ai/wanaku/issues/1430).
+
+```bash
+NS_MCP_SSE_URL="http://${ROUTER_HOST}/ns-0/mcp/sse"
+
+# Step 1: Unauthenticated request should return 401
+UNAUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Accept: text/event-stream" \
+  --max-time 5 \
+  "${NS_MCP_SSE_URL}" 2>/dev/null || echo "000")
+
+echo "ns-0-mcp-sse-unauth=${UNAUTH_CODE}"
+if [ "${UNAUTH_CODE}" = "401" ]; then
+  echo "PASS: namespace MCP SSE returns 401 without token"
+else
+  echo "FAIL: expected 401, got HTTP ${UNAUTH_CODE}"
+fi
+
+# Step 2: Authenticated request should be accepted
+KC_POD=$(oc get pods -l app=keycloak \
+  -n "${WANAKU_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}')
+
+NS_TOKEN=$(oc exec "${KC_POD}" -n "${WANAKU_NAMESPACE}" -- \
+  curl -sf \
+    -d "client_id=wanaku-service" \
+    -d "client_secret=${WANAKU_OIDC_CLIENT_SECRET}" \
+    -d "grant_type=client_credentials" \
+    "http://localhost:8080/realms/wanaku/protocol/openid-connect/token" \
+  | jq -r '.access_token')
+
+if [ -z "${NS_TOKEN}" ] || [ "${NS_TOKEN}" = "null" ]; then
+  echo "FAIL: could not obtain token for namespace MCP test"
+else
+  AUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Accept: text/event-stream" \
+    -H "Authorization: Bearer ${NS_TOKEN}" \
+    --max-time 5 \
+    "${NS_MCP_SSE_URL}" 2>/dev/null || echo "000")
+
+  echo "ns-0-mcp-sse-auth=${AUTH_CODE}"
+  # 200 = streaming, 000 = SSE timeout (normal for streaming endpoints)
+  if [ "${AUTH_CODE}" = "200" ] || [ "${AUTH_CODE}" = "000" ]; then
+    echo "PASS: namespace MCP SSE accepts authenticated request (HTTP ${AUTH_CODE})"
+  else
+    echo "FAIL: unexpected response from namespace MCP SSE with token (HTTP ${AUTH_CODE})"
+  fi
+fi
+```
+
+### Test 7.4: Verify router and capability pods are running
 
 ```bash
 echo "--- All pods in ${WANAKU_NAMESPACE} ---"
@@ -722,7 +773,7 @@ else
 fi
 ```
 
-### Test 7.4: Verify operator logs contain reconciliation records
+### Test 7.5: Verify operator logs contain reconciliation records
 
 ```bash
 OPERATOR_POD=$(oc get pods -l app.kubernetes.io/name=wanaku-operator \
@@ -853,7 +904,7 @@ Follow [common/cleanup.md](common/cleanup.md) for full teardown.
 | 4 | 4.1-4.6 | WanakuCapability lifecycle | Critical |
 | 5 | 5.1-5.2 | WanakuCapability negative tests | High |
 | 6 | 6.1-6.4 | WanakuServiceCatalog lifecycle | High |
-| 7 | 7.1-7.4 | Smoke test (full flow) | Critical |
+| 7 | 7.1-7.5 | Smoke test (full flow, incl. namespace OIDC) | Critical |
 | 8 | 8.1-8.2 | Update reconciliation | Medium |
 | 9 | 9.1-9.3 | Deletion and ownership cascade | Critical |
 | 10 | — | Cleanup | Critical |


### PR DESCRIPTION
## Summary

- Replace 10 static `quarkus.oidc.ns-*` tenant definitions with a `NamespaceTenantConfigResolver` that builds tenant config dynamically on first request, eliminating sequential OIDC discovery at startup
- Add `connection-delay=60S` for the remaining static tenants (Default, `mcp`) as defense-in-depth against slow Keycloak responses
- Remove ns-* tenant disabling from `AuthConfigSource` (no longer needed since dynamic tenants are not initialized at startup when OIDC is disabled)

## Test plan

- [x] Unit tests for `NamespaceTenantConfigResolver` (14 tests): valid paths, boundary conditions, config values
- [x] Updated `AuthConfigSourceTest` (12 tests): removed ns-* assertions
- [x] All 349 unit tests pass
- [x] OIDC integration tests pass
- [ ] Deploy on OpenShift with Keycloak and verify router starts without NPE
- [ ] Verify namespace MCP endpoints return correct 401 challenges with resource metadata

## Summary by Sourcery

Dynamically resolve per-namespace OIDC tenants at request time to avoid startup discovery issues and OidcProxy NPE when the OIDC server is slow.

Enhancements:
- Introduce NamespaceTenantConfigResolver to build namespace-specific OIDC tenant configurations on demand instead of via static properties.
- Add OIDC connection delay configuration for the default and mcp tenants to tolerate slow Keycloak responses.

Tests:
- Add unit tests covering NamespaceTenantConfigResolver behavior for valid, invalid, and boundary namespace paths.
- Update AuthConfigSource tests to remove expectations around disabled per-namespace OIDC tenants when auth is set to none.