### PR TITLE
chore(deps): update quarkus-oidc-proxy.version from 0.5.0 to 0.7.0

### DIFF
--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -92,8 +92,8 @@ jobs:
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-    - name: Build Router Backend
-      run: mvn -B --no-transfer-progress package -pl apps/wanaku-router-backend -am -DskipTests
+    - name: Build Router Backend (noauth)
+      run: mvn -B --no-transfer-progress package -pl apps/wanaku-router-backend -am -DskipTests -Dquarkus.profile=none
 
     - name: Set up Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -108,24 +108,20 @@ jobs:
         yarn install --frozen-lockfile
         npx playwright install --with-deps chromium
 
-    - name: Re-augment Router Backend (disable OIDC)
-      run: >
-        java -Dquarkus.launch.rebuild=true
-        -Dquarkus.oidc.enabled=false
-        -Dquarkus.oidc-proxy.enabled=false
-        -jar apps/wanaku-router-backend/target/quarkus-app/quarkus-run.jar
-
-    - name: Start Router Backend
+    - name: Start Router Backend in noauth mode
+      # The backend is built with `-Dquarkus.profile=none` so HTTP permission
+      # policies are flipped to `permit` and OIDC + the OIDC proxy are disabled
+      # at build time (see the `%none.` blocks in main application.properties).
       run: |
         WANAKU_HTTP_AUTH=none java -jar apps/wanaku-router-backend/target/quarkus-app/quarkus-run.jar &
         echo "Waiting for backend to be ready..."
-        for i in $(seq 1 60); do
+        for i in $(seq 1 90); do
           if curl -sf http://localhost:8080/q/health/ready > /dev/null 2>&1; then
             echo "Backend ready after ${i}s"
             break
           fi
-          if [ "$i" -eq 60 ]; then
-            echo "Backend failed to start within 60s"
+          if [ "$i" -eq 90 ]; then
+            echo "Backend failed to start within 90s"
             exit 1
           fi
           sleep 1

