### PR TITLE
chore: update test plan prerequisites to build from source

### DIFF
--- a/tests/plans/api-v2-features.md
+++ b/tests/plans/api-v2-features.md
@@ -17,7 +17,7 @@ Every step except the initial build is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `curl` | 7.68+ | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java -version` |

--- a/tests/plans/archetype-full-lifecycle.md
+++ b/tests/plans/archetype-full-lifecycle.md
@@ -21,7 +21,7 @@ Every step except "Phase 0: Prerequisites" is fully automatable.
 |------|-----------------|----------------|
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 
 ### CLI invocation

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -23,7 +23,7 @@ Every step is fully automatable.
 | `curl` | any (health checks via `oc exec`) | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `base64` | any (coreutils) | `base64 --version 2>/dev/null \|\| echo "available"` |
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `zip` | any | `zip --version` |
 
 ### Prerequisite check script

--- a/tests/plans/camel-qdrant-search-tool.md
+++ b/tests/plans/camel-qdrant-search-tool.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java --version` |

--- a/tests/plans/cli-auth-commands.md
+++ b/tests/plans/cli-auth-commands.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |
 | `oc` | 4.x | `oc version` |

--- a/tests/plans/cli-capabilities-management.md
+++ b/tests/plans/cli-capabilities-management.md
@@ -14,7 +14,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |
 | `jq` | 1.6+ | `jq --version` |

--- a/tests/plans/cli-forwards-datastores.md
+++ b/tests/plans/cli-forwards-datastores.md
@@ -12,7 +12,7 @@ Every step except the initial build is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |

--- a/tests/plans/cli-namespaces-labels.md
+++ b/tests/plans/cli-namespaces-labels.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |

--- a/tests/plans/cli-negative-tests.md
+++ b/tests/plans/cli-negative-tests.md
@@ -12,7 +12,7 @@ All steps are idempotent, POSIX-compatible, and fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |

--- a/tests/plans/cli-service-catalog-lifecycle.md
+++ b/tests/plans/cli-service-catalog-lifecycle.md
@@ -12,7 +12,7 @@ Every step except the initial build is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `curl` | any | `curl --version` |
 | `base64` | any (coreutils) | `base64 --version 2>/dev/null \|\| echo "available"` |

--- a/tests/plans/cli-tools-resources-prompts-local.md
+++ b/tests/plans/cli-tools-resources-prompts-local.md
@@ -12,7 +12,7 @@ Every step uses the Wanaku CLI. No `curl` or other HTTP clients are used except 
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn --version` |

--- a/tests/plans/cli-toolset-repos.md
+++ b/tests/plans/cli-toolset-repos.md
@@ -14,7 +14,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `curl` | any | `curl --version` |
 

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -15,7 +15,7 @@ Every step except the initial `oc login` is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 
 ### CLI invocation
@@ -383,7 +383,7 @@ The first `oc login` step is manual; everything else is automatable.
 |------|-----------------|----------------|
 | `oc` | 4.12+ | `oc version --client` |
 | `helm` | 3.x | `helm version --short` |
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `jq` | 1.6+ | `jq --version` |
 
 ### Environment variables

--- a/tests/plans/observability-tracing.md
+++ b/tests/plans/observability-tracing.md
@@ -11,7 +11,7 @@ This test plan verifies the OpenTelemetry tracing, Micrometer metrics, and MCP r
 - Prometheus metrics endpoint on the router
 - End-to-end trace visibility in Jaeger UI
 
-The plan uses the `wanaku mcp` CLI commands from PR #1393 (installed locally) as the MCP client to drive requests.
+The plan uses the `wanaku mcp` CLI commands (built from source) as the MCP client to drive requests.
 
 Every step is fully automatable.
 
@@ -25,7 +25,7 @@ Every step is fully automatable.
 | `helm` | 3.x | `helm version --short` |
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
-| `wanaku` | PR #1393 build | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 
 ### Prerequisite check script
 

--- a/tests/plans/openai-chat-tool-template.md
+++ b/tests/plans/openai-chat-tool-template.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java --version` |

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -19,7 +19,7 @@ Every step is fully automatable.
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `base64` | any (coreutils) | `base64 --version 2>/dev/null \|\| echo "available"` |
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 
 ### Prerequisite check script
 

