### PR TITLE
fix: enhance label expression parser to support AND, OR, and NOT keywords

### DIFF
--- a/apps/wanaku-cli/src/main/resources/docs/LABEL_EXPRESSIONS.md
+++ b/apps/wanaku-cli/src/main/resources/docs/LABEL_EXPRESSIONS.md
@@ -36,12 +36,14 @@ wanaku tools list -l "environment!=production"
 
 ### Logical Operators
 
+> **Note:** Logical keywords (`AND`, `OR`, `NOT`) are **case-sensitive** — only uppercase forms are recognized. Lowercase variants (`and`, `or`, `not`) are treated as identifiers.
+
 | Operator | Description | Example                             |
 |----------|-------------|-------------------------------------|
-| `&`      | Logical AND | `category=weather & version=2.0`    |
-| `\|`     | Logical OR  | `category=weather \| category=news` |
-| `!`      | Logical NOT | `!deprecated=true`                  |
-| `( )`    | Grouping    | `(a=1 \| b=2) & c=3`                |
+| `&` or `AND`| Logical AND | `category=weather AND version=2.0` |
+| `|` or `OR` | Logical OR  | `category=weather OR category=news`|
+| `!` or `NOT`| Logical NOT | `!deprecated=true` / `NOT deprecated=true` |
+| `( )` | Grouping | `(a=1 OR b=2) AND c=3` |
 
 ### Operator Precedence
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParser.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParser.java
@@ -16,22 +16,29 @@ import ai.wanaku.core.util.StringHelper;
  *   <li>"category=weather &amp; action=forecast"</li>
  *   <li>"category=weather &amp; !action=forecast"</li>
  *   <li>"(category=weather | category=news) &amp; !action=forecast"</li>
+ *   <li>"(category=weather OR category=news) AND !action=forecast"</li>
  * </ul>
  * <p>
  * Grammar:
  * <pre>
  * expression  ::= orExpr
- * orExpr      ::= andExpr ('|' andExpr)*
- * andExpr     ::= notExpr ('&amp;' notExpr)*
- * notExpr     ::= '!' notExpr | primary
+ * orExpr      ::= andExpr ('|' andExpr | 'OR' andExpr)*
+ * andExpr     ::= notExpr ('&amp;' notExpr | 'AND' notExpr)*
+ * notExpr     ::= '!' notExpr | 'NOT' notExpr | primary
  * primary     ::= '(' expression ')' | comparison
  * comparison  ::= IDENTIFIER '=' STRING | IDENTIFIER '!=' STRING
  * </pre>
