### PR TITLE
chore: fix code quality issues flagged by static analysis

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
@@ -178,7 +178,9 @@ public class ServiceExpose extends BaseCommand {
     private void generateToolRulesFile(File rulesFile, String systemName, List<String> routeIds) throws IOException {
         File parentDir = rulesFile.getParentFile();
         if (parentDir != null && !parentDir.exists()) {
-            parentDir.mkdirs();
+            if (!parentDir.mkdirs()) {
+                throw new IOException("Failed to create directory: " + parentDir);
+            }
         }
 
         try (PrintWriter pw = new PrintWriter(new FileWriter(rulesFile))) {
@@ -211,7 +213,9 @@ public class ServiceExpose extends BaseCommand {
             throws IOException {
         File parentDir = rulesFile.getParentFile();
         if (parentDir != null && !parentDir.exists()) {
-            parentDir.mkdirs();
+            if (!parentDir.mkdirs()) {
+                throw new IOException("Failed to create directory: " + parentDir);
+            }
         }
 
         try (PrintWriter pw = new PrintWriter(new FileWriter(rulesFile))) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/InsecureSSLHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/security/InsecureSSLHelper.java
@@ -23,20 +23,27 @@ public class InsecureSSLHelper {
 
     private static final X509ExtendedTrustManager[] TRUST_ALL = new X509ExtendedTrustManager[] {
         new X509ExtendedTrustManager() {
+            @Override
             public X509Certificate[] getAcceptedIssuers() {
                 return new X509Certificate[0];
             }
 
+            @Override
             public void checkClientTrusted(X509Certificate[] certs, String authType) {}
 
+            @Override
             public void checkServerTrusted(X509Certificate[] certs, String authType) {}
 
+            @Override
             public void checkClientTrusted(X509Certificate[] chain, String authType, java.net.Socket socket) {}
 
+            @Override
             public void checkServerTrusted(X509Certificate[] chain, String authType, java.net.Socket socket) {}
 
+            @Override
             public void checkClientTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
 
+            @Override
             public void checkServerTrusted(X509Certificate[] chain, String authType, javax.net.ssl.SSLEngine engine) {}
         }
     };

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/Matchers.java
@@ -161,12 +161,15 @@ public final class Matchers {
         }
 
         // Check if storage request matches
-        String desiredStorage =
-                desired.getSpec().getResources().getRequests().get("storage").toString();
-        String existingStorage =
-                existing.getSpec().getResources().getRequests().get("storage").toString();
+        Object desiredQuantity = desired.getSpec().getResources().getRequests().get("storage");
+        Object existingQuantity =
+                existing.getSpec().getResources().getRequests().get("storage");
 
-        return desiredStorage.equals(existingStorage)
+        if (desiredQuantity == null || existingQuantity == null) {
+            return Objects.equals(desiredQuantity, existingQuantity);
+        }
+
+        return desiredQuantity.toString().equals(existingQuantity.toString())
                 && desired.getSpec().getAccessModes().equals(existing.getSpec().getAccessModes());
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceCatalogBean.java
@@ -121,7 +121,9 @@ public class ServiceCatalogBean {
         DataStore existing = get(dataStore.getName());
         if (existing != null) {
             LOG.debugf("Replacing existing catalog: %s", dataStore.getName());
-            dataStoreRepository.deleteById(existing.getId());
+            if (!dataStoreRepository.deleteById(existing.getId())) {
+                LOG.warnf("Failed to delete existing catalog before replace: %s", existing.getId());
+            }
         }
 
         return dataStoreRepository.persist(dataStore);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/servicecatalog/ServiceTemplateBean.java
@@ -146,7 +146,9 @@ public class ServiceTemplateBean {
         DataStore existing = get(index.getName());
         if (existing != null) {
             LOG.debugf("Replacing existing template: %s", dataStore.getName());
-            dataStoreRepository.deleteById(existing.getId());
+            if (!dataStoreRepository.deleteById(existing.getId())) {
+                LOG.warnf("Failed to delete existing template before replace: %s", existing.getId());
+            }
         }
 
         return dataStoreRepository.persist(dataStore);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -295,7 +295,11 @@ public class ToolsetReposBean {
             return false;
         }
         try {
-            int second = Integer.parseInt(host.split("\\.")[1]);
+            String[] octets = host.split("\\.");
+            if (octets.length < 2) {
+                return false;
+            }
+            int second = Integer.parseInt(octets[1]);
             return second >= 16 && second <= 31;
         } catch (Exception e) {
             return false;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -149,7 +149,9 @@ public final class InvokerToolExecutor {
     private static String evalValue(Map.Entry<String, Property> entry, ToolManager.ToolArguments toolArguments) {
         if (entry.getValue() == null) {
             LOG.fatalf("Malformed value for key %s: null", entry.getKey());
-            return toolArguments.args().get(entry.getKey()).toString();
+            final Object fallback = toolArguments.args().get(entry.getKey());
+            requireNonNullValue(entry, fallback);
+            return fallback.toString();
         }
 
         if (entry.getValue().getValue() == null) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcResourceResponseTransformer.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcResourceResponseTransformer.java
@@ -20,6 +20,7 @@ class GrpcResourceResponseTransformer implements ResourceResponseTransformer<Res
      * @param mcpResource the resource reference
      * @return a list of resource contents
      */
+    @Override
     public List<ResourceContents> transformReply(
             ResourceReply reply, ResourceManager.ResourceArguments arguments, ResourceReference mcpResource) {
         ProtocolStringList contentList = reply.getContentList();

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcToolResponseTransformer.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/transports/grpc/GrpcToolResponseTransformer.java
@@ -16,6 +16,7 @@ class GrpcToolResponseTransformer implements ToolResponseTransformer<ToolInvokeR
      * @param reply the reply from the remote tool invocation
      * @return a ToolResponse containing the execution results
      */
+    @Override
     public ToolResponse transformReply(ToolInvokeReply reply) {
         ProtocolStringList contentList = reply.getContentList();
         List<TextContent> contents = new ArrayList<>(contentList.size());


### PR DESCRIPTION
## Summary

- Add missing `@Override` annotations on interface method implementations (`InsecureSSLHelper`, `GrpcToolResponseTransformer`, `GrpcResourceResponseTransformer`)
- Guard against array index out of bounds in `ToolsetReposBean.isPrivate172()` by checking split length before access
- Check ignored `mkdirs()` return value in `ServiceExpose` and `deleteById()` return value in `ServiceCatalogBean`/`ServiceTemplateBean`
- Prevent null dereference from `Map.get()` in `Matchers.match(PersistentVolumeClaim)` and `InvokerToolExecutor.evalValue()`

## Test plan

- [ ] `mvn compile` passes for affected modules (cli, router-backend, operator)
- [ ] Existing tests still pass

## Summary by Sourcery

Address static analysis findings by tightening null and error handling and adding missing override annotations.

Bug Fixes:
- Avoid NullPointerExceptions when matching PersistentVolumeClaim storage requests by null-checking retrieved quantities.
- Prevent potential ArrayIndexOutOfBoundsException in private IP detection by validating host octet count before parsing.
- Handle null fallback values in InvokerToolExecutor.evalValue() to avoid null dereferences when tool arguments are malformed.
- Fail fast when rule file parent directories cannot be created in ServiceExpose by checking mkdirs() return value.
- Log a warning when deletion of existing catalog or template entries fails before redeploying in ServiceCatalogBean and ServiceTemplateBean.

Enhancements:
- Add missing @Override annotations to SSL trust manager and gRPC response transformers to improve correctness and maintainability.