### PR TITLE
chore: centralize container runtime detection for test plans

### DIFF
--- a/tests/plans/camel-qdrant-search-tool.md
+++ b/tests/plans/camel-qdrant-search-tool.md
@@ -20,6 +20,11 @@ Every step is fully automatable.
 | `gh` | 2.x | `gh --version` |
 | `docker` or `podman` | 20+ | `docker --version` or `podman --version` |
 
+### Container runtime detection
+
+Follow [common/container-runtime.md](common/container-runtime.md). After completion,
+`CONTAINER_RUNTIME` is set and exported.
+
 ### Prerequisite check script
 
 ```bash
@@ -36,22 +41,6 @@ for CMD in curl jq java mvn gh; do
     echo "PASS: ${CMD} found at $(command -v ${CMD})"
   fi
 done
-
-# Accept either docker or podman
-CONTAINER_RUNTIME=""
-if command -v docker > /dev/null 2>&1; then
-  CONTAINER_RUNTIME="docker"
-elif command -v podman > /dev/null 2>&1; then
-  CONTAINER_RUNTIME="podman"
-fi
-
-if [ -z "${CONTAINER_RUNTIME}" ]; then
-  echo "FAIL: neither docker nor podman is installed"
-  FAIL=1
-else
-  echo "PASS: ${CONTAINER_RUNTIME} found at $(command -v ${CONTAINER_RUNTIME})"
-  export CONTAINER_RUNTIME
-fi
 
 JAVA_MAJOR=$(java --version 2>&1 | head -1 | sed 's/.*"\([0-9]*\)\..*/\1/')
 if [ "${JAVA_MAJOR}" -lt 21 ]; then
@@ -74,9 +63,6 @@ echo "PASS: all prerequisites met"
 ### Environment variables
 
 ```bash
-# Container runtime (auto-detected: docker or podman)
-export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-}"
-
 # Template naming -- adapt these if the implementation uses different names
 export TEMPLATE_NAME="${TEMPLATE_NAME:-camel-qdrant-search-tool}"
 export SYSTEM_NAME="${SYSTEM_NAME:-qdrant-search}"

--- a/tests/plans/common/container-runtime.md
+++ b/tests/plans/common/container-runtime.md
@@ -1,0 +1,129 @@
+# Common: Container Runtime Detection
+
+Reusable steps for detecting and configuring a local container runtime (Docker or Podman). Use this when a test plan needs to run containers locally (e.g., databases, Keycloak, supporting services).
+
+## Prerequisites
+
+- Either `docker` or `podman` must be installed and on the `PATH`.
+
+## Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CONTAINER_RUNTIME` | Override auto-detection with an explicit runtime | _(auto-detected)_ |
+
+## Output variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONTAINER_RUNTIME` | The detected runtime command (`docker` or `podman`) |
+
+## Steps
+
+### 1. Detect container runtime
+
+If `CONTAINER_RUNTIME` is already set (e.g., by the caller), skip auto-detection. Otherwise, prefer `docker` over `podman`.
+
+```bash
+if [ -n "${CONTAINER_RUNTIME}" ]; then
+  if command -v "${CONTAINER_RUNTIME}" > /dev/null 2>&1; then
+    echo "PASS: ${CONTAINER_RUNTIME} (pre-set) found at $(command -v ${CONTAINER_RUNTIME})"
+  else
+    echo "FAIL: CONTAINER_RUNTIME is set to '${CONTAINER_RUNTIME}' but it is not installed"
+    exit 1
+  fi
+else
+  if command -v docker > /dev/null 2>&1; then
+    CONTAINER_RUNTIME="docker"
+  elif command -v podman > /dev/null 2>&1; then
+    CONTAINER_RUNTIME="podman"
+  fi
+
+  if [ -z "${CONTAINER_RUNTIME}" ]; then
+    echo "FAIL: neither docker nor podman is installed"
+    exit 1
+  fi
+  echo "PASS: ${CONTAINER_RUNTIME} found at $(command -v ${CONTAINER_RUNTIME})"
+fi
+
+export CONTAINER_RUNTIME
+```
+
+### 2. Verify the runtime is functional
+
+```bash
+${CONTAINER_RUNTIME} info > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "PASS: ${CONTAINER_RUNTIME} is functional"
+else
+  echo "FAIL: ${CONTAINER_RUNTIME} is installed but not functional (daemon may not be running)"
+  exit 1
+fi
+```
+
+## Helper functions
+
+### Start a container (idempotent)
+
+Starts a named container if it is not already running. Skips gracefully if the container exists.
+
+```bash
+start_container_if_absent() {
+  local NAME="$1"
+  shift
+  # remaining args are the "docker/podman run" arguments
+
+  if ${CONTAINER_RUNTIME} ps --filter "name=^${NAME}$" --format '{{.Names}}' 2>/dev/null | grep -q "^${NAME}$"; then
+    echo "PASS: container '${NAME}' is already running"
+    return 0
+  fi
+
+  ${CONTAINER_RUNTIME} run -d --name "${NAME}" "$@"
+  if [ $? -eq 0 ]; then
+    echo "PASS: container '${NAME}' started"
+  else
+    echo "FAIL: could not start container '${NAME}'"
+    return 1
+  fi
+}
+```
+
+### Stop and remove a container (idempotent)
+
+Stops and removes a named container. No-ops if it does not exist.
+
+```bash
+stop_container() {
+  local NAME="$1"
+
+  ${CONTAINER_RUNTIME} stop "${NAME}" > /dev/null 2>&1 || true
+  ${CONTAINER_RUNTIME} rm "${NAME}" > /dev/null 2>&1 || true
+  echo "PASS: container '${NAME}' stopped and removed (or was not running)"
+}
+```
+
+## Usage
+
+Reference this file from a test plan:
+
+```markdown
+Follow [common/container-runtime.md](common/container-runtime.md). After completion,
+`CONTAINER_RUNTIME` is set and exported. The `start_container_if_absent` and
+`stop_container` helper functions are available.
+```
+
+Then use `${CONTAINER_RUNTIME}` in place of hardcoded `docker` or `podman` commands:
+
+```bash
+${CONTAINER_RUNTIME} run -d --name my-service -p 8080:8080 my-image:latest
+# ...
+${CONTAINER_RUNTIME} stop my-service && ${CONTAINER_RUNTIME} rm my-service
+```
+
+Or use the helper functions:
+
+```bash
+start_container_if_absent my-service -p 8080:8080 my-image:latest
+# ...
+stop_container my-service
+```

