### PR TITLE
fix #1474: add true --plain mode that bypasses JLine table rendering

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -2,11 +2,13 @@ package ai.wanaku.cli.main.support;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import org.jline.builtins.ConfigurationPath;
@@ -259,6 +261,11 @@ public class WanakuPrinter extends DefaultPrinter {
             List<Map<String, Object>> mappedObjects =
                     objectsToPrint.stream().map(toMap).toList();
 
+            if (plainMode) {
+                printPlainTable(mappedObjects, columns);
+                return;
+            }
+
             Map<String, Object> mergedOptions = createMergedOptions(options);
 
             if (columns != null && columns.length > 0) {
@@ -308,6 +315,10 @@ public class WanakuPrinter extends DefaultPrinter {
         }
 
         try {
+            if (plainMode) {
+                printPlainMap(map);
+                return;
+            }
             println(DEFAULT_MAP_OPTIONS, map);
         } catch (Exception e) {
             printErrorMessage("Failed to print object: " + e.getMessage());
@@ -492,6 +503,42 @@ public class WanakuPrinter extends DefaultPrinter {
             builder.append(exception.getMessage(), Styles.prntStyle().resolve(".em"));
             builder.toAttributedString().println(terminal());
         }
+    }
+
+    private void printPlainTable(List<Map<String, Object>> rows, String... columns) {
+        PrintWriter writer = terminal.writer();
+
+        List<String> cols;
+        if (columns != null && columns.length > 0) {
+            cols = Arrays.asList(columns);
+        } else if (!rows.isEmpty()) {
+            cols = List.copyOf(rows.get(0).keySet());
+        } else {
+            return;
+        }
+
+        writer.println(String.join("\t", cols));
+
+        for (Map<String, Object> row : rows) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < cols.size(); i++) {
+                if (i > 0) {
+                    sb.append('\t');
+                }
+                Object value = row.get(cols.get(i));
+                sb.append(Objects.toString(value, ""));
+            }
+            writer.println(sb.toString());
+        }
+        terminal.flush();
+    }
+
+    private void printPlainMap(Map<String, Object> map) {
+        PrintWriter writer = terminal.writer();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            writer.println(entry.getKey() + "\t" + Objects.toString(entry.getValue(), ""));
+        }
+        terminal.flush();
     }
 
     /**

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -1,0 +1,134 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledOnOs(OS.WINDOWS)
+class WanakuPrinterPlainModeTest {
+
+    private ByteArrayOutputStream outputStream;
+    private Terminal terminal;
+    private WanakuPrinter printer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        WanakuPrinter.setPlainMode(true);
+        outputStream = new ByteArrayOutputStream();
+        terminal = TerminalBuilder.builder()
+                .system(false)
+                .streams(System.in, outputStream)
+                .jni(false)
+                .color(false)
+                .build();
+        printer = new WanakuPrinter(null, terminal);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        WanakuPrinter.setPlainMode(false);
+        if (terminal != null) {
+            terminal.close();
+        }
+    }
+
+    @Test
+    void printTableProducesNonEmptyOutput() {
+        List<Map<String, Object>> data = List.of(
+                Map.of("name", "activemq6-tool", "description", "ActiveMQ 6 tool template"),
+                Map.of("name", "kafka-tool", "description", "Kafka tool template"));
+
+        printer.printTable(data, "name", "description");
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Plain-mode table output must not be blank");
+        assertTrue(output.contains("activemq6-tool"), "Output must contain row data 'activemq6-tool'");
+        assertTrue(output.contains("kafka-tool"), "Output must contain row data 'kafka-tool'");
+    }
+
+    @Test
+    void printTableIncludesHeaderRow() {
+        List<Map<String, Object>> data = List.of(Map.of("name", "sql-tool", "description", "SQL tool template"));
+
+        printer.printTable(data, "name", "description");
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("name"), "Output must contain column header 'name'");
+        assertTrue(output.contains("description"), "Output must contain column header 'description'");
+    }
+
+    @Test
+    void printTableHandlesEmptyList() {
+        printer.printTable(List.of(), "name", "description");
+        String output = outputStream.toString();
+        assertTrue(output.isEmpty(), "Empty list should produce no output");
+    }
+
+    @Test
+    void printTableHandlesNullList() {
+        printer.printTable(null, "name", "description");
+        String output = outputStream.toString();
+        assertTrue(output.isEmpty(), "Null list should produce no output");
+    }
+
+    @Test
+    void printTableWithoutColumnsUsesMapKeys() {
+        List<Map<String, Object>> data = List.of(Map.of("name", "test-tool", "uri", "http://example.com"));
+
+        printer.printTable(data);
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Output must not be blank");
+        assertTrue(output.contains("test-tool"), "Output must contain row value");
+    }
+
+    @Test
+    void printAsMapProducesNonEmptyOutput() {
+        Map<String, Object> data = Map.of("name", "my-capability", "host", "localhost", "port", 9000);
+
+        printer.printAsMap(data, "name", "host", "port");
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Plain-mode map output must not be blank");
+        assertTrue(output.contains("my-capability"), "Output must contain value 'my-capability'");
+        assertTrue(output.contains("localhost"), "Output must contain value 'localhost'");
+    }
+
+    @Test
+    void printInfoMessageProducesOutput() {
+        printer.printInfoMessage("Available service templates:");
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("Available service templates:"), "Info message must appear in plain-mode output");
+    }
+
+    @Test
+    void printTableRowsAreNotBlank() {
+        List<Map<String, Object>> data = List.of(
+                Map.of("name", "template-1", "description", "First"),
+                Map.of("name", "template-2", "description", "Second"),
+                Map.of("name", "template-3", "description", "Third"));
+
+        printer.printTable(data, "name", "description");
+
+        String output = outputStream.toString();
+        String[] lines = output.split("\n");
+        // Header + 3 data rows = at least 4 lines
+        assertTrue(lines.length >= 4, "Expected at least 4 lines (1 header + 3 data), got " + lines.length);
+
+        for (int i = 1; i < lines.length; i++) {
+            assertFalse(lines[i].isBlank(), "Data row " + i + " must not be blank");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- In plain mode, `printTable()` and `printAsMap()` now write tab-separated text directly to `terminal.writer()` instead of delegating to JLine's `DefaultPrinter.println()`, which produces blank lines in non-interactive terminals (piped, redirected, or agent-invoked).
- The existing `--plain` flag only changed terminal creation but did not bypass JLine's table rendering pipeline — this was the root cause of #1474.
- All list commands (`tools list`, `resources list`, `capabilities list`, `service template list`, etc.) benefit from this fix automatically.

## Test plan

- [x] 8 new unit tests in `WanakuPrinterPlainModeTest` covering table output, header rows, empty/null handling, map output, and row-level non-blank assertions
- [x] QA verified with `cli-service-catalog-lifecycle.md` Phase 8 (Tests 8.1–8.3): `service template list --plain` returns template names, search filter works
- [x] QA verified `tools list --plain` and `capabilities list --plain` produce readable tab-separated output
- [x] Full build passes (`mvn verify -DskipITs`)

## Summary by Sourcery

Implement a true plain-output mode for the CLI printer to bypass JLine table rendering and ensure non-blank tab-separated output in non-interactive environments.

New Features:
- Add plain-mode table printing that writes tab-separated headers and rows directly to the terminal writer.
- Add plain-mode map printing that outputs key–value pairs as tab-separated lines.

Bug Fixes:
- Prevent blank or missing table output in non-interactive terminals when using the --plain flag for list-style commands.

Tests:
- Add WanakuPrinterPlainModeTest to cover plain-mode table and map output, header handling, empty/null inputs, and non-blank row assertions.