### PR TITLE
fix #1489 #1490 #1491: fix CLI auth token handling, probe logging, and PKCE

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesCleanup.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesCleanup.java
@@ -86,7 +86,7 @@ public class CapabilitiesCleanup extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         long maxAgeSeconds = maxAgeDays * SECONDS_PER_DAY;
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesList.java
@@ -101,7 +101,7 @@ Note: If omitted, all capabilities are listed. Label matching is case-sensitive.
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
 
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
         var capabilities = fetchAndMergeCapabilities(capabilitiesService, labelExpression)
                 .await()
                 .atMost(API_TIMEOUT);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
@@ -105,7 +105,7 @@ public class CapabilitiesShow extends BaseCommand {
      */
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws IOException, Exception {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         // Fetch and filter capabilities by service name
         List<CapabilitiesHelper.PrintableCapability> capabilities =

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
@@ -55,7 +55,7 @@ public class CapabilitiesStatus extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         List<PrintableCapability> capabilities =
                 fetchAndMergeCapabilities(capabilitiesService).await().atMost(API_TIMEOUT);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresAdd.java
@@ -74,7 +74,7 @@ public class DataStoresAdd extends BaseCommand {
         dataStore.setData(base64Data);
 
         // Call API
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             WanakuResponse<DataStore> response = dataStoresService.add(dataStore);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresGet.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresGet.java
@@ -67,7 +67,7 @@ public class DataStoresGet extends BaseCommand {
             printer.printWarningMessage("Both --id and --name provided, using --id%n");
         }
 
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             DataStore dataStore = null;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
@@ -72,7 +72,7 @@ public class DataStoresLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (dataStoresService == null) {
-            dataStoresService = initService(DataStoresService.class, host);
+            dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
@@ -72,7 +72,7 @@ public class DataStoresLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (dataStoresService == null) {
-            dataStoresService = initService(DataStoresService.class, host);
+            dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresList.java
@@ -53,7 +53,7 @@ Note: If omitted, all data stores are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             WanakuResponse<List<DataStore>> response = dataStoresService.list(labelExpression);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresRemove.java
@@ -52,7 +52,7 @@ public class DataStoresRemove extends BaseCommand {
             printer.printWarningMessage("Both --id and --name provided. Using --id only.%n");
         }
 
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             // Prefer ID over name if both provided

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -46,7 +46,7 @@ public class ForwardsAdd extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         ForwardReference reference = new ForwardReference();
         reference.setName(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsList.java
@@ -35,7 +35,7 @@ public class ForwardsList extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             WanakuResponse<List<ForwardReference>> wanakuResponseRestResponse = forwardsService.listForwards(null);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
@@ -29,7 +29,7 @@ public class ForwardsRefresh extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             forwardsService.refreshForward(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRemove.java
@@ -29,7 +29,7 @@ public class ForwardsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             forwardsService.removeForward(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCleanup.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCleanup.java
@@ -55,7 +55,7 @@ public class NamespacesCleanup extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         long maxAgeSeconds = maxAgeDays * SECONDS_PER_DAY;
         boolean unassignedOnly = !includeAssigned;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreate.java
@@ -53,7 +53,7 @@ public class NamespacesCreate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         Namespace namespace = new Namespace();
         namespace.setPath(path);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesDelete.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesDelete.java
@@ -27,7 +27,7 @@ public class NamespacesDelete extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             namespacesService.delete(id);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
@@ -72,7 +72,7 @@ public class NamespacesLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (namespacesService == null) {
-            namespacesService = initService(NamespacesService.class, host);
+            namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
@@ -71,7 +71,7 @@ public class NamespacesLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (namespacesService == null) {
-            namespacesService = initService(NamespacesService.class, host);
+            namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesShow.java
@@ -33,7 +33,7 @@ public class NamespacesShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             WanakuResponse<Namespace> response = namespacesService.getById(id);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
@@ -60,7 +60,7 @@ public class NamespacesUpdate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         if (clearName && name != null) {
             printer.printErrorMessage("Cannot specify both --name and --clear-name.");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
@@ -120,7 +120,7 @@ public class PromptsAdd extends BaseCommand {
 
         FileHelper.loadConfigurationSources(configurationFromFile, promptPayload::setConfigurationData);
 
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
 
         try {
             WanakuResponse<PromptReference> data = promptsService.addWithPayload(promptPayload);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
@@ -81,7 +81,7 @@ public class PromptsEdit extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
 
         // First, fetch the existing prompt
         PromptReference existingPrompt;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsList.java
@@ -30,7 +30,7 @@ public class PromptsList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
         try {
             WanakuResponse<List<PromptReference>> response = promptsService.list();
             List<PromptReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsRemove.java
@@ -32,7 +32,7 @@ public class PromptsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
         try {
             promptsService.remove(name);
             printer.printSuccessMessage("Successfully removed prompt reference '" + name + "'");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
@@ -116,7 +116,7 @@ public class ResourcesExpose extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         ResourceReference resource = new ResourceReference();
         resource.setLocation(location);
         resource.setType(type);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
@@ -72,7 +72,7 @@ public class ResourcesLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (resourcesService == null) {
-            resourcesService = initService(ResourcesService.class, host);
+            resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
@@ -72,7 +72,7 @@ public class ResourcesLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (resourcesService == null) {
-            resourcesService = initService(ResourcesService.class, host);
+            resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesList.java
@@ -53,7 +53,7 @@ Note: If omitted, all resources are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         try {
             WanakuResponse<List<ResourceReference>> response = resourcesService.list(labelExpression);
             List<ResourceReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
@@ -58,7 +58,7 @@ public class ResourcesRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
         if (validationResult != EXIT_OK) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
@@ -49,7 +49,7 @@ public class ResourcesShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         try {
             WanakuResponse<ResourceReference> response = resourcesService.getByName(resourceName);
             ResourceReference resource = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogList.java
@@ -35,7 +35,7 @@ public class ServiceCatalogList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+        ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
 
         try {
             WanakuResponse<List<Map<String, Object>>> response = service.list(search);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
@@ -128,12 +128,12 @@ public class ServiceDeploy extends BaseCommand {
 
         try {
             if (template) {
-                ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+                ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
                 WanakuResponse<DataStore> response = service.deploy(dataStore);
                 printer.printSuccessMessage(
                         String.format("Service template '%s' deployed successfully%n", catalogName));
             } else {
-                ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+                ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
                 WanakuResponse<DataStore> response = service.deploy(dataStore);
                 printer.printSuccessMessage(String.format("Service catalog '%s' deployed successfully%n", catalogName));
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInstructions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInstructions.java
@@ -38,7 +38,7 @@ public class ServiceInstructions extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+        ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
 
         try {
             WanakuResponse<DeploymentInstructions> response = service.getDeploymentInstructions(name, model);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -110,7 +110,7 @@ public class ServiceTemplateInstantiate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+        ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
 
         Map<String, String> propsMap = resolveProperties(printer);
         if (propsMap == null) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
@@ -35,7 +35,7 @@ public class ServiceTemplateList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+        ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
 
         try {
             WanakuResponse<List<Map<String, Object>>> response = service.list(search);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
@@ -155,7 +155,7 @@ public class ToolsAdd extends BaseCommand {
         FileHelper.loadConfigurationSources(configurationFromFile, toolPayload::setConfigurationData);
         FileHelper.loadConfigurationSources(secretsFromFile, toolPayload::setSecretsData);
 
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         try {
             WanakuResponse<ToolReference> data = toolsService.addWithPayload(toolPayload);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
@@ -64,7 +64,7 @@ public class ToolsEdit extends BaseCommand {
      */
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         List<ToolReference> list = toolsService.list().data();
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
@@ -72,7 +72,7 @@ public class ToolsLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (toolsService == null) {
-            toolsService = initService(ToolsService.class, host);
+            toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
@@ -71,7 +71,7 @@ public class ToolsLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (toolsService == null) {
-            toolsService = initService(ToolsService.class, host);
+            toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsList.java
@@ -54,7 +54,7 @@ Note: If omitted, all tools are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
         try {
             WanakuResponse<List<ToolReference>> response = toolsService.list(labelExpression);
             List<ToolReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
@@ -97,7 +97,7 @@ public class ToolsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         int validationResult = validateLabelExpression(name, labelExpression, "--name", printer);
         if (validationResult != EXIT_OK) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
@@ -50,7 +50,7 @@ public class ToolsShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
         try {
             WanakuResponse<ToolReference> response = toolsService.getByName(toolName);
             ToolReference tool = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -95,7 +95,10 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             Thread.currentThread().interrupt();
             routerAuthEnabled = false;
         } catch (Exception e) {
-            LOG.debug("Could not reach OIDC endpoint at {}: {}", wellKnown, e.getMessage());
+            LOG.warn(
+                    "Could not reach OIDC endpoint at {}: {} — authentication headers will not be sent",
+                    wellKnown,
+                    e.getMessage());
             routerAuthEnabled = false;
         }
 

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -87,6 +87,7 @@ quarkus.oidc.application-type=hybrid
 # URL path where users can log out from the application (don't change)
 quarkus.oidc.logout.path=/logout
 quarkus.oidc.discovery-enabled=true
+quarkus.oidc.authentication.pkce-required=true
 quarkus.oidc.connection-delay=60S
 quarkus.oidc.resource-metadata.enabled=true
 


### PR DESCRIPTION
## Summary

Fixes three issues discovered during investigation of #1485 (CLI returns 302 after upgrade to 0.2.0):

- **#1489 — CLI `--token` flag silently ignored**: All ~40 CLI commands called the static `initService()` which hardcoded `tokenOverride=null`. Changed to `initAuthenticatedService()` so `--token` and `--no-auth` flags are properly read.

- **#1490 — Auth probe failure logged at DEBUG**: `AuthenticationInterceptor.isRouterAuthEnabled()` probes `/.well-known/oauth-authorization-server` before attaching the Bearer token. If this fails (e.g., K8s ingress doesn't route `/.well-known/*`), auth is silently skipped. Changed to WARN level so users can diagnose the issue.

- **#1491 — PKCE not configured for admin UI**: Modern Keycloak versions require PKCE for public clients. Added `quarkus.oidc.authentication.pkce-required=true` so the authorization code flow sends `code_challenge`.

## Test plan

- [ ] Verify `wanaku tools list --host <url> --token <token>` sends the Bearer header
- [ ] Verify `wanaku auth login --api-token <token>` followed by `wanaku tools list` works
- [ ] Verify WARN log appears when `/.well-known/oauth-authorization-server` is unreachable
- [ ] Verify `/admin` login flow works with Keycloak (PKCE)
- [ ] Run CLI unit tests (`mvn test -pl apps/wanaku-cli`)

## Summary by Sourcery

Ensure CLI commands consistently initialize authenticated service clients and improve observability of authentication failures.

Bug Fixes:
- Fix WANAKU CLI commands to respect authentication flags and tokens by using authenticated service initialization helpers.
- Log failures to reach the OIDC discovery endpoint at warning level so skipped authentication is visible to users.
- Require PKCE for OIDC authentication in the router backend admin UI to restore compatibility with modern identity providers.