### PR TITLE
feat:  WANAKU_HOME support for LocalRunner

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -25,6 +25,7 @@ import ai.wanaku.cli.main.support.RuntimeConstants;
 import ai.wanaku.cli.main.support.WanakuCliConfig;
 import ai.wanaku.cli.main.support.ZipHelper;
 import ai.wanaku.core.util.VersionHelper;
+import ai.wanaku.core.util.WanakuHome;
 
 public class LocalRunner {
     private static final Logger LOG = Logger.getLogger(LocalRunner.class);
@@ -49,10 +50,16 @@ public class LocalRunner {
 
         public LocalRunnerEnvironment() {
             withAuthMode("none");
+            withWanakuHome(WanakuHome.get());
         }
 
         private LocalRunnerEnvironment withAuthMode(String authMode) {
             servicesOptions.put("WANAKU_HTTP_AUTH", authMode);
+            return this;
+        }
+
+        private LocalRunnerEnvironment withWanakuHome(String home) {
+            servicesOptions.put("WANAKU_HOME", home);
             return this;
         }
 
@@ -158,6 +165,7 @@ public class LocalRunner {
 
         reaugmentComponent(
                 RuntimeConstants.WANAKU_ROUTER_BACKEND,
+                wanakuHomeOpt(),
                 "-Dquarkus.oidc.enabled=false",
                 "-Dquarkus.oidc-proxy.enabled=false");
 
@@ -167,7 +175,7 @@ public class LocalRunner {
                     LOG.infof("Skipping re-augmentation for non-Quarkus component %s", component.getKey());
                     continue;
                 }
-                reaugmentComponent(component.getKey(), "-Dquarkus.oidc-client.enabled=false");
+                reaugmentComponent(component.getKey(), wanakuHomeOpt(), "-Dquarkus.oidc-client.enabled=false");
             }
         }
     }
@@ -263,6 +271,10 @@ public class LocalRunner {
         return first.compareTo(second) <= 0 ? first : second;
     }
 
