### PR TITLE
Fix #849: cache gRPC channels with thread-safe computeIfAbsent

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManager.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManager.java
@@ -1,6 +1,7 @@
 package ai.wanaku.backend.bridge.transports.grpc;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
 import java.util.Map;
@@ -12,6 +13,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.quarkus.runtime.ShutdownEvent;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 
 /**
@@ -34,7 +36,7 @@ import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 @ApplicationScoped
 public class GrpcChannelManager {
     private static final Logger LOG = Logger.getLogger(GrpcChannelManager.class);
-    private static final Map<ServiceTarget, ManagedChannel> CHANNEL_MAP = new ConcurrentHashMap<>();
+    private final Map<ServiceTarget, ManagedChannel> channelMap = new ConcurrentHashMap<>();
     private static final String WANAKU_BRIDGE_GRPC_TRANSPORT_TLS_ENABLED = "wanaku.bridge.grpc.transport.tls.enabled";
 
     /**
@@ -70,21 +72,26 @@ public class GrpcChannelManager {
     }
 
     /**
-     * Creates a new gRPC channel for the specified service target.
+     * Returns a cached gRPC channel for the specified service target, creating one if absent.
      * <p>
-     * The channel uses plaintext or TLS depending on
-     * {@code wanaku.bridge.grpc.transport.tls.enabled}. The caller is responsible for managing the
-     * channel lifecycle, including shutdown.
+     * Channels are cached per {@link ServiceTarget} and reused across requests.
+     * A cached channel that has been shut down or terminated is automatically replaced.
      *
      * @param service the service target containing the address to connect to
-     * @return a new ManagedChannel configured for the service
+     * @return a ManagedChannel configured for the service
      */
     public ManagedChannel createChannel(ServiceTarget service) {
-        if (CHANNEL_MAP.containsKey(service)) {
-            LOG.debugf("Reusing gRPC channel for service: %s", service.toAddress());
-            return CHANNEL_MAP.get(service);
+        ManagedChannel channel = channelMap.computeIfAbsent(service, this::buildChannel);
+
+        if (channel.isShutdown() || channel.isTerminated()) {
+            channelMap.remove(service, channel);
+            channel = channelMap.computeIfAbsent(service, this::buildChannel);
         }
 
+        return channel;
+    }
+
+    private ManagedChannel buildChannel(ServiceTarget service) {
         LOG.debugf("Creating gRPC channel for service: %s (TLS: %s)", service.toAddress(), tlsEnabled);
         ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forTarget(service.toAddress());
         if (tlsEnabled) {
@@ -100,10 +107,7 @@ public class GrpcChannelManager {
             builder.intercept(requestIdInterceptor);
         }
 
-        ManagedChannel channel = builder.build();
-
-        CHANNEL_MAP.put(service, channel);
-        return channel;
+        return builder.build();
     }
 
     /**
@@ -137,9 +141,14 @@ public class GrpcChannelManager {
         // NO-OP
     }
 
+    void onShutdown(@Observes ShutdownEvent ev) {
+        shutdown();
+    }
+
     public void shutdown() {
-        for (Map.Entry<ServiceTarget, ManagedChannel> entry : CHANNEL_MAP.entrySet()) {
+        for (Map.Entry<ServiceTarget, ManagedChannel> entry : channelMap.entrySet()) {
             doCloseChannel(entry.getValue());
         }
+        channelMap.clear();
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManagerTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/transports/grpc/GrpcChannelManagerTest.java
@@ -1,0 +1,80 @@
+package ai.wanaku.backend.bridge.transports.grpc;
+
+import io.grpc.ManagedChannel;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GrpcChannelManagerTest {
+
+    private GrpcChannelManager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = new GrpcChannelManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        manager.shutdown();
+    }
+
+    @Test
+    void createChannel_reusesSameChannel() {
+        ServiceTarget target =
+                new ServiceTarget("id-1", "svc-a", "localhost", 9090, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel first = manager.createChannel(target);
+        ManagedChannel second = manager.createChannel(target);
+
+        assertSame(first, second);
+    }
+
+    @Test
+    void createChannel_differentTargets_differentChannels() {
+        ServiceTarget targetA =
+                new ServiceTarget("id-1", "svc-a", "localhost", 9090, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget targetB =
+                new ServiceTarget("id-2", "svc-b", "localhost", 9091, "resource-provider", "mcp", null, null, null);
+
+        ManagedChannel channelA = manager.createChannel(targetA);
+        ManagedChannel channelB = manager.createChannel(targetB);
+
+        assertNotSame(channelA, channelB);
+    }
+
+    @Test
+    void createChannel_replacesStaleChannel() {
+        ServiceTarget target =
+                new ServiceTarget("id-1", "svc-a", "localhost", 9090, "tool-invoker", "mcp", null, null, null);
+
+        ManagedChannel original = manager.createChannel(target);
+        original.shutdownNow();
+
+        ManagedChannel replacement = manager.createChannel(target);
+
+        assertNotSame(original, replacement);
+        assertTrue(original.isShutdown());
+    }
+
+    @Test
+    void shutdown_closesAllChannels() {
+        ServiceTarget targetA =
+                new ServiceTarget("id-1", "svc-a", "localhost", 9090, "tool-invoker", "mcp", null, null, null);
+        ServiceTarget targetB =
+                new ServiceTarget("id-2", "svc-b", "localhost", 9091, "resource-provider", "mcp", null, null, null);
+
+        ManagedChannel channelA = manager.createChannel(targetA);
+        ManagedChannel channelB = manager.createChannel(targetB);
+
+        manager.shutdown();
+
+        assertTrue(channelA.isShutdown());
+        assertTrue(channelB.isShutdown());
+    }
+}


### PR DESCRIPTION
## Summary

- Replace non-atomic `containsKey`/`put` pattern with `computeIfAbsent` to prevent channel leaks under concurrent load
- Add stale channel detection — cached channels that are shut down or terminated are automatically replaced
- Wire `shutdown()` to Quarkus `ShutdownEvent` for graceful channel cleanup on application exit
- Change `CHANNEL_MAP` from `static` to instance field to avoid leaking state across test instances

## Test plan

- [x] New `GrpcChannelManagerTest` with 4 tests: reuse, different targets, stale replacement, shutdown
- [x] Existing `GrpcTransportTest` (9 tests) continues to pass
- [x] Full module test suite (354 tests) passes

## Summary by Sourcery

Cache gRPC ManagedChannels per service target with thread-safe creation and graceful shutdown handling.

New Features:
- Add caching of gRPC channels per ServiceTarget with automatic reuse and stale-channel replacement.
- Introduce Quarkus shutdown event handling to close and clear all cached gRPC channels on application exit.

Bug Fixes:
- Prevent concurrent channel creation races and leaks by replacing non-atomic map access with computeIfAbsent.

Enhancements:
- Make the gRPC channel map an instance field to avoid state leakage across tests and application instances.

Tests:
- Add GrpcChannelManagerTest coverage for channel reuse, different targets, stale replacement, and shutdown cleanup.