### PR TITLE
chore: use Picocli ArgGroup for mutually exclusive and co-dependent CLI options

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/BaseCommand.java
@@ -38,15 +38,20 @@ public abstract class BaseCommand implements Callable<Integer> {
             description = "Display the help and sub-commands")
     private boolean helpRequested = false;
 
-    @CommandLine.Option(
-            names = {"--token"},
-            description = "Override authentication token for this command")
-    protected String authTokenOverride;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    protected AuthOptions authOptions;
 
-    @CommandLine.Option(
-            names = {"--no-auth"},
-            description = "Disable authentication for this command")
-    protected boolean noAuth = false;
+    static class AuthOptions {
+        @CommandLine.Option(
+                names = {"--token"},
+                description = "Override authentication token for this command")
+        String authTokenOverride;
+
+        @CommandLine.Option(
+                names = {"--no-auth"},
+                description = "Disable authentication for this command")
+        boolean noAuth = false;
+    }
 
     @CommandLine.Option(
             names = {"--insecure"},
@@ -86,8 +91,16 @@ public abstract class BaseCommand implements Callable<Integer> {
         return initService(clazz, host, null, false);
     }
 
+    protected String getAuthTokenOverride() {
+        return authOptions != null ? authOptions.authTokenOverride : null;
+    }
+
+    protected boolean isNoAuth() {
+        return authOptions != null && authOptions.noAuth;
+    }
+
     protected <T> T initAuthenticatedService(Class<T> clazz, String host) {
-        return initService(clazz, host, this.authTokenOverride, this.noAuth);
+        return initService(clazz, host, getAuthTokenOverride(), isNoAuth());
     }
 
     /**

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommand.java
@@ -43,17 +43,24 @@ public abstract class BaseAdminCommand extends BaseCommand {
             defaultValue = DEFAULT_REALM)
     protected String realm;
 
-    @CommandLine.Option(
-            names = {"--admin-username"},
-            description = "Admin username for Keycloak (or set " + ENV_ADMIN_USERNAME + ")")
-    protected String adminUsername;
+    @CommandLine.ArgGroup(exclusive = false, multiplicity = "0..1")
+    protected AdminCredentials adminCredentials;
 
-    @CommandLine.Option(
-            names = {"--admin-password"},
-            description = "Admin password for Keycloak (or set " + ENV_ADMIN_PASSWORD + ")",
-            interactive = true,
-            arity = "0..1")
-    protected String adminPassword;
+    static class AdminCredentials {
+        @CommandLine.Option(
+                names = {"--admin-username"},
+                required = true,
+                description = "Admin username for Keycloak (or set " + ENV_ADMIN_USERNAME + ")")
+        String adminUsername;
+
+        @CommandLine.Option(
+                names = {"--admin-password"},
+                required = true,
+                description = "Admin password for Keycloak (or set " + ENV_ADMIN_PASSWORD + ")",
+                interactive = true,
+                arity = "0..1")
+        String adminPassword;
+    }
 
     private final KeycloakAdminClient adminClientOverride;
     private final EnvironmentProvider environmentProvider;
@@ -121,8 +128,10 @@ public abstract class BaseAdminCommand extends BaseCommand {
     }
 
     protected String resolveAdminUsername() {
-        if (adminUsername != null && !adminUsername.isBlank()) {
-            return adminUsername;
+        if (adminCredentials != null
+                && adminCredentials.adminUsername != null
+                && !adminCredentials.adminUsername.isBlank()) {
+            return adminCredentials.adminUsername;
         }
         String envValue = environmentProvider.get(ENV_ADMIN_USERNAME);
         if (envValue != null && !envValue.isBlank()) {
@@ -132,8 +141,10 @@ public abstract class BaseAdminCommand extends BaseCommand {
     }
 
     protected String resolveAdminPassword() {
-        if (adminPassword != null && !adminPassword.isBlank()) {
-            return adminPassword;
+        if (adminCredentials != null
+                && adminCredentials.adminPassword != null
+                && !adminCredentials.adminPassword.isBlank()) {
+            return adminCredentials.adminPassword;
         }
         String envValue = environmentProvider.get(ENV_ADMIN_PASSWORD);
         if (envValue != null && !envValue.isBlank()) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthLogin.java
@@ -16,26 +16,38 @@ public class AuthLogin extends BaseCommand {
     private static final String DEFAULT_CLIENT_ID = "admin-cli";
     private static final String DEFAULT_AUTH_MODE = "token";
 
-    @CommandLine.Option(
-            names = {"--api-token"},
-            description = "API token for authentication")
-    private String apiToken;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    AuthMode authMode;
+
+    static class AuthMode {
+        @CommandLine.Option(
+                names = {"--api-token"},
+                description = "API token for authentication")
+        String apiToken;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        UserPassCredentials credentials;
+    }
+
+    static class UserPassCredentials {
+        @CommandLine.Option(
+                names = {"--username"},
+                required = true,
+                description = "Username for authentication")
+        String username;
+
+        @CommandLine.Option(
+                names = {"--password"},
+                required = true,
+                description = "Password for authentication",
+                interactive = true)
+        String password;
+    }
 
     @CommandLine.Option(
             names = {"--auth-server"},
             description = "Authentication server URL (Wanaku or Keycloak)")
     private String authServerUrl;
-
-    @CommandLine.Option(
-            names = {"--username"},
-            description = "Username for authentication")
-    private String username;
-
-    @CommandLine.Option(
-            names = {"--password"},
-            description = "Password for authentication",
-            interactive = true)
-    private String password;
 
     @CommandLine.Option(
             names = {"--realm"},
@@ -52,9 +64,8 @@ public class AuthLogin extends BaseCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
         AuthCredentialStore credentialStore = new AuthCredentialStore();
 
-        // Handle direct API token authentication
-        if (apiToken != null) {
-            credentialStore.storeApiToken(apiToken);
+        if (authMode.apiToken != null) {
+            credentialStore.storeApiToken(authMode.apiToken);
             credentialStore.storeAuthMode(DEFAULT_AUTH_MODE);
 
             if (authServerUrl != null) {
@@ -65,42 +76,31 @@ public class AuthLogin extends BaseCommand {
             return EXIT_OK;
         }
 
-        // Handle username/password authentication
-        if (username != null && password != null) {
-            String serverUrl = authServerUrl != null ? authServerUrl : DEFAULT_AUTH_SERVER;
+        String serverUrl = authServerUrl != null ? authServerUrl : DEFAULT_AUTH_SERVER;
 
-            try {
-                printer.printInfoMessage("Authenticating with username and password...");
-                CustomSecurityServiceConfig config = new CustomSecurityServiceConfig();
-                config.setClientId(clientId);
-                config.setUsername(username);
-                config.setPassword(password);
-                config.setTokenEndpoint(TokenEndpoint.forDiscovery(serverUrl, realm));
-                ServiceAuthenticator serviceAuthenticator = new ServiceAuthenticator(config, insecure);
+        try {
+            printer.printInfoMessage("Authenticating with username and password...");
+            CustomSecurityServiceConfig config = new CustomSecurityServiceConfig();
+            config.setClientId(clientId);
+            config.setUsername(authMode.credentials.username);
+            config.setPassword(authMode.credentials.password);
+            config.setTokenEndpoint(TokenEndpoint.forDiscovery(serverUrl, realm));
+            ServiceAuthenticator serviceAuthenticator = new ServiceAuthenticator(config, insecure);
 
-                credentialStore.storeApiToken(serviceAuthenticator.currentValidAccessToken());
-                credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
-                credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
-                credentialStore.storeClientId(clientId);
-                credentialStore.storeRealm(realm != null && realm.isBlank() ? null : realm);
+            credentialStore.storeApiToken(serviceAuthenticator.currentValidAccessToken());
+            credentialStore.storeRefreshToken(serviceAuthenticator.currentValidRefreshToken());
+            credentialStore.storeTokenExpiry(serviceAuthenticator.getTokenExpiryEpochSeconds());
+            credentialStore.storeClientId(clientId);
+            credentialStore.storeRealm(realm != null && realm.isBlank() ? null : realm);
 
-                credentialStore.storeAuthMode("token");
-                credentialStore.storeAuthServerUrl(serverUrl);
+            credentialStore.storeAuthMode("token");
+            credentialStore.storeAuthServerUrl(serverUrl);
 
-                printer.printSuccessMessage("Successfully authenticated and stored credentials");
-                return EXIT_OK;
-            } catch (Exception e) {
-                printer.printErrorMessage("Authentication failed: " + e.getMessage());
-                return EXIT_ERROR;
-            }
+            printer.printSuccessMessage("Successfully authenticated and stored credentials");
+            return EXIT_OK;
+        } catch (Exception e) {
+            printer.printErrorMessage("Authentication failed: " + e.getMessage());
+            return EXIT_ERROR;
         }
-
-        // Interactive mode - show help
-        printer.printInfoMessage("Interactive login mode");
-        printer.printInfoMessage("To login with an API token, use: wanaku auth login --api-token <your-token>");
-        printer.printInfoMessage(
-                "To login with username/password, use: wanaku auth login --username <user> --password <pass>");
-
-        return EXIT_OK;
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -51,12 +51,14 @@ public class AuthToken extends BaseCommand {
             return EXIT_OK;
         }
 
-        String currentToken = credentialStore.getApiToken();
-        if (currentToken != null) {
-            credentialStore.storeApiToken("");
-            printer.printSuccessMessage("API token has been cleared");
-        } else {
-            printer.printInfoMessage("No API token was set");
+        if (operation.clearToken) {
+            String currentToken = credentialStore.getApiToken();
+            if (currentToken != null) {
+                credentialStore.storeApiToken("");
+                printer.printSuccessMessage("API token has been cleared");
+            } else {
+                printer.printInfoMessage("No API token was set");
+            }
         }
         return EXIT_OK;
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -9,33 +9,38 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "token", description = "Manage API tokens")
 public class AuthToken extends BaseCommand {
 
-    @CommandLine.Option(
-            names = {"--set"},
-            description = "Set the API token")
-    private String setToken;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    TokenOperation operation;
 
-    @CommandLine.Option(
-            names = {"--get"},
-            description = "Get the current API token (masked)")
-    private boolean getToken;
+    static class TokenOperation {
+        @CommandLine.Option(
+                names = {"--set"},
+                description = "Set the API token")
+        String setToken;
 
-    @CommandLine.Option(
-            names = {"--clear"},
-            description = "Clear the API token")
-    private boolean clearToken;
+        @CommandLine.Option(
+                names = {"--get"},
+                description = "Get the current API token (masked)")
+        boolean getToken;
+
+        @CommandLine.Option(
+                names = {"--clear"},
+                description = "Clear the API token")
+        boolean clearToken;
+    }
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
         AuthCredentialStore credentialStore = new AuthCredentialStore();
 
-        if (setToken != null) {
-            credentialStore.storeApiToken(setToken);
+        if (operation.setToken != null) {
+            credentialStore.storeApiToken(operation.setToken);
             credentialStore.storeAuthMode("token");
             printer.printSuccessMessage("API token has been set");
             return EXIT_OK;
         }
 
-        if (getToken) {
+        if (operation.getToken) {
             String apiToken = credentialStore.getApiToken();
             if (apiToken != null) {
                 String maskedToken = maskToken(apiToken);
@@ -46,19 +51,14 @@ public class AuthToken extends BaseCommand {
             return EXIT_OK;
         }
 
-        if (clearToken) {
-            String currentToken = credentialStore.getApiToken();
-            if (currentToken != null) {
-                credentialStore.storeApiToken("");
-                printer.printSuccessMessage("API token has been cleared");
-            } else {
-                printer.printInfoMessage("No API token was set");
-            }
-            return EXIT_OK;
+        String currentToken = credentialStore.getApiToken();
+        if (currentToken != null) {
+            credentialStore.storeApiToken("");
+            printer.printSuccessMessage("API token has been cleared");
+        } else {
+            printer.printInfoMessage("No API token was set");
         }
-
-        CommandLine.usage(this, System.out);
-        return EXIT_ERROR;
+        return EXIT_OK;
     }
 
     private String maskToken(String token) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelAdd.java
@@ -9,6 +9,7 @@ import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.cli.main.support.LabelHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.DataStoresService;
@@ -50,10 +51,8 @@ public class DataStoresLabelAdd extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"--id"},
-            description = "ID of the data store to add labels to. Cannot be used with --label-expression.")
-    String id;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    IdSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -61,11 +60,6 @@ public class DataStoresLabelAdd extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labels;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Add labels to all data stores matching this label expression. Cannot be used with --id.")
-    String labelExpression;
 
     DataStoresService dataStoresService;
 
@@ -75,17 +69,12 @@ public class DataStoresLabelAdd extends BaseCommand {
             dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
         Map<String, String> labelsToAdd = LabelHelper.parseLabels(labels, printer);
         if (labelsToAdd == null) {
             return EXIT_ERROR;
         }
 
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return addLabelsByExpression(labelsToAdd, printer);
         }
 
@@ -94,24 +83,24 @@ public class DataStoresLabelAdd extends BaseCommand {
 
     private Integer addLabelsById(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<DataStore> response = dataStoresService.getById(id);
+            WanakuResponse<DataStore> response = dataStoresService.getById(selector.id);
             DataStore dataStore = response.data();
 
             if (dataStore == null) {
-                printer.printErrorMessage(String.format("Data store with ID '%s' not found", id));
+                printer.printErrorMessage(String.format("Data store with ID '%s' not found", selector.id));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.addLabelsToEntity(
-                    dataStore, labelsToAdd, printer, dataStoresService::update, "data store", id);
+                    dataStore, labelsToAdd, printer, dataStoresService::update, "data store", selector.id);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Data store", id, printer);
+            return handleNotFound(ex, "Data store", selector.id, printer);
         }
     }
 
     private Integer addLabelsByExpression(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<DataStore>> response = dataStoresService.list(labelExpression);
+            WanakuResponse<List<DataStore>> response = dataStoresService.list(selector.labelExpression);
             return LabelHelper.addLabelsByExpression(
                     response,
                     labelsToAdd,
@@ -119,7 +108,7 @@ public class DataStoresLabelAdd extends BaseCommand {
                     dataStoresService::update,
                     DataStore::getId,
                     "data store(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/datastores/DataStoresLabelRemove.java
@@ -8,6 +8,7 @@ import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.cli.main.support.LabelHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.DataStoresService;
@@ -49,10 +50,8 @@ public class DataStoresLabelRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"--id"},
-            description = "ID of the data store to remove labels from. Cannot be used with --label-expression.")
-    String id;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    IdSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -60,12 +59,6 @@ public class DataStoresLabelRemove extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labelKeys;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description =
-                    "Remove labels from all data stores matching this label expression. Cannot be used with --id.")
-    String labelExpression;
 
     DataStoresService dataStoresService;
 
@@ -75,12 +68,7 @@ public class DataStoresLabelRemove extends BaseCommand {
             dataStoresService = initAuthenticatedService(DataStoresService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeLabelsByExpression(printer);
         }
 
@@ -89,24 +77,24 @@ public class DataStoresLabelRemove extends BaseCommand {
 
     private Integer removeLabelsById(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<DataStore> response = dataStoresService.getById(id);
+            WanakuResponse<DataStore> response = dataStoresService.getById(selector.id);
             DataStore dataStore = response.data();
 
             if (dataStore == null) {
-                printer.printErrorMessage(String.format("Data store with ID '%s' not found", id));
+                printer.printErrorMessage(String.format("Data store with ID '%s' not found", selector.id));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.removeLabelsFromEntity(
-                    dataStore, labelKeys, printer, dataStoresService::update, "data store", id);
+                    dataStore, labelKeys, printer, dataStoresService::update, "data store", selector.id);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Data store", id, printer);
+            return handleNotFound(ex, "Data store", selector.id, printer);
         }
     }
 
     private Integer removeLabelsByExpression(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<DataStore>> response = dataStoresService.list(labelExpression);
+            WanakuResponse<List<DataStore>> response = dataStoresService.list(selector.labelExpression);
             return LabelHelper.removeLabelsByExpression(
                     response,
                     labelKeys,
@@ -114,7 +102,7 @@ public class DataStoresLabelRemove extends BaseCommand {
                     dataStoresService::update,
                     DataStore::getId,
                     "data store(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -71,6 +71,6 @@ public class McpPrompt extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -44,7 +44,7 @@ public class McpPromptList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -62,6 +62,6 @@ public class McpResource extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -46,7 +46,7 @@ public class McpResourceList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -70,7 +70,7 @@ public class McpTool extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 
     static String serializeParams(Map<String, String> params) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -45,7 +45,7 @@ public class McpToolList extends BaseCommand {
         if (mcpClient != null) {
             return mcpClient;
         }
-        return ClientUtil.createClient(uri, authTokenOverride);
+        return ClientUtil.createClient(uri, getAuthTokenOverride());
     }
 
     private static String nullSafe(String value) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAdd.java
@@ -9,6 +9,7 @@ import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.cli.main.support.LabelHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.NamespacesService;
@@ -50,10 +51,8 @@ public class NamespacesLabelAdd extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-i", "--id"},
-            description = "ID of the namespace to add labels to. Cannot be used with --label-expression.")
-    String id;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    IdSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -61,11 +60,6 @@ public class NamespacesLabelAdd extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labels;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Add labels to all namespaces matching this label expression. Cannot be used with --id.")
-    String labelExpression;
 
     NamespacesService namespacesService;
 
@@ -75,17 +69,12 @@ public class NamespacesLabelAdd extends BaseCommand {
             namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
         Map<String, String> labelsToAdd = LabelHelper.parseLabels(labels, printer);
         if (labelsToAdd == null) {
             return EXIT_ERROR;
         }
 
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return addLabelsByExpression(labelsToAdd, printer);
         }
 
@@ -94,24 +83,29 @@ public class NamespacesLabelAdd extends BaseCommand {
 
     private Integer addLabelsById(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<Namespace> response = namespacesService.getById(id);
+            WanakuResponse<Namespace> response = namespacesService.getById(selector.id);
             Namespace namespace = response.data();
 
             if (namespace == null) {
-                printer.printErrorMessage(String.format("Namespace with ID '%s' not found", id));
+                printer.printErrorMessage(String.format("Namespace with ID '%s' not found", selector.id));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.addLabelsToEntity(
-                    namespace, labelsToAdd, printer, n -> namespacesService.update(id, n), "namespace with ID", id);
+                    namespace,
+                    labelsToAdd,
+                    printer,
+                    n -> namespacesService.update(selector.id, n),
+                    "namespace with ID",
+                    selector.id);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Namespace", id, printer);
+            return handleNotFound(ex, "Namespace", selector.id, printer);
         }
     }
 
     private Integer addLabelsByExpression(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
+            WanakuResponse<List<Namespace>> response = namespacesService.list(selector.labelExpression);
             return LabelHelper.addLabelsByExpression(
                     response,
                     labelsToAdd,
@@ -119,7 +113,7 @@ public class NamespacesLabelAdd extends BaseCommand {
                     n -> namespacesService.update(n.getId(), n),
                     Namespace::getId,
                     "namespace(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemove.java
@@ -8,6 +8,7 @@ import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.cli.main.support.LabelHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.NamespacesService;
@@ -49,10 +50,8 @@ public class NamespacesLabelRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-i", "--id"},
-            description = "ID of the namespace to remove labels from. Cannot be used with --label-expression.")
-    String id;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    IdSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -60,11 +59,6 @@ public class NamespacesLabelRemove extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labels;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Remove labels from all namespaces matching this label expression. Cannot be used with --id.")
-    String labelExpression;
 
     NamespacesService namespacesService;
 
@@ -74,12 +68,7 @@ public class NamespacesLabelRemove extends BaseCommand {
             namespacesService = initAuthenticatedService(NamespacesService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(id, labelExpression, "--id", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeLabelsByExpression(printer);
         }
 
@@ -88,24 +77,29 @@ public class NamespacesLabelRemove extends BaseCommand {
 
     private Integer removeLabelsById(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<Namespace> response = namespacesService.getById(id);
+            WanakuResponse<Namespace> response = namespacesService.getById(selector.id);
             Namespace namespace = response.data();
 
             if (namespace == null) {
-                printer.printErrorMessage(String.format("Namespace with ID '%s' not found", id));
+                printer.printErrorMessage(String.format("Namespace with ID '%s' not found", selector.id));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.removeLabelsFromEntity(
-                    namespace, labels, printer, n -> namespacesService.update(id, n), "namespace with ID", id);
+                    namespace,
+                    labels,
+                    printer,
+                    n -> namespacesService.update(selector.id, n),
+                    "namespace with ID",
+                    selector.id);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Namespace", id, printer);
+            return handleNotFound(ex, "Namespace", selector.id, printer);
         }
     }
 
     private Integer removeLabelsByExpression(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
+            WanakuResponse<List<Namespace>> response = namespacesService.list(selector.labelExpression);
             return LabelHelper.removeLabelsByExpression(
                     response,
                     labels,
@@ -113,7 +107,7 @@ public class NamespacesLabelRemove extends BaseCommand {
                     n -> namespacesService.update(n.getId(), n),
                     Namespace::getId,
                     "namespace(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdate.java
@@ -33,16 +33,21 @@ public class NamespacesUpdate extends BaseCommand {
     @CommandLine.Parameters(description = "The ID of the namespace to update", arity = "1")
     String id;
 
-    @CommandLine.Option(
-            names = {"--name"},
-            description = "Set the namespace name (omit for pre-allocated namespaces)",
-            arity = "0..1")
-    String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    NameUpdate nameUpdate;
 
-    @CommandLine.Option(
-            names = {"--clear-name"},
-            description = "Clear the namespace name (mark as pre-allocated)")
-    boolean clearName;
+    static class NameUpdate {
+        @CommandLine.Option(
+                names = {"--name"},
+                description = "Set the namespace name (omit for pre-allocated namespaces)",
+                arity = "0..1")
+        String name;
+
+        @CommandLine.Option(
+                names = {"--clear-name"},
+                description = "Clear the namespace name (mark as pre-allocated)")
+        boolean clearName;
+    }
 
     @CommandLine.Option(
             names = {"--path"},
@@ -62,12 +67,7 @@ public class NamespacesUpdate extends BaseCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
-        if (clearName && name != null) {
-            printer.printErrorMessage("Cannot specify both --name and --clear-name.");
-            return EXIT_ERROR;
-        }
-
-        boolean hasUpdates = name != null || clearName || path != null || (labels != null && !labels.isEmpty());
+        boolean hasUpdates = nameUpdate != null || path != null || (labels != null && !labels.isEmpty());
         if (!hasUpdates) {
             printer.printErrorMessage("No updates specified. Use --name, --clear-name, --path, or --label.");
             return EXIT_ERROR;
@@ -82,11 +82,13 @@ public class NamespacesUpdate extends BaseCommand {
                 return EXIT_ERROR;
             }
 
-            if (clearName) {
-                namespace.setName(null);
-            } else if (name != null) {
-                String trimmed = name.trim();
-                namespace.setName(trimmed.isEmpty() ? null : trimmed);
+            if (nameUpdate != null) {
+                if (nameUpdate.clearName) {
+                    namespace.setName(null);
+                } else if (nameUpdate.name != null) {
+                    String trimmed = nameUpdate.name.trim();
+                    namespace.setName(trimmed.isEmpty() ? null : trimmed);
+                }
             }
 
             if (path != null) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAdd.java
@@ -10,6 +10,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.LabelHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
@@ -50,10 +51,8 @@ public class ResourcesLabelAdd extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-n", "--name"},
-            description = "Name of the resource to add labels to. Cannot be used with --label-expression.")
-    String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -61,11 +60,6 @@ public class ResourcesLabelAdd extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labels;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Add labels to all resources matching this label expression. Cannot be used with --name.")
-    String labelExpression;
 
     ResourcesService resourcesService;
 
@@ -75,17 +69,12 @@ public class ResourcesLabelAdd extends BaseCommand {
             resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
         Map<String, String> labelsToAdd = LabelHelper.parseLabels(labels, printer);
         if (labelsToAdd == null) {
             return EXIT_ERROR;
         }
 
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return addLabelsByExpression(labelsToAdd, printer);
         }
 
@@ -94,24 +83,29 @@ public class ResourcesLabelAdd extends BaseCommand {
 
     private Integer addLabelsByName(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<ResourceReference> response = resourcesService.getByName(name);
+            WanakuResponse<ResourceReference> response = resourcesService.getByName(selector.name);
             ResourceReference resource = response.data();
 
             if (resource == null) {
-                printer.printErrorMessage(String.format("Resource '%s' not found", name));
+                printer.printErrorMessage(String.format("Resource '%s' not found", selector.name));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.addLabelsToEntity(
-                    resource, labelsToAdd, printer, r -> resourcesService.update(r.getName(), r), "resource", name);
+                    resource,
+                    labelsToAdd,
+                    printer,
+                    r -> resourcesService.update(r.getName(), r),
+                    "resource",
+                    selector.name);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Resource", name, printer);
+            return handleNotFound(ex, "Resource", selector.name, printer);
         }
     }
 
     private Integer addLabelsByExpression(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ResourceReference>> response = resourcesService.list(labelExpression);
+            WanakuResponse<List<ResourceReference>> response = resourcesService.list(selector.labelExpression);
             return LabelHelper.addLabelsByExpression(
                     response,
                     labelsToAdd,
@@ -119,7 +113,7 @@ public class ResourcesLabelAdd extends BaseCommand {
                     r -> resourcesService.update(r.getName(), r),
                     ResourceReference::getName,
                     "resource(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemove.java
@@ -9,6 +9,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.LabelHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
@@ -49,10 +50,8 @@ public class ResourcesLabelRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-n", "--name"},
-            description = "Name of the resource to remove labels from. Cannot be used with --label-expression.")
-    String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -60,12 +59,6 @@ public class ResourcesLabelRemove extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labelKeys;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description =
-                    "Remove labels from all resources matching this label expression. Cannot be used with --name.")
-    String labelExpression;
 
     ResourcesService resourcesService;
 
@@ -75,12 +68,7 @@ public class ResourcesLabelRemove extends BaseCommand {
             resourcesService = initAuthenticatedService(ResourcesService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeLabelsByExpression(printer);
         }
 
@@ -89,24 +77,29 @@ public class ResourcesLabelRemove extends BaseCommand {
 
     private Integer removeLabelsByName(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<ResourceReference> response = resourcesService.getByName(name);
+            WanakuResponse<ResourceReference> response = resourcesService.getByName(selector.name);
             ResourceReference resource = response.data();
 
             if (resource == null) {
-                printer.printErrorMessage(String.format("Resource '%s' not found", name));
+                printer.printErrorMessage(String.format("Resource '%s' not found", selector.name));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.removeLabelsFromEntity(
-                    resource, labelKeys, printer, r -> resourcesService.update(r.getName(), r), "resource", name);
+                    resource,
+                    labelKeys,
+                    printer,
+                    r -> resourcesService.update(r.getName(), r),
+                    "resource",
+                    selector.name);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Resource", name, printer);
+            return handleNotFound(ex, "Resource", selector.name, printer);
         }
     }
 
     private Integer removeLabelsByExpression(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ResourceReference>> response = resourcesService.list(labelExpression);
+            WanakuResponse<List<ResourceReference>> response = resourcesService.list(selector.labelExpression);
             return LabelHelper.removeLabelsByExpression(
                     response,
                     labelKeys,
@@ -114,7 +107,7 @@ public class ResourcesLabelRemove extends BaseCommand {
                     r -> resourcesService.update(r.getName(), r),
                     ResourceReference::getName,
                     "resource(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesRemove.java
@@ -10,7 +10,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.CommandHelper;
-import ai.wanaku.cli.main.support.LabelHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
@@ -28,26 +28,8 @@ public class ResourcesRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"--name"},
-            description = "A human-readable name for the resource. Cannot be used with --label-expression.",
-            arity = "0..1")
-    private String name;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = {
-                """
-            Remove resources matching a label filter expression. Supports logical operators for complex queries.",
-            For detailed information see the label expression manual page:
-            `wanaku man label-expression`
-            Note: Use --name to remove a single resource by name. The --label-expression,
-            option enables batch removal of multiple resources. Use with caution as this,
-            operation cannot be undone.
-            """
-            },
-            arity = "0..1")
-    private String labelExpression;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-y", "--assume-yes"},
@@ -60,12 +42,7 @@ public class ResourcesRemove extends BaseCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         resourcesService = initAuthenticatedService(ResourcesService.class, host);
 
-        int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeByLabelExpression(terminal, printer);
         }
 
@@ -74,26 +51,28 @@ public class ResourcesRemove extends BaseCommand {
 
     private Integer removeByName(WanakuPrinter printer) throws IOException {
         try {
-            resourcesService.remove(name);
-            printer.printSuccessMessage("Successfully removed resource reference '" + name + "'");
+            resourcesService.remove(selector.name);
+            printer.printSuccessMessage("Successfully removed resource reference '" + selector.name + "'");
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Resource", name, printer);
+            return handleNotFound(ex, "Resource", selector.name, printer);
         }
         return EXIT_OK;
     }
 
     private Integer removeByLabelExpression(Terminal terminal, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ResourceReference>> response = resourcesService.list(labelExpression);
+            WanakuResponse<List<ResourceReference>> response = resourcesService.list(selector.labelExpression);
             List<ResourceReference> matchingResources = response.data();
 
             if (matchingResources == null || matchingResources.isEmpty()) {
-                printer.printWarningMessage("No resources found matching label expression: " + labelExpression);
+                printer.printWarningMessage(
+                        "No resources found matching label expression: " + selector.labelExpression);
                 return EXIT_OK;
             }
 
             printer.printInfoMessage(String.format(
-                    "Found %d resource(s) matching label expression '%s'", matchingResources.size(), labelExpression));
+                    "Found %d resource(s) matching label expression '%s'",
+                    matchingResources.size(), selector.labelExpression));
 
             printer.printTable(matchingResources, "name", "type", "location", "labels");
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAdd.java
@@ -10,6 +10,7 @@ import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.LabelHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsService;
 import picocli.CommandLine;
@@ -50,10 +51,8 @@ public class ToolsLabelAdd extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-n", "--name"},
-            description = "Name of the tool to add labels to. Cannot be used with --label-expression.")
-    String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -61,11 +60,6 @@ public class ToolsLabelAdd extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labels;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Add labels to all tools matching this label expression. Cannot be used with --name.")
-    String labelExpression;
 
     ToolsService toolsService;
 
@@ -75,17 +69,12 @@ public class ToolsLabelAdd extends BaseCommand {
             toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
         Map<String, String> labelsToAdd = LabelHelper.parseLabels(labels, printer);
         if (labelsToAdd == null) {
             return EXIT_ERROR;
         }
 
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return addLabelsByExpression(labelsToAdd, printer);
         }
 
@@ -94,24 +83,24 @@ public class ToolsLabelAdd extends BaseCommand {
 
     private Integer addLabelsByName(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<ToolReference> response = toolsService.getByName(name);
+            WanakuResponse<ToolReference> response = toolsService.getByName(selector.name);
             ToolReference tool = response.data();
 
             if (tool == null) {
-                printer.printErrorMessage(String.format("Tool '%s' not found", name));
+                printer.printErrorMessage(String.format("Tool '%s' not found", selector.name));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.addLabelsToEntity(
-                    tool, labelsToAdd, printer, t -> toolsService.update(t.getName(), t), "tool", name);
+                    tool, labelsToAdd, printer, t -> toolsService.update(t.getName(), t), "tool", selector.name);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Tool", name, printer);
+            return handleNotFound(ex, "Tool", selector.name, printer);
         }
     }
 
     private Integer addLabelsByExpression(Map<String, String> labelsToAdd, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ToolReference>> response = toolsService.list(labelExpression);
+            WanakuResponse<List<ToolReference>> response = toolsService.list(selector.labelExpression);
             return LabelHelper.addLabelsByExpression(
                     response,
                     labelsToAdd,
@@ -119,7 +108,7 @@ public class ToolsLabelAdd extends BaseCommand {
                     t -> toolsService.update(t.getName(), t),
                     ToolReference::getName,
                     "tool(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemove.java
@@ -9,6 +9,7 @@ import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.LabelHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsService;
 import picocli.CommandLine;
@@ -49,10 +50,8 @@ public class ToolsLabelRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-n", "--name"},
-            description = "Name of the tool to remove labels from. Cannot be used with --label-expression.")
-    String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-l", "--label"},
@@ -60,11 +59,6 @@ public class ToolsLabelRemove extends BaseCommand {
             required = true,
             arity = "1..*")
     List<String> labelKeys;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = "Remove labels from all tools matching this label expression. Cannot be used with --name.")
-    String labelExpression;
 
     ToolsService toolsService;
 
@@ -74,12 +68,7 @@ public class ToolsLabelRemove extends BaseCommand {
             toolsService = initAuthenticatedService(ToolsService.class, host);
         }
 
-        int validationResult = LabelHelper.validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeLabelsByExpression(printer);
         }
 
@@ -88,24 +77,24 @@ public class ToolsLabelRemove extends BaseCommand {
 
     private Integer removeLabelsByName(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<ToolReference> response = toolsService.getByName(name);
+            WanakuResponse<ToolReference> response = toolsService.getByName(selector.name);
             ToolReference tool = response.data();
 
             if (tool == null) {
-                printer.printErrorMessage(String.format("Tool '%s' not found", name));
+                printer.printErrorMessage(String.format("Tool '%s' not found", selector.name));
                 return EXIT_ERROR;
             }
 
             return LabelHelper.removeLabelsFromEntity(
-                    tool, labelKeys, printer, t -> toolsService.update(t.getName(), t), "tool", name);
+                    tool, labelKeys, printer, t -> toolsService.update(t.getName(), t), "tool", selector.name);
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Tool", name, printer);
+            return handleNotFound(ex, "Tool", selector.name, printer);
         }
     }
 
     private Integer removeLabelsByExpression(WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ToolReference>> response = toolsService.list(labelExpression);
+            WanakuResponse<List<ToolReference>> response = toolsService.list(selector.labelExpression);
             return LabelHelper.removeLabelsByExpression(
                     response,
                     labelKeys,
@@ -113,7 +102,7 @@ public class ToolsLabelRemove extends BaseCommand {
                     t -> toolsService.update(t.getName(), t),
                     ToolReference::getName,
                     "tool(s)",
-                    labelExpression);
+                    selector.labelExpression);
         } catch (WebApplicationException ex) {
             commonResponseErrorHandler(ex.getResponse());
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsRemove.java
@@ -10,11 +10,11 @@ import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.CommandHelper;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsService;
 import picocli.CommandLine;
 
-import static ai.wanaku.cli.main.support.LabelHelper.validateLabelExpression;
 import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
 import static ai.wanaku.cli.main.support.ResponseHelper.handleNotFound;
 
@@ -68,30 +68,13 @@ public class ToolsRemove extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-n", "--name"},
-            description = "Name of the tool to remove. Cannot be used with --label-expression.")
-    private String name;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NameSelector selector;
 
     @CommandLine.Option(
             names = {"-y", "--assume-yes"},
             description = "automatically answer yes for all questions")
     private boolean assumeYes;
-
-    @CommandLine.Option(
-            names = {"-e", "--label-expression"},
-            description = {
-                """
-            Remove tools matching a label filter expression. Supports logical operators for complex queries.",
-            For detailed information see the label expression manual page:
-            `wanaku man label-expression`
-            Note: Use --name to remove a single tool by name. The --label-expression,
-            option enables batch removal of multiple tools. Use with caution as this,
-            operation cannot be undone.
-            """
-            },
-            arity = "0..1")
-    private String labelExpression;
 
     ToolsService toolsService;
 
@@ -99,12 +82,7 @@ public class ToolsRemove extends BaseCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         toolsService = initAuthenticatedService(ToolsService.class, host);
 
-        int validationResult = validateLabelExpression(name, labelExpression, "--name", printer);
-        if (validationResult != EXIT_OK) {
-            return validationResult;
-        }
-
-        if (labelExpression != null) {
+        if (selector.labelExpression != null) {
             return removeByLabelExpression(terminal, printer);
         }
 
@@ -113,26 +91,26 @@ public class ToolsRemove extends BaseCommand {
 
     private Integer removeByName(WanakuPrinter printer) throws IOException {
         try {
-            toolsService.remove(name);
-            printer.printSuccessMessage("Successfully removed tool reference '" + name + "'");
+            toolsService.remove(selector.name);
+            printer.printSuccessMessage("Successfully removed tool reference '" + selector.name + "'");
         } catch (WebApplicationException ex) {
-            return handleNotFound(ex, "Tool", name, printer);
+            return handleNotFound(ex, "Tool", selector.name, printer);
         }
         return EXIT_OK;
     }
 
     private Integer removeByLabelExpression(Terminal terminal, WanakuPrinter printer) throws IOException {
         try {
-            WanakuResponse<List<ToolReference>> response = toolsService.list(labelExpression);
+            WanakuResponse<List<ToolReference>> response = toolsService.list(selector.labelExpression);
             List<ToolReference> matchingTools = response.data();
 
             if (matchingTools == null || matchingTools.isEmpty()) {
-                printer.printWarningMessage("No tools found matching label expression: " + labelExpression);
+                printer.printWarningMessage("No tools found matching label expression: " + selector.labelExpression);
                 return EXIT_OK;
             }
 
             printer.printInfoMessage(String.format(
-                    "Found %d tool(s) matching label expression '%s'", matchingTools.size(), labelExpression));
+                    "Found %d tool(s) matching label expression '%s'", matchingTools.size(), selector.labelExpression));
 
             printer.printTable(matchingTools, "name", "type", "uri", "labels");
 
@@ -145,7 +123,7 @@ public class ToolsRemove extends BaseCommand {
             int removed = 0;
 
             if (continues) {
-                removed = toolsService.removeIf(labelExpression).data();
+                removed = toolsService.removeIf(selector.labelExpression).data();
             }
 
             printer.printInfoMessage(String.format("Removal complete: %d tools removed", removed));

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/IdSelector.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/IdSelector.java
@@ -1,0 +1,15 @@
+package ai.wanaku.cli.main.support;
+
+import picocli.CommandLine;
+
+public class IdSelector {
+    @CommandLine.Option(
+            names = {"-i", "--id"},
+            description = "Select by ID. Cannot be used with --label-expression.")
+    public String id;
+
+    @CommandLine.Option(
+            names = {"-e", "--label-expression"},
+            description = "Select by label expression. Cannot be used with --id.")
+    public String labelExpression;
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/LabelHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/LabelHelper.java
@@ -33,22 +33,6 @@ public final class LabelHelper {
         return labelMap;
     }
 
-    public static int validateLabelExpression(
-            String identifier, String labelExpression, String identifierOption, WanakuPrinter printer) {
-        if (identifier != null && labelExpression != null) {
-            printer.printErrorMessage(String.format(
-                    "Cannot specify both %s and --label-expression. Use one or the other.", identifierOption));
-            return BaseCommand.EXIT_ERROR;
-        }
-
-        if (identifier == null && labelExpression == null) {
-            printer.printErrorMessage(String.format("Must specify either %s or --label-expression.", identifierOption));
-            return BaseCommand.EXIT_ERROR;
-        }
-
-        return BaseCommand.EXIT_OK;
-    }
-
     public static <T extends LabelsAwareEntity<String>> int addLabelsToEntity(
             T entity,
             Map<String, String> labelsToAdd,

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NameSelector.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NameSelector.java
@@ -1,0 +1,15 @@
+package ai.wanaku.cli.main.support;
+
+import picocli.CommandLine;
+
+public class NameSelector {
+    @CommandLine.Option(
+            names = {"-n", "--name"},
+            description = "Select by name. Cannot be used with --label-expression.")
+    public String name;
+
+    @CommandLine.Option(
+            names = {"-e", "--label-expression"},
+            description = "Select by label expression. Cannot be used with --name.")
+    public String labelExpression;
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommandTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/admin/BaseAdminCommandTest.java
@@ -73,8 +73,9 @@ class BaseAdminCommandTest {
         TestAdminCommand command = new TestAdminCommand(Map.of(
                 "WANAKU_ADMIN_USERNAME", "env-admin",
                 "WANAKU_ADMIN_PASSWORD", "env-pass"));
-        command.adminUsername = "cli-admin";
-        command.adminPassword = "cli-pass";
+        command.adminCredentials = new BaseAdminCommand.AdminCredentials();
+        command.adminCredentials.adminUsername = "cli-admin";
+        command.adminCredentials.adminPassword = "cli-pass";
 
         assertEquals("cli-admin", command.resolveUsernameForTest());
         assertEquals("cli-pass", command.resolvePasswordForTest());

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAddTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelAddTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.core.services.api.NamespacesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ public class NamespacesLabelAddTest {
         command = new NamespacesLabelAdd();
         command.namespacesService = namespacesService;
         command.host = "http://localhost:8080";
+        command.selector = new IdSelector();
     }
 
     @Nested
@@ -56,7 +58,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.getById("test-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "test-id";
+            command.selector.id = "test-id";
             command.labels = List.of("env=production");
 
             // Act
@@ -79,7 +81,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.getById("test-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "test-id";
+            command.selector.id = "test-id";
             command.labels = List.of("env=production", "tier=backend", "version=2.0");
 
             // Act
@@ -99,7 +101,7 @@ public class NamespacesLabelAddTest {
         @DisplayName("Should reject invalid label format")
         void shouldRejectInvalidLabelFormat() throws Exception {
             // Arrange
-            command.id = "test-id";
+            command.selector.id = "test-id";
             command.labels = List.of("invalid-label-without-equals");
 
             // Act
@@ -120,7 +122,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.getById("test-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "test-id";
+            command.selector.id = "test-id";
             command.labels = List.of("config=key=value");
 
             // Act
@@ -148,7 +150,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("new=value");
 
             // Act
@@ -174,7 +176,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("env=production");
 
             // Act
@@ -193,7 +195,7 @@ public class NamespacesLabelAddTest {
             // Arrange
             when(namespacesService.getById("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.id = "nonexistent";
+            command.selector.id = "nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -221,7 +223,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.list("category=internal")).thenReturn(listResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "category=internal";
+            command.selector.labelExpression = "category=internal";
             command.labels = List.of("migrated=true");
 
             // Act
@@ -240,7 +242,7 @@ public class NamespacesLabelAddTest {
 
             when(namespacesService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -264,7 +266,7 @@ public class NamespacesLabelAddTest {
             when(namespacesService.update(anyString(), eq(namespace1))).thenReturn(new WanakuResponse<>());
             when(namespacesService.update(anyString(), eq(namespace2))).thenThrow(new WebApplicationException());
 
-            command.labelExpression = "category=test";
+            command.selector.labelExpression = "category=test";
             command.labels = List.of("label=value");
 
             // Act
@@ -273,43 +275,6 @@ public class NamespacesLabelAddTest {
             // Assert
             assertEquals(1, result); // EXIT_ERROR due to one failure
             verify(namespacesService, times(2)).update(anyString(), any(Namespace.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both id and label-expression")
-        void shouldRejectBothIdAndExpression() throws Exception {
-            // Arrange
-            command.id = "test-id";
-            command.labelExpression = "category=test";
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(namespacesService, never()).getById(any());
-            verify(namespacesService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither id nor label-expression")
-        void shouldRejectNeitherIdNorExpression() throws Exception {
-            // Arrange
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(namespacesService, never()).getById(any());
-            verify(namespacesService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemoveTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesLabelRemoveTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.IdSelector;
 import ai.wanaku.core.services.api.NamespacesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,7 @@ public class NamespacesLabelRemoveTest {
         command = new NamespacesLabelRemove();
         command.namespacesService = namespacesService;
         command.host = "http://localhost:8080";
+        command.selector = new IdSelector();
     }
 
     @Nested
@@ -57,7 +59,7 @@ public class NamespacesLabelRemoveTest {
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("env");
 
             // Act
@@ -84,7 +86,7 @@ public class NamespacesLabelRemoveTest {
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("env", "version");
 
             // Act
@@ -108,7 +110,7 @@ public class NamespacesLabelRemoveTest {
 
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("nonexistent");
 
             // Act
@@ -128,7 +130,7 @@ public class NamespacesLabelRemoveTest {
 
             when(namespacesService.getById("my-id")).thenReturn(getResponse);
 
-            command.id = "my-id";
+            command.selector.id = "my-id";
             command.labels = List.of("env");
 
             // Act
@@ -145,7 +147,7 @@ public class NamespacesLabelRemoveTest {
             // Arrange
             when(namespacesService.getById("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.id = "nonexistent";
+            command.selector.id = "nonexistent";
             command.labels = List.of("label");
 
             // Act
@@ -173,7 +175,7 @@ public class NamespacesLabelRemoveTest {
             when(namespacesService.list("status=temp")).thenReturn(listResponse);
             when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "status=temp";
+            command.selector.labelExpression = "status=temp";
             command.labels = List.of("status");
 
             // Act
@@ -192,7 +194,7 @@ public class NamespacesLabelRemoveTest {
 
             when(namespacesService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labels = List.of("label");
 
             // Act
@@ -216,7 +218,7 @@ public class NamespacesLabelRemoveTest {
             when(namespacesService.update(anyString(), eq(namespace1))).thenReturn(new WanakuResponse<>());
             when(namespacesService.update(anyString(), eq(namespace2))).thenThrow(new WebApplicationException());
 
-            command.labelExpression = "env=dev";
+            command.selector.labelExpression = "env=dev";
             command.labels = List.of("env");
 
             // Act
@@ -225,43 +227,6 @@ public class NamespacesLabelRemoveTest {
             // Assert
             assertEquals(1, result); // EXIT_ERROR due to one failure
             verify(namespacesService, times(2)).update(anyString(), any(Namespace.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both id and label-expression")
-        void shouldRejectBothIdAndExpression() throws Exception {
-            // Arrange
-            command.id = "test-id";
-            command.labelExpression = "category=test";
-            command.labels = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(namespacesService, never()).getById(any());
-            verify(namespacesService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither id nor label-expression")
-        void shouldRejectNeitherIdNorExpression() throws Exception {
-            // Arrange
-            command.labels = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(namespacesService, never()).getById(any());
-            verify(namespacesService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdateTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesUpdateTest.java
@@ -50,7 +50,8 @@ public class NamespacesUpdateTest {
         when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
         command.id = "ns-1";
-        command.name = "new";
+        command.nameUpdate = new NamespacesUpdate.NameUpdate();
+        command.nameUpdate.name = "new";
         command.path = "ns-new";
         command.labels = Map.of("tier", "backend");
 
@@ -78,7 +79,8 @@ public class NamespacesUpdateTest {
         when(namespacesService.update(anyString(), any(Namespace.class))).thenReturn(new WanakuResponse<>());
 
         command.id = "ns-1";
-        command.clearName = true;
+        command.nameUpdate = new NamespacesUpdate.NameUpdate();
+        command.nameUpdate.clearName = true;
 
         Integer result = command.doCall(null, mock(WanakuPrinter.class));
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAddTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelAddTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.core.services.api.ResourcesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ public class ResourcesLabelAddTest {
         command = new ResourcesLabelAdd();
         command.resourcesService = resourcesService;
         command.host = "http://localhost:8080";
+        command.selector = new NameSelector();
     }
 
     @Nested
@@ -54,7 +56,7 @@ public class ResourcesLabelAddTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "test-resource";
+            command.selector.name = "test-resource";
             command.labels = List.of("category=finance");
 
             // Act
@@ -78,7 +80,7 @@ public class ResourcesLabelAddTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "test-resource";
+            command.selector.name = "test-resource";
             command.labels = List.of("category=data", "year=2024", "department=sales");
 
             // Act
@@ -98,7 +100,7 @@ public class ResourcesLabelAddTest {
         @DisplayName("Should reject invalid label format")
         void shouldRejectInvalidLabelFormat() throws Exception {
             // Arrange
-            command.name = "test-resource";
+            command.selector.name = "test-resource";
             command.labels = List.of("invalid-label");
 
             // Act
@@ -125,7 +127,7 @@ public class ResourcesLabelAddTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "my-resource";
+            command.selector.name = "my-resource";
             command.labels = List.of("new=value");
 
             // Act
@@ -152,7 +154,7 @@ public class ResourcesLabelAddTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "my-resource";
+            command.selector.name = "my-resource";
             command.labels = List.of("year=2024");
 
             // Act
@@ -171,7 +173,7 @@ public class ResourcesLabelAddTest {
             // Arrange
             when(resourcesService.getByName("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.name = "nonexistent";
+            command.selector.name = "nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -200,7 +202,7 @@ public class ResourcesLabelAddTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "category=data";
+            command.selector.labelExpression = "category=data";
             command.labels = List.of("migrated=true");
 
             // Act
@@ -219,7 +221,7 @@ public class ResourcesLabelAddTest {
 
             when(resourcesService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -228,43 +230,6 @@ public class ResourcesLabelAddTest {
             // Assert
             assertEquals(0, result); // Success but no changes
             verify(resourcesService, never()).update(anyString(), any());
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both name and label-expression")
-        void shouldRejectBothNameAndExpression() throws Exception {
-            // Arrange
-            command.name = "test-resource";
-            command.labelExpression = "category=test";
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(resourcesService, never()).getByName(any());
-            verify(resourcesService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither name nor label-expression")
-        void shouldRejectNeitherNameNorExpression() throws Exception {
-            // Arrange
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(resourcesService, never()).getByName(any());
-            verify(resourcesService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemoveTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/resources/ResourcesLabelRemoveTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.core.services.api.ResourcesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,7 @@ public class ResourcesLabelRemoveTest {
         command = new ResourcesLabelRemove();
         command.resourcesService = resourcesService;
         command.host = "http://localhost:8080";
+        command.selector = new NameSelector();
     }
 
     @Nested
@@ -56,7 +58,7 @@ public class ResourcesLabelRemoveTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "my-resource";
+            command.selector.name = "my-resource";
             command.labelKeys = List.of("year");
 
             // Act
@@ -84,7 +86,7 @@ public class ResourcesLabelRemoveTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.name = "my-resource";
+            command.selector.name = "my-resource";
             command.labelKeys = List.of("year", "department");
 
             // Act
@@ -108,7 +110,7 @@ public class ResourcesLabelRemoveTest {
 
             when(resourcesService.getByName("my-resource")).thenReturn(getResponse);
 
-            command.name = "my-resource";
+            command.selector.name = "my-resource";
             command.labelKeys = List.of("nonexistent");
 
             // Act
@@ -125,7 +127,7 @@ public class ResourcesLabelRemoveTest {
             // Arrange
             when(resourcesService.getByName("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.name = "nonexistent";
+            command.selector.name = "nonexistent";
             command.labelKeys = List.of("label");
 
             // Act
@@ -156,7 +158,7 @@ public class ResourcesLabelRemoveTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "status=archived";
+            command.selector.labelExpression = "status=archived";
             command.labelKeys = List.of("status");
 
             // Act
@@ -181,7 +183,7 @@ public class ResourcesLabelRemoveTest {
             when(resourcesService.update(anyString(), any(ResourceReference.class)))
                     .thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "category=data|status=active";
+            command.selector.labelExpression = "category=data|status=active";
             command.labelKeys = List.of("status");
 
             // Act
@@ -201,7 +203,7 @@ public class ResourcesLabelRemoveTest {
 
             when(resourcesService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labelKeys = List.of("label");
 
             // Act
@@ -210,43 +212,6 @@ public class ResourcesLabelRemoveTest {
             // Assert
             assertEquals(0, result); // Success but no changes
             verify(resourcesService, never()).update(anyString(), any());
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both name and label-expression")
-        void shouldRejectBothNameAndExpression() throws Exception {
-            // Arrange
-            command.name = "test-resource";
-            command.labelExpression = "category=test";
-            command.labelKeys = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(resourcesService, never()).getByName(any());
-            verify(resourcesService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither name nor label-expression")
-        void shouldRejectNeitherNameNorExpression() throws Exception {
-            // Arrange
-            command.labelKeys = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(resourcesService, never()).getByName(any());
-            verify(resourcesService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAddTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/tools/ToolsLabelAddTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.core.services.api.ToolsService;
 
 import static ai.wanaku.test.assertions.WanakuAssertions.assertSuccessResponse;
@@ -42,6 +43,7 @@ public class ToolsLabelAddTest {
         command = new ToolsLabelAdd();
         command.toolsService = toolsService;
         command.host = "http://localhost:8080";
+        command.selector = new NameSelector();
     }
 
     @Nested
@@ -58,7 +60,7 @@ public class ToolsLabelAddTest {
             when(toolsService.getByName("test-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "test-tool";
+            command.selector.name = "test-tool";
             command.labels = List.of("env=production");
 
             // Act
@@ -82,7 +84,7 @@ public class ToolsLabelAddTest {
             when(toolsService.getByName("test-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "test-tool";
+            command.selector.name = "test-tool";
             command.labels = List.of("env=production", "tier=backend", "version=2.0");
 
             // Act
@@ -103,7 +105,7 @@ public class ToolsLabelAddTest {
         @DisplayName("Should reject invalid label format")
         void shouldRejectInvalidLabelFormat() throws Exception {
             // Arrange
-            command.name = "test-tool";
+            command.selector.name = "test-tool";
             command.labels = List.of("invalid-label-without-equals");
 
             // Act
@@ -124,7 +126,7 @@ public class ToolsLabelAddTest {
             when(toolsService.getByName("test-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "test-tool";
+            command.selector.name = "test-tool";
             command.labels = List.of("config=key=value");
 
             // Act
@@ -153,7 +155,7 @@ public class ToolsLabelAddTest {
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labels = List.of("new=value");
 
             // Act
@@ -180,7 +182,7 @@ public class ToolsLabelAddTest {
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labels = List.of("env=production");
 
             // Act
@@ -200,7 +202,7 @@ public class ToolsLabelAddTest {
             // Arrange
             when(toolsService.getByName("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.name = "nonexistent";
+            command.selector.name = "nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -228,7 +230,7 @@ public class ToolsLabelAddTest {
             when(toolsService.list("category=weather")).thenReturn(listResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "category=weather";
+            command.selector.labelExpression = "category=weather";
             command.labels = List.of("migrated=true");
 
             // Act
@@ -248,7 +250,7 @@ public class ToolsLabelAddTest {
 
             when(toolsService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labels = List.of("label=value");
 
             // Act
@@ -273,7 +275,7 @@ public class ToolsLabelAddTest {
             when(toolsService.update(eq("tool1"), eq(tool1))).thenReturn(new WanakuResponse<>());
             when(toolsService.update(eq("tool2"), eq(tool2))).thenThrow(new WebApplicationException());
 
-            command.labelExpression = "category=test";
+            command.selector.labelExpression = "category=test";
             command.labels = List.of("label=value");
 
             // Act
@@ -283,43 +285,6 @@ public class ToolsLabelAddTest {
             assertEquals(1, result); // EXIT_ERROR due to one failure
             assertSuccessResponse(listResponse);
             verify(toolsService, times(2)).update(anyString(), any(ToolReference.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both name and label-expression")
-        void shouldRejectBothNameAndExpression() throws Exception {
-            // Arrange
-            command.name = "test-tool";
-            command.labelExpression = "category=test";
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(toolsService, never()).getByName(any());
-            verify(toolsService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither name nor label-expression")
-        void shouldRejectNeitherNameNorExpression() throws Exception {
-            // Arrange
-            command.labels = List.of("label=value");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(toolsService, never()).getByName(any());
-            verify(toolsService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemoveTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/tools/ToolsLabelRemoveTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.NameSelector;
 import ai.wanaku.core.services.api.ToolsService;
 
 import static ai.wanaku.test.assertions.WanakuAssertions.assertSuccessResponse;
@@ -43,6 +44,7 @@ public class ToolsLabelRemoveTest {
         command = new ToolsLabelRemove();
         command.toolsService = toolsService;
         command.host = "http://localhost:8080";
+        command.selector = new NameSelector();
     }
 
     @Nested
@@ -59,7 +61,7 @@ public class ToolsLabelRemoveTest {
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labelKeys = List.of("env");
 
             // Act
@@ -87,7 +89,7 @@ public class ToolsLabelRemoveTest {
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labelKeys = List.of("env", "version");
 
             // Act
@@ -112,7 +114,7 @@ public class ToolsLabelRemoveTest {
 
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labelKeys = List.of("nonexistent");
 
             // Act
@@ -133,7 +135,7 @@ public class ToolsLabelRemoveTest {
 
             when(toolsService.getByName("my-tool")).thenReturn(getResponse);
 
-            command.name = "my-tool";
+            command.selector.name = "my-tool";
             command.labelKeys = List.of("env");
 
             // Act
@@ -151,7 +153,7 @@ public class ToolsLabelRemoveTest {
             // Arrange
             when(toolsService.getByName("nonexistent")).thenReturn(new WanakuResponse<>(null));
 
-            command.name = "nonexistent";
+            command.selector.name = "nonexistent";
             command.labelKeys = List.of("label");
 
             // Act
@@ -179,7 +181,7 @@ public class ToolsLabelRemoveTest {
             when(toolsService.list("status=deprecated")).thenReturn(listResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "status=deprecated";
+            command.selector.labelExpression = "status=deprecated";
             command.labelKeys = List.of("status");
 
             // Act
@@ -204,7 +206,7 @@ public class ToolsLabelRemoveTest {
             when(toolsService.list(anyString())).thenReturn(listResponse);
             when(toolsService.update(anyString(), any(ToolReference.class))).thenReturn(new WanakuResponse<>());
 
-            command.labelExpression = "env=dev|status=active|tier=backend";
+            command.selector.labelExpression = "env=dev|status=active|tier=backend";
             command.labelKeys = List.of("status");
 
             // Act
@@ -224,7 +226,7 @@ public class ToolsLabelRemoveTest {
 
             when(toolsService.list("category=nonexistent")).thenReturn(listResponse);
 
-            command.labelExpression = "category=nonexistent";
+            command.selector.labelExpression = "category=nonexistent";
             command.labelKeys = List.of("label");
 
             // Act
@@ -249,7 +251,7 @@ public class ToolsLabelRemoveTest {
             when(toolsService.update(eq("tool1"), eq(tool1))).thenReturn(new WanakuResponse<>());
             when(toolsService.update(eq("tool2"), eq(tool2))).thenThrow(new WebApplicationException());
 
-            command.labelExpression = "env=dev";
+            command.selector.labelExpression = "env=dev";
             command.labelKeys = List.of("env");
 
             // Act
@@ -259,43 +261,6 @@ public class ToolsLabelRemoveTest {
             assertEquals(1, result); // EXIT_ERROR due to one failure
             assertSuccessResponse(listResponse);
             verify(toolsService, times(2)).update(anyString(), any(ToolReference.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("Validation Tests")
-    class ValidationTests {
-
-        @Test
-        @DisplayName("Should reject both name and label-expression")
-        void shouldRejectBothNameAndExpression() throws Exception {
-            // Arrange
-            command.name = "test-tool";
-            command.labelExpression = "category=test";
-            command.labelKeys = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(toolsService, never()).getByName(any());
-            verify(toolsService, never()).list(any());
-        }
-
-        @Test
-        @DisplayName("Should reject neither name nor label-expression")
-        void shouldRejectNeitherNameNorExpression() throws Exception {
-            // Arrange
-            command.labelKeys = List.of("label");
-
-            // Act
-            Integer result = command.doCall(null, createMockPrinter());
-
-            // Assert
-            assertEquals(1, result); // EXIT_ERROR
-            verify(toolsService, never()).getByName(any());
-            verify(toolsService, never()).list(any());
         }
     }
 

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/LabelHelperTest.java
@@ -80,34 +80,6 @@ class LabelHelperTest {
     }
 
     @Nested
-    class ValidateLabelExpressionTests {
-
-        @Test
-        void returnErrorWhenBothProvided() {
-            int result = LabelHelper.validateLabelExpression("id", "expr", "--id", printer);
-            assertEquals(BaseCommand.EXIT_ERROR, result);
-        }
-
-        @Test
-        void returnErrorWhenNeitherProvided() {
-            int result = LabelHelper.validateLabelExpression(null, null, "--id", printer);
-            assertEquals(BaseCommand.EXIT_ERROR, result);
-        }
-
-        @Test
-        void returnOkWhenOnlyIdentifierProvided() {
-            int result = LabelHelper.validateLabelExpression("id", null, "--id", printer);
-            assertEquals(BaseCommand.EXIT_OK, result);
-        }
-
-        @Test
-        void returnOkWhenOnlyExpressionProvided() {
-            int result = LabelHelper.validateLabelExpression(null, "expr", "--id", printer);
-            assertEquals(BaseCommand.EXIT_OK, result);
-        }
-    }
-
-    @Nested
     class AddLabelsToEntityTests {
 
         @Test


### PR DESCRIPTION
## Summary

- Replace manual validation with declarative Picocli `@ArgGroup` annotations across the CLI
- `--token`/`--no-auth`: exclusive in `BaseCommand` (was silently undefined behavior)
- `--admin-username`/`--admin-password`: co-dependent in `BaseAdminCommand`
- `--name`/`--label-expression` and `--id`/`--label-expression`: exclusive via reusable `NameSelector` and `IdSelector` across 10 commands
- `--set`/`--get`/`--clear`: exclusive in `AuthToken` (was silently ignoring later options)
- `--api-token` vs `--username`+`--password`: exclusive with nested co-dependency in `AuthLogin`
- `--name`/`--clear-name`: exclusive in `NamespacesUpdate`
- Remove `LabelHelper.validateLabelExpression()` — Picocli now enforces these constraints at parse time with proper usage help

## Test plan

- [x] All existing unit tests pass (313 CLI tests, 0 failures)
- [ ] Verify `--token` and `--no-auth` cannot be used together
- [ ] Verify `--admin-username` requires `--admin-password` and vice versa
- [ ] Verify `--name`/`--label-expression` exclusivity in tools/resources/namespaces/datastores commands
- [ ] Verify `--set`/`--get`/`--clear` are mutually exclusive in `auth token`
- [ ] Verify `auth login` requires either `--api-token` or both `--username` and `--password`
- [ ] Verify `namespaces update --name` and `--clear-name` are mutually exclusive

## Summary by Sourcery

Enforce mutually exclusive and co-dependent CLI options across authentication, admin, and label-management commands using Picocli ArgGroups, while simplifying validation logic and centralizing selector handling.

New Features:
- Introduce reusable NameSelector and IdSelector argument groups to standardize name/id vs label-expression selection across tools, resources, namespaces, and datastores commands.
- Require explicit authentication mode in auth login, supporting either API token or username/password credentials as structured argument groups.
- Allow namespace name updates to be specified via a dedicated grouped option that enforces exclusivity between setting and clearing the name.

Bug Fixes:
- Prevent ambiguous auth token handling by making auth token override mutually exclusive with disabling authentication on all commands.
- Ensure auth token management subcommands (--set, --get, --clear) are mutually exclusive and no longer silently ignore additional options.
- Require both admin username and password when provided via CLI, avoiding partial admin credential configurations.
- Eliminate undefined combinations of auth login options by enforcing either API token or username/password, not both or neither.
- Prevent invalid combinations of id/name and label-expression selectors by delegating enforcement to Picocli ArgGroups instead of manual runtime checks.

Enhancements:
- Refactor label add/remove and resource/tool/datastore/namespaces removal commands to use shared selector types, reducing duplication and improving consistency.
- Simplify label expression validation by removing custom helper logic and relying on Picocli’s built-in argument group constraints.
- Update MCP commands to consume the new auth token override accessor, aligning them with the revised BaseCommand authentication options.

Tests:
- Update existing CLI tests to work with the new selector and name-update structures and remove now-obsolete validation tests tied to manual label expression checks.
- Adjust admin command tests to validate behavior with the new grouped admin credential options.