### PR TITLE
Move test service account to a dedicated persistent namespace

### DIFF
--- a/tests/plans/common/cleanup.md
+++ b/tests/plans/common/cleanup.md
@@ -92,6 +92,8 @@ echo "SKIP: CRD deletion (uncomment to enable)"
 
 ### 9. Delete the namespace (optional)
 
+The test service account lives in `wanaku-test-infra`, not in `${WANAKU_NAMESPACE}`, so deleting the test namespace does not affect the service account or its RBAC.
+
 ```bash
 # WARNING: This deletes everything in the namespace.
 # Uncomment the following line for a full cleanup:

--- a/tests/plans/setup/create-service-account.sh
+++ b/tests/plans/setup/create-service-account.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 set -e
 
-WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+WANAKU_SA_NAMESPACE="${WANAKU_SA_NAMESPACE:-wanaku-test-infra}"
 TOKEN_DURATION="${TOKEN_DURATION:-8760h}"
 
 echo "=== Wanaku Test Service Account Setup ==="
-echo "Namespace: ${WANAKU_NAMESPACE}"
+echo "Service account namespace: ${WANAKU_SA_NAMESPACE}"
 
-# 1. Create namespace if it doesn't exist
-if oc get namespace "${WANAKU_NAMESPACE}" > /dev/null 2>&1; then
-  echo "PASS: namespace ${WANAKU_NAMESPACE} already exists"
+# 1. Create the service account namespace if it doesn't exist
+if oc get namespace "${WANAKU_SA_NAMESPACE}" > /dev/null 2>&1; then
+  echo "PASS: namespace ${WANAKU_SA_NAMESPACE} already exists"
 else
-  oc new-project "${WANAKU_NAMESPACE}" --display-name="Wanaku Operator Test" 2>/dev/null \
-    || oc create namespace "${WANAKU_NAMESPACE}"
-  echo "PASS: namespace ${WANAKU_NAMESPACE} created"
+  oc new-project "${WANAKU_SA_NAMESPACE}" --display-name="Wanaku Test Infrastructure" 2>/dev/null \
+    || oc create namespace "${WANAKU_SA_NAMESPACE}"
+  echo "PASS: namespace ${WANAKU_SA_NAMESPACE} created"
 fi
 
 # 2. Create the ServiceAccount
-if oc get serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}" > /dev/null 2>&1; then
+if oc get serviceaccount wanaku-test-runner -n "${WANAKU_SA_NAMESPACE}" > /dev/null 2>&1; then
   echo "PASS: serviceaccount wanaku-test-runner already exists"
 else
-  oc create serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}"
+  oc create serviceaccount wanaku-test-runner -n "${WANAKU_SA_NAMESPACE}"
   echo "PASS: serviceaccount wanaku-test-runner created"
 fi
 
@@ -89,14 +89,14 @@ if oc get clusterrolebinding wanaku-test-runner > /dev/null 2>&1; then
 else
   oc create clusterrolebinding wanaku-test-runner \
     --clusterrole=wanaku-test-runner \
-    --serviceaccount="${WANAKU_NAMESPACE}:wanaku-test-runner"
+    --serviceaccount="${WANAKU_SA_NAMESPACE}:wanaku-test-runner"
   echo "PASS: clusterrolebinding wanaku-test-runner created"
 fi
 
 # 5. Generate a token
 echo ""
 echo "=== Service Account Token ==="
-TOKEN=$(oc create token wanaku-test-runner -n "${WANAKU_NAMESPACE}" --duration="${TOKEN_DURATION}")
+TOKEN=$(oc create token wanaku-test-runner -n "${WANAKU_SA_NAMESPACE}" --duration="${TOKEN_DURATION}")
 echo "${TOKEN}"
 echo ""
 echo "To log in as this service account:"
@@ -104,4 +104,4 @@ echo "  oc login <cluster-api-url> --token=<token-above>"
 echo ""
 echo "To verify:"
 echo "  oc whoami"
-echo "  # Expected: system:serviceaccount:${WANAKU_NAMESPACE}:wanaku-test-runner"
+echo "  # Expected: system:serviceaccount:${WANAKU_SA_NAMESPACE}:wanaku-test-runner"

--- a/tests/plans/setup/service-account-setup.md
+++ b/tests/plans/setup/service-account-setup.md
@@ -2,10 +2,11 @@
 
 Running operator test plans with your personal (admin) credentials is dangerous. This guide creates a dedicated service account with only the permissions the test plans require.
 
+The service account lives in a dedicated `wanaku-test-infra` namespace, separate from the `wanaku-test` namespace where tests run. This ensures the service account survives test cleanup and namespace deletion across test executions.
+
 ## Prerequisites
 
 - `oc` CLI logged in as a cluster admin (one-time setup)
-- The `wanaku-test` namespace (created by the test plans or manually)
 
 ## Quick Start
 
@@ -16,7 +17,7 @@ From the repository root:
 ./tests/plans/setup/create-service-account.sh
 
 # Save the token for CI or local use
-export WANAKU_TEST_TOKEN=$(oc create token wanaku-test-runner -n wanaku-test --duration=8760h)
+export WANAKU_TEST_TOKEN=$(oc create token wanaku-test-runner -n wanaku-test-infra --duration=8760h)
 ```
 
 Then log in as the service account instead of your admin user:
