### PR TITLE
fix #1510: tools import shows spurious Internal Server Error messages

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsGenerate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsGenerate.java
@@ -99,7 +99,7 @@ public class ToolsGenerate extends BaseCommand {
                 System.err.print("\n\nImporting toolset...");
                 int failures = importToolset(toolReferences, host);
                 if (failures > 0) {
-                    System.err.printf("Import completed with %d failure(s)%n", failures);
+                    printer.printErrorMessage(String.format("Import completed with %d failure(s)", failures));
                     return EXIT_ERROR;
                 }
                 System.err.print("Done.");

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsGenerate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsGenerate.java
@@ -97,7 +97,11 @@ public class ToolsGenerate extends BaseCommand {
 
             if (importToolset) {
                 System.err.print("\n\nImporting toolset...");
-                importToolset(toolReferences, host);
+                int failures = importToolset(toolReferences, host);
+                if (failures > 0) {
+                    System.err.printf("Import completed with %d failure(s)%n", failures);
+                    return EXIT_ERROR;
+                }
                 System.err.print("Done.");
             }
         } catch (Exception e) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
@@ -54,7 +54,11 @@ public class ToolsImport extends BaseCommand {
                 }
             }
 
-            importToolset(toolReferences, host);
+            int failures = importToolset(toolReferences, host);
+            if (failures > 0) {
+                printer.printErrorMessage(String.format("Import completed with %d failure(s)", failures));
+                return EXIT_ERROR;
+            }
         } catch (Exception e) {
             printer.printErrorMessage(String.format("Failed to load tools index: %s", e.getMessage()));
             throw new RuntimeException(e);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ToolHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ToolHelper.java
@@ -31,10 +31,11 @@ public class ToolHelper {
      * @throws IllegalArgumentException if the host URI is invalid
      * @throws RuntimeException if there's an error connecting to or communicating with the service
      */
-    public static void importToolset(List<ToolReference> toolReferences, String host) throws IOException {
+    public static int importToolset(List<ToolReference> toolReferences, String host) throws IOException {
         ToolsService toolsService =
                 QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host)).build(ToolsService.class);
 
+        int failures = 0;
         for (var toolReference : toolReferences) {
             try {
                 WanakuResponse<ToolReference> ignored = toolsService.add(toolReference);
@@ -46,11 +47,15 @@ public class ToolHelper {
                             toolReference.getType(), response.getStatusInfo().getReasonPhrase());
 
                     System.exit(1);
+                } else if (response.getStatus() == Response.Status.CONFLICT.getStatusCode()) {
+                    System.err.printf("Skipping '%s': already exists%n", toolReference.getName());
                 } else {
                     commonResponseErrorHandler(response);
+                    failures++;
                 }
             }
         }
+        return failures;
     }
 
     /**
@@ -65,7 +70,7 @@ public class ToolHelper {
      * @throws RuntimeException if there's an error connecting to or communicating with the service
      * @see #importToolset(List, String)
      */
-    public static void importToolset(ToolReference toolReference, String host) throws IOException {
-        importToolset(List.of(toolReference), host);
+    public static int importToolset(ToolReference toolReference, String host) throws IOException {
+        return importToolset(List.of(toolReference), host);
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ResourceHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ResourceHelper.java
@@ -51,11 +51,12 @@ public final class ResourceHelper {
         }
 
         try {
+            String description = resourceReference.getDescription() != null ? resourceReference.getDescription() : "";
             final ResourceManager.ResourceDefinition resourceDefinition = resourceManager
                     .newResource(resourceReference.getName())
                     .setUri(resourceReference.getLocation())
                     .setMimeType(resourceReference.getMimeType())
-                    .setDescription(resourceReference.getDescription())
+                    .setDescription(description)
                     .setAsyncHandler(args -> handler.apply(args, resourceReference));
 
             if (namespace != null) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
@@ -85,8 +85,9 @@ public class ToolsHelper {
         }
 
         try {
+            String description = toolReference.getDescription() != null ? toolReference.getDescription() : "";
             ToolManager.ToolDefinition toolDefinition =
-                    toolManager.newTool(toolReference.getName()).setDescription(toolReference.getDescription());
+                    toolManager.newTool(toolReference.getName()).setDescription(description);
 
             final boolean required = isRequired(toolReference);
 


### PR DESCRIPTION
## Summary

- Guard against `null` description in `ToolsHelper.registerTool()` and `ResourceHelper.expose()` — the MCP library's `setDescription()` calls `Objects.requireNonNull()`, which throws NPE when OpenAPI-generated tools have no description. Defaults to empty string.
- Track import failures in `ToolHelper.importToolset()` and return `EXIT_ERROR` from `ToolsImport` and `ToolsGenerate` when any tool fails to import.
- Handle HTTP 409 (already exists) gracefully during import — prints a skip message instead of treating it as an error.

## Test plan

- [x] `mvn verify` passes for `wanaku-router-backend` (69 tests)
- [x] `mvn verify` passes for `wanaku-cli`
- [ ] Manual test: import tools with `null` description — should succeed without 500
- [ ] Manual test: re-import existing tools — should print skip messages, exit 0
- [ ] Manual test: import with a mix of valid and server-error tools — should exit 1 with failure count

## Summary by Sourcery

Handle null tool and resource descriptions and improve CLI tool import error reporting and exit codes.

Bug Fixes:
- Avoid null pointer exceptions when registering tools or exposing resources that have no description.
- Treat HTTP 409 conflicts during tool import as non-fatal, printing a skip message instead of failing the import.
- Return non-zero exit codes from ToolsImport and ToolsGenerate when any tool import fails.

Enhancements:
- Track and report the number of failed tool imports in CLI commands to provide clearer feedback.