### PR TITLE
chore: fix documentation drift, duplication, and ambiguity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Wanaku Development Guidelines
 
-Last updated: 2026-05-26
+Last updated: 2026-07-02
 
 ## Core Guidelines
 
@@ -24,7 +24,7 @@ apps/
   wanaku-operator/         # Kubernetes operator (JOSDK)
   wanaku-jbang/            # JBang integration
   ui/admin/                # Admin UI (React + Vite + Carbon)
-archetypes/                # Maven archetypes for tools/providers
+archetypes/                # Maven archetypes for tools/providers/MCP servers
 capabilities/              # Built-in capability services
 capabilities-quarkus-sdk/  # Quarkus SDK for capabilities
 core/
@@ -35,8 +35,15 @@ core/
   core-mcp-client/         # MCP client (router)
 deploy/                    # Deployment scripts and configs
 docs/                      # Documentation
-tests/                     # Integration, MCP server, and load tests
-tests/plans                # Test plans for humans and AI agents to follow
+parent/                    # Maven parent POM
+services/
+  service-templates/       # Service templates
+tests/
+  e2e/                     # End-to-end tests
+  archetype-tests/         # Archetype tests
+  mcp-servers/             # MCP server tests
+  load/                    # Load tests
+  plans/                   # Test plans for humans and AI agents
 ```
 
 ## Commands
@@ -70,7 +77,7 @@ make install
 
 ## Operator
 
-- CRDs: `WanakuRouter`, `WanakuCapability`, `WanakuServiceCatalog` (all `wanaku.ai/v1alpha1`)
+- CRDs: `WanakuRouter`, `WanakuCapability`, `WanakuServiceCatalog`, `WanakuCamelRoute` (all `wanaku.ai/v1alpha1`)
 - Helm chart: `apps/wanaku-operator/deploy/helm/wanaku-operator/`
 - When adding new CRDs, RBAC rules must be added to the Helm chart (see `docs/contributing.md`)
 - CRD manifests are auto-generated during build in `target/kubernetes/`, must be copied to `crds/`

--- a/docs/building.md
+++ b/docs/building.md
@@ -14,10 +14,10 @@ Before running or deploying the Wanaku MCP Router, you need to build the project
 To build the Wanaku MCP Router, run:
 
 ```shell
-mvn clean package
+mvn verify
 ```
 
-This command will compile the source code and package it.
+This command will compile, test, and verify the project.
 
 To package it into a distributable format (i.e.: tarballs), run:
 

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -190,6 +190,7 @@ These `wanaku.router.health-check.*` properties control the periodic health prob
 | Property                                        | Description                                                                                                                           |
 |-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | `wanaku.bridge.grpc.transport.deadline-seconds` | `10` - The deadline in seconds for gRPC transport calls to capability services. Requests that exceed this deadline will be cancelled. |
+| `wanaku.bridge.grpc.transport.tls.enabled`      | `false` - Whether to enable TLS for gRPC transport calls to capability services.                                                     |
 
 ### Persistence (`core-persistence-infinispan`)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,13 +72,13 @@ Alternatively, if you don't have the CLI installed locally, you can obtain it us
 
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-tool-service-archetype \
-  -DarchetypeVersion=0.0.8 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.tool.kafka -DartifactId=wanaku-tool-service-kafka \
-  -Dname=Kafka -Dwanaku-version=0.0.8 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=LATEST_VERSION -DgroupId=ai.wanaku -Dpackage=ai.wanaku.tool.kafka -DartifactId=wanaku-tool-service-kafka \
+  -Dname=Kafka -Dwanaku-version=LATEST_VERSION -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]
-> When using the maven way, please make sure to adjust the version of Wanaku
-> to be used by correctly setting the `wanaku-version` property to the base Wanaku version to use.
+> Replace `LATEST_VERSION` with the actual Wanaku version from the [releases page](https://github.com/wanaku-ai/wanaku/releases).
+> Both `archetypeVersion` and `wanaku-version` must match.
 
 ### Adjusting the Tool Service
 
@@ -131,13 +131,13 @@ Alternatively, if you don't have the CLI installed locally, you can obtain it us
 
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-provider-archetype \
-  -DarchetypeVersion=0.0.8 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.provider.s3 -DartifactId=wanaku-provider-s3 \
-  -Dname=S3 -Dwanaku-version=0.0.8 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=LATEST_VERSION -DgroupId=ai.wanaku -Dpackage=ai.wanaku.provider.s3 -DartifactId=wanaku-provider-s3 \
+  -Dname=S3 -Dwanaku-version=LATEST_VERSION -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]
-> Make sure to adjust the version of Wanaku to be used by correctly setting the `wanaku-version` property to the base Wanaku
-> version to use.
+> Replace `LATEST_VERSION` with the actual Wanaku version from the [releases page](https://github.com/wanaku-ai/wanaku/releases).
+> Both `archetypeVersion` and `wanaku-version` must match.
 
 ### Adjusting the Provider Service
 
@@ -298,7 +298,7 @@ There are multiple ways you can test Wanaku and the integrations you develop.
 
 1. Wanaku's LLMchat page in the Web UI
 2. You can use the [MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) to easily test your tool or provider.
-3. Use the maintained test suites under `tests/integration`, `tests/mcp-servers`, and `tests/load`.
+3. Use the maintained test suites under `tests/e2e`, `tests/mcp-servers`, and `tests/load`.
 4. Follow or create test plans under `tests/plans/` (see [Writing Test Plans](contributing-test-plans.md)).
 5. Any agent application (such as [HyperChat](https://github.com/BigSweetPotatoStudio/HyperChat))
 


### PR DESCRIPTION
## Summary

Documentation audit found several issues where docs had fallen out of sync with the codebase. This PR fixes them:

- **CLAUDE.md project structure** — added missing directories (`services/service-templates/`, `parent/`, `tests/e2e/`, `tests/archetype-tests/`), updated `tests/` to reflect actual sub-directory layout
- **Missing CRD** — added `WanakuCamelRoute` to the operator CRD list in CLAUDE.md (was undocumented despite existing in the codebase)
- **Stale version `0.0.8`** — replaced hardcoded archetype versions in `docs/contributing.md` with `LATEST_VERSION` placeholder and added note pointing to the releases page
- **Dead reference** — fixed `tests/integration` (doesn't exist) to `tests/e2e` in `docs/contributing.md`
- **Build command inconsistency** — aligned `docs/building.md` to use `mvn verify` (matching CLAUDE.md and `.oss-ai-helper-rules/project-standards.md`)
- **Missing config property** — documented `wanaku.bridge.grpc.transport.tls.enabled` in `docs/configurations.md`

## Test plan

- [ ] Verify project structure tree in CLAUDE.md matches `find . -maxdepth 2 -type d`
- [ ] Verify all 4 operator CRDs are listed
- [ ] Confirm no hardcoded `0.0.8` remains in docs
- [ ] Confirm `tests/integration` is no longer referenced
- [ ] Verify build command is consistent across CLAUDE.md, docs/building.md, and .oss-ai-helper-rules

## Summary by Sourcery

Align and update documentation to match the current project structure, configuration, test layout, and build process.

Documentation:
- Replace hardcoded archetype version examples with a LATEST_VERSION placeholder and guidance to use the GitHub releases page.
- Correct references to test suites and expand the documented project directory tree to match the actual layout, including services, parent POM, and detailed tests subdirectories.
- Document the WanakuCamelRoute CRD alongside the other operator CRDs and add the missing TLS configuration property for gRPC transport.
- Standardize the documented Maven build command to use mvn verify and clarify its behavior.