### PR TITLE
Fix #1549: add --unmask option to wanaku auth token --get

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -12,21 +12,14 @@ public class AuthToken extends BaseCommand {
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     TokenOperation operation;
 
-    @CommandLine.Option(
-            names = {"--unmask"},
-            description = "When used with --get, output the full unmasked token value")
-    boolean unmask;
-
     static class TokenOperation {
         @CommandLine.Option(
                 names = {"--set"},
                 description = "Set the API token")
         String setToken;
 
-        @CommandLine.Option(
-                names = {"--get"},
-                description = "Get the current API token (masked)")
-        boolean getToken;
+        @CommandLine.ArgGroup(exclusive = false)
+        GetOptions getOptions;
 
         @CommandLine.Option(
                 names = {"--clear"},
@@ -34,7 +27,20 @@ public class AuthToken extends BaseCommand {
         boolean clearToken;
     }
 
-    private AuthCredentialStore credentialStore;
+    static class GetOptions {
+        @CommandLine.Option(
+                names = {"--get"},
+                required = true,
+                description = "Get the current API token (masked by default)")
+        boolean getToken;
+
+        @CommandLine.Option(
+                names = {"--unmask"},
+                description = "Output the full unmasked token value")
+        boolean unmask;
+    }
+
+    private final AuthCredentialStore credentialStore;
 
     public AuthToken() {
         this(new AuthCredentialStore());
@@ -54,10 +60,10 @@ public class AuthToken extends BaseCommand {
             return EXIT_OK;
         }
 
-        if (operation.getToken) {
+        if (operation.getOptions != null) {
             String apiToken = credentialStore.getApiToken();
             if (apiToken != null) {
-                if (unmask) {
+                if (operation.getOptions.unmask) {
                     printer.printInfoMessage(apiToken);
                 } else {
                     String maskedToken = maskToken(apiToken);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -12,6 +12,11 @@ public class AuthToken extends BaseCommand {
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     TokenOperation operation;
 
+    @CommandLine.Option(
+            names = {"--unmask"},
+            description = "When used with --get, output the full unmasked token value")
+    boolean unmask;
+
     static class TokenOperation {
         @CommandLine.Option(
                 names = {"--set"},
@@ -29,9 +34,18 @@ public class AuthToken extends BaseCommand {
         boolean clearToken;
     }
 
+    private AuthCredentialStore credentialStore;
+
+    public AuthToken() {
+        this(new AuthCredentialStore());
+    }
+
+    public AuthToken(AuthCredentialStore credentialStore) {
+        this.credentialStore = credentialStore;
+    }
+
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
-        AuthCredentialStore credentialStore = new AuthCredentialStore();
 
         if (operation.setToken != null) {
             credentialStore.storeApiToken(operation.setToken);
@@ -43,8 +57,12 @@ public class AuthToken extends BaseCommand {
         if (operation.getToken) {
             String apiToken = credentialStore.getApiToken();
             if (apiToken != null) {
-                String maskedToken = maskToken(apiToken);
-                printer.printInfoMessage("Current API token: " + maskedToken);
+                if (unmask) {
+                    printer.printInfoMessage(apiToken);
+                } else {
+                    String maskedToken = maskToken(apiToken);
+                    printer.printInfoMessage("Current API token: " + maskedToken);
+                }
             } else {
                 printer.printInfoMessage("No API token is currently set");
             }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
@@ -79,6 +79,22 @@ class AuthCommandsTest {
     }
 
     @Test
+    void authTokenGetUnmaskShouldOutputFullToken() throws Exception {
+        AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
+        store.storeApiToken("test-token-123456789");
+
+        AuthToken authToken = new AuthToken(store);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getToken = true;
+        authToken.unmask = true;
+
+        int result = authToken.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        verify(printer).printInfoMessage("test-token-123456789");
+    }
+
+    @Test
     void authStatusShouldDisplayStatus() throws Exception {
         AuthCredentialStore store = new AuthCredentialStore(credentialsFile.toUri());
         store.storeApiToken("test-token-123456789");

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
@@ -85,8 +85,9 @@ class AuthCommandsTest {
 
         AuthToken authToken = new AuthToken(store);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getToken = true;
-        authToken.unmask = true;
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
 
         int result = authToken.doCall(terminal, printer);
 

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -78,18 +78,13 @@ export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
 
 Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the `wait_for_deletion` function.
 
-### Helper: obtain a Bearer token from Keycloak
+### Helper: obtain a Bearer token from the CLI
 
-For direct REST API queries against the router (bypassing the `wanaku` CLI), obtain a Bearer token from Keycloak using the external Keycloak URL. The Keycloak container image does not include `curl`, so the token request is made from the test runner, not from inside the pod.
+For direct REST API queries against the router (bypassing the `wanaku` CLI), retrieve the Bearer token stored by `wanaku auth login` (performed in Phase 3, Test 3.4 via [common/oidc-login-verification.md](common/oidc-login-verification.md)).
 
 ```bash
 get_router_token() {
-  curl -sf \
-    -d "client_id=wanaku-service" \
-    -d "client_secret=${WANAKU_OIDC_SECRET}" \
-    -d "grant_type=client_credentials" \
-    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
-  | jq -r '.access_token'
+  wanaku auth token --get --unmask --plain 2>/dev/null
 }
 ```
 

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -19,6 +19,7 @@ Every step is fully automatable.
 | `curl` | any | `curl --version` |
 | `jq` | 1.6+ | `jq --version` |
 | `base64` | any (coreutils) | `base64 --version 2>/dev/null \|\| echo "available"` |
+| `wanaku` | build from source | `wanaku --version` |
 
 ### Prerequisite check script
 
@@ -28,7 +29,7 @@ set -e
 
 FAIL=0
 
-for CMD in oc helm curl jq base64; do
+for CMD in oc helm curl jq base64 wanaku; do
   if ! command -v "${CMD}" > /dev/null 2>&1; then
     echo "FAIL: ${CMD} is not installed"
     FAIL=1
@@ -724,17 +725,11 @@ else
 fi
 
 # Step 2: Authenticated request should be accepted
-# Note: The Keycloak container image does not include curl, so obtain the token
-# from outside the pod using the external Keycloak URL (set by keycloak-setup.md).
-NS_TOKEN=$(curl -sf \
-    -d "client_id=wanaku-service" \
-    -d "client_secret=${WANAKU_OIDC_SECRET}" \
-    -d "grant_type=client_credentials" \
-    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
-  | jq -r '.access_token')
+# Retrieve the token stored by wanaku auth login (Phase 3, Test 3.9)
+NS_TOKEN=$(wanaku auth token --get --unmask --plain 2>/dev/null)
 
-if [ -z "${NS_TOKEN}" ] || [ "${NS_TOKEN}" = "null" ]; then
-  echo "FAIL: could not obtain token for namespace MCP test"
+if [ -z "${NS_TOKEN}" ]; then
+  echo "FAIL: could not obtain token for namespace MCP test (is wanaku auth login done?)"
 else
   AUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
     -H "Accept: text/event-stream" \

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -72,18 +72,13 @@ export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
 
 Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the `wait_for_deletion` function.
 
-### Helper: obtain a Bearer token from Keycloak
+### Helper: obtain a Bearer token from the CLI
 
-The router has OIDC auth enabled, so all API requests (even from inside the pod) require a Bearer token. This helper obtains a token from Keycloak using the `wanaku-service` client credentials. The token request is made from the test runner using the external Keycloak URL because the Keycloak container image does not include `curl`.
+The router has OIDC auth enabled, so all API requests (even from inside the pod) require a Bearer token. This helper retrieves the token stored by `wanaku auth login` (performed in Phase 3, Test 3.4 via [common/oidc-login-verification.md](common/oidc-login-verification.md)). The `--unmask` flag outputs the full token value for use in `curl` headers.
 
 ```bash
 get_router_token() {
-  curl -sf \
-    -d "client_id=wanaku-service" \
-    -d "client_secret=${WANAKU_OIDC_SECRET}" \
-    -d "grant_type=client_credentials" \
-    "${KEYCLOAK_URL}/realms/wanaku/protocol/openid-connect/token" \
-  | jq -r '.access_token'
+  wanaku auth token --get --unmask --plain 2>/dev/null
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add `--unmask` flag to `wanaku auth token --get` that outputs the full unmasked token value for test automation use cases
- Update test plans (`camel-integration-capability.md`, `operator-camel-route.md`, `operator-basic-functionality.md`) to use `wanaku auth token --get --unmask --plain` instead of raw `curl` calls against Keycloak for token acquisition
- Add `wanaku` CLI to `operator-basic-functionality.md` prerequisites

## Test plan

- [x] New unit test `authTokenGetUnmaskShouldOutputFullToken` verifies full token output with `--unmask`
- [x] All 314 existing tests pass (`mvn verify -pl apps/wanaku-cli -am`)
- [ ] Manual: `wanaku auth token --get` still shows masked output
- [ ] Manual: `wanaku auth token --get --unmask` shows full token value
- [ ] QE: test plans use CLI-based token acquisition instead of raw `curl`

## Summary by Sourcery

Add support for outputting the full stored API token via the auth token CLI and update test plans to consume this CLI-based token retrieval instead of direct Keycloak curl calls.

New Features:
- Introduce a --unmask flag for wanaku auth token --get to print the full unmasked API token value.

Enhancements:
- Make AuthToken use an injectable AuthCredentialStore to enable targeted testing of token retrieval behavior.
- Update operator and camel integration test plans to use wanaku auth token --get --unmask --plain for Bearer token acquisition instead of raw Keycloak API calls.
- Add wanaku CLI as an explicit prerequisite in the operator basic functionality test plan.

Tests:
- Add a unit test verifying that wanaku auth token --get --unmask outputs the full stored token value.