### PR TITLE
chore: fix test plan defects found during automated review

### DIFF
--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -80,21 +80,16 @@ Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the 
 
 ### Helper: obtain a Bearer token from Keycloak
 
-For direct REST API queries against the router (bypassing the `wanaku` CLI), obtain a Bearer token from Keycloak using `oc exec` into the Keycloak pod.
+For direct REST API queries against the router (bypassing the `wanaku` CLI), obtain a Bearer token from Keycloak using the external Keycloak URL. The Keycloak container image does not include `curl`, so the token request is made from the test runner, not from inside the pod.
 
 ```bash
 get_router_token() {
-  local KC_POD
-  KC_POD=$(oc get pods -l app=keycloak \
-    -n "${WANAKU_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}')
-
-  oc exec "${KC_POD}" -n "${WANAKU_NAMESPACE}" -- \
-    curl -sf \
-      -d "client_id=wanaku-service" \
-      -d "client_secret=${WANAKU_OIDC_CLIENT_SECRET}" \
-      -d "grant_type=client_credentials" \
-      "http://localhost:8080/realms/wanaku/protocol/openid-connect/token" \
-    | jq -r '.access_token'
+  curl -sf \
+    -d "client_id=wanaku-service" \
+    -d "client_secret=${WANAKU_OIDC_SECRET}" \
+    -d "grant_type=client_credentials" \
+    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
+  | jq -r '.access_token'
 }
 ```
 
@@ -864,6 +859,10 @@ mkdir -p "${TEMP_DIR}/hello-system"
 
 cat > "${TEMP_DIR}/index.properties" <<'PROPS'
 catalog.name = hello-system
+catalog.description = Minimal hello-world catalog for CIC operator verification
+catalog.services = hello-system
+catalog.routes.hello-system = hello-system/hello-system.camel.yaml
+catalog.rules.hello-system = hello-system/hello-system.wanaku-rules.yaml
 PROPS
 
 cat > "${TEMP_DIR}/hello-system/hello-system.camel.yaml" <<'ROUTES'

--- a/tests/plans/common/cleanup.md
+++ b/tests/plans/common/cleanup.md
@@ -35,17 +35,24 @@ echo "routers-deleted=$?"
 ### 4. Wait for operator-managed resources to be cleaned up
 
 ```bash
-# Wait for operator-managed deployments to be garbage-collected (excludes the operator itself and keycloak)
+# Wait for operator-managed deployments to be garbage-collected (excludes the operator itself and keycloak).
+# Router deployments carry component=wanaku-router-backend.
+# Capability deployments carry component=<capability-name> (not a fixed label), so we poll
+# until no non-infra deployments remain.
 oc wait --for=delete deployment -l component=wanaku-router-backend -n "${WANAKU_NAMESPACE}" --timeout=60s 2>/dev/null || true
-oc wait --for=delete deployment -l component=wanaku-capability -n "${WANAKU_NAMESPACE}" --timeout=60s 2>/dev/null || true
 
-# Verify no operator-managed deployments remain (except the operator itself and keycloak)
-REMAINING=$(oc get deployments -n "${WANAKU_NAMESPACE}" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
-  | grep -v -E "^(wanaku-operator|keycloak)$" | wc -l | tr -d ' ')
+# Poll until all operator-managed deployments are garbage-collected
+END=$((SECONDS + 60))
+while [ $SECONDS -lt $END ]; do
+  REMAINING=$(oc get deployments -n "${WANAKU_NAMESPACE}" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+    | grep -v -E "^(wanaku-operator|keycloak)$" | wc -l | tr -d ' ')
+  [ "${REMAINING}" = "0" ] && break
+  sleep 3
+done
 
 if [ "${REMAINING}" != "0" ]; then
-  echo "WARN: ${REMAINING} non-operator deployments still present"
+  echo "WARN: ${REMAINING} non-operator deployments still present after cleanup"
   oc get deployments -n "${WANAKU_NAMESPACE}" -o name
 else
   echo "PASS: operator-managed deployments cleaned up"

--- a/tests/plans/common/cleanup.md
+++ b/tests/plans/common/cleanup.md
@@ -35,24 +35,17 @@ echo "routers-deleted=$?"
 ### 4. Wait for operator-managed resources to be cleaned up
 
 ```bash
-# Wait for operator-managed deployments to be garbage-collected (excludes the operator itself and keycloak).
-# Router deployments carry component=wanaku-router-backend.
-# Capability deployments carry component=<capability-name> (not a fixed label), so we poll
-# until no non-infra deployments remain.
+# Wait for operator-managed deployments to be garbage-collected (excludes the operator itself and keycloak)
 oc wait --for=delete deployment -l component=wanaku-router-backend -n "${WANAKU_NAMESPACE}" --timeout=60s 2>/dev/null || true
