### PR TITLE
cli: Add --insecure cli parameter to trust all server certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ plan
 .claude/worktrees
 .claude/settings.local.json
 working-data/
+.bob/

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
@@ -1,11 +1,14 @@
 package ai.wanaku.cli.main.commands;
 
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.concurrent.Callable;
 import org.jline.terminal.Terminal;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.cli.main.support.AuthenticationInterceptor;
+import ai.wanaku.cli.main.support.HttpUtil;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.cli.main.support.security.InsecureSSLHelper;
 import picocli.CommandLine;
 
 /**
@@ -46,9 +49,24 @@ public abstract class BaseCommand implements Callable<Integer> {
     protected boolean noAuth = false;
 
     @CommandLine.Option(
+            names = {"--insecure"},
+            description =
+                    "Skip certificate checks for the TLS connections (insecure, use only for development purposes)")
+    protected boolean insecure = false;
+
+    @CommandLine.Option(
             names = {"--plain"},
             description = "Route output through stdout so it can be captured by a parent process")
     boolean plain = false;
+
+    /**
+     * Creates an HttpClient instance, optionally configured for insecure SSL.
+     *
+     * @return a configured HttpClient
+     */
+    protected HttpClient createHttpClient() {
+        return HttpUtil.newHttpClient(insecure);
+    }
 
     /**
      * Initializes and configures the REST client for communicating with the Wanaku service.
@@ -64,7 +82,7 @@ public abstract class BaseCommand implements Callable<Integer> {
      * @throws IllegalArgumentException if the host URL is invalid or malformed
      * @throws NullPointerException if host is null
      */