+ * <p>
+ * Keywords (AND, OR, NOT) are recognized case-sensitively and may be adjacent
+ * to parentheses, e.g. {@code NOT(deprecated=true)} or {@code env=prod AND(tier=frontend)}.
  */
 public class LabelExpressionParser {
 
     private List<Token> tokens;
     private int position;
+    private static final String KEYWORD_AND = "AND";
+    private static final String KEYWORD_OR = "OR";
+    private static final String KEYWORD_NOT = "NOT";
 
     /**
      * Constructs a new LabelExpressionParser instance.
@@ -179,7 +186,9 @@ public class LabelExpressionParser {
                         break;
                     }
                 }
-                result.add(new Token(TokenType.IDENTIFIER, sb.toString()));
+                String text = sb.toString();
+                TokenType type = keywordTokenType(text, i, expression);
+                result.add(new Token(type != null ? type : TokenType.IDENTIFIER, text));
                 continue;
             }
 
@@ -255,6 +264,29 @@ public class LabelExpressionParser {
     }
 
     // Helper methods
+
+    private static boolean isKeywordBoundary(char c) {
+        return Character.isWhitespace(c) || c == '(' || c == ')';
+    }
+
+    private static TokenType keywordTokenType(String text, int nextPosition, String expression) {
+        if (!text.equals(KEYWORD_AND) && !text.equals(KEYWORD_OR) && !text.equals(KEYWORD_NOT)) {
+            return null;
+        }
+        int charBeforeIdx = nextPosition - text.length() - 1;
+        if (charBeforeIdx >= 0 && !isKeywordBoundary(expression.charAt(charBeforeIdx))) {
+            return null;
+        }
+        if (nextPosition < expression.length() && !isKeywordBoundary(expression.charAt(nextPosition))) {
+            return null;
+        }
+        return switch (text) {
+            case KEYWORD_AND -> TokenType.AND;
+            case KEYWORD_OR -> TokenType.OR;
+            case KEYWORD_NOT -> TokenType.NOT;
+            default -> null;
+        };
+    }
 
     private boolean match(TokenType type) {
         if (position >= tokens.size()) {

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParserTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/core/mcp/util/LabelExpressionParserTest.java
@@ -351,4 +351,121 @@ class LabelExpressionParserTest {
         // Should not match entity with no labels
         assertFalse(predicate.test(new TestEntity("empty")));
     }
+
+    @Test
+    void testAndKeyword() throws Exception {
+        String expression = "env=prod AND tier=frontend";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "env", "prod", "tier", "frontend")));
+        assertFalse(predicate.test(createEntity("2", "env", "prod", "tier", "backend")));
+        assertFalse(predicate.test(createEntity("3", "env", "dev", "tier", "frontend")));
+    }
+
+    @Test
+    void testOrKeyword() throws Exception {
+        String expression = "category=weather OR category=news";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "category", "weather")));
+        assertTrue(predicate.test(createEntity("2", "category", "news")));
+        assertFalse(predicate.test(createEntity("3", "category", "sports")));
+    }
+
+    @Test
+    void testNotKeyword() throws Exception {
+        String expression = "NOT deprecated=true";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "status", "active")));
+        assertTrue(predicate.test(createEntity("2")));
+        assertFalse(predicate.test(createEntity("3", "deprecated", "true")));
+    }
+
+    @Test
+    void testMixedKeywordsAndSymbols() throws Exception {
+        String expression = "env=prod & tier=frontend OR tier=backend";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "env", "prod", "tier", "frontend")));
+        assertTrue(predicate.test(createEntity("2", "tier", "backend")));
+        assertFalse(predicate.test(createEntity("3", "env", "dev", "tier", "frontend")));
+    }
+
+    @Test
+    void testMultipleAndKeyword() throws Exception {
+        String expression = "a=1 AND b=2 AND c=3";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "a", "1", "b", "2", "c", "3")));
+        assertFalse(predicate.test(createEntity("2", "a", "1", "b", "2", "c", "4")));
+    }
+
+    @Test
+    void testMixedAndOrKeywords() throws Exception {
+        String expression = "a=1 AND b=2 OR c=3";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        // (a=1 AND b=2) OR c=3
+        assertTrue(predicate.test(createEntity("1", "a", "1", "b", "2")));
+        assertTrue(predicate.test(createEntity("2", "c", "3")));
+        assertFalse(predicate.test(createEntity("3", "a", "1", "b", "3", "c", "4")));
+    }
+
+    @Test
+    void testKeywordInParenthesizedExpression() throws Exception {
+        String expression = "(category=weather OR category=news) AND environment=production";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "category", "weather", "environment", "production")));
+        assertTrue(predicate.test(createEntity("2", "category", "news", "environment", "production")));
+        assertFalse(predicate.test(createEntity("3", "category", "weather", "environment", "staging")));
+    }
+
+    @Test
+    void testKeywordAsIdentifierValue() throws Exception {
+        String expression = "label=AND";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "label", "AND")));
+        assertFalse(predicate.test(createEntity("2", "label", "other")));
+    }
+
+    @Test
+    void testNotKeywordAdjacentToParenthesis() throws Exception {
+        String expression = "NOT(deprecated=true)";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "status", "active")));
+        assertFalse(predicate.test(createEntity("2", "deprecated", "true")));
+    }
+
+    @Test
+    void testAndKeywordAdjacentToParenthesis() throws Exception {
+        String expression = "env=prod AND(tier=frontend)";
+        Predicate<LabelsAwareEntity<?>> predicate = LabelExpressionParser.parse(expression);
+
+        assertNotNull(predicate);
+
+        assertTrue(predicate.test(createEntity("1", "env", "prod", "tier", "frontend")));
+        assertFalse(predicate.test(createEntity("2", "env", "prod", "tier", "backend")));
+    }
 }


### PR DESCRIPTION
Closes: #1508

## Summary by Sourcery

Extend label expression parsing to recognize AND/OR/NOT as logical operators alongside existing symbols, and update docs and tests accordingly.

New Features:
- Support the AND keyword as a logical conjunction in label expressions.
- Support the OR keyword as a logical disjunction in label expressions.
- Support the NOT keyword as a logical negation in label expressions.

Enhancements:
- Improve tokenizer to distinguish logical operator keywords from identifier values based on surrounding whitespace.

Documentation:
- Document support for the AND keyword as an alternative to the & operator in label expressions.

Tests:
- Add unit tests covering AND, OR, and NOT keyword usage, mixed keyword/symbol expressions, parenthesized keyword expressions, and keywords used as label values.