### PR TITLE
fix #1557: validate required tool parameters before forwarding to capability

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -1,11 +1,14 @@
 package ai.wanaku.backend.bridge;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ToolManager;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
@@ -47,6 +50,9 @@ public final class InvokerToolExecutor {
      */
     static ToolInvokeRequest buildToolInvokeRequest(
             ToolReference toolReference, ToolManager.ToolArguments toolArguments, String requestId) {
+
+        // Validate required parameters before processing
+        validateRequiredParameters(toolReference, toolArguments.args());
 
         // Filter out metadata and auth args before converting to string map
         Map<String, Object> filteredArgs = filterOutReservedArgs(toolArguments.args());
@@ -178,6 +184,40 @@ public final class InvokerToolExecutor {
             throw new NullPointerException(
                     "Malformed value for key %s: neither a default value nor an argument were provided (null)"
                             .formatted(entry.getKey()));
+        }
+    }
+
+    /**
+     * Validates that all required parameters declared in the tool's input schema are present in the
+     * provided arguments. Throws an {@link IllegalArgumentException} if any required parameter is
+     * missing or has a null/blank value.
+     *
+     * @param toolReference the tool reference containing the input schema with required field declarations
+     * @param args the arguments provided by the caller
+     * @throws IllegalArgumentException if one or more required parameters are missing
+     */
+    static void validateRequiredParameters(ToolReference toolReference, Map<String, Object> args) {
+        InputSchema inputSchema = toolReference.getInputSchema();
+        if (inputSchema == null) {
+            return;
+        }
+
+        List<String> required = inputSchema.getRequired();
+        if (required == null || required.isEmpty()) {
+            return;
+        }
+
+        List<String> missing = new ArrayList<>();
+        for (String param : required) {
+            Object value = args.get(param);
+            if (value == null || (value instanceof String s && s.isBlank())) {
+                missing.add(param);
+            }
+        }
+
+        if (!missing.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required parameter(s): %s".formatted(String.join(", ", missing)));
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -207,9 +207,11 @@ public final class InvokerToolExecutor {
             return;
         }
 
+        Map<String, Object> safeArgs = args != null ? args : Map.of();
+
         List<String> missing = new ArrayList<>();
         for (String param : required) {
-            Object value = args.get(param);
+            Object value = safeArgs.get(param);
             if (value == null || (value instanceof String s && s.isBlank())) {
                 missing.add(param);
             }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -1,6 +1,7 @@
 package ai.wanaku.backend.bridge;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import io.quarkiverse.mcp.server.ToolManager;
 import ai.wanaku.capabilities.sdk.api.types.InputSchema;
@@ -8,8 +9,10 @@ import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -327,5 +330,122 @@ class InvokerBridgeTest {
 
         assertEquals(1, metaHeaders.size());
         assertEquals("ctx-123", metaHeaders.get("contextId"));
+    }
+
+    @Test
+    void validateRequiredParameters_throwsWhenRequiredParamMissing() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query"));
+
+        Map<String, Object> args = Map.of();
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+        assertTrue(ex.getMessage().contains("query"), "Error should name the missing parameter");
+    }
+
+    @Test
+    void validateRequiredParameters_throwsWhenRequiredParamIsBlank() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query"));
+
+        Map<String, Object> args = Map.of("query", "   ");
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+        assertTrue(ex.getMessage().contains("query"));
+    }
+
+    @Test
+    void validateRequiredParameters_throwsWhenRequiredParamIsNull() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query"));
+
+        Map<String, Object> args = new HashMap<>();
+        args.put("query", null);
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+        assertTrue(ex.getMessage().contains("query"));
+    }
+
+    @Test
+    void validateRequiredParameters_passesWhenAllRequiredPresent() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query"));
+
+        Map<String, Object> args = Map.of("query", "search term");
+
+        assertDoesNotThrow(() -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+    }
+
+    @Test
+    void validateRequiredParameters_passesWhenNoRequiredList() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        // required is null by default
+
+        Map<String, Object> args = Map.of();
+
+        assertDoesNotThrow(() -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+    }
+
+    @Test
+    void validateRequiredParameters_passesWhenRequiredListIsEmpty() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of());
+
+        Map<String, Object> args = Map.of();
+
+        assertDoesNotThrow(() -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+    }
+
+    @Test
+    void validateRequiredParameters_passesWhenInputSchemaIsNull() {
+        ToolReference ref = new ToolReference();
+        ref.setName("sample");
+        ref.setType("http");
+        ref.setUri("https://example.com");
+        // no input schema set
+
+        Map<String, Object> args = Map.of();
+
+        assertDoesNotThrow(() -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+    }
+
+    @Test
+    void validateRequiredParameters_reportsAllMissingParams() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+        props.put("format", prop(null, null, null));
+        props.put("limit", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query", "format", "limit"));
+
+        Map<String, Object> args = Map.of("format", "json");
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, args));
+        assertTrue(ex.getMessage().contains("query"), "Should report 'query' as missing");
+        assertTrue(ex.getMessage().contains("limit"), "Should report 'limit' as missing");
+        assertFalse(ex.getMessage().contains("format"), "Should NOT report 'format' (it was provided)");
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -448,4 +448,17 @@ class InvokerBridgeTest {
         assertTrue(ex.getMessage().contains("limit"), "Should report 'limit' as missing");
         assertFalse(ex.getMessage().contains("format"), "Should NOT report 'format' (it was provided)");
     }
+
+    @Test
+    void validateRequiredParameters_throwsWhenArgsIsNull() {
+        Map<String, Property> props = new HashMap<>();
+        props.put("query", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.getInputSchema().setRequired(List.of("query"));
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, null));
+        assertTrue(ex.getMessage().contains("query"), "Should report 'query' as missing");
+    }
 }


### PR DESCRIPTION
Closes #1557

## Summary
- Added server-side validation of required tool parameters in the router before forwarding to downstream capabilities
- Missing required parameters now return an MCP error response instead of being silently forwarded

## Test plan
- [ ] Register a tool with `--required query`
- [ ] Call it via MCP without `query` parameter — should get error
- [ ] Call it via MCP with `query` parameter — should succeed

## Summary by Sourcery

Validate MCP tool invocations against required input parameters before forwarding to downstream capabilities.

Bug Fixes:
- Reject tool invocations that omit or provide null/blank values for schema-declared required parameters instead of forwarding them silently.

Tests:
- Add unit tests covering required-parameter validation for present, missing, blank, null, and multiple-required argument scenarios.