### PR TITLE
Use Picocli exclusive ArgGroup for namespace options in ForwardsAdd

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -3,7 +3,6 @@ package ai.wanaku.cli.main.commands.forwards;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,9 +27,6 @@ public class ForwardsAdd extends BaseCommand {
     private static final String ERROR_NO_NAMESPACE_MATCH =
             "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
 
-    private static final String ERROR_BOTH_FLAGS =
-        "Cannot use both --namespace and --namespace-name. Use --namespace with the ID or --namespace-name with the name.";
-
     @Option(
             names = {"--host"},
             description = "The API host",
@@ -52,28 +48,24 @@ public class ForwardsAdd extends BaseCommand {
             arity = "0..1")
     protected String service;
 
-    @Option(
-            names = {"-N", "--namespace"},
-            description = "The namespace ID associated with the tool")
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NamespaceOptions namespaceOptions;
 
-    @Option(
-            names = {"--namespace-name"},
-            description = "The namespace name to use (looked up automatically)")
-    private String namespaceName;
+    static class NamespaceOptions {
+        @Option(
+                names = {"-N", "--namespace"},
+                description = "The namespace ID associated with the tool")
+        String namespace;
+
+        @Option(
+                names = {"--namespace-name"},
+                description = "The namespace name to use (looked up automatically)")
+        String namespaceName;
+    }
 
     private String resolveNamespaceId() throws Exception {
-        if (namespace != null && !namespace.isBlank()
-            && namespaceName != null && !namespaceName.isBlank()) {
-            throw new IllegalArgumentException(ERROR_BOTH_FLAGS);
-        }
-
-        if (namespace != null && !namespace.isBlank()) {
-            return namespace;
-        }
-
-        if (namespaceName == null || namespaceName.isBlank()) {
-            throw new IllegalArgumentException("Either --namespace or --namespace-name is required.");
+        if (namespaceOptions.namespace != null && !namespaceOptions.namespace.isBlank()) {
+            return namespaceOptions.namespace;
         }
 
         NamespacesService namespacesService =
@@ -82,15 +74,15 @@ public class ForwardsAdd extends BaseCommand {
         try {
             WanakuResponse<List<Namespace>> response = namespacesService.list();
             List<Namespace> matches = response.data().stream()
-                    .filter(n -> namespaceName.equals(n.getName()))
+                    .filter(n -> namespaceOptions.namespaceName.equals(n.getName()))
                     .collect(Collectors.toList());
 
             if (matches.isEmpty()) {
-                throw new IllegalArgumentException(ERROR_NO_NAMESPACE_MATCH.formatted(namespaceName));
+                throw new IllegalArgumentException(ERROR_NO_NAMESPACE_MATCH.formatted(namespaceOptions.namespaceName));
             }
             if (matches.size() > 1) {
                 throw new IllegalStateException("Multiple namespaces matched '%s'. Use --namespace with the ID instead."
-                        .formatted(namespaceName));
+                        .formatted(namespaceOptions.namespaceName));
             }
             return matches.getFirst().getId();
         } catch (WebApplicationException ex) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -3,11 +3,9 @@ package ai.wanaku.cli.main.commands.forwards;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jline.terminal.Terminal;
-import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
@@ -64,16 +62,20 @@ public class ForwardsAdd extends BaseCommand {
     }
 
     private String resolveNamespaceId() throws Exception {
-        if (namespaceOptions.namespace != null && !namespaceOptions.namespace.isBlank()) {
+        if (namespaceOptions.namespace != null) {
             return namespaceOptions.namespace;
         }
 
-        NamespacesService namespacesService =
-                QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host)).build(NamespacesService.class);
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
 
         try {
             WanakuResponse<List<Namespace>> response = namespacesService.list();
-            List<Namespace> matches = response.data().stream()
+            List<Namespace> data = response.data();
+            if (data == null) {
+                throw new IllegalStateException("No namespace data returned from server.");
+            }
+
+            List<Namespace> matches = data.stream()
                     .filter(n -> namespaceOptions.namespaceName.equals(n.getName()))
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
## Summary
- Refactored `--namespace` and `--namespace-name` options in `ForwardsAdd` to use a Picocli `@ArgGroup(exclusive = true, multiplicity = "1")`, replacing manual runtime validation
- Fixed namespace lookup to use `initAuthenticatedService()` instead of raw `QuarkusRestClientBuilder`, so it respects `--token`, `--no-auth`, and `--insecure` flags
- Added null-safety guard on `response.data()` to prevent NPE when the server returns null data
- Removed unused imports (`IOException`, `java.net.URI`, `QuarkusRestClientBuilder`)

## Test plan
- [ ] Verify `wanaku forwards add --namespace <id> --name foo --service http://...` works
- [ ] Verify `wanaku forwards add --namespace-name <name> --name foo --service http://...` works
- [ ] Verify providing both `--namespace` and `--namespace-name` produces a Picocli usage error
- [ ] Verify providing neither produces a Picocli usage error
- [ ] Verify `--namespace-name` works against an authenticated deployment

## Summary by Sourcery

Refine `wanaku forwards add` namespace handling and improve robustness of namespace lookup.

New Features:
- Introduce an exclusive Picocli argument group for namespace ID vs namespace name options in `ForwardsAdd`.

Bug Fixes:
- Ensure namespace lookup uses the authenticated `NamespacesService` so token, no-auth, and insecure flags are honored.
- Prevent a potential null pointer when the namespace list response has no data payload.

Enhancements:
- Simplify namespace resolution logic by delegating mutual exclusivity and required-option checks to Picocli.
- Remove unused imports from `ForwardsAdd` to keep the class lean.