### PR TITLE
Fix #1375: add AUTH_REALM to router deployment and merge template env vars

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/RouterResourceFactory.java
@@ -2,6 +2,7 @@ package ai.wanaku.operator.util;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.jboss.logging.Logger;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -266,6 +267,17 @@ public final class RouterResourceFactory {
                             .build();
                     envVars.add(customEnvVar);
                 }
+            }
+        }
+
+        final List<EnvVar> templateEnvs = service.getEnv();
+        for (EnvVar templateVar : templateEnvs) {
+            final Optional<EnvVar> override = envVars.stream()
+                    .filter(envVar -> envVar.getName().equals(templateVar.getName()))
+                    .findFirst();
+
+            if (override.isEmpty()) {
+                envVars.add(templateVar);
             }
         }
 

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -33,6 +33,8 @@ spec:
               value: ""
             - name: AUTH_PROXY
               value: ""
+            - name: AUTH_REALM
+              value: ""
             - name: QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED
               value: "true"
           livenessProbe:

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/RouterResourceFactoryTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/RouterResourceFactoryTest.java
@@ -1,0 +1,123 @@
+package ai.wanaku.operator.util;
+
+import java.util.List;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import ai.wanaku.operator.wanaku.WanakuRouter;
+import ai.wanaku.operator.wanaku.WanakuRouterSpec;
+import ai.wanaku.operator.wanaku.WanakuTypes;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RouterResourceFactoryTest {
+
+    @Test
+    void authEnabledSetsAllAuthEnvVars() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+
+        WanakuRouter router = createRouter(auth, null);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertEquals("http://keycloak:8080", getEnvValue(deployment, EnvironmentVariables.AUTH_SERVER));
+        assertEquals("http://keycloak:8080", getEnvValue(deployment, EnvironmentVariables.AUTH_PROXY));
+        assertEquals("wanaku", getEnvValue(deployment, EnvironmentVariables.AUTH_REALM));
+    }
+
+    @Test
+    void authEnabledWithCustomRealmPropagatesRealm() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+        auth.setAuthRealm("custom-realm");
+
+        WanakuRouter router = createRouter(auth, null);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertEquals("custom-realm", getEnvValue(deployment, EnvironmentVariables.AUTH_REALM));
+    }
+
+    @Test
+    void authDisabledPreservesTemplateEnvVars() {
+        WanakuRouter router = createRouter(null, null);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertEquals("true", getEnvValue(deployment, EnvironmentVariables.QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED));
+
+        assertEquals("", getEnvValue(deployment, EnvironmentVariables.AUTH_SERVER));
+        assertEquals("", getEnvValue(deployment, EnvironmentVariables.AUTH_PROXY));
+        assertEquals("", getEnvValue(deployment, EnvironmentVariables.AUTH_REALM));
+    }
+
+    @Test
+    void templateEnvVarsPreservedWhenAuthEnabled() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+
+        WanakuRouter router = createRouter(auth, null);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertNotNull(getEnvValue(deployment, EnvironmentVariables.QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED));
+        assertEquals("true", getEnvValue(deployment, EnvironmentVariables.QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED));
+        assertNotNull(getEnvValue(deployment, EnvironmentVariables.AUTH_SERVER));
+    }
+
+    @Test
+    void customEnvVarsFromRouterSpec() {
+        WanakuRouterSpec.RouterSpec routerSpec = new WanakuRouterSpec.RouterSpec();
+        WanakuTypes.EnvVar customVar = new WanakuTypes.EnvVar();
+        customVar.setName("MY_VAR");
+        customVar.setValue("my_value");
+        routerSpec.setEnv(List.of(customVar));
+
+        WanakuRouter router = createRouter(null, routerSpec);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertEquals("my_value", getEnvValue(deployment, "MY_VAR"));
+    }
+
+    @Test
+    void authProxyAutoUsesHost() {
+        WanakuTypes.AuthSpec auth = new WanakuTypes.AuthSpec();
+        auth.setAuthServer("http://keycloak:8080");
+        auth.setAuthProxy("auto");
+
+        WanakuRouter router = createRouter(auth, null);
+        Deployment deployment =
+                RouterResourceFactory.makeDesiredRouterBackendDeployment(router, null, "router.example.com");
+
+        assertEquals("http://router.example.com", getEnvValue(deployment, EnvironmentVariables.AUTH_PROXY));
+    }
+
+    private static WanakuRouter createRouter(WanakuTypes.AuthSpec auth, WanakuRouterSpec.RouterSpec routerSpec) {
+        WanakuRouter router = new WanakuRouter();
+        router.setMetadata(new ObjectMetaBuilder()
+                .withName("test-router")
+                .withNamespace("default")
+                .withUid("test-uid-1234")
+                .build());
+        WanakuRouterSpec spec = new WanakuRouterSpec();
+        spec.setAuth(auth);
+        spec.setRouter(routerSpec);
+        router.setSpec(spec);
+        return router;
+    }
+
+    private static String getEnvValue(Deployment deployment, String name) {
+        return deployment.getSpec().getTemplate().getSpec().getContainers().stream()
+                .filter(c -> c.getName().equals("wanaku-mcp-router"))
+                .findFirst()
+                .flatMap(c -> c.getEnv().stream()
+                        .filter(e -> e.getName().equals(name))
+                        .findFirst())
+                .map(EnvVar::getValue)
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AUTH_REALM` env var to the router deployment YAML template for consistency with `AUTH_SERVER` and `AUTH_PROXY`
- Refactor `RouterResourceFactory.setupBackendContainer` to merge template env vars instead of replacing them, matching the pattern used by `CapabilityResourceFactory`
- This fixes `QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED` being silently dropped from the template
- Add unit tests for `RouterResourceFactory` covering auth enabled/disabled, custom realm, template var preservation, custom env vars, and auth proxy auto mode

## Test plan
- [x] All 6 new `RouterResourceFactoryTest` tests pass
- [x] All 87 operator unit tests pass
- [x] Full reactor build passes (integration tests skipped due to pre-existing Keycloak testcontainer issue)
- [ ] Deploy operator on OpenShift, create WanakuRouter CR with auth section, verify AUTH_REALM is set on router deployment

## Summary by Sourcery

Ensure router deployments preserve and extend template environment variables while supporting authentication realm configuration.

New Features:
- Add AUTH_REALM environment variable to the wanaku router deployment template to support configurable authentication realms.

Bug Fixes:
- Prevent template environment variables such as QUARKUS_MCP_SERVER_TRAFFIC_LOGGING_ENABLED from being dropped when building router backend deployments.

Enhancements:
- Merge router backend container environment variables with those from the deployment YAML template instead of replacing them to allow overrides while retaining defaults.

Tests:
- Add RouterResourceFactory unit tests covering auth enable/disable, custom realms, template env var preservation, custom env vars from router spec, and auth proxy auto mode.