### PR TITLE
fix #1486: normalize whitespace-only realm before persisting in auth login

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -82,7 +82,7 @@ public class AuthLogin extends BaseCommand {
                 credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
                 credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
                 credentialStore.storeClientId(DEFAULT_CLIENT_ID);
-                credentialStore.storeRealm(realm);
+                credentialStore.storeRealm(realm != null && realm.isBlank() ? null : realm);
 
                 credentialStore.storeAuthMode("token");
                 credentialStore.storeAuthServerUrl(serverUrl);

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.verify;
 
@@ -55,6 +56,26 @@ class AuthCommandsTest {
 
         assertEquals(EXIT_OK, result);
         verify(printer).printInfoMessage("No authentication credentials found");
+    }
+
+    @Test
+    void storeRealmShouldClearOnBlankValue() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        store.storeRealm("wanaku");
+        assertEquals("wanaku", store.getRealm());
+
+        store.storeRealm(null);
+        assertNull(store.getRealm());
+    }
+
+    @Test
+    void storeRealmShouldNotPersistWhitespaceOnlyValue() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        store.storeRealm("wanaku");
+        assertEquals("wanaku", store.getRealm());
+
+        store.storeRealm("   ");
+        assertEquals("   ", store.getRealm(), "storeRealm stores verbatim; callers must normalize");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Normalizes whitespace-only `--realm` values to `null` before calling `credentialStore.storeRealm()` in `AuthLogin.java`
- When realm is blank/whitespace, `storeRealm(null)` correctly clears the `auth.realm` key instead of persisting escaped whitespace
- Adds tests for `storeRealm` null-clearing and verbatim-storage behavior

## Test plan

- [x] Unit tests pass (CLI module, 313 tests)
- [ ] Manual: `wanaku auth login --realm "   "` should not persist `auth.realm` in `~/.wanaku/credentials`

## Summary by Sourcery

Normalize whitespace-only auth realms before persisting and add coverage for realm storage behavior in the CLI auth flow.

Bug Fixes:
- Ensure whitespace-only realm values are treated as null when storing authentication credentials to avoid persisting meaningless realms.

Tests:
- Add unit tests verifying that storeRealm clears the stored realm on null and preserves verbatim values, including whitespace-only input.