--- a/tests/plans/performance-testing-local.md
+++ b/tests/plans/performance-testing-local.md
@@ -25,7 +25,7 @@ Every step is fully automatable.
 | `curl` | any | `curl --version` |
 | `k6` | 0.50+ (with xk6-mcp) | `k6 version` |
 | `python3` | 3.8+ | `python3 --version` |
-| `wanaku` | 0.1.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 
 ### k6 with xk6-mcp extension
 
@@ -35,7 +35,8 @@ The k6 binary must be compiled with the `xk6-mcp` extension. A standard k6 insta
 
 ```bash
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
-export WANAKU_VERSION="${WANAKU_VERSION:-0.1.0}"
+# WANAKU_VERSION is derived from the build output in Phase 1.
+# Override manually if needed: export WANAKU_VERSION="x.y.z"
 export K6_BIN="${K6_BIN:-$HOME/bin/k6}"
 export WANAKU_BIN="${WANAKU_BIN:-$HOME/bin/wanaku}"
 export JAVA_OPTS="${JAVA_OPTS:--XX:+UseNUMA -Xmx4G -Xms4G}"
@@ -121,7 +122,7 @@ fi
 ### Test 0.3: Verify environment variables
 
 ```bash
-for VAR_NAME in WANAKU_REPO_ROOT WANAKU_VERSION K6_BIN TEST_DURATION; do
+for VAR_NAME in WANAKU_REPO_ROOT K6_BIN TEST_DURATION; do
   eval "VAL=\${${VAR_NAME}}"
   if [ -z "${VAL}" ]; then
     echo "FAIL: ${VAR_NAME} is not set"
@@ -154,6 +155,13 @@ done
 ```bash
 cd "${WANAKU_REPO_ROOT}"
 mvn package -Pdist -DskipTests -T1C -q
+```
+
+**Derive `WANAKU_VERSION` from build output:**
+
+```bash
+export WANAKU_VERSION="${WANAKU_VERSION:-$(cat ${WANAKU_REPO_ROOT}/core/core-util/target/classes/version.txt)}"
+echo "WANAKU_VERSION=${WANAKU_VERSION}"
 ```
 
 **Verification:**

--- a/tests/plans/service-template-langchain4j-agent.md
+++ b/tests/plans/service-template-langchain4j-agent.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java --version` |

--- a/tests/plans/service-template-pinecone-search.md
+++ b/tests/plans/service-template-pinecone-search.md
@@ -12,7 +12,7 @@ Every step is fully automatable.
 
 | Tool | Minimum version | Verify command |
 |------|-----------------|----------------|
-| `wanaku` | 0.2.0+ | `wanaku --version` |
+| `wanaku` | build from source | `wanaku --version` |
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `java` | 21+ | `java --version` |


### PR DESCRIPTION
## Summary

- Replaced hardcoded version references (`0.2.0+`, `0.1.0+`, `PR #1393 build`) with `build from source` across all 19 test plan prerequisite tables
- Updated `performance-testing-local.md` to derive `WANAKU_VERSION` from build output (`core/core-util/target/classes/version.txt`) instead of hardcoding a stale `0.1.0` default
- Updated `observability-tracing.md` overview text to remove merged PR #1393 reference

## Test plan

- [ ] Verify prerequisite tables in all test plans show `build from source`
- [ ] Verify `performance-testing-local.md` Phase 1 correctly derives version from build output
- [ ] Verify no remaining hardcoded `0.1.0` or `0.2.0+` version references in test plans

## Summary by Sourcery

Align Wanaku CLI test plans to assume builds from source and derive WANAKU_VERSION dynamically from build artifacts.

Documentation:
- Update all Wanaku prerequisites in test plans to state "build from source" instead of specific version numbers or PR builds.
- Document deriving WANAKU_VERSION from the core-util build output in the performance testing local plan and clarify manual override guidance.
- Refresh observability tracing plan overview to remove outdated PR references and describe use of locally built Wanaku MCP CLI.