-    protected static <T> T initService(Class<T> clazz, String host) {
+    protected <T> T initService(Class<T> clazz, String host) {
         return initService(clazz, host, null, false);
     }
 
@@ -72,7 +90,23 @@ public abstract class BaseCommand implements Callable<Integer> {
         return initService(clazz, host, this.authTokenOverride, this.noAuth);
     }
 
-    protected static <T> T initService(Class<T> clazz, String host, String tokenOverride, boolean noAuth) {
+    /**
+     * Initializes and configures the REST client for communicating with the Wanaku service.
+     *
+     * <p>Creates a properly configured Quarkus REST client builder with the specified host URL.
+     * The client is configured with appropriate timeouts and error handling for reliable
+     * communication with the Wanaku API endpoints.</p>
+     *
+     * @param <T> the type of the service interface
+     * @param clazz the Class object representing the service interface
+     * @param host the base URL of the Wanaku service API (must be a valid URI)
+     * @param tokenOverride to set the Bearer token in the http call
+     * @param noAuth to skip the keycloak authentication
+     * @return a configured Service instance ready for API calls
+     * @throws IllegalArgumentException if the host URL is invalid or malformed
+     * @throws NullPointerException if host is null
+     */
+    protected <T> T initService(Class<T> clazz, String host, String tokenOverride, boolean noAuth) {
         if (host == null) {
             throw new NullPointerException("Host URL cannot be null");
         }
@@ -81,10 +115,14 @@ public abstract class BaseCommand implements Callable<Integer> {
             QuarkusRestClientBuilder builder =
                     QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host));
 
+            if (insecure) {
+                builder.trustAll(true).hostnameVerifier(InsecureSSLHelper.getInsecureHostnameVerifier());
+            }
+
             if (!noAuth) {
                 AuthenticationInterceptor authInterceptor = tokenOverride != null
                         ? newAuthenticationInterceptor(tokenOverride)
-                        : new AuthenticationInterceptor();
+                        : new AuthenticationInterceptor(insecure);
                 builder.register(authInterceptor);
             }
 
@@ -94,7 +132,7 @@ public abstract class BaseCommand implements Callable<Integer> {
         }
     }
 
-    protected static <T> T initServiceIfNeeded(T existing, Class<T> clazz, String host) {
+    protected <T> T initServiceIfNeeded(T existing, Class<T> clazz, String host) {
         if (existing != null) {
             return existing;
         }
@@ -108,8 +146,8 @@ public abstract class BaseCommand implements Callable<Integer> {
         return initAuthenticatedService(clazz, host);
     }
 
-    private static AuthenticationInterceptor newAuthenticationInterceptor(String tokenOverride) {
-        return new AuthenticationInterceptor() {
+    private AuthenticationInterceptor newAuthenticationInterceptor(String tokenOverride) {
+        return new AuthenticationInterceptor(insecure) {
             @Override
             public void filter(jakarta.ws.rs.client.ClientRequestContext requestContext) {
                 requestContext
@@ -124,6 +162,10 @@ public abstract class BaseCommand implements Callable<Integer> {
         WanakuPrinter.setPlainMode(plain);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
             WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            if (insecure) {
+                printer.printWarningMessage(
+                        "WARNING: TLS certificate verification is disabled. This is insecure and should only be used for development.");
+            }
             return doCall(terminal, printer);
         } finally {
             WanakuPrinter.setPlainMode(false);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
@@ -77,7 +77,7 @@ public abstract class BaseAdminCommand extends BaseCommand {
         }
 
         String token = obtainAdminToken();
-        return new KeycloakAdminClient(keycloakUrl, token);
+        return KeycloakAdminClient.create(keycloakUrl, token, insecure);
     }
 
     private String obtainAdminToken() {
@@ -97,7 +97,7 @@ public abstract class BaseAdminCommand extends BaseCommand {
                 .build();
 
         try {
-            HttpClient client = HttpClient.newHttpClient();
+            HttpClient client = createHttpClient();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() != 200) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -23,7 +23,7 @@ public class AuthLogin extends BaseCommand {
 
     @CommandLine.Option(
             names = {"--auth-server"},
-            description = "Authentication server URL")
+            description = "Authentication server URL (Wanaku or Keycloak)")
     private String authServerUrl;
 
     @CommandLine.Option(
@@ -72,16 +72,16 @@ public class AuthLogin extends BaseCommand {
             try {
                 printer.printInfoMessage("Authenticating with username and password...");
                 CustomSecurityServiceConfig config = new CustomSecurityServiceConfig();
-                config.setClientId(DEFAULT_CLIENT_ID);
+                config.setClientId(clientId);
                 config.setUsername(username);
                 config.setPassword(password);
                 config.setTokenEndpoint(TokenEndpoint.forDiscovery(serverUrl, realm));
-                ServiceAuthenticator serviceAuthenticator = new ServiceAuthenticator(config);
+                ServiceAuthenticator serviceAuthenticator = new ServiceAuthenticator(config, insecure);
 
                 credentialStore.storeApiToken(serviceAuthenticator.currentValidAccessToken());
                 credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
                 credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
-                credentialStore.storeClientId(DEFAULT_CLIENT_ID);
+                credentialStore.storeClientId(clientId);
                 credentialStore.storeRealm(realm != null && realm.isBlank() ? null : realm);
 
                 credentialStore.storeAuthMode("token");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesWatch.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesWatch.java
@@ -53,7 +53,7 @@ public class CapabilitiesWatch extends BaseCommand {
         printer.printInfoMessage("Connecting to " + url + " ...");
         printer.printInfoMessage("Press Ctrl+C to stop watching.\n");
 
-        HttpClient client = HttpClient.newHttpClient();
+        HttpClient client = createHttpClient();
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Accept", "text/event-stream")

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -114,7 +114,7 @@ public class StartLocal extends StartBase {
 
         environment.withFailFast(failFast);
 
-        LocalRunner localRunner = new LocalRunner(config, environment);
+        LocalRunner localRunner = new LocalRunner(config, environment, insecure);
         try {
             localRunner.start(services);
         } catch (WanakuException | IOException e) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -31,22 +31,27 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
 
     private final AuthCredentialStore credentialStore;
     private final TokenRefresher tokenRefresher;
+    private final boolean insecure;
 
     private volatile Boolean routerAuthEnabled;
 
-    public AuthenticationInterceptor() {
+    public AuthenticationInterceptor(boolean insecure) {
         this.credentialStore = new AuthCredentialStore();
-        this.tokenRefresher = new TokenRefresher();
+        this.tokenRefresher = new TokenRefresher(insecure);
+        this.insecure = insecure;
     }
 
-    public AuthenticationInterceptor(AuthCredentialStore credentialStore) {
+    public AuthenticationInterceptor(AuthCredentialStore credentialStore, boolean insecure) {
         this.credentialStore = credentialStore;
-        this.tokenRefresher = new TokenRefresher();
+        this.tokenRefresher = new TokenRefresher(insecure);
+        this.insecure = insecure;
     }
 
-    public AuthenticationInterceptor(AuthCredentialStore credentialStore, TokenRefresher tokenRefresher) {
+    public AuthenticationInterceptor(
+            AuthCredentialStore credentialStore, TokenRefresher tokenRefresher, boolean insecure) {
         this.credentialStore = credentialStore;
         this.tokenRefresher = tokenRefresher;
+        this.insecure = insecure;
     }
 
     @Override
@@ -82,8 +87,7 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
         }
 
         URI wellKnown = requestUri.resolve("/.well-known/oauth-authorization-server");
-        try (HttpClient client =
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build()) {
+        try (HttpClient client = HttpUtil.newHttpClient(insecure, Duration.ofSeconds(3))) {
             HttpRequest request = HttpRequest.newBuilder(wellKnown)
                     .timeout(Duration.ofSeconds(5))
                     .GET()

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/HttpUtil.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/HttpUtil.java
@@ -1,0 +1,70 @@
+package ai.wanaku.cli.main.support;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import ai.wanaku.cli.main.support.security.InsecureSSLHelper;
+
+/**
+ * Factory methods for {@link java.net.http.HttpClient}.
+ * <p>
+ * Centralises the optional insecure-SSL wiring so that callers never need to
+ * reference {@link InsecureSSLHelper} directly.
+ * </p>
+ * <p>
+ * WARNING: The insecure variants completely disable SSL certificate validation
+ * and hostname verification. Use only for development/testing with self-signed
+ * certificates.
+ * </p>
+ */
+public final class HttpUtil {
+
+    private HttpUtil() {}
+
+    /**
+     * Returns a plain, secure {@link HttpClient}.
+     *
+     * @return a new HttpClient with default (secure) settings
+     */
+    public static HttpClient newHttpClient() {
+        return HttpClient.newHttpClient();
+    }
+
+    /**
+     * Returns an {@link HttpClient}, optionally configured to skip SSL certificate
+     * and hostname verification.
+     *
+     * @param insecure when {@code true}, disables SSL verification (development only)
+     * @return a configured HttpClient
+     */
+    public static HttpClient newHttpClient(boolean insecure) {
+        if (!insecure) {
+            return HttpClient.newHttpClient();
+        }
+        return applyInsecureSsl(HttpClient.newBuilder()).build();
+    }
+
+    /**
+     * Returns an {@link HttpClient}, optionally configured to skip SSL certificate
+     * and hostname verification, with a TCP-level connect timeout.
+     *
+     * @param insecure       when {@code true}, disables SSL verification (development only)
+     * @param connectTimeout TCP connect timeout to apply to the client
+     * @return a configured HttpClient
+     */
+    public static HttpClient newHttpClient(boolean insecure, Duration connectTimeout) {
+        HttpClient.Builder builder = HttpClient.newBuilder().connectTimeout(connectTimeout);
+        if (insecure) {
+            builder = applyInsecureSsl(builder);
+        }
+        return builder.build();
+    }
+
+    private static HttpClient.Builder applyInsecureSsl(HttpClient.Builder builder) {
+        try {
+            return builder.sslContext(InsecureSSLHelper.createInsecureSSLContext())
+                    .sslParameters(InsecureSSLHelper.createInsecureSSLParameters());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create insecure SSL context", e);
+        }
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -174,7 +174,7 @@ public class WanakuPrinter extends DefaultPrinter {
     }
 
     private static TerminalBuilder newBuilder() {
-        TerminalBuilder builder = TerminalBuilder.builder().system(!plainMode);
+        TerminalBuilder builder = TerminalBuilder.builder().system(true);
         if (plainMode) {
             // When not using the system terminal, JLine needs explicit streams
             // otherwise masterInput/masterOutput are null and any I/O throws NPE

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClient.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/keycloak/KeycloakAdminClient.java
@@ -8,6 +8,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import ai.wanaku.cli.main.support.HttpUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,18 @@ public class KeycloakAdminClient {
         this.keycloakUrl = keycloakUrl.endsWith("/") ? keycloakUrl.substring(0, keycloakUrl.length() - 1) : keycloakUrl;
         this.accessToken = accessToken;
         this.objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    /**
+     * Creates a KeycloakAdminClient with optional insecure SSL configuration.
+     *
+     * @param keycloakUrl the Keycloak server URL
+     * @param accessToken the access token for authentication
+     * @param insecure whether to skip SSL certificate verification
+     * @return a configured KeycloakAdminClient instance
+     */
+    public static KeycloakAdminClient create(String keycloakUrl, String accessToken, boolean insecure) {
+        return new KeycloakAdminClient(HttpUtil.newHttpClient(insecure), keycloakUrl, accessToken);
     }
 
     // ---- User methods ----

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/InsecureSSLHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/InsecureSSLHelper.java
@@ -1,0 +1,88 @@
+package ai.wanaku.cli.main.support.security;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+
+/**
+ * Utility for creating insecure SSL contexts that skip certificate verification.
+ * <p>
+ * WARNING: Only use for development/testing with self-signed certificates.
+ * This completely disables SSL certificate validation and hostname verification,
+ * making connections vulnerable to man-in-the-middle attacks.
+ * </p>
+ */
+public class InsecureSSLHelper {
+
+    private InsecureSSLHelper() {}
+
+    private static final X509ExtendedTrustManager[] TRUST_ALL = new X509ExtendedTrustManager[] {
+        new X509ExtendedTrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+
+            public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+            public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+
+            public void checkClientTrusted(X509Certificate[] chain, String authType, java.net.Socket socket) {}
+
+            public void checkServerTrusted(X509Certificate[] chain, String authType, java.net.Socket socket) {}
+
+            public void checkClientTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
+
+            public void checkServerTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
+        }
+    };
+
+    private static final HostnameVerifier TRUST_ALL_HOSTS = (hostname, session) -> true;
+
+    /**
+     * Creates an insecure SSL context that trusts all certificates.
+     *
+     * @return an SSLContext configured to trust all certificates
+     * @throws GeneralSecurityException if SSL context creation fails
+     */
+    public static SSLContext createInsecureSSLContext() throws GeneralSecurityException {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, TRUST_ALL, new java.security.SecureRandom());
+        return sslContext;
+    }
+
+    /**
+     * Returns a hostname verifier that accepts all hostnames.
+     *
+     * @return a HostnameVerifier that always returns true
+     */
+    public static HostnameVerifier getInsecureHostnameVerifier() {
+        return TRUST_ALL_HOSTS;
+    }
+
+    /**
+     * Creates an insecure SSL socket factory that trusts all certificates.
+     *
+     * @return an SSLSocketFactory configured to trust all certificates
+     * @throws GeneralSecurityException if SSL socket factory creation fails
+     */
+    public static SSLSocketFactory getInsecureSSLSocketFactory() throws GeneralSecurityException {
+        return createInsecureSSLContext().getSocketFactory();
+    }
+
+    /**
+     * Creates SSL parameters that disable endpoint identification (hostname verification).
+     * This is required for java.net.http.HttpClient to skip hostname verification.
+     *
+     * @return SSLParameters with endpoint identification disabled
+     */
+    public static SSLParameters createInsecureSSLParameters() {
+        SSLParameters sslParameters = new SSLParameters();
+        sslParameters.setEndpointIdentificationAlgorithm(null); // Disable hostname verification
+        return sslParameters;
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/OIDCHttpUtils.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/OIDCHttpUtils.java
@@ -1,0 +1,37 @@
+package ai.wanaku.cli.main.support.security;
+
+import java.io.IOException;
+import java.net.URL;
+import com.nimbusds.oauth2.sdk.GeneralException;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import net.minidev.json.JSONObject;
+
+public class OIDCHttpUtils {
+
+    private OIDCHttpUtils() {}
+
+    public static OIDCProviderMetadata performHttpRequest(Issuer issuer, boolean insecure)
+            throws GeneralException, IOException {
+        final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);
+        HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, openIdConfigUrl);
+        if (insecure) {
+            try {
+                httpRequest.setSSLSocketFactory(InsecureSSLHelper.getInsecureSSLSocketFactory());
+                httpRequest.setHostnameVerifier(InsecureSSLHelper.getInsecureHostnameVerifier());
+            } catch (Exception e) {
+                throw new ServiceAuthException("Failed to configure insecure SSL: " + e.getMessage(), e);
+            }
+        }
+        HTTPResponse httpResponse = httpRequest.send();
+        if (httpResponse.getStatusCode() != 200) {
+            throw new ServiceAuthException("Unable to download OpenID Provider metadata from " + openIdConfigUrl
+                    + ": Status code " + httpResponse.getStatusCode());
+        }
+        JSONObject jsonObject = httpResponse.getBodyAsJSONObject();
+        OIDCProviderMetadata resolvedOp = OIDCProviderMetadata.parse(jsonObject);
+        return resolvedOp;
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/ServiceAuthenticator.java
@@ -2,7 +2,6 @@ package ai.wanaku.cli.main.support.security;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;
@@ -20,13 +19,11 @@ import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import net.minidev.json.JSONObject;
 
 /**
  * Handles OAuth2 authentication with the Wanaku.
@@ -35,6 +32,7 @@ import net.minidev.json.JSONObject;
 public class ServiceAuthenticator {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceAuthenticator.class);
     private final SecurityServiceConfig config;
+    private final boolean insecure;
     private AccessToken accessToken;
     private RefreshToken refreshToken;
     private Instant creationTime;
@@ -45,7 +43,18 @@ public class ServiceAuthenticator {
      * @param config The security service configuration containing OAuth2 credentials.
      */
     public ServiceAuthenticator(SecurityServiceConfig config) {
+        this(config, false);
+    }
+
+    /**
+     * Creates a new authenticator and obtains an initial access token.
+     *
+     * @param config The security service configuration containing OAuth2 credentials.
+     * @param insecure Whether to skip SSL certificate verification.
+     */
+    public ServiceAuthenticator(SecurityServiceConfig config, boolean insecure) {
         this.config = config;
+        this.insecure = insecure;
 
         renewToken(config);
 
@@ -94,29 +103,15 @@ public class ServiceAuthenticator {
      * This mimics the resolve logic, but ignores the validation and other things we don't
      * need.
      */
-    private static Issuer resolveIssuer(SecurityServiceConfig config) {
+    private Issuer resolveIssuer(SecurityServiceConfig config) {
         // The OpenID provider issuer URL (strip trailing slash to avoid malformed paths)
         String endpoint = config.getTokenEndpoint();
         if (endpoint != null && endpoint.endsWith("/")) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);
         }
         Issuer issuer = new Issuer(endpoint);
-
         try {
-            final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);
-
-            HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, openIdConfigUrl);
-            HTTPResponse httpResponse = httpRequest.send();
-
-            if (httpResponse.getStatusCode() != 200) {
-                throw new ServiceAuthException("Unable to download OpenID Provider metadata from " + openIdConfigUrl
-                        + ": Status code " + httpResponse.getStatusCode());
-            }
-
-            JSONObject jsonObject = httpResponse.getBodyAsJSONObject();
-
-            OIDCProviderMetadata op = OIDCProviderMetadata.parse(jsonObject);
-
+            OIDCProviderMetadata op = OIDCHttpUtils.performHttpRequest(issuer, insecure);
             return op.getIssuer();
         } catch (GeneralException e) {
             throw new ServiceAuthException("Unable to resolve token endpoint URI: " + e.getMessage(), e);
@@ -125,17 +120,15 @@ public class ServiceAuthenticator {
         }
     }
 
-    private static URI resolveTokenEndpointUri(SecurityServiceConfig config) {
+    private URI resolveTokenEndpointUri(SecurityServiceConfig config) {
 
         /* We cannot use Wanaku's base address because it's typically behind the OIDC
          * proxy. Therefore, we first need to resolve the issuer address, and then
          * use the issuer address to resolve the OIDC metadata.
          */
         Issuer issuer = new Issuer(resolveIssuer(config));
-
         try {
-            final OIDCProviderMetadata resolvedOp = OIDCProviderMetadata.resolve(issuer);
-
+            OIDCProviderMetadata resolvedOp = OIDCHttpUtils.performHttpRequest(issuer, insecure);
             return resolvedOp.getTokenEndpointURI();
         } catch (GeneralException e) {
             throw new ServiceAuthException("Unable to resolve token endpoint URI: " + e.getMessage(), e);
@@ -167,7 +160,18 @@ public class ServiceAuthenticator {
     private void requestToken(TokenRequest request) {
         TokenResponse response = null;
         try {
-            response = TokenResponse.parse(request.toHTTPRequest().send());
+            HTTPRequest httpRequest = request.toHTTPRequest();
+
+            if (insecure) {
+                try {
+                    httpRequest.setSSLSocketFactory(InsecureSSLHelper.getInsecureSSLSocketFactory());
+                    httpRequest.setHostnameVerifier(InsecureSSLHelper.getInsecureHostnameVerifier());
+                } catch (Exception e) {
+                    throw new ServiceAuthException("Failed to configure insecure SSL: " + e.getMessage(), e);
+                }
+            }
+
+            response = TokenResponse.parse(httpRequest.send());
         } catch (IOException | ParseException e) {
             throw new ServiceAuthException(e);
         }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/TokenRefresher.java
@@ -2,7 +2,6 @@ package ai.wanaku.cli.main.support.security;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,13 +14,11 @@ import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import net.minidev.json.JSONObject;
 
 /**
  * Handles OAuth2 token refresh using stored refresh tokens.
@@ -30,6 +27,12 @@ import net.minidev.json.JSONObject;
  */
 public class TokenRefresher {
     private static final Logger LOG = LoggerFactory.getLogger(TokenRefresher.class);
+
+    private final boolean insecure;
+
+    public TokenRefresher(boolean insecure) {
+        this.insecure = insecure;
+    }
 
     /**
      * Result of a token refresh operation.
@@ -78,7 +81,18 @@ public class TokenRefresher {
             TokenRequest request = new TokenRequest(tokenEndpoint, clientID, refreshTokenGrant, null);
 
             LOG.debug("Sending token refresh request to {}", tokenEndpoint);
-            TokenResponse response = TokenResponse.parse(request.toHTTPRequest().send());
+            HTTPRequest httpRequest = request.toHTTPRequest();
+
+            if (insecure) {
+                try {
+                    httpRequest.setSSLSocketFactory(InsecureSSLHelper.getInsecureSSLSocketFactory());
+                    httpRequest.setHostnameVerifier(InsecureSSLHelper.getInsecureHostnameVerifier());
+                } catch (Exception e) {
+                    throw new TokenRefreshException("Failed to configure insecure SSL: " + e.getMessage(), e);
+                }
+            }
+
+            TokenResponse response = TokenResponse.parse(httpRequest.send());
 
             if (!response.indicatesSuccess()) {
                 TokenErrorResponse errorResponse = response.toErrorResponse();
@@ -105,24 +119,12 @@ public class TokenRefresher {
         }
     }
 
-    private static Issuer resolveIssuer(String authServerUrl, String realm) {
+    private Issuer resolveIssuer(String authServerUrl, String realm) {
         String discoveryUrl = TokenEndpoint.forDiscovery(authServerUrl, realm);
         Issuer issuer = new Issuer(discoveryUrl);
 
         try {
-            final URL openIdConfigUrl = OIDCProviderMetadata.resolveURL(issuer);
-
-            HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, openIdConfigUrl);
-            HTTPResponse httpResponse = httpRequest.send();
-
-            if (httpResponse.getStatusCode() != 200) {
-                throw new TokenRefreshException("Unable to download OpenID Provider metadata from " + openIdConfigUrl
-                        + ": Status code " + httpResponse.getStatusCode());
-            }
-
-            JSONObject jsonObject = httpResponse.getBodyAsJSONObject();
-            OIDCProviderMetadata op = OIDCProviderMetadata.parse(jsonObject);
-
+            OIDCProviderMetadata op = OIDCHttpUtils.performHttpRequest(issuer, insecure);
             return op.getIssuer();
         } catch (GeneralException e) {
             throw new TokenRefreshException("Unable to resolve token endpoint URI: " + e.getMessage(), e);
@@ -131,11 +133,11 @@ public class TokenRefresher {
         }
     }
 
-    private static URI resolveTokenEndpointUri(String authServerUrl, String realm) {
+    private URI resolveTokenEndpointUri(String authServerUrl, String realm) {
         Issuer issuer = new Issuer(resolveIssuer(authServerUrl, realm));
 
         try {
-            final OIDCProviderMetadata resolvedOp = OIDCProviderMetadata.resolve(issuer);
+            OIDCProviderMetadata resolvedOp = OIDCHttpUtils.performHttpRequest(issuer, insecure);
             return resolvedOp.getTokenEndpointURI();
         } catch (GeneralException e) {
             throw new TokenRefreshException("Unable to resolve token endpoint URI: " + e.getMessage(), e);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.common.ProcessRunner;
 import ai.wanaku.cli.main.support.Downloader;
+import ai.wanaku.cli.main.support.HttpUtil;
 import ai.wanaku.cli.main.support.RuntimeConstants;
 import ai.wanaku.cli.main.support.WanakuCliConfig;
 import ai.wanaku.cli.main.support.ZipHelper;
@@ -131,8 +132,8 @@ public class LocalRunner {
 
     private final LocalRunnerEnvironment environment;
 
-    public LocalRunner(WanakuCliConfig config, LocalRunnerEnvironment environment) {
-        this(config, environment, HttpClient.newHttpClient(), DEFAULT_ROUTER_READINESS_URI);
+    public LocalRunner(WanakuCliConfig config, LocalRunnerEnvironment environment, boolean insecure) {
+        this(config, environment, HttpUtil.newHttpClient(insecure), DEFAULT_ROUTER_READINESS_URI);
     }
 
     LocalRunner(

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/BaseCommandTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/BaseCommandTest.java
@@ -1,0 +1,60 @@
+package ai.wanaku.cli.main.commands;
+
+import javax.net.ssl.SSLContext;
+
+import java.net.http.HttpClient;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class BaseCommandTest {
+
+    /** Minimal concrete subclass used to exercise {@link BaseCommand} behaviour. */
+    private static class TestCommand extends BaseCommand {
+        @Override
+        public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+            return EXIT_OK;
+        }
+
+        HttpClient buildHttpClient(boolean insecureFlag) {
+            this.insecure = insecureFlag;
+            return createHttpClient();
+        }
+    }
+
+    // ---- --insecure flag tests ----
+
+    @Test
+    void createHttpClientWithInsecureFlag() throws Exception {
+        TestCommand cmd = new TestCommand();
+
+        HttpClient client = cmd.buildHttpClient(true);
+
+        // A custom SSLContext must have been set — it must differ from the JVM default.
+        assertNotSame(
+                SSLContext.getDefault(), client.sslContext(), "Expected a custom SSLContext when --insecure is set");
+
+        // InsecureSSLHelper.createInsecureSSLParameters() sets endpointIdentificationAlgorithm to null,
+        // which disables hostname verification in java.net.http.HttpClient.
+        assertNull(
+                client.sslParameters().getEndpointIdentificationAlgorithm(),
+                "Expected hostname verification to be disabled (endpointIdentificationAlgorithm == null)");
+    }
+
+    @Test
+    void createHttpClientWithoutInsecureFlag() throws Exception {
+        TestCommand cmd = new TestCommand();
+
+        HttpClient client = cmd.buildHttpClient(false);
+
+        // When --insecure is not set the builder must not override the JVM default SSLContext.
+        assertSame(
+                SSLContext.getDefault(),
+                client.sslContext(),
+                "Expected the JVM default SSLContext when --insecure is not set");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthenticationInterceptorTest.java
@@ -45,7 +45,7 @@ class AuthenticationInterceptorTest {
         Path credentialsFile = tempDir.resolve("test-credentials");
         URI credentialsUri = credentialsFile.toUri();
         credentialStore = new AuthCredentialStore(credentialsUri);
-        interceptor = new AuthenticationInterceptor(credentialStore);
+        interceptor = new AuthenticationInterceptor(credentialStore, false);
     }
 
     @Test
@@ -119,7 +119,8 @@ class AuthenticationInterceptorTest {
         when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
 
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
@@ -151,7 +152,8 @@ class AuthenticationInterceptorTest {
         when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, realm))
                 .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
 
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, realm);
@@ -169,7 +171,8 @@ class AuthenticationInterceptorTest {
         credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 300);
 
         TokenRefresher mockRefresher = mock(TokenRefresher.class);
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         verify(mockRefresher, never()).refresh(any(), any(), any(), any());
@@ -196,7 +199,8 @@ class AuthenticationInterceptorTest {
         when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenThrow(new TokenRefresher.TokenRefreshException("Refresh failed"));
 
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         // Should still use old token as fallback
@@ -211,7 +215,8 @@ class AuthenticationInterceptorTest {
         // No expiry stored (legacy token)
 
         TokenRefresher mockRefresher = mock(TokenRefresher.class);
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         verify(mockRefresher, never()).refresh(any(), any(), any(), any());
@@ -240,7 +245,8 @@ class AuthenticationInterceptorTest {
         when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
                 .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
 
-        AuthenticationInterceptor interceptorWithMock = new AuthenticationInterceptor(credentialStore, mockRefresher);
+        AuthenticationInterceptor interceptorWithMock =
+                new AuthenticationInterceptor(credentialStore, mockRefresher, false);
         interceptorWithMock.filter(requestContext);
 
         verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -49,7 +49,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
@@ -338,6 +338,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-ui-dist</id>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -227,6 +227,11 @@ Currently, all authenticated users have admin access to tools and resources. Fin
 
 While not recommended for production, you can set `wanaku.http.auth=none` to disable authentication for development and testing.
 
+### How to skip certificate validation for development purposes
+
+- Wanaku CLI: you can set the `--insecure` parameter to trust the server certificates.
+- Wanaku MCP server: set the environment variable `QUARKUS_TLS_TRUST_ALL=true`.
+
 ## Troubleshooting
 
 ### Why aren't my capability services showing up?
@@ -258,6 +263,8 @@ quarkus.log.level=DEBUG
 quarkus.log.category."ai.wanaku".level=DEBUG
 quarkus.mcp.server.traffic-logging.enabled=true
 ```
+
+When using the Wanaku CLI, set the `--verbose` parameter to show additional logging.
 
 ### Where can I get help?
 


### PR DESCRIPTION
partial of #1264

## Summary by Sourcery

Add an --insecure CLI option to the Wanaku CLI to allow optional, development-only disabling of TLS certificate and hostname verification across HTTP, authentication, and admin flows, and centralize insecure HTTP/SSL handling.

New Features:
- Introduce a global --insecure CLI flag on base commands to trust all TLS certificates and disable hostname verification for development use.
- Add a convenience factory method on KeycloakAdminClient to create instances with optional insecure SSL configuration.
- Add HttpUtil and InsecureSSLHelper utilities to centralize creation of HttpClient and SSL contexts that support insecure TLS modes.
- Add OIDCHttpUtils utility to centralize OIDC metadata HTTP requests with optional insecure SSL support.

Enhancements:
- Wire the --insecure flag through authentication, token refresh, admin, and local runner flows so that all CLI HTTP interactions can consistently use insecure TLS when requested.
- Refine AuthLogin to respect the provided clientId and support insecure authentication flows.
- Adjust router backend build configuration to use an explicit maven-resources-plugin version.
- Improve terminal handling by always using the system terminal while keeping plain output mode support.
- Document how to skip certificate validation in the CLI and MCP server and clarify logging options in the FAQ.

Build:
- Pin the maven-resources-plugin version in the router backend Maven configuration.

Documentation:
- Extend the FAQ with instructions for disabling certificate validation for development and enabling verbose CLI logging.

Tests:
- Add tests for BaseCommand to verify secure vs insecure HttpClient configuration and extend AuthenticationInterceptor tests for the new constructor signature.