### PR TITLE
fix #1553: document noauth workaround for archetype-generated capabilities

### DIFF
--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/README.md
@@ -1,3 +1,7 @@
 # Wanaku Provider - ${name}
 
 Write the description of the provider here
+
+## Local Development
+
+To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/contributing.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Contributing guide.

--- a/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/wanaku-provider-archetype/src/main/resources/archetype-resources/README.md
@@ -4,4 +4,4 @@ Write the description of the provider here
 
 ## Local Development
 
-To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/contributing.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Contributing guide.
+To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/usage.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Usage guide.

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/README.md
@@ -4,4 +4,4 @@ Write the description of the tool here
 
 ## Local Development
 
-To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/contributing.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Contributing guide.
+To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/usage.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Usage guide.

--- a/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/wanaku-tool-service-archetype/src/main/resources/archetype-resources/README.md
@@ -1,3 +1,7 @@
 # Wanaku Tool - ${name}
 
 Write the description of the tool here
+
+## Local Development
+
+To run this capability against a local Wanaku router in `noauth` mode, see the [Running Archetype-Generated Capabilities Locally](https://github.com/wanaku-ai/wanaku/blob/main/docs/contributing.md#running-archetype-generated-capabilities-locally-no-authentication) section in the Contributing guide.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -168,61 +168,6 @@ And run it:
 java -jar target/quarkus-app/quarkus-run.jar
 ```
 
-## Running Archetype-Generated Capabilities Locally (No Authentication)
-
-When you scaffold a capability using `wanaku services create tool` or `wanaku services create resource`, the generated service includes OIDC authentication by default. If you're running against a local Wanaku router in `noauth` mode, the capability will fail to register because it tries to contact a Keycloak server that doesn't exist.
-
-You'll see errors like:
-
-```text
-Failed to acquire tokens from OpenId Connect Provider
-```
-
-### Workaround: Reaugment for No-Auth Mode
-
-To run an archetype-generated capability locally without authentication, you need to reaugment it first to disable OIDC, then start it normally.
-
-**Step 1: Reaugment the capability to disable OIDC**
-
-```shell
-java -Dquarkus.launch.rebuild=true -Dquarkus.oidc-client.enabled=false -jar target/quarkus-app/quarkus-run.jar
-```
-
-This rebuilds the augmentation layer with OIDC disabled. The process will exit after augmentation completes.
-
-**Step 2: Start the capability against your local router**
-
-```shell
-java -Dquarkus.http.port=9010 -Dwanaku.service.registration.uri=http://localhost:8080 -jar target/quarkus-app/quarkus-run.jar
-```
-
-Adjust the port (`9010`) and router URL (`http://localhost:8080`) as needed.
-
-### Why This Works
-
-Archetype-generated capabilities use the Wanaku SDK's `AuthConfigSource`, which dynamically sets `quarkus.oidc-client.enabled=false` when `WANAKU_HTTP_AUTH=none` is detected. However, this dynamic configuration only applies at runtime. The Quarkus augmentation phase (where build-time config is resolved) happens during `mvn package` and bakes OIDC as **enabled** into the application bytecode.
-
-When you run the capability without reaugmentation, Quarkus tries to initialize the OIDC client, contacts the configured Keycloak server (which doesn't exist locally), and fails before the runtime `AuthConfigSource` can disable it.
-
-Reaugmenting with `-Dquarkus.launch.rebuild=true -Dquarkus.oidc-client.enabled=false` forces Quarkus to rebuild the augmentation layer with OIDC explicitly disabled at build time, so the OIDC client extension never initializes.
-
-### Alternative: Use Environment Variables
-
-If you prefer not to reaugment, set `WANAKU_HTTP_AUTH=none` before building:
-
-```shell
-export WANAKU_HTTP_AUTH=none
-mvn clean package
-```
-
-Then start normally:
-
-```shell
-java -Dquarkus.http.port=9010 -Dwanaku.service.registration.uri=http://localhost:8080 -jar target/quarkus-app/quarkus-run.jar
-```
-
-This approach bakes the no-auth configuration into the build from the start, avoiding the need for reaugmentation.
-
 ## Building Containers
 
 You can also build containers using:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -168,6 +168,61 @@ And run it:
 java -jar target/quarkus-app/quarkus-run.jar
 ```
 
+## Running Archetype-Generated Capabilities Locally (No Authentication)
+
+When you scaffold a capability using `wanaku services create tool` or `wanaku services create resource`, the generated service includes OIDC authentication by default. If you're running against a local Wanaku router in `noauth` mode, the capability will fail to register because it tries to contact a Keycloak server that doesn't exist.
+
+You'll see errors like:
+
+```text
+Failed to acquire tokens from OpenId Connect Provider
+```
+
+### Workaround: Reaugment for No-Auth Mode
+
+To run an archetype-generated capability locally without authentication, you need to reaugment it first to disable OIDC, then start it normally.
+
+**Step 1: Reaugment the capability to disable OIDC**
+
+```shell
+java -Dquarkus.launch.rebuild=true -Dquarkus.oidc-client.enabled=false -jar target/quarkus-app/quarkus-run.jar
+```
+
+This rebuilds the augmentation layer with OIDC disabled. The process will exit after augmentation completes.
+
+**Step 2: Start the capability against your local router**
+
+```shell
+java -Dquarkus.http.port=9010 -Dwanaku.service.registration.uri=http://localhost:8080 -jar target/quarkus-app/quarkus-run.jar
+```
+
+Adjust the port (`9010`) and router URL (`http://localhost:8080`) as needed.
+
+### Why This Works
+
+Archetype-generated capabilities use the Wanaku SDK's `AuthConfigSource`, which dynamically sets `quarkus.oidc-client.enabled=false` when `WANAKU_HTTP_AUTH=none` is detected. However, this dynamic configuration only applies at runtime. The Quarkus augmentation phase (where build-time config is resolved) happens during `mvn package` and bakes OIDC as **enabled** into the application bytecode.
+
+When you run the capability without reaugmentation, Quarkus tries to initialize the OIDC client, contacts the configured Keycloak server (which doesn't exist locally), and fails before the runtime `AuthConfigSource` can disable it.
+
+Reaugmenting with `-Dquarkus.launch.rebuild=true -Dquarkus.oidc-client.enabled=false` forces Quarkus to rebuild the augmentation layer with OIDC explicitly disabled at build time, so the OIDC client extension never initializes.
+
+### Alternative: Use Environment Variables
+
+If you prefer not to reaugment, set `WANAKU_HTTP_AUTH=none` before building:
+
+```shell
+export WANAKU_HTTP_AUTH=none
+mvn clean package
+```
+
+Then start normally:
+
+```shell
+java -Dquarkus.http.port=9010 -Dwanaku.service.registration.uri=http://localhost:8080 -jar target/quarkus-app/quarkus-run.jar
+```
+
+This approach bakes the no-auth configuration into the build from the start, avoiding the need for reaugmentation.
+
 ## Building Containers
 
 You can also build containers using:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -604,6 +604,22 @@ java -Dwanaku.service.registration.uri=http://<wanaku-router-host>:8080 \
 > requires additional properties to connect to different systems.
 > Always consult the specific documentation for the capability you are using for more details.
 
+### Running Archetype-Generated Capabilities Locally (No Authentication)
+
+Capabilities scaffolded with `wanaku services create tool` or `wanaku services create resource` include OIDC authentication by default. When running against a local router in `noauth` mode, the capability fails at startup because it tries to contact a non-existent Keycloak server. To run locally without authentication, reaugment the capability to disable OIDC, then start it:
+
+```shell
+java -Dquarkus.launch.rebuild=true -Dquarkus.oidc-client.enabled=false -jar target/quarkus-app/quarkus-run.jar
+```
+
+Then start normally (adjust port and router URL as needed):
+
+```shell
+java -Dquarkus.http.port=9010 -Dwanaku.service.registration.uri=http://localhost:8080 -jar target/quarkus-app/quarkus-run.jar
+```
+
+This reaugmentation step is only needed once per build. The augmentation layer change persists until the next `mvn clean package`.
+
 #### Prerequisites
 
 Before deploying Wanaku on OpenShift, ensure you have:


### PR DESCRIPTION
Closes #1553

## Summary
- Added "Running Archetype-Generated Capabilities Locally" section to `docs/contributing.md` with reaugmentation workaround and build-time alternative
- Updated tool and provider archetype README templates with local development section pointing to the contributing guide

## Test plan
- [ ] Verify documentation is clear and accurate

## Summary by Sourcery

Document how to run archetype-generated capabilities locally without authentication and prepare archetype README templates for local development guidance.

Documentation:
- Add detailed guidance for running archetype-generated capabilities locally in no-auth mode, including reaugmentation steps and an environment-variable-based alternative.
- Introduce a local development section in provider and tool archetype README templates to point developers to the contributing guide.