+    private static String wanakuHomeOpt() {
+        return "-Dwanaku.home=" + WanakuHome.get();
+    }
+
     private static void startRouter(
             String component,
             String profileOpt,
@@ -274,7 +286,13 @@ public class LocalRunner {
         executorService.submit(() -> {
             try {
                 ProcessRunner.run(
-                        componentDir, environment.serviceOptions(), "java", profileOpt, "-jar", "quarkus-run.jar");
+                        componentDir,
+                        environment.serviceOptions(),
+                        "java",
+                        profileOpt,
+                        wanakuHomeOpt(),
+                        "-jar",
+                        "quarkus-run.jar");
             } catch (Exception e) {
                 LOG.errorf("Failed to start Wanaku Router Service: %s", e.getMessage(), e);
             } finally {
@@ -309,6 +327,7 @@ public class LocalRunner {
         File componentDir = quarkusAppDir(componentName);
         String grpcPortOpt = String.format("-Dquarkus.grpc.server.port=%d", grpcPort);
         String httpPortOpt = String.format("-Dquarkus.http.port=%d", grpcPort);
+        String wanakuHomeArg = wanakuHomeOpt();
 
         executorService.submit(() -> {
             try {
@@ -317,6 +336,7 @@ public class LocalRunner {
                         environment.serviceOptions(),
                         "java",
                         profileOpt,
+                        wanakuHomeArg,
                         grpcPortOpt,
                         httpPortOpt,
                         "-jar",

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/runner/local/LocalRunnerTest.java
@@ -1,6 +1,7 @@
 package ai.wanaku.cli.runner.local;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -8,11 +9,13 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import ai.wanaku.cli.main.support.WanakuCliConfig;
+import ai.wanaku.core.util.WanakuHome;
 import com.sun.net.httpserver.HttpServer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -94,5 +97,21 @@ class LocalRunnerTest {
         Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
 
         assertTrue(elapsed.compareTo(Duration.ofSeconds(1)) < 0);
+    }
+
+    @Test
+    void runnerEnvironmentPropagatesWanakuHomeAsEnvVar() {
+        LocalRunner.LocalRunnerEnvironment env = new LocalRunner.LocalRunnerEnvironment();
+        assertEquals(WanakuHome.get(), env.serviceOptions().get("WANAKU_HOME"));
+    }
+
+    @Test
+    void wanakuHomeOptReturnsSystemPropertyFlag() throws Exception {
+        Method wanakuHomeOpt = LocalRunner.class.getDeclaredMethod("wanakuHomeOpt");
+        wanakuHomeOpt.setAccessible(true);
+
+        String resolvedHome = WanakuHome.get();
+        String expected = "-Dwanaku.home=" + resolvedHome;
+        assertEquals(expected, wanakuHomeOpt.invoke(null));
     }
 }

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -175,6 +175,67 @@ java -Dwanaku.http.auth=none -jar quarkus-run.jar
 
 See the [Usage Guide](usage.md#running-without-authentication) for end-to-end instructions.
 
+### Home Directory Resolution
+
+Wanaku uses a single home directory for all persistent data. The location is resolved by `WanakuHome` in the following
+precedence order:
+
+1. System property `wanaku.home`
+2. Environment variable `WANAKU_HOME`
+3. Default: `${user.home}/.wanaku`
+
+> [!IMPORTANT]
+> `wanaku.home` is a **Wanaku-native** property. It is resolved by the custom `WanakuHome` class, not directly by
+> Quarkus MicroProfile Config. This ensures consistent resolution across all components (CLI, router, capabilities)
+> regardless of Quarkus' own `${...}` placeholder handling.
+
+```properties
+# Set the Wanaku home directory (all components)
+wanaku.home=/path/to/custom/home
+```
+
+```shell
+# Or via environment variable (recommended for containers / wanaku start local)
+export WANAKU_HOME=/path/to/custom/home
+```
+
+```shell
+# Or via system property (direct router/capability start)
+java -Dwanaku.home=/path/to/custom/home -jar quarkus-run.jar
+```
+
+#### What is stored under the home directory?
+
+| Directory | Purpose |
+|-----------|---------|
+| `<home>/router/` | Infinispan data store (SoftIndexFileStore for tools, resources, namespaces) |
+| `<home>/local/` | CLI-extracted service instances (when using `wanaku start local`) |
+| `<home>/cache/` | CLI download cache for component ZIPs/JARs |
+| `<home>/local/logs/` | Log files for router and capability services (`wanaku-router.log`, `<service>.log`) |
+| `<home>/credentials` | CLI credential store (0600 permissions) |
+
+#### Behavior with `wanaku start local`
+
+When using `wanaku start local`, the CLI automatically:
+
+- Sets `WANAKU_HOME` as an environment variable in all spawned child processes (router, capabilities, standalone
+  services).
+- Passes `-Dwanaku.home=<resolved-path>` as a JVM argument to all Quarkus-based child processes (router, re-augmented
+  capabilities).
+
+This ensures all components write to the same resolved home directory without requiring manual configuration.
+
+#### Behavior with direct JVM start
+
+When starting the router or a capability directly with `java -jar`, the system property takes precedence over the
+environment variable. Set both to test precedence:
+
+```shell
+export WANAKU_HOME=/tmp/env-var-home
+java -Dwanaku.home=/tmp/sysprop-home -jar quarkus-run.jar
+# Uses /tmp/sysprop-home (system property wins)
+```
+
 ### Health Check
 
 These `wanaku.router.health-check.*` properties control the periodic health probing of registered capabilities.


### PR DESCRIPTION
Closes: #1504

## Summary by Sourcery

Integrate centralized Wanaku home directory resolution into the local CLI runner and document its behavior.

New Features:
- Support WANAKU_HOME and wanaku.home-based home directory resolution in LocalRunner processes so all child services share a consistent data location.

Enhancements:
- Automatically propagate WANAKU_HOME as an environment variable and -Dwanaku.home as a JVM option when starting router and Quarkus capabilities via wanaku start local.
- Document home directory precedence, stored data layout, and behavior for both CLI-driven and direct JVM starts in the configuration guide.

Tests:
- Add unit tests to verify WANAKU_HOME propagation in LocalRunnerEnvironment and correct formatting of the wanaku.home JVM flag.