### PR TITLE
refactor: error handling in DefaultMcpBridge

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -29,6 +29,7 @@ import ai.wanaku.backend.core.mcp.util.LabelExpressionParser;
 import ai.wanaku.backend.core.persistence.api.ForwardReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.WanakuRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.LabelsAwareEntity;
@@ -176,54 +177,48 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
         String address = forwardReference.getAddress();
 
         final List<RemoteToolReference> locallyRegisteredTools = new ArrayList<>();
-        try (var forwardClient = ForwardClient.newClient(address)) {
-            List<ResourceReference> resourceReferences = mcpBridge.listResources(forwardClient);
-            for (ResourceReference reference : resourceReferences) {
-                LOG.debugf("Exposing remote resource %s", reference.getName());
-                ResourceHelper.expose(
-                        reference, resourceManager, ns, (args, res) -> mcpBridge.read(forwardClient, args, res));
+        executeForwardRegistration(forwardReference, nameNamespacePair, address, locallyRegisteredTools, ns);
+    }
+
+    private void registerTools(
+            ForwardClient forwardClient,
+            ForwardReference forwardReference,
+            List<RemoteToolReference> locallyRegisteredTools,
+            Namespace ns)
+            throws ServiceUnavailableException {
+        Set<String> reservedNames = new HashSet<>();
+        for (RemoteToolReference reference : mcpBridge.listTools(forwardClient)) {
+            String remoteName = reference.getName();
+            String localName = ForwardToolHelper.buildUniqueRemoteToolName(
+                    remoteName, forwardReference.getName(), name -> toolManager.getTool(name) != null, reservedNames);
+
+            if (!remoteName.equals(localName)) {
+                LOG.infof("Binding remote tool %s as %s", remoteName, localName);
+            } else {
+                LOG.infof("Binding remote tool %s", remoteName);
             }
 
-            List<RemoteToolReference> toolReferences = mcpBridge.listTools(forwardClient);
-            Set<String> reservedNames = new HashSet<>();
-            for (RemoteToolReference reference : toolReferences) {
-                String remoteName = reference.getName();
-                String localName = ForwardToolHelper.buildUniqueRemoteToolName(
-                        remoteName,
-                        forwardReference.getName(),
-                        name -> toolManager.getTool(name) != null,
-                        reservedNames);
+            RemoteToolReference localReference = ForwardToolHelper.copyRemoteToolReference(reference);
+            localReference.setName(localName);
+            localReference.setNamespace(forwardReference.getNamespace());
 
-                if (!remoteName.equals(localName)) {
-                    LOG.infof("Binding remote tool %s as %s", remoteName, localName);
-                } else {
-                    LOG.infof("Binding remote tool %s", remoteName);
-                }
+            ToolsHelper.registerTool(
+                    localReference,
+                    toolManager,
+                    ns,
+                    (args, ignored) -> mcpBridge.executeTool(forwardClient.address(), args, reference));
 
-                RemoteToolReference localReference = ForwardToolHelper.copyRemoteToolReference(reference);
-                localReference.setName(localName);
-                localReference.setNamespace(forwardReference.getNamespace());
+            reservedNames.add(localName);
+            locallyRegisteredTools.add(localReference);
+        }
+    }
 
-                ToolsHelper.registerTool(
-                        localReference,
-                        toolManager,
-                        ns,
-                        (args, ignored) -> mcpBridge.executeTool(forwardClient.address(), args, reference));
-
-                reservedNames.add(localName);
-                locallyRegisteredTools.add(localReference);
-            }
-
-            registeredRemoteToolsByForward.put(nameNamespacePair, List.copyOf(locallyRegisteredTools));
-            forwardRegistry.link(nameNamespacePair, forwardClient.address());
-        } catch (WanakuException e) {
-            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
-
-            throw e;
-        } catch (Exception e) {
-            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
-
-            throw new WanakuException(e);
+    private void registerResources(ForwardClient forwardClient, Namespace ns) throws ServiceUnavailableException {
+        List<ResourceReference> resourceReferences = mcpBridge.listResources(forwardClient);
+        for (ResourceReference reference : resourceReferences) {
+            LOG.debugf("Exposing remote resource %s", reference.getName());
+            ResourceHelper.expose(
+                    reference, resourceManager, ns, (args, res) -> mcpBridge.read(forwardClient, args, res));
         }
     }
 
@@ -241,6 +236,29 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
             }
         }
         registeredRemoteToolsByForward.remove(nameNamespacePair);
+    }
+
+    private void executeForwardRegistration(
+            ForwardReference forwardReference,
+            NameNamespacePair nameNamespacePair,
+            String address,
+            List<RemoteToolReference> locallyRegisteredTools,
+            Namespace ns) {
+        try (var forwardClient = ForwardClient.newClient(address)) {
+            registerResources(forwardClient, ns);
+            registerTools(forwardClient, forwardReference, locallyRegisteredTools, ns);
+
+            registeredRemoteToolsByForward.put(nameNamespacePair, List.copyOf(locallyRegisteredTools));
+            forwardRegistry.link(nameNamespacePair, forwardClient.address());
+        } catch (WanakuException e) {
+            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
+
+            throw e;
+        } catch (Exception e) {
+            cleanupPartiallyRegistered(locallyRegisteredTools, nameNamespacePair);
+
+            throw new WanakuException(e);
+        }
     }
 
     public List<ResourceReference> listAllResources() {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridge.java
@@ -29,6 +29,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpException;
 import dev.langchain4j.mcp.client.McpReadResourceResult;
 import dev.langchain4j.mcp.client.McpResource;
 import dev.langchain4j.mcp.client.McpResourceContents;
@@ -43,6 +44,8 @@ import dev.langchain4j.service.tool.ToolExecutionResult;
  */
 @ApplicationScoped
 public class DefaultMcpBridge implements McpBridge {
+    static final int JSON_RPC_METHOD_NOT_FOUND = -32601;
+
     private static final Logger LOG = Logger.getLogger(DefaultMcpBridge.class);
 
     private final Map<String, ReentrantLock> locks = new ConcurrentHashMap<>();
@@ -60,8 +63,18 @@ public class DefaultMcpBridge implements McpBridge {
             }
 
             return references;
+        } catch (McpException e) {
+            if (e.errorCode() == JSON_RPC_METHOD_NOT_FOUND) {
+                LOG.infof(
+                        "Remote MCP server at %s does not support tools/list, continuing without tools",
+                        forwardClient.address());
+                return List.of();
+            }
+            throw new ServiceUnavailableException(
+                    String.format("Service is not available at %s", forwardClient.address()), e, false);
         } catch (Exception e) {
-            throw ServiceUnavailableException.forName(forwardClient.address());
+            throw new ServiceUnavailableException(
+                    String.format("Service is not available at %s", forwardClient.address()), e, false);
         }
     }
 
