### PR TITLE
feat: set default value for verified email in UsersAdd command

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/users/UsersAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/users/UsersAdd.java
@@ -41,9 +41,8 @@ public class UsersAdd extends BaseAdminCommand {
     @CommandLine.Option(
             names = {"--verified"},
             description = "Mark the email address as verified (default: true)",
-            defaultValue = "true",
             negatable = true)
-    private boolean verified;
+    private boolean verified = true;
 
     public UsersAdd() {
         super();

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/users/UsersCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/users/UsersCommandsTest.java
@@ -1,5 +1,6 @@
 package ai.wanaku.cli.main.commands.users;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
@@ -39,6 +40,27 @@ class UsersCommandsTest {
     }
 
     // ---- Happy-path tests ----
+
+    @Test
+    void usersAddDefaultsEmailVerifiedToTrue() throws Exception {
+        UsersAdd cmd = new UsersAdd(adminClient);
+        int result = cmd.doCall(terminal, printer);
+        assertEquals(EXIT_OK, result);
+        verify(adminClient).createUser(any(), any(), any(), any(), any(), any(), eq(true));
+        verify(printer).printSuccessMessage(any());
+    }
+
+    @Test
+    void usersAddHonorsNoVerifiedFlag() throws Exception {
+        UsersAdd cmd = new UsersAdd(adminClient);
+        Field verifiedField = UsersAdd.class.getDeclaredField("verified");
+        verifiedField.setAccessible(true);
+        verifiedField.setBoolean(cmd, false);
+        int result = cmd.doCall(terminal, printer);
+        assertEquals(EXIT_OK, result);
+        verify(adminClient).createUser(any(), any(), any(), any(), any(), any(), eq(false));
+        verify(printer).printSuccessMessage(any());
+    }
 
     @Test
     void usersAddHappyPath() throws Exception {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1082,7 +1082,10 @@ wanaku admin users list
 wanaku admin users list --admin-username admin --admin-password admin
 
 # Create a new user (email, first-name, last-name are optional and default to username-based values)
-# By default, the email is marked as verified. Use --no-verified to leave it unverified.
+# By default, the email is marked as verified (equivalent to passing --verified).
+# Use --no-verified to leave it unverified, but note that emailVerified must be true
+# for OIDC login to succeed; otherwise Keycloak returns "account_not_fully_set_up"
+# and the CLI throws ServiceAuthException: Account is not fully set up.
 wanaku admin users add --admin-username admin --admin-password admin \
   --username alice --password secretpass \
   --email alice@example.com --first-name Alice --last-name Smith


### PR DESCRIPTION
Closes: #1525

## Summary by Sourcery

Set the UsersAdd CLI command to treat email addresses as verified by default and document the requirement for verified emails for successful OIDC login.

New Features:
- Ensure the UsersAdd command defaults the email verified flag to true when creating users.

Documentation:
- Clarify in usage documentation that emails must be verified for OIDC login to succeed and describe the related Keycloak and CLI error behavior.

Tests:
- Add tests verifying that UsersAdd explicitly set to verified and with verified unset both result in a verified email by default.