+oc wait --for=delete deployment -l component=wanaku-capability -n "${WANAKU_NAMESPACE}" --timeout=60s 2>/dev/null || true
 
-# Poll until all operator-managed deployments are garbage-collected
-END=$((SECONDS + 60))
-while [ $SECONDS -lt $END ]; do
-  REMAINING=$(oc get deployments -n "${WANAKU_NAMESPACE}" \
-    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
-    | grep -v -E "^(wanaku-operator|keycloak)$" | wc -l | tr -d ' ')
-  [ "${REMAINING}" = "0" ] && break
-  sleep 3
-done
+# Verify no operator-managed deployments remain (except the operator itself and keycloak)
+REMAINING=$(oc get deployments -n "${WANAKU_NAMESPACE}" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | grep -v -E "^(wanaku-operator|keycloak)$" | wc -l | tr -d ' ')
 
 if [ "${REMAINING}" != "0" ]; then
-  echo "WARN: ${REMAINING} non-operator deployments still present after cleanup"
+  echo "WARN: ${REMAINING} non-operator deployments still present"
   oc get deployments -n "${WANAKU_NAMESPACE}" -o name
 else
   echo "PASS: operator-managed deployments cleaned up"

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -724,15 +724,13 @@ else
 fi
 
 # Step 2: Authenticated request should be accepted
-KC_POD=$(oc get pods -l app=keycloak \
-  -n "${WANAKU_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}')
-
-NS_TOKEN=$(oc exec "${KC_POD}" -n "${WANAKU_NAMESPACE}" -- \
-  curl -sf \
+# Note: The Keycloak container image does not include curl, so obtain the token
+# from outside the pod using the external Keycloak URL (set by keycloak-setup.md).
+NS_TOKEN=$(curl -sf \
     -d "client_id=wanaku-service" \
-    -d "client_secret=${WANAKU_OIDC_CLIENT_SECRET}" \
+    -d "client_secret=${WANAKU_OIDC_SECRET}" \
     -d "grant_type=client_credentials" \
-    "http://localhost:8080/realms/wanaku/protocol/openid-connect/token" \
+    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
   | jq -r '.access_token')
 
 if [ -z "${NS_TOKEN}" ] || [ "${NS_TOKEN}" = "null" ]; then

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -74,21 +74,16 @@ Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the 
 
 ### Helper: obtain a Bearer token from Keycloak
 
-The router has OIDC auth enabled, so all API requests (even from inside the pod) require a Bearer token. This helper obtains a token from Keycloak using the `wanaku-service` client credentials. It uses `oc exec` into the Keycloak pod since the Keycloak route may not be accessible from outside the cluster.
+The router has OIDC auth enabled, so all API requests (even from inside the pod) require a Bearer token. This helper obtains a token from Keycloak using the `wanaku-service` client credentials. The token request is made from the test runner using the external Keycloak URL because the Keycloak container image does not include `curl`.
 
 ```bash
 get_router_token() {
-  local KC_POD
-  KC_POD=$(oc get pods -l app=keycloak \
-    -n "${WANAKU_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}')
-
-  oc exec "${KC_POD}" -n "${WANAKU_NAMESPACE}" -- \
-    curl -sf \
-      -d "client_id=wanaku-service" \
-      -d "client_secret=${WANAKU_OIDC_CLIENT_SECRET}" \
-      -d "grant_type=client_credentials" \
-      "http://localhost:8080/realms/wanaku/protocol/openid-connect/token" \
-    | jq -r '.access_token'
+  curl -sf \
+    -d "client_id=wanaku-service" \
+    -d "client_secret=${WANAKU_OIDC_SECRET}" \
+    -d "grant_type=client_credentials" \
+    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
+  | jq -r '.access_token'
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes test plan defects discovered during an automated test plan review. These are all test plan bugs, not application bugs.

- **Incomplete `index.properties`**: `camel-integration-capability.md` Test 7.2 only had `catalog.name` but was missing four required properties (`catalog.description`, `catalog.services`, `catalog.routes.*`, `catalog.rules.*`), causing `ServiceCatalogIndex.parseAndValidate()` to throw
- **Keycloak pod has no `curl`**: Three test plans used `oc exec` to run `curl` inside the Keycloak pod, but the Keycloak image doesn't include `curl`. Changed to run `curl` from the test runner using `${KEYCLOAK_URL}`. Also fixed a variable name bug: `WANAKU_OIDC_CLIENT_SECRET` -> `WANAKU_OIDC_SECRET`

## Test plan

- [ ] Verify `camel-integration-capability.md` Test 7.2 service catalog ZIP is accepted by router
- [ ] Verify Keycloak token acquisition works from test runner in all three plans