### PR TITLE
fix #1489 #1490 #1491: fix CLI auth token handling, probe logging, and PKCE

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesCleanup.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesCleanup.java
@@ -86,7 +86,7 @@ public class CapabilitiesCleanup extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         long maxAgeSeconds = maxAgeDays * SECONDS_PER_DAY;
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesList.java
@@ -101,7 +101,7 @@ Note: If omitted, all capabilities are listed. Label matching is case-sensitive.
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
 
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
         var capabilities = fetchAndMergeCapabilities(capabilitiesService, labelExpression)
                 .await()
                 .atMost(API_TIMEOUT);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesShow.java
@@ -105,7 +105,7 @@ public class CapabilitiesShow extends BaseCommand {
      */
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws IOException, Exception {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         // Fetch and filter capabilities by service name
         List<CapabilitiesHelper.PrintableCapability> capabilities =

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/capabilities/CapabilitiesStatus.java
@@ -55,7 +55,7 @@ public class CapabilitiesStatus extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
-        CapabilitiesService capabilitiesService = initService(CapabilitiesService.class, host);
+        CapabilitiesService capabilitiesService = initAuthenticatedService(CapabilitiesService.class, host);
 
         List<PrintableCapability> capabilities =
                 fetchAndMergeCapabilities(capabilitiesService).await().atMost(API_TIMEOUT);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresAdd.java
@@ -74,7 +74,7 @@ public class DataStoresAdd extends BaseCommand {
         dataStore.setData(base64Data);
 
         // Call API
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             WanakuResponse<DataStore> response = dataStoresService.add(dataStore);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresGet.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresGet.java
@@ -67,7 +67,7 @@ public class DataStoresGet extends BaseCommand {
             printer.printWarningMessage("Both --id and --name provided, using --id%n");
         }
 
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             DataStore dataStore = null;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
@@ -72,7 +72,7 @@ public class DataStoresLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (dataStoresService == null) {
-            dataStoresService = initService(DataStoresService.class, host);
+            dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
@@ -72,7 +72,7 @@ public class DataStoresLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (dataStoresService == null) {
-            dataStoresService = initService(DataStoresService.class, host);
+            dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresList.java
@@ -53,7 +53,7 @@ Note: If omitted, all data stores are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             WanakuResponse<List<DataStore>> response = dataStoresService.list(labelExpression);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresRemove.java
@@ -52,7 +52,7 @@ public class DataStoresRemove extends BaseCommand {
             printer.printWarningMessage("Both --id and --name provided. Using --id only.%n");
         }
 
-        dataStoresService = initService(DataStoresService.class, host);
+        dataStoresService = initAuthenticatedService(DataStoresService.class, host);
 
         try {
             // Prefer ID over name if both provided

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -46,7 +46,7 @@ public class ForwardsAdd extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         ForwardReference reference = new ForwardReference();
         reference.setName(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsList.java
@@ -35,7 +35,7 @@ public class ForwardsList extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             WanakuResponse<List<ForwardReference>> wanakuResponseRestResponse = forwardsService.listForwards(null);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRefresh.java
@@ -29,7 +29,7 @@ public class ForwardsRefresh extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             forwardsService.refreshForward(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsRemove.java
@@ -29,7 +29,7 @@ public class ForwardsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ForwardsService forwardsService = initService(ForwardsService.class, host);
+        ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
         try {
             forwardsService.removeForward(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCleanup.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCleanup.java
@@ -55,7 +55,7 @@ public class NamespacesCleanup extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         long maxAgeSeconds = maxAgeDays * SECONDS_PER_DAY;
         boolean unassignedOnly = !includeAssigned;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreate.java
@@ -53,7 +53,7 @@ public class NamespacesCreate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         Namespace namespace = new Namespace();
         namespace.setPath(path);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesDelete.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesDelete.java
@@ -27,7 +27,7 @@ public class NamespacesDelete extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             namespacesService.delete(id);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
@@ -72,7 +72,7 @@ public class NamespacesLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (namespacesService == null) {
-            namespacesService = initService(NamespacesService.class, host);
+            namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
@@ -71,7 +71,7 @@ public class NamespacesLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (namespacesService == null) {
-            namespacesService = initService(NamespacesService.class, host);
+            namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesShow.java
@@ -33,7 +33,7 @@ public class NamespacesShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             WanakuResponse<Namespace> response = namespacesService.getById(id);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
@@ -60,7 +60,7 @@ public class NamespacesUpdate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService = initServiceIfNeeded(namespacesService, NamespacesService.class, host);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         if (clearName && name != null) {
             printer.printErrorMessage("Cannot specify both --name and --clear-name.");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
@@ -120,7 +120,7 @@ public class PromptsAdd extends BaseCommand {
 
         FileHelper.loadConfigurationSources(configurationFromFile, promptPayload::setConfigurationData);
 
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
 
         try {
             WanakuResponse<PromptReference> data = promptsService.addWithPayload(promptPayload);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
@@ -81,7 +81,7 @@ public class PromptsEdit extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
 
         // First, fetch the existing prompt
         PromptReference existingPrompt;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsList.java
@@ -30,7 +30,7 @@ public class PromptsList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
         try {
             WanakuResponse<List<PromptReference>> response = promptsService.list();
             List<PromptReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsRemove.java
@@ -32,7 +32,7 @@ public class PromptsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        promptsService = initService(PromptsService.class, host);
+        promptsService = initAuthenticatedService(PromptsService.class, host);
         try {
             promptsService.remove(name);
             printer.printSuccessMessage("Successfully removed prompt reference '" + name + "'");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
@@ -116,7 +116,7 @@ public class ResourcesExpose extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         ResourceReference resource = new ResourceReference();
         resource.setLocation(location);
         resource.setType(type);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
@@ -72,7 +72,7 @@ public class ResourcesLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (resourcesService == null) {
-            resourcesService = initService(ResourcesService.class, host);
+            resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
@@ -72,7 +72,7 @@ public class ResourcesLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (resourcesService == null) {
-            resourcesService = initService(ResourcesService.class, host);
+            resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesList.java
@@ -53,7 +53,7 @@ Note: If omitted, all resources are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         try {
             WanakuResponse<List<ResourceReference>> response = resourcesService.list(labelExpression);
             List<ResourceReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
@@ -58,7 +58,7 @@ public class ResourcesRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
         if (validationResult != EXIT_OK) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesShow.java
@@ -49,7 +49,7 @@ public class ResourcesShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        resourcesService = initService(ResourcesService.class, host);
+        resourcesService = initAuthenticatedService(ResourcesService.class, host);
         try {
             WanakuResponse<ResourceReference> response = resourcesService.getByName(resourceName);
             ResourceReference resource = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogList.java
@@ -35,7 +35,7 @@ public class ServiceCatalogList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+        ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
 
         try {
             WanakuResponse<List<Map<String, Object>>> response = service.list(search);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceDeploy.java
@@ -128,12 +128,12 @@ public class ServiceDeploy extends BaseCommand {
 
         try {
             if (template) {
-                ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+                ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
                 WanakuResponse<DataStore> response = service.deploy(dataStore);
                 printer.printSuccessMessage(
                         String.format("Service template '%s' deployed successfully%n", catalogName));
             } else {
-                ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+                ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
                 WanakuResponse<DataStore> response = service.deploy(dataStore);
                 printer.printSuccessMessage(String.format("Service catalog '%s' deployed successfully%n", catalogName));
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInstructions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceInstructions.java
@@ -38,7 +38,7 @@ public class ServiceInstructions extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceCatalogService service = initService(ServiceCatalogService.class, host);
+        ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
 
         try {
             WanakuResponse<DeploymentInstructions> response = service.getDeploymentInstructions(name, model);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateInstantiate.java
@@ -110,7 +110,7 @@ public class ServiceTemplateInstantiate extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+        ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
 
         Map<String, String> propsMap = resolveProperties(printer);
         if (propsMap == null) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceTemplateList.java
@@ -35,7 +35,7 @@ public class ServiceTemplateList extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        ServiceTemplateService service = initService(ServiceTemplateService.class, host);
+        ServiceTemplateService service = initAuthenticatedService(ServiceTemplateService.class, host);
 
         try {
             WanakuResponse<List<Map<String, Object>>> response = service.list(search);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
@@ -155,7 +155,7 @@ public class ToolsAdd extends BaseCommand {
         FileHelper.loadConfigurationSources(configurationFromFile, toolPayload::setConfigurationData);
         FileHelper.loadConfigurationSources(secretsFromFile, toolPayload::setSecretsData);
 
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         try {
             WanakuResponse<ToolReference> data = toolsService.addWithPayload(toolPayload);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsEdit.java
@@ -64,7 +64,7 @@ public class ToolsEdit extends BaseCommand {
      */
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         List<ToolReference> list = toolsService.list().data();
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
@@ -72,7 +72,7 @@ public class ToolsLabelAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (toolsService == null) {
-            toolsService = initService(ToolsService.class, host);
+            toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
@@ -71,7 +71,7 @@ public class ToolsLabelRemove extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         if (toolsService == null) {
-            toolsService = initService(ToolsService.class, host);
+            toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
         int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsList.java
@@ -54,7 +54,7 @@ Note: If omitted, all tools are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
         try {
             WanakuResponse<List<ToolReference>> response = toolsService.list(labelExpression);
             List<ToolReference> list = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
@@ -97,7 +97,7 @@ public class ToolsRemove extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
 
         int validationResult = validateLabelExpression(name, labelExpression, "--name", printer);
         if (validationResult != EXIT_OK) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsShow.java
@@ -50,7 +50,7 @@ public class ToolsShow extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        toolsService = initService(ToolsService.class, host);
+        toolsService = initAuthenticatedService(ToolsService.class, host);
         try {
             WanakuResponse<ToolReference> response = toolsService.getByName(toolName);
             ToolReference tool = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthenticationInterceptor.java
@@ -95,7 +95,10 @@ public class AuthenticationInterceptor implements ClientRequestFilter {
             Thread.currentThread().interrupt();
             routerAuthEnabled = false;
         } catch (Exception e) {
-            LOG.debug("Could not reach OIDC endpoint at {}: {}", wellKnown, e.getMessage());
+            LOG.warn(
+                    "Could not reach OIDC endpoint at {}: {} — authentication headers will not be sent",
+                    wellKnown,
+                    e.getMessage());
             routerAuthEnabled = false;
         }
 

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -87,6 +87,7 @@ quarkus.oidc.application-type=hybrid
 # URL path where users can log out from the application (don't change)
 quarkus.oidc.logout.path=/logout
 quarkus.oidc.discovery-enabled=true
+quarkus.oidc.authentication.pkce-required=true
 quarkus.oidc.connection-delay=60S
 quarkus.oidc.resource-metadata.enabled=true
 

--- a/tests/plans/cli-auth-commands.md
+++ b/tests/plans/cli-auth-commands.md
@@ -1344,6 +1344,184 @@ echo "PASS: auth login test user cleanup complete"
 
 ---
 
+## Phase 18: CLI --token Flag Verification (#1489)
+
+This phase verifies that the `--token` flag works on CLI commands after the fix in #1489 (all commands now use `initAuthenticatedService()`). Requires `WANAKU_ROUTER_URL` to be set (router deployed with OIDC enabled).
+
+### Test 18.1: Obtain a Keycloak access token
+
+```bash
+if [ -z "${WANAKU_ROUTER_URL}" ]; then
+  echo "SKIP: WANAKU_ROUTER_URL not set -- skipping --token tests"
+  exit 0
+fi
+
+TOKEN_RESPONSE=$(curl -s -X POST \
+  "${KEYCLOAK_URL}/realms/${WANAKU_REALM}/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password" \
+  -d "client_id=wanaku-mcp-router" \
+  -d "username=${WANAKU_TEST_USER}" \
+  -d "password=${WANAKU_TEST_PASS}")
+
+TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+  echo "FAIL: could not obtain access token from Keycloak"
+  echo "${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+echo "PASS: obtained access token (length: ${#TOKEN})"
+```
+
+### Test 18.2: tools list with --token succeeds
+
+```bash
+rm -f "${CREDENTIALS_FILE}"
+
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --token "${TOKEN}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: tools list with --token failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: tools list with --token succeeded (fix for #1489 confirmed)"
+```
+
+### Test 18.3: resources list with --token succeeds
+
+```bash
+OUTPUT=$(wanaku resources list --host "${WANAKU_ROUTER_URL}" --token "${TOKEN}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: resources list with --token failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: resources list with --token succeeded"
+```
+
+### Test 18.4: prompts list with --token succeeds
+
+```bash
+OUTPUT=$(wanaku prompts list --host "${WANAKU_ROUTER_URL}" --token "${TOKEN}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: prompts list with --token failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: prompts list with --token succeeded"
+```
+
+### Test 18.5: capabilities list with --token succeeds
+
+```bash
+OUTPUT=$(wanaku capabilities list --host "${WANAKU_ROUTER_URL}" --token "${TOKEN}" --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "FAIL: capabilities list with --token failed (exit code ${EXIT_CODE})"
+  echo "${OUTPUT}"
+  exit 1
+fi
+
+echo "PASS: capabilities list with --token succeeded"
+```
+
+### Test 18.6: --no-auth skips authentication
+
+```bash
+OUTPUT=$(wanaku tools list --host "${WANAKU_ROUTER_URL}" --no-auth --plain 2>&1)
+EXIT_CODE=$?
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: tools list with --no-auth failed as expected against OIDC-protected router (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: tools list with --no-auth should have failed against OIDC-protected router"
+fi
+```
+
+---
+
+## Phase 19: Auth Probe WARN Logging (#1490)
+
+This phase verifies that the OIDC auth probe failure is logged at WARN level.
+
+### Test 19.1: Probe failure against unreachable host produces WARN
+
+```bash
+OUTPUT=$(wanaku tools list --host "http://localhost:59999" --token "dummy-token" --plain 2>&1)
+
+if echo "${OUTPUT}" | grep -qi "WARN.*Could not reach OIDC endpoint"; then
+  echo "PASS: OIDC probe failure logged at WARN level (fix for #1490 confirmed)"
+elif echo "${OUTPUT}" | grep -qi "Could not reach OIDC endpoint"; then
+  echo "PASS: OIDC probe failure message present in output"
+elif echo "${OUTPUT}" | grep -q "authentication headers will not be sent"; then
+  echo "PASS: WARN message with consequence detail found"
+else
+  echo "WARN: probe failure message not found in CLI output -- may require Quarkus log configuration"
+  echo "INFO: output was: ${OUTPUT}"
+fi
+```
+
+---
+
+## Phase 20: Admin UI PKCE (#1491)
+
+This phase verifies that the router sends PKCE parameters in the OIDC authorization code flow for the admin UI.
+
+### Test 20.1: Admin UI redirect includes PKCE code_challenge
+
+```bash
+if [ -z "${WANAKU_ROUTER_URL}" ]; then
+  echo "SKIP: WANAKU_ROUTER_URL not set -- skipping PKCE tests"
+  exit 0
+fi
+
+REDIRECT_URL=$(curl -sI "${WANAKU_ROUTER_URL}/admin" 2>/dev/null | grep -i "^location:" | sed 's/[Ll]ocation: //' | tr -d '\r')
+
+if [ -z "${REDIRECT_URL}" ]; then
+  echo "FAIL: no redirect Location header found for /admin"
+  exit 1
+fi
+
+if echo "${REDIRECT_URL}" | grep -q "code_challenge="; then
+  echo "PASS: redirect includes code_challenge parameter (PKCE enabled, fix for #1491 confirmed)"
+else
+  echo "FAIL: redirect does not include code_challenge parameter"
+  echo "INFO: redirect URL: ${REDIRECT_URL}"
+fi
+
+if echo "${REDIRECT_URL}" | grep -q "code_challenge_method=S256"; then
+  echo "PASS: code_challenge_method is S256"
+else
+  echo "WARN: code_challenge_method=S256 not found in redirect"
+fi
+```
+
+### Test 20.2: No PKCE error in Keycloak redirect chain
+
+```bash
+ERROR_PAGE=$(curl -sL "${WANAKU_ROUTER_URL}/admin" 2>/dev/null)
+
+if echo "${ERROR_PAGE}" | grep -qi "Missing parameter.*code_challenge"; then
+  echo "FAIL: PKCE error found -- Keycloak is rejecting the login flow"
+else
+  echo "PASS: no PKCE-related error in the login redirect chain"
+fi
+```
+
+---
+
 ## Summary Matrix
 
 | Phase | Test ID | Test Name | Priority |
@@ -1366,3 +1544,6 @@ echo "PASS: auth login test user cleanup complete"
 | 15 | 15.1–15.2 | Token refresh with stored realm (forced expiry, realm preserved) | Critical |
 | 16 | 16.1–16.6 | Negative tests — auth login (invalid realm, wrong creds, unreachable, missing username, blank realm) | High |
 | 17 | 17.1–17.5 | Cleanup (admin users/clients, auth credentials, auth login test user) | Critical |
+| 18 | 18.1–18.6 | CLI --token flag verification (tools, resources, prompts, capabilities, --no-auth) | Critical |
+| 19 | 19.1 | Auth probe WARN logging on unreachable host | High |
+| 20 | 20.1–20.2 | Admin UI PKCE (code_challenge in redirect, no PKCE error) | Critical |


### PR DESCRIPTION
## Summary

Fixes three issues discovered during investigation of #1485 (CLI returns 302 after upgrade to 0.2.0):

- **#1489 — CLI `--token` flag silently ignored**: All ~40 CLI commands called the static `initService()` which hardcoded `tokenOverride=null`. Changed to `initAuthenticatedService()` so `--token` and `--no-auth` flags are properly read.

- **#1490 — Auth probe failure logged at DEBUG**: `AuthenticationInterceptor.isRouterAuthEnabled()` probes `/.well-known/oauth-authorization-server` before attaching the Bearer token. If this fails (e.g., K8s ingress doesn't route `/.well-known/*`), auth is silently skipped. Changed to WARN level so users can diagnose the issue.

- **#1491 — PKCE not configured for admin UI**: Modern Keycloak versions require PKCE for public clients. Added `quarkus.oidc.authentication.pkce-required=true` so the authorization code flow sends `code_challenge`.

Supersedes #1492 (branch renamed for CI automation).

## Test plan

- [ ] Verify `wanaku tools list --host <url> --token <token>` sends the Bearer header
- [ ] Verify `wanaku auth login --api-token <token>` followed by `wanaku tools list` works
- [ ] Verify WARN log appears when `/.well-known/oauth-authorization-server` is unreachable
- [ ] Verify `/admin` login flow works with Keycloak (PKCE)
- [ ] Run CLI unit tests (`mvn test -pl apps/wanaku-cli`)

## Summary by Sourcery

Fix CLI authentication handling so user-supplied tokens and no-auth flags are respected, and improve observability of router auth while enabling PKCE for the admin UI OIDC flow.

Bug Fixes:
- Ensure all CLI commands initialize authenticated services so the --token and --no-auth flags correctly control API authentication.
- Log failures to reach the OIDC discovery endpoint at WARN level so skipped authentication is visible to users.

Enhancements:
- Require PKCE for the admin UI OIDC authorization code flow via Quarkus configuration.