### PR TITLE
fix #1473: add Content-Type header for admin UI HEAD responses

### DIFF
--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -45,6 +45,11 @@ quarkus.mcp.server.ns-9.sse.root-path=/ns-9/mcp
 # Public NS
 quarkus.mcp.server.public.sse.root-path=/public/mcp
 
+# Workaround: Vert.x StaticHandler omits Content-Type on HEAD responses (#1473)
+quarkus.http.header."Content-Type".value=text/html;charset=UTF-8
+quarkus.http.header."Content-Type".path=/admin(/index\\.html)?/?
+quarkus.http.header."Content-Type".methods=HEAD
+
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:8080,http://127.0.0.1:8080,http://localhost:5173,http://localhost:6274
 quarkus.http.cors.exposed-headers=Mcp-Session-Id


### PR DESCRIPTION
## Summary

- Adds a Quarkus HTTP header filter in `application.properties` that sets `Content-Type: text/html;charset=UTF-8` on HEAD responses to the admin UI index path (`/admin/`, `/admin/index.html`)
- Works around a Vert.x Web `StaticHandlerImpl` bug where `Content-Type` is set *after* the HEAD early-return, so HEAD responses never receive it

## Root Cause

Vert.x Web's `StaticHandlerImpl.sendFile()` method returns early for HEAD requests before setting the `Content-Type` header. This violates RFC 9110 Section 9.3.2 (HEAD responses should include the same headers as GET).

## Test Plan

1. Start the router: `wanaku start local`
2. `curl -sI http://localhost:8080/admin/` — verify `Content-Type: text/html;charset=UTF-8` is present
3. `curl -s -D- http://localhost:8080/admin/ -o /dev/null` — verify GET still works correctly

Closes #1473

## Summary by Sourcery

Bug Fixes:
- Set a default Content-Type of text/html;charset=UTF-8 for HEAD responses to the admin UI index paths to work around Vert.x StaticHandler omitting this header.