### PR TITLE
feat: add --namespace-name option for adding forwards and update documentation

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -3,11 +3,19 @@ package ai.wanaku.cli.main.commands.forwards;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jline.terminal.Terminal;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ForwardsService;
+import ai.wanaku.core.services.api.NamespacesService;
 import picocli.CommandLine;
 
 import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
@@ -16,6 +24,13 @@ import static picocli.CommandLine.Option;
 
 @Command(name = "add", description = "Add forward targets")
 public class ForwardsAdd extends BaseCommand {
+
+    private static final String ERROR_NO_NAMESPACE_MATCH =
+            "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
+
+    private static final String ERROR_BOTH_FLAGS =
+        "Cannot use both --namespace and --namespace-name. Use --namespace with the ID or --namespace-name with the name.";
+
     @Option(
             names = {"--host"},
             description = "The API host",
@@ -37,21 +52,63 @@ public class ForwardsAdd extends BaseCommand {
             arity = "0..1")
     protected String service;
 
-    @CommandLine.Option(
+    @Option(
             names = {"-N", "--namespace"},
-            description = "The namespace associated with the tool",
-            defaultValue = "",
-            required = true)
+            description = "The namespace ID associated with the tool")
     private String namespace;
+
+    @Option(
+            names = {"--namespace-name"},
+            description = "The namespace name to use (looked up automatically)")
+    private String namespaceName;
+
+    private String resolveNamespaceId() throws Exception {
+        if (namespace != null && !namespace.isBlank()
+            && namespaceName != null && !namespaceName.isBlank()) {
+            throw new IllegalArgumentException(ERROR_BOTH_FLAGS);
+        }
+
+        if (namespace != null && !namespace.isBlank()) {
+            return namespace;
+        }
+
+        if (namespaceName == null || namespaceName.isBlank()) {
+            throw new IllegalArgumentException("Either --namespace or --namespace-name is required.");
+        }
+
+        NamespacesService namespacesService =
+                QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host)).build(NamespacesService.class);
+
+        try {
+            WanakuResponse<List<Namespace>> response = namespacesService.list();
+            List<Namespace> matches = response.data().stream()
+                    .filter(n -> namespaceName.equals(n.getName()))
+                    .collect(Collectors.toList());
+
+            if (matches.isEmpty()) {
+                throw new IllegalArgumentException(ERROR_NO_NAMESPACE_MATCH.formatted(namespaceName));
+            }
+            if (matches.size() > 1) {
+                throw new IllegalStateException("Multiple namespaces matched '%s'. Use --namespace with the ID instead."
+                        .formatted(namespaceName));
+            }
+            return matches.getFirst().getId();
+        } catch (WebApplicationException ex) {
+            commonResponseErrorHandler(ex.getResponse());
+            throw ex;
+        }
+    }
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
+        String namespaceId = resolveNamespaceId();
+
         ForwardReference reference = new ForwardReference();
         reference.setName(name);
         reference.setAddress(service);