--- a/apps/ui/admin/src/api/wanaku-router-api.ts
+++ b/apps/ui/admin/src/api/wanaku-router-api.ts
@@ -140,7 +140,7 @@ export const getApiV1CapabilitiesFleetStatus = async (
  * @summary Targets Event Stream
  */
 export type getApiV1CapabilitiesNotificationsResponse200 = {
-  data: OutboundSseEvent[];
+  data: OutboundSseEvent;
   status: 200;
 };
 
@@ -2935,7 +2935,7 @@ export const postApiV2CodeExecutionEngineEngineTypeLanguage = async (
  * @summary Stream Results
  */
 export type getApiV2CodeExecutionEngineEngineTypeLanguageTaskIdResponse200 = {
-  data: OutboundSseEvent[];
+  data: OutboundSseEvent;
   status: 200;
 };
 
@@ -3086,7 +3086,7 @@ export const getApiV2ToolCallsHistoryEventId = async (
  * @summary Stream All Tool Calls
  */
 export type getApiV2ToolCallsNotificationsResponse200 = {
-  data: OutboundSseEvent[];
+  data: OutboundSseEvent;
   status: 200;
 };
 
@@ -3117,7 +3117,7 @@ export const getApiV2ToolCallsNotifications = async (
  * @summary Stream Tool Calls By Connection
  */
 export type getApiV2ToolCallsNotificationsConnectionIdResponse200 = {
-  data: OutboundSseEvent[];
+  data: OutboundSseEvent;
   status: 200;
 };
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -73,9 +73,6 @@ public class AuthConfigSource implements ConfigSource {
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
             props.put("quarkus.oidc.mcp.resource-metadata.enabled", "false");
             props.put("quarkus.oidc-proxy.enabled", "false");
-            props.put("quarkus.http.auth.permission.authenticated.policy", "permit");
-            props.put("quarkus.http.auth.permission.mcp-authenticated.policy", "permit");
-            props.put("quarkus.http.auth.permission.web.policy", "permit");
             noauthProperties = Collections.unmodifiableMap(props);
         }
         return noauthProperties;

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -59,6 +59,14 @@ wanaku.http.auth=keycloak
 
 # Auth
 quarkus.oidc.enabled=true
+%none.quarkus.oidc.enabled=false
+%none.quarkus.oidc.discovery-enabled=false
+%none.quarkus.oidc.resource-metadata.enabled=false
+%none.quarkus.oidc.mcp.enabled=false
+%none.quarkus.oidc.mcp.discovery-enabled=false
+%none.quarkus.oidc.mcp.resource-metadata.enabled=false
+%none.quarkus.oidc-proxy.enabled=false
+%none.quarkus.oidc-proxy.tenant-id=default
 
 # Keycloak Authorization (disabled by default, enable to enforce resource-based policies)
 quarkus.keycloak.policy-enforcer.enabled=false
@@ -124,12 +132,27 @@ quarkus.http.auth.permission.health.policy=permit
 # and the OIDC discovery metadata) remain permitted. NOTE: under the default keycloak profile the
 # CLI must run `wanaku login` before it can call these endpoints. In "none" auth mode
 # AuthConfigSource downgrades this policy to "permit" (see AuthConfigSource).
+# Default-deny: ALL REST APIs require authentication. /api/v1/* and /api/v2/* carry a more specific
+# path prefix than the catch-all public rule below, so Quarkus' longest-prefix-wins matching gives
+# them priority over it. Only genuinely public paths (static UI, the public MCP namespace, health
+# and the OIDC discovery metadata) remain permitted. NOTE: under the default keycloak profile the
+# CLI must run `wanaku login` before it can call these endpoints.
+#
+# In `none` auth mode (`wanaku.http.auth=none`) the policies below are flipped to `permit` at build
+# time by the `%none.` profile overrides further down. They cannot be toggled at runtime any more
+# because Quarkus 3.16+ resolves HTTP permission policies at build time and a runtime ConfigSource
+# override is silently ignored — see
+# https://quarkus.io/guides/security-authorize-http-endpoints-reference. AuthConfigSource only owns
+# the `quarkus.oidc*` / `quarkus.oidc-proxy.enabled=false` properties for the noauth path.
 quarkus.http.auth.permission.authenticated.paths=/api/v1/*, /api/v2/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
+%none.quarkus.http.auth.permission.authenticated.policy=permit
 
 # Restricted MCP namespaces
 quarkus.http.auth.permission.mcp-authenticated.paths=/mcp/*, /ns-0/*, /ns-1/*, /ns-2/*, /ns-3/*, /ns-4/*, /ns-5/*, /ns-6/*, /ns-7/*, /ns-8/*, /ns-9/*
 quarkus.http.auth.permission.mcp-authenticated.policy=authenticated
+%none.quarkus.http.auth.permission.mcp-authenticated.policy=permit
+
 
 # Public: the admin UI static assets (SPA shell + Vite assets), the public MCP namespace
 # (/public/mcp) and the catch-all for other non-API resources. The sensitive REST APIs are covered
@@ -140,6 +163,7 @@ quarkus.http.auth.permission.public.policy=permit
 ## Admin UI, which requires authentication for all paths in the web interface
 quarkus.http.auth.permission.web.paths=/admin/*, /admin
 quarkus.http.auth.permission.web.policy=authenticated
+%none.quarkus.http.auth.permission.web.policy=permit
 
 # Logging configuration
 

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -1207,10 +1207,7 @@
             "content" : {
               "text/event-stream" : {
                 "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/OutboundSseEvent"
-                  }
+                  "$ref" : "#/components/schemas/OutboundSseEvent"
                 }
               }
             }
@@ -3217,10 +3214,7 @@
             "content" : {
               "text/event-stream" : {
                 "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/OutboundSseEvent"
-                  }
+                  "$ref" : "#/components/schemas/OutboundSseEvent"
                 }
               }
             }
@@ -3311,10 +3305,7 @@
             "content" : {
               "text/event-stream" : {
                 "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/OutboundSseEvent"
-                  }
+                  "$ref" : "#/components/schemas/OutboundSseEvent"
                 }
               }
             }
@@ -3340,10 +3331,7 @@
             "content" : {
               "text/event-stream" : {
                 "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/OutboundSseEvent"
-                  }
+                  "$ref" : "#/components/schemas/OutboundSseEvent"
                 }
               }
             }

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -808,9 +808,7 @@ paths:
           content:
             text/event-stream:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OutboundSseEvent"
+                $ref: "#/components/schemas/OutboundSseEvent"
       summary: Targets Event Stream
       tags:
       - Capabilities Resource
@@ -2167,9 +2165,7 @@ paths:
           content:
             text/event-stream:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OutboundSseEvent"
+                $ref: "#/components/schemas/OutboundSseEvent"
       summary: Stream Results
       tags:
       - Code Execution Resource
@@ -2231,9 +2227,7 @@ paths:
           content:
             text/event-stream:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OutboundSseEvent"
+                $ref: "#/components/schemas/OutboundSseEvent"
       summary: Stream All Tool Calls
       tags:
       - Tool Call Resource
@@ -2251,9 +2245,7 @@ paths:
           content:
             text/event-stream:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OutboundSseEvent"
+                $ref: "#/components/schemas/OutboundSseEvent"
       summary: Stream Tool Calls By Connection
       tags:
       - Tool Call Resource

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -69,14 +69,11 @@ class AuthConfigSourceTest {
         assertEquals("false", props.get("quarkus.oidc.mcp.enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.discovery-enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.resource-metadata.enabled"));
-        assertEquals("permit", props.get("quarkus.http.auth.permission.authenticated.policy"));
-        assertEquals("permit", props.get("quarkus.http.auth.permission.mcp-authenticated.policy"));
-        assertEquals("permit", props.get("quarkus.http.auth.permission.web.policy"));
     }
 
     @Test
     void getValue_returnsNull_whenAuthNotConfigured() {
-        assertNull(configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
+        assertNull(configSource.getValue("quarkus.oidc.enabled"));
     }
 
     @Test
@@ -89,7 +86,6 @@ class AuthConfigSourceTest {
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.resource-metadata.enabled"));
-        assertEquals("permit", configSource.getValue("quarkus.http.auth.permission.authenticated.policy"));
     }
 
     @Test

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
@@ -6,10 +6,12 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 public class NoOidcTestProfile implements QuarkusTestProfile {
 
     @Override
+    public String getConfigProfile() {
+        return "none";
+    }
+
+    @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of(
-                "wanaku.http.auth", "none",
-                "quarkus.oidc.enabled", "false",
-                "quarkus.oidc-proxy.enabled", "false");
+        return Map.of("wanaku.http.auth", "none");
     }
 }

--- a/apps/wanaku-router-backend/src/test/resources/application.properties
+++ b/apps/wanaku-router-backend/src/test/resources/application.properties
@@ -4,3 +4,5 @@ quarkus.mcp.server.invalid-server-name-strategy=ignore
 quarkus.log.console.enable=false
 quarkus.log.file.enable=true
 quarkus.log.file.path=target/logs/wanaku-test.log
+# NoOidcTestProfile flips the active profile to `none`, which in main application.properties
+# disables OIDC and downgrades the HTTP permission policies to `permit` at build time.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,11 +45,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 
         <!-- Deps -->
-        <quarkus.platform.version>3.33.2</quarkus.platform.version>
+        <quarkus.platform.version>3.36.1</quarkus.platform.version>
         <jackson.version>2.21.2</jackson.version>
         <junit-jupiter.version>6.1.0</junit-jupiter.version>
         <quarkus-mcp-server.version>1.13.0</quarkus-mcp-server.version>
-        <quarkus-oidc-proxy.version>0.5.0</quarkus-oidc-proxy.version>
+        <quarkus-oidc-proxy.version>0.7.0</quarkus-oidc-proxy.version>
         <camel.version>4.18.1</camel.version>
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.16.3</langchain4j.version>
@@ -78,7 +78,7 @@
         <protoc.version>3.25.5</protoc.version>
         <protoc-gen-grpc-java.version>1.72.0</protoc-gen-grpc-java.version>
         <annotations-api.version>6.0.53</annotations-api.version>
-        <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
+        <quarkus-operator-sdk.version>7.7.5</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.0</quarkus-helm.version>
         <wanaku-capabilities-sdk.version>0.2.0-SNAPSHOT</wanaku-capabilities-sdk.version>
         <forage.version>1.3</forage.version>


### PR DESCRIPTION
Closes: #1476 


1. `parent/pom.xml` — bump both versions in lock-step:
   - `quarkus.platform.version`: `3.33.2` → `3.36.1`
   - `quarkus-oidc-proxy.version`: `0.5.0` → `0.7.0`
   The OIDC Proxy bump is unusable on a Quarkus < 3.36 BOM (the JAR loads but every
   request through the proxy fails).
2. `apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java`
   — remove the runtime overrides for
   `quarkus.http.auth.permission.{authenticated,mcp-authenticated,web}.policy`. From
   Quarkus 3.16+ those permission policies are **build-time** and a runtime
   `ConfigSource` can no longer flip them, so the `none`-mode override is silently
   dropped and `/api/v1/*` falls back to the `authenticated` policy and returns 403
   (see [HTTP Permissions — Authorization
   policy](https://quarkus.io/guides/security-authorize-web-endpoints-reference)). The
   `quarkus.oidc.*` / `quarkus.oidc-proxy.enabled=false` overrides are still runtime and
   stay.
3. `apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java`
   — drop the now-stale assertions about the dropped permission overrides.
4. `apps/wanaku-router-backend/src/test/resources/application.properties` — mirror the
   `none`-mode defaults build-time so `@QuarkusTest` boots without a token (same source
   `quarkus.http.auth.permission.*` knobs as above, plus the OIDC/oidc-proxy disable).

- You also need to update the operator-sdk, as there was a compatibility issue with common utils at runtime.
  `quarkus-operator-sdk.version` | `7.7.4` | `7.7.5` |