--- a/tests/plans/performance-testing-local.md
+++ b/tests/plans/performance-testing-local.md
@@ -9,7 +9,7 @@ The plan supports two modes:
 1. **Single run** — build from the current branch, launch services, run k6, collect metrics.
 2. **Baseline comparison** — run the same tests against a CI-built baseline (main branch) and the current branch, then generate a Markdown comparison report highlighting regressions and improvements.
 
-Authentication is handled via Keycloak (podman). The router and all capabilities run locally as Java processes.
+Authentication is handled via Keycloak (Docker or Podman). The router and all capabilities run locally as Java processes.
 
 Every step is fully automatable.
 
@@ -21,11 +21,16 @@ Every step is fully automatable.
 |------|-----------------|----------------|
 | `java` | 21+ | `java -version` |
 | `mvn` | 3.9+ | `mvn -version` |
-| `podman` | 4.0+ | `podman --version` |
+| `docker` or `podman` | 20+ / 4.0+ | `docker --version` or `podman --version` |
 | `curl` | any | `curl --version` |
 | `k6` | 0.50+ (with xk6-mcp) | `k6 version` |
 | `python3` | 3.8+ | `python3 --version` |
 | `wanaku` | build from source | `wanaku --version` |
+
+### Container runtime detection
+
+Follow [common/container-runtime.md](common/container-runtime.md). After completion,
+`CONTAINER_RUNTIME` is set and exported.
 
 ### k6 with xk6-mcp extension
 
@@ -70,7 +75,7 @@ This plan is designed to run as a single session. Variables set in earlier phase
 ```bash
 FAIL=0
 
-for CMD in java mvn podman curl python3; do
+for CMD in java mvn curl python3; do
   if ! command -v "${CMD}" > /dev/null 2>&1; then
     echo "FAIL: ${CMD} is not installed"
     FAIL=1
@@ -240,10 +245,10 @@ If a keycloak container is already running, skip the start.
 export KEYCLOAK_HOST="${KEYCLOAK_HOST:-localhost}"
 export KEYCLOAK_URL="http://${KEYCLOAK_HOST}:8543"
 
-if podman ps --filter name=keycloak --format '{{.Names}}' 2>/dev/null | grep -q '^keycloak$'; then
+if ${CONTAINER_RUNTIME} ps --filter name=keycloak --format '{{.Names}}' 2>/dev/null | grep -q '^keycloak$'; then
   echo "PASS: Keycloak container already running"
 else
-  podman run -d --name keycloak --rm -p 0.0.0.0:8543:8080 \
+  ${CONTAINER_RUNTIME} run -d --name keycloak --rm -p 0.0.0.0:8543:8080 \
     -e KC_BOOTSTRAP_ADMIN_USERNAME="${KEYCLOAK_ADMIN_USER}" \
     -e KC_BOOTSTRAP_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASS}" \
     -v keycloak-dev:/opt/keycloak/data \
@@ -735,7 +740,7 @@ done
 ### Test 9.2: Stop Keycloak container
 
 ```bash
-podman stop keycloak 2>/dev/null || true
+${CONTAINER_RUNTIME} stop keycloak 2>/dev/null || true
 echo "PASS: Keycloak stopped (or was not running)"
 ```
 


### PR DESCRIPTION
## Summary

- Extracts duplicated Docker/Podman detection logic into a reusable common step at `tests/plans/common/container-runtime.md`
- Updates `camel-qdrant-search-tool.md` to remove inline detection block and reference the common step
- Updates `performance-testing-local.md` to replace hardcoded `podman` with `${CONTAINER_RUNTIME}` and reference the common step
- Common step includes auto-detection (prefers Docker), explicit override via env var, daemon health check, and idempotent helper functions (`start_container_if_absent`, `stop_container`)

## Test plan

- [ ] Verify `common/container-runtime.md` detection logic works with Docker
- [ ] Verify `common/container-runtime.md` detection logic works with Podman
- [ ] Run `camel-qdrant-search-tool` test plan prerequisites check
- [ ] Run `performance-testing-local` test plan prerequisites check

## Summary by Sourcery

Centralize container runtime detection logic into a shared test plan step and update existing plans to consume the shared configuration.

Enhancements:
- Introduce a common container runtime detection and helper utilities document for test plans.
- Update the camel-qdrant-search-tool test plan to rely on the shared container runtime detection step.
- Update the performance-testing-local test plan to use the shared container runtime detection step and the CONTAINER_RUNTIME variable instead of hardcoded podman commands.

Documentation:
- Add shared documentation for container runtime detection and helper functions used across test plans.

Chores:
- Align test plans around a unified container runtime configuration to reduce duplication and improve consistency.