@@ -24,7 +25,7 @@ Then log in as the service account instead of your admin user:
 ```bash
 oc login <cluster-api-url> --token=${WANAKU_TEST_TOKEN}
 oc whoami
-# Expected: system:serviceaccount:wanaku-test:wanaku-test-runner
+# Expected: system:serviceaccount:wanaku-test-infra:wanaku-test-runner
 ```
 
 ## What the Service Account Can Do
@@ -45,7 +46,7 @@ The `create-service-account.sh` script prints a token valid for 1 year. For CI s
 To rotate the token:
 
 ```bash
-oc create token wanaku-test-runner -n wanaku-test --duration=8760h
+oc create token wanaku-test-runner -n wanaku-test-infra --duration=8760h
 ```
 
 ## Teardown

--- a/tests/plans/setup/service-account-setup.md
+++ b/tests/plans/setup/service-account-setup.md
@@ -17,13 +17,13 @@ From the repository root:
 ./tests/plans/setup/create-service-account.sh
 
 # Save the token for CI or local use
-export WANAKU_TEST_TOKEN=$(oc create token wanaku-test-runner -n wanaku-test-infra --duration=8760h)
+export OPENSHIFT_SA_TOKEN=$(oc create token wanaku-test-runner -n wanaku-test-infra --duration=8760h)
 ```
 
 Then log in as the service account instead of your admin user:
 
 ```bash
-oc login <cluster-api-url> --token=${WANAKU_TEST_TOKEN}
+oc login <cluster-api-url> --token=${OPENSHIFT_SA_TOKEN}
 oc whoami
 # Expected: system:serviceaccount:wanaku-test-infra:wanaku-test-runner
 ```

--- a/tests/plans/setup/teardown-service-account.sh
+++ b/tests/plans/setup/teardown-service-account.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+WANAKU_SA_NAMESPACE="${WANAKU_SA_NAMESPACE:-wanaku-test-infra}"
 
 echo "=== Wanaku Test Service Account Teardown ==="
-echo "Namespace: ${WANAKU_NAMESPACE}"
+echo "Service account namespace: ${WANAKU_SA_NAMESPACE}"
 
 oc delete clusterrolebinding wanaku-test-runner --ignore-not-found=true
 echo "PASS: clusterrolebinding deleted"
@@ -12,8 +12,8 @@ echo "PASS: clusterrolebinding deleted"
 oc delete clusterrole wanaku-test-runner --ignore-not-found=true
 echo "PASS: clusterrole deleted"
 
-oc delete serviceaccount wanaku-test-runner -n "${WANAKU_NAMESPACE}" --ignore-not-found=true
+oc delete serviceaccount wanaku-test-runner -n "${WANAKU_SA_NAMESPACE}" --ignore-not-found=true
 echo "PASS: serviceaccount deleted"
 
 echo ""
-echo "Done. The namespace ${WANAKU_NAMESPACE} was not deleted (it may contain other resources)."
+echo "Done. The namespace ${WANAKU_SA_NAMESPACE} was not deleted (it only contains test infrastructure)."


### PR DESCRIPTION
## Summary

- Moved the test service account from `wanaku-test` to a dedicated `wanaku-test-infra` namespace so it survives test cleanup and namespace deletion across test executions
- Updated `create-service-account.sh`, `teardown-service-account.sh`, and documentation to use `WANAKU_SA_NAMESPACE` (defaults to `wanaku-test-infra`)
- Added a note in `cleanup.md` clarifying that namespace deletion does not affect the service account

## Test plan

- [ ] Run `create-service-account.sh` and verify the SA is created in `wanaku-test-infra`
- [ ] Run a test plan that includes cleanup, verify the SA still exists afterward
- [ ] Run `teardown-service-account.sh` and verify the SA is removed from `wanaku-test-infra`

## Summary by Sourcery

Move the Wanaku test service account into a dedicated persistent namespace and update scripts and docs accordingly.

Enhancements:
- Parameterize the test service account namespace via WANAKU_SA_NAMESPACE defaulting to wanaku-test-infra in setup and teardown scripts.
- Clarify in cleanup documentation that deleting the test namespace does not remove the shared test service account or its RBAC.
- Update service account setup documentation and token examples to use the new wanaku-test-infra namespace.