### PR TITLE
fix: compatibility in scripts and documentation

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/CliMain.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/CliMain.java
@@ -79,6 +79,7 @@ public class CliMain implements Callable<Integer>, QuarkusApplication {
     public Integer call() {
         if (versionRequested) {
             System.out.println("Wanaku CLI version " + VersionHelper.VERSION);
+            return BaseCommand.EXIT_OK;
         }
 
         CommandLine.usage(this, System.out);

--- a/apps/wanaku-cli/src/main/scripts/wanaku
+++ b/apps/wanaku-cli/src/main/scripts/wanaku
@@ -7,4 +7,4 @@ if [ -x "${localDir}/wanaku-cli" ]; then
 fi
 
 installDir="$(dirname "${localDir}")"
-java -jar "${installDir}"/quarkus-run.jar "$@"
+exec java --add-opens=java.base/java.lang=ALL-UNNAMED -jar "${installDir}"/quarkus-run.jar "$@"

--- a/apps/wanaku-router-backend/src/main/scripts/wanaku-router
+++ b/apps/wanaku-router-backend/src/main/scripts/wanaku-router
@@ -4,4 +4,8 @@ localDir="$(dirname $0)"
 installDir="$(dirname "${localDir}")"
 WANAKU_JAVA_OPTS="${WANAKU_JAVA_OPTS:-""}"
 
+if ! echo "${WANAKU_JAVA_OPTS}" | grep -q "add-opens"; then
+WANAKU_JAVA_OPTS="${WANAKU_JAVA_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED"
+fi
+
 java ${WANAKU_JAVA_OPTS} -jar "${installDir}"/quarkus-run.jar "$@"

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,6 +6,7 @@ Before running or deploying the Wanaku MCP Router, you need to build the project
 
 ## Prerequisites
 
+- Java 21 or later
 - [Apache Maven](https://maven.apache.org) 3.x is required to build and package the project.
 - For (experimental) native CLI builds, please follow the [Quarkus instructions on how to set up your environment](https://quarkus.io/guides/building-native-image).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -60,7 +60,7 @@ Keycloak provides authentication and authorization for:
 
 **For development:**
 
-- Java 17 or later
+- Java 21 or later
 - Maven 3.x
 - Keycloak instance (optional — can run via Podman/Docker, or set `wanaku.http.auth=none`)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -373,6 +373,27 @@ quarkus.log.category."ai.wanaku".level=DEBUG
 
 ## System-Level Issues
 
+### Module access errors on Java 25
+
+**Symptoms:**
+
+- `wanaku --version` or any `wanaku` command fails immediately with `IllegalAccessError`, `InaccessibleObjectException`, or a stack trace mentioning `java.base/java.lang` module access
+- Running with `JAVA_TOOL_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'` resolves the error
+
+**Why this happens:**
+
+Java 25 tightened strong encapsulation of internal JDK classes. Some dependencies used by Quarkus and the CLI attempt reflective access to `java.lang` internals that are no longer automatically open.
+
+**Fix:**
+
+The Wanaku CLI and router scripts already pass `--add-opens=java.base/java.lang=ALL-UNNAMED` by default on Java 25. If you run the JAR directly (e.g., `java -jar quarkus-run.jar`), add the option manually:
+
+```shell
+java --add-opens=java.base/java.lang=ALL-UNNAMED -jar quarkus-run.jar --version
+```
+
+If you still encounter module access errors for other packages, add the corresponding `--add-opens` or `--add-exports` flag. Report the full stack trace as a new issue so we can extend the launcher defaults.
+
 ### Infinispan data directory permissions in containers
 
 **Symptoms:**

--- a/get-wanaku.sh
+++ b/get-wanaku.sh
@@ -184,15 +184,23 @@ install_java() {
 
     cat > "${INSTALL_DIR}/wanaku" <<'WRAPPER'
 #!/bin/sh
+# --add-opens is included unconditionally so the installed wrapper works across
+# all supported Java versions (21+), including Java 25 which tightened
+# strong encapsulation of java.lang internals. The flag is idempotent on JVMs
+# where the package is already open.
 installDir="$(dirname "$0")/wanaku-java"
-exec java -jar "${installDir}/quarkus-run.jar" "$@"
+exec java --add-opens=java.base/java.lang=ALL-UNNAMED -jar "${installDir}/quarkus-run.jar" "$@"
 WRAPPER
     chmod 750 "${INSTALL_DIR}/wanaku"
 
     cat > "${INSTALL_DIR}/wanaku-cli" <<'WRAPPER'
 #!/bin/sh
+# --add-opens is included unconditionally so the installed wrapper works across
+# all supported Java versions (21+), including Java 25 which tightened
+# strong encapsulation of java.lang internals. The flag is idempotent on JVMs
+# where the package is already open.
 installDir="$(dirname "$0")/wanaku-java"
-exec java -jar "${installDir}/quarkus-run.jar" "$@"
+exec java --add-opens=java.base/java.lang=ALL-UNNAMED -jar "${installDir}/quarkus-run.jar" "$@"
 WRAPPER
     chmod 750 "${INSTALL_DIR}/wanaku-cli"
 }

--- a/tests/wanaku-start-local-test.sh
+++ b/tests/wanaku-start-local-test.sh
@@ -1,2 +1,2 @@
 version=$(cat core/core-util/target/classes/version.txt)
-java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${version}.zip
+JAVA_OPTS="--add-opens=java.base/java.lang=ALL-UNNAMED" java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip --local-dist capabilities/tools/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${version}.zip


### PR DESCRIPTION
Fixes: #1513

## Summary by Sourcery

Ensure Wanaku CLI and router are compatible with newer Java versions and update related documentation and scripts.

Bug Fixes:
- Make the wanaku and wanaku-cli launcher scripts pass the required --add-opens flag to avoid module access errors on Java 25.
- Change the CLI version command to exit successfully instead of treating a version request as an error.

Documentation:
- Add troubleshooting guidance for Java 25 module access errors and how to use --add-opens with direct JAR execution.
- Update FAQs and build documentation to require Java 21 or later as the supported baseline.

Tests:
- Align the local startup test script with the current CLI/router launch behavior and Java requirements.