### PR TITLE
Fix #1555: standardize --namespace and --namespace-id across CLI commands

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/forwards/ForwardsAdd.java
@@ -3,13 +3,10 @@ package ai.wanaku.cli.main.commands.forwards;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
-import ai.wanaku.capabilities.sdk.api.types.Namespace;
-import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ForwardsService;
 import ai.wanaku.core.services.api.NamespacesService;
@@ -21,9 +18,6 @@ import static picocli.CommandLine.Option;
 
 @Command(name = "add", description = "Add forward targets")
 public class ForwardsAdd extends BaseCommand {
-
-    private static final String ERROR_NO_NAMESPACE_MATCH =
-            "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
 
     @Option(
             names = {"--host"},
@@ -49,55 +43,12 @@ public class ForwardsAdd extends BaseCommand {
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     NamespaceOptions namespaceOptions;
 
-    static class NamespaceOptions {
-        @Option(
-                names = {"-N", "--namespace"},
-                description = "The namespace ID associated with the tool")
-        String namespace;
-
-        @Option(
-                names = {"--namespace-name"},
-                description = "The namespace name to use (looked up automatically)")
-        String namespaceName;
-    }
-
-    private String resolveNamespaceId() throws Exception {
-        if (namespaceOptions.namespace != null) {
-            return namespaceOptions.namespace;
-        }
-
-        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
-
-        try {
-            WanakuResponse<List<Namespace>> response = namespacesService.list();
-            List<Namespace> data = response.data();
-            if (data == null) {
-                throw new IllegalStateException("No namespace data returned from server.");
-            }
-
-            List<Namespace> matches = data.stream()
-                    .filter(n -> namespaceOptions.namespaceName.equals(n.getName()))
-                    .collect(Collectors.toList());
-
-            if (matches.isEmpty()) {
-                throw new IllegalArgumentException(ERROR_NO_NAMESPACE_MATCH.formatted(namespaceOptions.namespaceName));
-            }
-            if (matches.size() > 1) {
-                throw new IllegalStateException("Multiple namespaces matched '%s'. Use --namespace with the ID instead."
-                        .formatted(namespaceOptions.namespaceName));
-            }
-            return matches.getFirst().getId();
-        } catch (WebApplicationException ex) {
-            commonResponseErrorHandler(ex.getResponse());
-            throw ex;
-        }
-    }
-
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         ForwardsService forwardsService = initAuthenticatedService(ForwardsService.class, host);
 
-        String namespaceId = resolveNamespaceId();
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceId = namespaceOptions.resolveNamespaceId(namespacesService);
 
         ForwardReference reference = new ForwardReference();
         reference.setName(name);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
@@ -19,6 +19,7 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.PromptPayload;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
@@ -42,12 +43,8 @@ public class PromptsAdd extends BaseCommand {
             required = true)
     private String name;
 
-    @CommandLine.Option(
-            names = {"-N", "--namespace"},
-            description = "The namespace associated with the prompt",
-            defaultValue = "",
-            required = true)
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Option(
             names = {"-d", "--description"},
@@ -92,7 +89,7 @@ public class PromptsAdd extends BaseCommand {
         PromptReference promptReference = new PromptReference();
         promptReference.setName(name);
         promptReference.setDescription(description);
-        promptReference.setNamespace(namespace);
+        promptReference.setNamespace(namespaceOptions.getNamespaceValue());
 
         // Parse messages
         List<PromptMessage> promptMessages = new ArrayList<>();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
@@ -17,6 +17,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.TextContent;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
@@ -40,10 +41,8 @@ public class PromptsEdit extends BaseCommand {
             required = true)
     private String name;
 
-    @CommandLine.Option(
-            names = {"-N", "--namespace"},
-            description = "The namespace associated with the prompt")
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Option(
             names = {"-d", "--description"},
@@ -99,8 +98,11 @@ public class PromptsEdit extends BaseCommand {
         }
 
         // Update only the fields that were provided
-        if (namespace != null) {
-            existingPrompt.setNamespace(namespace);
+        if (namespaceOptions != null) {
+            String ns = namespaceOptions.getNamespaceValue();
+            if (ns != null) {
+                existingPrompt.setNamespace(ns);
+            }
         }
 
         if (description != null) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
@@ -11,6 +11,7 @@ import ai.wanaku.capabilities.sdk.api.types.ResourceReference;
 import ai.wanaku.capabilities.sdk.api.types.io.ResourcePayload;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
@@ -66,12 +67,8 @@ public class ResourcesExpose extends BaseCommand {
             arity = "0..1")
     private String name;
 
-    @CommandLine.Option(
-            names = {"-N", "--namespace"},
-            description = "The namespace associated with the tool",
-            defaultValue = "",
-            required = true)
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Option(
             names = {"--description"},
@@ -123,7 +120,7 @@ public class ResourcesExpose extends BaseCommand {
         resource.setName(name);
         resource.setDescription(description);
         resource.setMimeType(mimeType);
-        resource.setNamespace(namespace);
+        resource.setNamespace(namespaceOptions.getNamespaceValue());
         resource.setLabels(labels);
 
         ResourcePayload resourcePayload = new ResourcePayload();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/service/ServiceExpose.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import picocli.CommandLine;
 
@@ -30,11 +31,8 @@ public class ServiceExpose extends BaseCommand {
             arity = "0..1")
     private String path;
 
-    @CommandLine.Option(
-            names = {"--namespace"},
-            description = "Namespace for generated rules",
-            arity = "0..1")
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Option(
             names = {"--type"},
@@ -194,8 +192,11 @@ public class ServiceExpose extends BaseCommand {
                 pw.println("        route:");
                 pw.println("          id: \"" + routeId + "\"");
                 pw.println("        description: \"Invoke route " + routeId + " in " + systemName + "\"");
-                if (namespace != null && !namespace.isBlank()) {
-                    pw.println("        namespace: \"" + namespace + "\"");
+                if (namespaceOptions != null) {
+                    String ns = namespaceOptions.getNamespaceValue();
+                    if (ns != null && !ns.isBlank()) {
+                        pw.println("        namespace: \"" + ns + "\"");
+                    }
                 }
                 pw.println("        properties:");
                 pw.println("          - name: wanaku_body");
@@ -232,8 +233,11 @@ public class ServiceExpose extends BaseCommand {
                 pw.println("        description: \"Resource from route " + routeId + " in " + systemName + "\"");
                 pw.println("        uri: \"" + resourceUri + "\"");
                 pw.println("        mimeType: \"" + mimeType + "\"");
-                if (namespace != null && !namespace.isBlank()) {
-                    pw.println("        namespace: \"" + namespace + "\"");
+                if (namespaceOptions != null) {
+                    String ns = namespaceOptions.getNamespaceValue();
+                    if (ns != null && !ns.isBlank()) {
+                        pw.println("        namespace: \"" + ns + "\"");
+                    }
                 }
             }
         }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
@@ -14,6 +14,7 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.capabilities.sdk.api.types.io.ToolPayload;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.PropertyHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsService;
@@ -55,12 +56,8 @@ public class ToolsAdd extends BaseCommand {
             required = true)
     private String name;
 
-    @CommandLine.Option(
-            names = {"-N", "--namespace"},
-            description = "The namespace associated with the tool",
-            defaultValue = "",
-            required = true)
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Option(
             names = {"-d", "--description"},
@@ -125,7 +122,7 @@ public class ToolsAdd extends BaseCommand {
         toolReference.setDescription(description);
         toolReference.setUri(uri);
         toolReference.setType(type);
-        toolReference.setNamespace(namespace);
+        toolReference.setNamespace(namespaceOptions.getNamespaceValue());
         toolReference.setLabels(labels);
 
         InputSchema inputSchema = new InputSchema();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
@@ -7,6 +7,7 @@ import org.jline.terminal.Terminal;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.converter.URLConverter;
+import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.services.api.ToolsService;
 import ai.wanaku.core.util.ToolsetIndexHelper;
@@ -25,11 +26,8 @@ public class ToolsImport extends BaseCommand {
             arity = "0..1")
     protected String host;
 
-    @CommandLine.Option(
-            names = {"-N", "--namespace"},
-            description = "Default namespace for tools that don't have one set",
-            arity = "0..1")
-    private String namespace;
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    NamespaceOptions namespaceOptions;
 
     @CommandLine.Parameters(
             description = "location to the toolset, can be a local path or an URL",
@@ -45,11 +43,14 @@ public class ToolsImport extends BaseCommand {
             List<ToolReference> toolReferences = ToolsetIndexHelper.loadToolsIndex(location);
 
             // Apply default namespace to tools that don't have one
-            if (namespace != null && !namespace.isEmpty()) {
-                for (ToolReference toolReference : toolReferences) {
-                    if (toolReference.getNamespace() == null
-                            || toolReference.getNamespace().isEmpty()) {
-                        toolReference.setNamespace(namespace);
+            if (namespaceOptions != null) {
+                String ns = namespaceOptions.getNamespaceValue();
+                if (ns != null && !ns.isEmpty()) {
+                    for (ToolReference toolReference : toolReferences) {
+                        if (toolReference.getNamespace() == null
+                                || toolReference.getNamespace().isEmpty()) {
+                            toolReference.setNamespace(ns);
+                        }
                     }
                 }
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -92,6 +92,11 @@ public class NamespaceOptions {
             return namespaceId;
         }
 
+        if (namespace == null || namespace.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Either --namespace or --namespace-id must be provided with a non-blank value.");
+        }
+
         try {
             WanakuResponse<List<Namespace>> response = namespacesService.list();
             List<Namespace> data = response.data();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -1,0 +1,119 @@
+package ai.wanaku.cli.main.support;
+
+import jakarta.ws.rs.WebApplicationException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.core.services.api.NamespacesService;
+import picocli.CommandLine.Option;
+
+import static ai.wanaku.cli.main.support.ResponseHelper.commonResponseErrorHandler;
+
+/**
+ * Shared Picocli argument group for namespace identification.
+ * <p>
+ * Provides two mutually exclusive ways to identify a namespace:
+ * </p>
+ * <ul>
+ *   <li>{@code --namespace} ({@code -N}): a human-readable namespace name (common case)</li>
+ *   <li>{@code --namespace-id}: a namespace UUID (scripting/advanced use)</li>
+ * </ul>
+ * <p>
+ * When {@code --namespace-id} is provided, it is returned directly.
+ * When {@code --namespace} is provided, the name is either passed through as-is
+ * (for commands where the server resolves names) or resolved to a UUID via
+ * {@link #resolveNamespaceId(NamespacesService)}.
+ * </p>
+ */
+public class NamespaceOptions {
+
+    private static final String ERROR_NO_NAMESPACE_MATCH =
+            "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
+
+    @Option(
+            names = {"-N", "--namespace"},
+            description = "The namespace name associated with this entity")
+    String namespace;
+
+    @Option(
+            names = {"--namespace-id"},
+            description = "The namespace UUID (alternative to --namespace)")
+    String namespaceId;
+
+    /**
+     * Returns the namespace name, if provided via {@code --namespace}.
+     *
+     * @return the namespace name, or {@code null} if {@code --namespace-id} was used instead
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns the namespace UUID, if provided via {@code --namespace-id}.
+     *
+     * @return the namespace UUID, or {@code null} if {@code --namespace} was used instead
+     */
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+
+    /**
+     * Returns the namespace value to pass to the server.
+     * <p>
+     * If {@code --namespace-id} was provided, returns the UUID directly.
+     * Otherwise returns the namespace name (the server resolves names for most commands).
+     * </p>
+     *
+     * @return the namespace identifier (name or UUID)
+     */
+    public String getNamespaceValue() {
+        if (namespaceId != null) {
+            return namespaceId;
+        }
+        return namespace;
+    }
+
+    /**
+     * Resolves the namespace to its UUID.
+     * <p>
+     * If {@code --namespace-id} was provided, returns it directly.
+     * If {@code --namespace} was provided, queries the server to look up the UUID by name.
+     * </p>
+     *
+     * @param namespacesService the service to use for looking up namespace by name
+     * @return the namespace UUID
+     * @throws Exception if the lookup fails or no matching namespace is found
+     */
+    public String resolveNamespaceId(NamespacesService namespacesService) throws Exception {
+        if (namespaceId != null) {
+            return namespaceId;
+        }
+
+        try {
+            WanakuResponse<List<Namespace>> response = namespacesService.list();
+            List<Namespace> data = response.data();
+            if (data == null) {
+                throw new IllegalStateException("No namespace data returned from server.");
+            }
+
+            List<Namespace> matches =
+                    data.stream().filter(n -> namespace.equals(n.getName())).collect(Collectors.toList());
+
+            if (matches.isEmpty()) {
+                throw new IllegalArgumentException(ERROR_NO_NAMESPACE_MATCH.formatted(namespace));
+            }
+            if (matches.size() > 1) {
+                throw new IllegalStateException(
+                        "Multiple namespaces matched '%s'. Use --namespace-id with the UUID instead."
+                                .formatted(namespace));
+            }
+            return matches.getFirst().getId();
+        } catch (WebApplicationException ex) {
+            commonResponseErrorHandler(ex.getResponse());
+            throw ex;
+        }
+    }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2371,10 +2371,10 @@ wanaku forwards add --service="http://your-mcp-server.com:8080/mcp/sse" --name m
 
 - `--service`: The URL of the external MCP server's SSE (Server-Sent Events) endpoint.
 - `--name`: A unique human-readable name for the forward, used for identification and management purposes.
-- `--namespace` (required): The namespace ID to associate the forward with. Use `wanaku namespace list` to find the ID.
-- `--namespace-name` (alternative to `--namespace`): The namespace name to use. The CLI will automatically resolve it to the corresponding ID.
+- `--namespace` / `-N` (required): The namespace name to associate the forward with (e.g., `public`, `default`). The CLI resolves the name to its UUID automatically.
+- `--namespace-id` (alternative to `--namespace`): The namespace UUID to use directly, for scripting or when the UUID is already known.
 
-Use `--namespace` if you already know the namespace UUID, or `--namespace-name` to specify the namespace by its human-readable name (e.g. `public`, `default`).
+Use `--namespace` for the common case (human-readable name), or `--namespace-id` when scripting with known UUIDs. These options are mutually exclusive.
 
 Once a forward is added, all tools and resources provided by the external MCP server will be mapped in the Wanaku instance.
 
@@ -2473,6 +2473,8 @@ In the example above, the *`meow-facts-3`* tool will be associated with the firs
 
 When you provide a namespace name like *`test`*, Wanaku automatically associates it with an available numerical slot from ns-0
 to ns-9.
+
+All commands that accept `--namespace` (`-N`) also support `--namespace-id` for passing the namespace UUID directly. These options are mutually exclusive. Use `--namespace-id` when scripting with known UUIDs.
 
 ### Checking Namespace Assignments
 

--- a/tests/plans/cli-forwards-datastores.md
+++ b/tests/plans/cli-forwards-datastores.md
@@ -116,21 +116,21 @@ else
 fi
 ```
 
-### Test 2.5: Add a forward using --namespace-name instead of --namespace
+### Test 2.5: Add a forward using --namespace (name resolution)
 
-This verifies the `--namespace-name` flag by resolving the namespace name to its ID before registering the forward.
+This verifies the `--namespace` flag resolves the namespace name to its ID before registering the forward.
 
 ```bash
 wanaku forwards add \
   --host "${WANAKU_ROUTER_URL}" \
   --name ns-name-test-forward \
   --service "http://localhost:9999/mcp/sse" \
-  --namespace-name public
+  --namespace public
 EXIT_CODE=$?
 if [ "${EXIT_CODE}" -eq 0 ]; then
-  echo "PASS: forward 'ns-name-test-forward' added using --namespace-name"
+  echo "PASS: forward 'ns-name-test-forward' added using --namespace"
 else
-  echo "FAIL: could not add forward with --namespace-name (exit code ${EXIT_CODE})"
+  echo "FAIL: could not add forward with --namespace (exit code ${EXIT_CODE})"
 fi
 
 # Clean up
@@ -139,19 +139,19 @@ wanaku forwards remove \
   --name ns-name-test-forward 2>/dev/null || true
 ```
 
-### Test 2.6: Verify --namespace-name with non-existent namespace name fails
+### Test 2.6: Verify --namespace with non-existent namespace name fails
 
 ```bash
 OUTPUT=$(wanaku forwards add \
   --host "${WANAKU_ROUTER_URL}" \
   --name ns-name-invalid-test \
   --service "http://localhost:9999/mcp/sse" \
-  --namespace-name non-existent-namespace 2>&1)
+  --namespace non-existent-namespace 2>&1)
 EXIT_CODE=$?
 if [ "${EXIT_CODE}" -ne 0 ]; then
-  echo "PASS: add forward with non-existent --namespace-name rejected (exit code ${EXIT_CODE})"
+  echo "PASS: add forward with non-existent --namespace rejected (exit code ${EXIT_CODE})"
 else
-  echo "FAIL: add forward with non-existent --namespace-name should fail"
+  echo "FAIL: add forward with non-existent --namespace should fail"
   wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name ns-name-invalid-test 2>/dev/null || true
 fi
 ```
@@ -527,7 +527,7 @@ wanaku forwards add \
   --service "http://localhost:9999/mcp/sse" 2>&1
 EXIT_CODE=$?
 if [ "${EXIT_CODE}" -ne 0 ]; then
-  echo "PASS: forwards add without --namespace or --namespace-name rejected (exit code ${EXIT_CODE})"
+  echo "PASS: forwards add without --namespace or --namespace-id rejected (exit code ${EXIT_CODE})"
 else
   echo "FAIL: forwards add without a namespace identifier should fail"
   wanaku forwards remove --host "${WANAKU_ROUTER_URL}" --name negative-test-forward 2>/dev/null || true
@@ -669,7 +669,7 @@ fi
 |-------|---------|-----------|----------|
 | 0 | 0.1 | Prerequisites check | High |
 | 1 | 1.1 | Start local stack and verify connectivity | Critical |
-| 2 | 2.1-2.6 | Forward add, list, remove, verify gone, namespace-name | Critical |
+| 2 | 2.1-2.6 | Forward add, list, remove, verify gone, namespace resolution | Critical |
 | 3 | 3.1-3.4 | Forward refresh lifecycle | High |
 | 4 | 4.1-4.2 | Data store add from file | Critical |
 | 5 | 5.1-5.2 | Data store list and get with content verification | Critical |

--- a/tests/plans/cli-negative-tests.md
+++ b/tests/plans/cli-negative-tests.md
@@ -492,7 +492,7 @@ assert_failure "5.2" "forwards add with no service rejected" \
 
 ### Test 5.3: Add forward with no namespace identifier should fail
 
-Providing neither `--namespace` nor `--namespace-name` should be rejected.
+Providing neither `--namespace` nor `--namespace-id` should be rejected.
 
 ```bash
 assert_failure "5.3" "forwards add with no namespace identifier rejected" \
@@ -503,19 +503,19 @@ assert_failure "5.3" "forwards add with no namespace identifier rejected" \
   --service "http://example.com:8080"
 ```
 
-### Test 5.4: Add forward with both --namespace and --namespace-name should fail
+### Test 5.4: Add forward with both --namespace and --namespace-id should fail
 
 Both flags cannot be used together.
 
 ```bash
-assert_failure "5.4" "forwards add with both --namespace and --namespace-name rejected" \
+assert_failure "5.4" "forwards add with both --namespace and --namespace-id rejected" \
   wanaku forwards add \
   --host "${WANAKU_ROUTER_URL}" \
   --no-auth \
   --name "neg-test-both-ns" \
   --service "http://example.com:8080" \
   --namespace public \
-  --namespace-name public
+  --namespace-id some-uuid-value
 ```
 ### Test 5.5: Add duplicate forward name
 


### PR DESCRIPTION
Closes #1555

## Summary
- Extracted shared `NamespaceOptions` class with Picocli `@ArgGroup(exclusive = true)` for mutual exclusion
- `--namespace` (`-N`) now consistently accepts namespace **name** across all 7 commands
- Added `--namespace-id` for passing UUID directly (scripting/advanced use)
- `ForwardsAdd`: renamed old `--namespace` (UUID) to `--namespace-id`, old `--namespace-name` to `--namespace`; delegates to shared `NamespaceOptions.resolveNamespaceId()`
- `ToolsAdd`, `ResourcesExpose`, `PromptsAdd`: required namespace via ArgGroup (multiplicity `1`)
- `ToolsImport`, `PromptsEdit`, `ServiceExpose`: optional namespace via ArgGroup (multiplicity `0..1`)

## Test plan
- [ ] Verify `tools add --namespace public` works
- [ ] Verify `tools add --namespace-id <uuid>` works
- [ ] Verify `forwards add --namespace public` works (was `--namespace-name` before)
- [ ] Verify `forwards add --namespace-id <uuid>` works (was `--namespace` before)
- [ ] Verify providing both `--namespace` and `--namespace-id` fails with usage error
- [ ] Verify `prompts edit` works without namespace (optional)
- [ ] Verify `service expose --namespace public` works

## Summary by Sourcery

Standardize namespace handling across CLI commands by introducing a shared namespace argument group and aligning flags and behavior.

New Features:
- Add a shared NamespaceOptions argument group supporting both --namespace (name) and --namespace-id (UUID) for CLI commands.
- Support passing namespace UUIDs explicitly via --namespace-id for advanced and scripting use cases.

Bug Fixes:
- Prevent ambiguous or conflicting namespace specification by enforcing mutual exclusion between --namespace and --namespace-id across relevant commands.

Enhancements:
- Update forwards, tools, resources, prompts, and service commands to use the shared NamespaceOptions group with consistent mutual exclusion and required/optional semantics.
- Change ForwardsAdd to resolve namespace IDs via the shared NamespaceOptions helper instead of an inline implementation.
- Ensure generated tool and resource rule files include an optional namespace derived from the shared namespace options when provided.