### PR TITLE
chore: add graceful stop script for wanaku start local

### DIFF
--- a/docs/testing-wanaku-start-local.md
+++ b/docs/testing-wanaku-start-local.md
@@ -46,4 +46,18 @@ The `camel-integration` service is automatically added when any CIC option is pr
 
 ## Stopping the router
 
-The router must be stopped gently. Do not kill the process with signal -9 because it leaves dangling process.
+The router must be stopped gently. Do not kill the process with signal -9 because it leaves dangling processes.
+
+Use the stop script to gracefully shut down the router and all capability services:
+
+```shell
+./tests/wanaku-start-local-stop.sh
+```
+
+If you captured the PID at startup, you can pass it directly:
+
+```shell
+WANAKU_PID=<pid> ./tests/wanaku-start-local-stop.sh
+```
+
+The script sends SIGTERM first and waits for processes to exit. SIGKILL is only used as a last resort if processes do not respond.

--- a/tests/plans/common/start-local.md
+++ b/tests/plans/common/start-local.md
@@ -96,6 +96,8 @@ fi
 
 ## Shutdown
 
+When `WANAKU_PID` is available (captured at startup), you can stop the process directly:
+
 ```bash
 if [ -n "${WANAKU_PID}" ]; then
   kill "${WANAKU_PID}" 2>/dev/null || true
@@ -103,3 +105,11 @@ if [ -n "${WANAKU_PID}" ]; then
   echo "PASS: Wanaku process stopped"
 fi
 ```
+
+Alternatively, use the stop script which discovers and gracefully shuts down all wanaku processes (router + capabilities):
+
+```bash
+./tests/wanaku-start-local-stop.sh
+```
+
+Do **not** use `kill -9` — it bypasses shutdown hooks and leaves child processes (capabilities) running.

--- a/tests/wanaku-start-local-stop.sh
+++ b/tests/wanaku-start-local-stop.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Gracefully stops a Wanaku local stack started with "wanaku start local".
+#
+# Usage:
+#   ./tests/wanaku-start-local-stop.sh
+#   WANAKU_PID=12345 ./tests/wanaku-start-local-stop.sh
+#
+
+set -euo pipefail
+
+TERM_TIMEOUT=${TERM_TIMEOUT:-10}
+RETRY_TIMEOUT=${RETRY_TIMEOUT:-5}
+
+find_cli_pid() {
+    if [ -n "${WANAKU_PID:-}" ]; then
+        if kill -0 "${WANAKU_PID}" 2>/dev/null; then
+            echo "${WANAKU_PID}"
+            return
+        fi
+        echo "WARNING: WANAKU_PID=${WANAKU_PID} is not running, searching..." >&2
+    fi
+
+    local pids
+    pids=$(pgrep -f "quarkus-run.jar start local" 2>/dev/null || true)
+    if [ -z "$pids" ]; then
+        return
+    fi
+    echo "$pids"
+}
+
+find_children() {
+    pgrep -P "$1" 2>/dev/null || true
+}
+
+collect_all_pids() {
+    local cli_pids="$1"
+    local all_pids="$cli_pids"
+
+    for pid in $cli_pids; do
+        local children
+        children=$(find_children "$pid")
+        if [ -n "$children" ]; then
+            all_pids="$all_pids $children"
+        fi
+    done
+    echo "$all_pids"
+}
+
+any_alive() {
+    for pid in $1; do
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+wait_for_exit() {
+    local pids="$1"
+    local timeout="$2"
+    local elapsed=0
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        if ! any_alive "$pids"; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+main() {
+    local cli_pids
+    cli_pids=$(find_cli_pid)
+
+    if [ -z "$cli_pids" ]; then
+        echo "No wanaku start local process found."
+        exit 0
+    fi
+
+    local all_pids
+    all_pids=$(collect_all_pids "$cli_pids")
+
+    echo "Found wanaku processes:"
+    for pid in $all_pids; do
+        local cmd
+        cmd=$(ps -p "$pid" -o args= 2>/dev/null || echo "(exited)")
+        echo "  PID $pid: $cmd"
+    done
+
+    # Phase 1: SIGTERM the CLI parent(s) — shutdown hooks propagate to children
+    echo "Sending SIGTERM to CLI process(es)..."
+    for pid in $cli_pids; do
+        kill "$pid" 2>/dev/null || true
+    done
+
+    if wait_for_exit "$all_pids" "$TERM_TIMEOUT"; then
+        echo "All processes stopped gracefully."
+        exit 0
+    fi
+
+    # Phase 2: SIGTERM any remaining processes individually
+    echo "Some processes still running after ${TERM_TIMEOUT}s, sending SIGTERM to remaining..."
+    for pid in $all_pids; do
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "  SIGTERM -> PID $pid"
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+
+    if wait_for_exit "$all_pids" "$RETRY_TIMEOUT"; then
+        echo "All processes stopped."
+        exit 0
+    fi
+
+    # Phase 3: SIGKILL as last resort
+    for pid in $all_pids; do
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "WARNING: PID $pid did not respond to SIGTERM, sending SIGKILL..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+
+    echo "Stop complete."
+}
+
+main


### PR DESCRIPTION
## Summary

- Add `tests/wanaku-start-local-stop.sh` — a script that gracefully stops all processes spawned by `wanaku start local`
- Uses three-phase shutdown: SIGTERM parent (shutdown hooks propagate), SIGTERM remaining children, SIGKILL only as last resort
- Process discovery via `pgrep -f "quarkus-run.jar start local"` (parent) and `pgrep -P` (children) — no lsof, no port matching
- Accepts `WANAKU_PID` env var if already known from startup
- Updated `docs/testing-wanaku-start-local.md` and `tests/plans/common/start-local.md` to reference the script

## Test plan

- [ ] Build and start wanaku locally: `./tests/wanaku-start-local-test.sh &`
- [ ] Verify processes are running: `pgrep -f "quarkus-run.jar"`
- [ ] Run the stop script: `./tests/wanaku-start-local-stop.sh`
- [ ] Verify all processes stopped: `pgrep -f "quarkus-run.jar"` returns nothing
- [ ] Test with `WANAKU_PID` env var: `WANAKU_PID=<pid> ./tests/wanaku-start-local-stop.sh`

## Summary by Sourcery

Add a script to gracefully stop a locally started Wanaku stack and update related documentation and test plans to use it.

New Features:
- Introduce a wanaku-start-local-stop.sh helper script to discover and gracefully stop wanaku start local processes, including capability children.

Enhancements:
- Improve shutdown guidance by discouraging kill -9 and explaining the graceful multi-phase termination behavior.

Documentation:
- Update Wanaku local testing documentation to describe using the new stop script and optional WANAKU_PID for shutdown.

Tests:
- Update the common start-local test plan to prefer the new stop script while still supporting direct shutdown when WANAKU_PID is known.