### PR TITLE
fix #1502: return stub responses instead of null in archetype templates

### DIFF
--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceConsumer.java
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceConsumer.java
@@ -14,6 +14,6 @@ public class ${name}ResourceConsumer implements ResourceConsumer {
     @Override
     public Object consume(String uri, ResourceRequest request) {
         // TODO: Implement your resource consumption logic here
-        return null;
+        return "TODO: implement resource logic";
     }
 }

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceDelegate.java
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/src/main/java/__name__ResourceDelegate.java
@@ -53,7 +53,6 @@ public class ${name}ResourceDelegate extends AbstractResourceDelegate {
             throw new InvalidResponseTypeException("Invalid response type from the consumer: null");
         }
 
-        // Here, convert the response from whatever format it is, to a String instance.
-        throw new InvalidResponseTypeException("The downstream service has not implemented the response coercion method");
+        return List.of(response.toString());
     }
 }

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Client.java
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Client.java
@@ -60,8 +60,8 @@ public class ${name}Client implements Client {
 
         LOG.infof("Invoking tool at URI: %s", parsedRequest.uri());
 
-        // Execute and return the result
-        return null;
+        // TODO: Execute and return the result
+        return "TODO: implement tool logic";
     }
 #end
 }

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Delegate.java
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/src/main/java/__name__Delegate.java
@@ -17,7 +17,6 @@ public class ${name}Delegate extends AbstractToolDelegate {
             throw new InvalidResponseTypeException("Invalid response type from the consumer: null");
         }
 
-        // Here, convert the response from whatever format it is, to a String instance.
-        throw new InvalidResponseTypeException("The downstream service has not implemented the response coercion method");
+        return List.of(response.toString());
     }
 }


### PR DESCRIPTION
## Summary
- Tool archetype `__name__Client.exchange()` now returns a stub string instead of `null`
- Provider archetype `__name__ResourceConsumer.consume()` now returns a stub string instead of `null`
- Both `__name__Delegate.coerceResponse()` and `__name__ResourceDelegate.coerceResponse()` now return `List.of(response.toString())` instead of always throwing, matching the pattern used by all existing capability implementations (ExecDelegate, HttpDelegate, etc.)

## Test plan
- [ ] Generate a project from the tool archetype, build and invoke via MCP -- should return the stub string instead of failing with null
- [ ] Generate a project from the provider archetype, build and invoke via MCP -- should return the stub string instead of failing with null
- [ ] Verify existing archetype tests still pass

## Summary by Sourcery

Ensure generated tool and provider archetypes return stub responses instead of failing at runtime

Bug Fixes:
- Return stub strings from generated tool client and provider consumer methods instead of null to avoid runtime failures
- Coerce non-null responses to string lists in generated delegates instead of always throwing invalid response exceptions