### PR TITLE
Update stale version references in documentation

### DIFF
--- a/docs/performance-tests.md
+++ b/docs/performance-tests.md
@@ -76,8 +76,8 @@ This produces `.tar.gz` archives under each module's `target/distributions/` dir
 
 ```bash
 tests/load/run-perf-test.sh \
-  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.1.1-SNAPSHOT.tar.gz \
-  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.1.1-SNAPSHOT.tar.gz \
+  --router-from apps/wanaku-router-backend/target/distributions/wanaku-router-backend-0.2.0-SNAPSHOT.tar.gz \
+  --capability-from capabilities/tools/wanaku-tool-performance-noop/target/distributions/wanaku-tool-performance-noop-0.2.0-SNAPSHOT.tar.gz \
   --suite tools-sse \
   --test-name my-run \
   --test-base-dir /tmp/perf-results

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3100,8 +3100,8 @@ open http://localhost:8080
 
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-mcp-servers-archetype \
-  -DarchetypeVersion=0.1.1 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
-  -Dname=S3 -Dwanaku-version=0.1.1 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=0.2.0 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
+  -Dname=S3 -Dwanaku-version=0.2.0 -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

- Updated archetype example in `docs/usage.md` from `0.1.1` to `0.2.0`
- Updated performance test archive paths in `docs/performance-tests.md` from `0.1.1-SNAPSHOT` to `0.2.0-SNAPSHOT`

## Test plan

- [ ] Verify no other stale version references remain in docs

## Summary by Sourcery

Update documentation examples to reference version 0.2.0 instead of 0.1.1.

Documentation:
- Refresh usage archetype command to use version 0.2.0 for archetype and Wanaku version parameters.
- Update performance test documentation to use 0.2.0-SNAPSHOT distribution archive paths.