@@ -115,8 +128,18 @@ public class DefaultMcpBridge implements McpBridge {
             List<McpResource> resourceRefs = forwardClient.client().listResources();
 
             return resourceRefs.stream().map(DefaultMcpBridge::remoteToLocal).collect(Collectors.toList());
+        } catch (McpException e) {
+            if (e.errorCode() == JSON_RPC_METHOD_NOT_FOUND) {
+                LOG.infof(
+                        "Remote MCP server at %s does not support resources/list, continuing without resources",
+                        forwardClient.address());
+                return List.of();
+            }
+            throw new ServiceUnavailableException(
+                    String.format("Service is not available at %s", forwardClient.address()), e, false);
         } catch (Exception e) {
-            throw ServiceUnavailableException.forName(forwardClient.address());
+            throw new ServiceUnavailableException(
+                    String.format("Service is not available at %s", forwardClient.address()), e, false);
         }
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/mcp/DefaultMcpBridgeTest.java
@@ -1,0 +1,97 @@
+package ai.wanaku.backend.bridge.mcp;
+
+import java.util.Collections;
+import java.util.List;
+import ai.wanaku.backend.bridge.ForwardClient;
+import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
+import ai.wanaku.capabilities.sdk.api.types.RemoteToolReference;
+import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultMcpBridgeTest {
+
+    private final DefaultMcpBridge bridge = new DefaultMcpBridge();
+
+    @Test
+    void listResources_returnsEmptyList_whenServerReturnsMethodNotFound() {
+        McpClient client = mock(McpClient.class);
+        when(client.listResources())
+                .thenThrow(new McpException(DefaultMcpBridge.JSON_RPC_METHOD_NOT_FOUND, "Method not found"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        List<ResourceReference> result = bridge.listResources(forwardClient);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void listResources_returnsResources_whenServerSupportsResources() {
+        McpClient client = mock(McpClient.class);
+        when(client.listResources()).thenReturn(Collections.emptyList());
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        List<ResourceReference> result = bridge.listResources(forwardClient);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void listResources_throwsServiceUnavailableException_whenServerUnreachable() {
+        McpClient client = mock(McpClient.class);
+        when(client.listResources()).thenThrow(new McpException(-32600, "Invalid request"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        ServiceUnavailableException thrown = assertThrows(
+                ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException.class,
+                () -> bridge.listResources(forwardClient));
+
+        assertEquals("Service is not available at http://localhost:9090", thrown.getMessage());
+    }
+
+    @Test
+    void listResources_throwsServiceUnavailableException_whenServerReturnsOtherRpcErrors() {
+        McpClient client = mock(McpClient.class);
+        when(client.listResources()).thenThrow(new McpException(-32600, "Invalid params"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        assertThrows(ServiceUnavailableException.class, () -> bridge.listResources(forwardClient));
+    }
+
+    @Test
+    void listResources_throwsServiceUnavailableException_whenIoError() {
+        McpClient client = mock(McpClient.class);
+        when(client.listResources()).thenThrow(new RuntimeException("Connection refused"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        assertThrows(ServiceUnavailableException.class, () -> bridge.listResources(forwardClient));
+    }
+
+    @Test
+    void listTools_returnsEmptyList_whenServerReturnsMethodNotFound() {
+        McpClient client = mock(McpClient.class);
+        when(client.listTools())
+                .thenThrow(new McpException(DefaultMcpBridge.JSON_RPC_METHOD_NOT_FOUND, "Method not found"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        List<RemoteToolReference> result = bridge.listTools(forwardClient);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void listTools_throwsServiceUnavailableException_whenServerUnreachable() {
+        McpClient client = mock(McpClient.class);
+        when(client.listTools()).thenThrow(new McpException(-32603, "Internal error"));
+        ForwardClient forwardClient = new ForwardClient("http://localhost:9090", client);
+
+        assertThrows(ServiceUnavailableException.class, () -> bridge.listTools(forwardClient));
+    }
+}


### PR DESCRIPTION
Fixes: #1516

## Summary by Sourcery

Refine MCP bridge error handling for resource listing and forward registration to better tolerate unsupported methods while preserving consistent service unavailability semantics.

Bug Fixes:
- Treat MCP JSON-RPC 'method not found' errors on resources/list as an absence of resources instead of a hard failure.

Enhancements:
- Extract forward registration into dedicated helper methods for tools and resources to simplify control flow and cleanup.
- Standardize translation of MCP client failures during resource listing into ServiceUnavailableException, except when the method is not supported.

Tests:
- Add unit tests for DefaultMcpBridge.listResources covering unsupported methods, successful responses, and various error conditions.