-        reference.setNamespace(namespace);
+        reference.setNamespace(namespaceId);
 
         try {
             forwardsService.addForward(reference);

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2368,6 +2368,10 @@ wanaku forwards add --service="http://your-mcp-server.com:8080/mcp/sse" --name m
 
 - `--service`: The URL of the external MCP server's SSE (Server-Sent Events) endpoint.
 - `--name`: A unique human-readable name for the forward, used for identification and management purposes.
+- `--namespace` (required): The namespace ID to associate the forward with. Use `wanaku namespace list` to find the ID.
+- `--namespace-name` (alternative to `--namespace`): The namespace name to use. The CLI will automatically resolve it to the corresponding ID.
+
+Use `--namespace` if you already know the namespace UUID, or `--namespace-name` to specify the namespace by its human-readable name (e.g. `public`, `default`).
 
 Once a forward is added, all tools and resources provided by the external MCP server will be mapped in the Wanaku instance.
 

--- a/tests/plans/cli-forwards-datastores.md
+++ b/tests/plans/cli-forwards-datastores.md
@@ -116,14 +116,43 @@ else
 fi
 ```
 
-### Test 2.4: Verify forward is gone from list
+### Test 2.5: Add a forward using --namespace-name instead of --namespace
+
+This verifies the `--namespace-name` flag by resolving the namespace name to its ID before registering the forward.
 
 ```bash
-OUTPUT=$(wanaku forwards list --host "${WANAKU_ROUTER_URL}" --plain 2>&1)
-if echo "${OUTPUT}" | grep -q "test-forward"; then
-  echo "FAIL: 'test-forward' still appears after removal"
+wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name ns-name-test-forward \
+  --service "http://localhost:9999/mcp/sse" \
+  --namespace-name public
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "PASS: forward 'ns-name-test-forward' added using --namespace-name"
 else
-  echo "PASS: 'test-forward' no longer in forwards list"
+  echo "FAIL: could not add forward with --namespace-name (exit code ${EXIT_CODE})"
+fi
+
+# Clean up
+wanaku forwards remove \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name ns-name-test-forward 2>/dev/null || true
+```
+
+### Test 2.6: Verify --namespace-name with non-existent namespace name fails
+
+```bash
+OUTPUT=$(wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --name ns-name-invalid-test \
+  --service "http://localhost:9999/mcp/sse" \
+  --namespace-name non-existent-namespace 2>&1)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "PASS: add forward with non-existent --namespace-name rejected (exit code ${EXIT_CODE})"
+else
+  echo "FAIL: add forward with non-existent --namespace-name should fail"
+  wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name ns-name-invalid-test 2>/dev/null || true
 fi
 ```
 
@@ -489,7 +518,7 @@ else
 fi
 ```
 
-### Test 9.3: Add forward with no namespace should fail
+### Test 9.3: Add forward with no namespace identifier should fail
 
 ```bash
 wanaku forwards add \
@@ -498,9 +527,9 @@ wanaku forwards add \
   --service "http://localhost:9999/mcp/sse" 2>&1
 EXIT_CODE=$?
 if [ "${EXIT_CODE}" -ne 0 ]; then
-  echo "PASS: forwards add without --namespace rejected (exit code ${EXIT_CODE})"
+  echo "PASS: forwards add without --namespace or --namespace-name rejected (exit code ${EXIT_CODE})"
 else
-  echo "FAIL: forwards add without --namespace should fail"
+  echo "FAIL: forwards add without a namespace identifier should fail"
   wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name negative-test-forward 2>/dev/null || true
 fi
 ```
@@ -640,7 +669,7 @@ fi
 |-------|---------|-----------|----------|
 | 0 | 0.1 | Prerequisites check | High |
 | 1 | 1.1 | Start local stack and verify connectivity | Critical |
-| 2 | 2.1-2.4 | Forward add, list, remove, verify gone | Critical |
+| 2 | 2.1-2.6 | Forward add, list, remove, verify gone, namespace-name | Critical |
 | 3 | 3.1-3.4 | Forward refresh lifecycle | High |
 | 4 | 4.1-4.2 | Data store add from file | Critical |
 | 5 | 5.1-5.2 | Data store list and get with content verification | Critical |

--- a/tests/plans/cli-negative-tests.md
+++ b/tests/plans/cli-negative-tests.md
@@ -490,7 +490,34 @@ assert_failure "5.2" "forwards add with no service rejected" \
     --name "neg-test-no-service"
 ```
 
-### Test 5.3: Add duplicate forward name
+### Test 5.3: Add forward with no namespace identifier should fail
+
+Providing neither `--namespace` nor `--namespace-name` should be rejected.
+
+```bash
+assert_failure "5.3" "forwards add with no namespace identifier rejected" \
+  wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name "neg-test-no-ns" \
+  --service "http://example.com:8080"
+```
+
+### Test 5.4: Add forward with both --namespace and --namespace-name should fail
+
+Both flags cannot be used together.
+
+```bash
+assert_failure "5.4" "forwards add with both --namespace and --namespace-name rejected" \
+  wanaku forwards add \
+  --host "${WANAKU_ROUTER_URL}" \
+  --no-auth \
+  --name "neg-test-both-ns" \
+  --service "http://example.com:8080" \
+  --namespace public \
+  --namespace-name public
+```
+### Test 5.5: Add duplicate forward name
 
 First register a forward, then try to add another with the same name.
 
@@ -503,7 +530,7 @@ wanaku forwards add \
 SETUP_EXIT=$?
 
 if [ "${SETUP_EXIT}" -ne 0 ]; then
-  echo "SKIP [5.3]: could not register setup forward"
+  echo "SKIP [5.5]: could not register setup forward"
 else
   OUTPUT=$(wanaku forwards add \
     --host "${WANAKU_ROUTER_URL}" \
@@ -513,9 +540,9 @@ else
   EXIT_CODE=$?
 
   if [ "${EXIT_CODE}" -ne 0 ]; then
-    echo "PASS [5.3]: duplicate forward name rejected (exit code ${EXIT_CODE})"
+    echo "PASS [5.5]: duplicate forward name rejected (exit code ${EXIT_CODE})"
   else
-    echo "WARN [5.3]: duplicate forward was accepted -- server may allow overwrite"
+    echo "WARN [5.5]: duplicate forward was accepted -- server may allow overwrite"
   fi
 
   # Cleanup
@@ -523,17 +550,7 @@ else
 fi
 ```
 
-### Test 5.4: Remove non-existent forward
-
-```bash
-assert_graceful "5.4" "remove non-existent forward handled gracefully" \
-  wanaku forwards remove \
-    --host "${WANAKU_ROUTER_URL}" \
-    --no-auth \
-    --name "nonexistent-forward-12345"
-```
-
-### Test 5.5: Refresh non-existent forward
+### Test 5.6: Remove non-existent forward
 
 ```bash
 assert_failure "5.5" "refresh non-existent forward rejected" \


### PR DESCRIPTION
Closes: #1514

## Summary by Sourcery

Add support for resolving forwards namespace by name in the CLI and update documentation and tests to cover the new behavior.

New Features:
- Allow forwards to be added using a --namespace-name option that automatically resolves the namespace name to its ID.

Documentation:
- Document the new --namespace-name option for forwards and clarify usage of namespace identifiers.

Tests:
- Extend CLI forwards and negative test plans to cover using --namespace-name, missing namespace identifiers, and invalid combinations of namespace flags.