### PR TITLE
feat: add remove command for service catalogs

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalog.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalog.java
@@ -8,7 +8,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "catalog",
         description = "Manage service catalogs",
-        subcommands = {ServiceCatalogList.class})
+        subcommands = {ServiceCatalogList.class, ServiceCatalogRemove.class})
 public class ServiceCatalog extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogRemove.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceCatalogRemove.java
@@ -1,0 +1,43 @@
+package ai.wanaku.cli.main.commands.service;
+
+import jakarta.ws.rs.WebApplicationException;
+
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.ServiceCatalogService;
+import picocli.CommandLine;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.handleNotFound;
+
+@CommandLine.Command(name = "remove", description = "Remove a service catalog by name")
+public class ServiceCatalogRemove extends BaseCommand {
+
+    @CommandLine.Option(
+            names = {"--host"},
+            description = "The API host",
+            defaultValue = "http://localhost:8080",
+            arity = "0..1")
+    protected String host;
+
+    @CommandLine.Option(
+            names = {"--name"},
+            description = "Name of the service catalog to remove",
+            required = true,
+            arity = "0..1")
+    private String name;
+
+    @Override
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        ServiceCatalogService service = initAuthenticatedService(ServiceCatalogService.class, host);
+
+        try {
+            service.remove(name);
+            printer.printSuccessMessage("Successfully removed service catalog '" + name + "'");
+        } catch (WebApplicationException ex) {
+            return handleNotFound(ex, "Service catalog", name, printer);
+        }
+
+        return EXIT_OK;
+    }
+}

--- a/docs/service-catalogs.md
+++ b/docs/service-catalogs.md
@@ -238,6 +238,24 @@ This command:
 
 Once deployed, the service catalog appears in the Wanaku admin UI under the **Service Catalog** page.
 
+Use `wanaku service catalog list` to see currently deployed catalogs, and `wanaku service catalog remove` to delete one by name:
+
+```shell
+wanaku service catalog list --host=http://localhost:8080
+
+wanaku service catalog remove --host=http://localhost:8080 --name=my-catalog
+```
+
+### Step 6: Remove a Catalog
+
+Remove a deployed service catalog by name:
+
+```shell
+wanaku service catalog remove --name=my-catalog --host=http://localhost:8080
+```
+
+This sends a `DELETE` request to the router and removes the catalog and all its associated routes and rules. Use `wanaku service catalog list` to see currently deployed catalogs and their names.
+
 > [!TIP]
 > Use `wanaku service deploy` for quick iteration during development. Use the operator approach (below) for production deployments on Kubernetes.
 


### PR DESCRIPTION
Closes: #1501

## Summary by Sourcery

Introduce a CLI command to remove service catalogs by name and update the service catalog documentation to cover listing and deletion workflows.

New Features:
- Add a `wanaku service catalog remove` CLI command to delete a service catalog by name.

Documentation:
- Document listing and removing service catalogs, including a new step explaining how to remove a catalog and what it does.