### PR TITLE
fix #1556: improve error message when browsing non-existent toolset repository

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/toolset/ToolSetRepoBrowse.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/toolset/ToolSetRepoBrowse.java
@@ -1,5 +1,7 @@
 package ai.wanaku.cli.main.commands.toolset;
 
+import jakarta.ws.rs.WebApplicationException;
+
 import java.util.List;
 import java.util.Map;
 import org.jboss.logging.Logger;
@@ -9,6 +11,8 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsetReposService;
 import picocli.CommandLine;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.handleNotFound;
 
 @CommandLine.Command(name = "browse", description = "Browse a toolset repository's catalog")
 public class ToolSetRepoBrowse extends BaseCommand {
@@ -26,7 +30,7 @@ public class ToolSetRepoBrowse extends BaseCommand {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+    public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         ToolsetReposService service = initAuthenticatedService(ToolsetReposService.class, host);
 
         try {
@@ -48,6 +52,8 @@ public class ToolSetRepoBrowse extends BaseCommand {
                             String.format("  %-20s %s", toolset.get("name"), toolset.getOrDefault("description", "")));
                 }
             }
+        } catch (WebApplicationException ex) {
+            return handleNotFound(ex, "Repository", name, printer);
         } catch (Exception e) {
             printer.printErrorMessage(String.format("Failed to browse toolset repository: %s", e.getMessage()));
             return EXIT_ERROR;


### PR DESCRIPTION
Closes #1556

## Summary
- Improved error handling in `ToolSetRepoBrowse` to catch `WebApplicationException` and display appropriate messages based on HTTP status code
- Non-existent repos now show "Repository 'name' not found" instead of misleading "Internal Server Error"

## Test plan
- [ ] Verify `wanaku toolset repo browse non-existent-repo` shows "not found" message
- [ ] Verify `wanaku toolset repo browse valid-repo` still works correctly

## Summary by Sourcery

Bug Fixes:
- Return a clear 'Repository <name> not found' message when browsing a non-existent toolset repository instead of a generic internal error.