### PR TITLE
docs: update CLI login examples

### DIFF
--- a/apps/wanaku-cli/README.md
+++ b/apps/wanaku-cli/README.md
@@ -46,8 +46,18 @@ If you installed via `get-wanaku.sh`, the CLI is placed in `$HOME/bin` which may
 ## Basic Usage
 
 ```shell
-# Authenticate with router
-wanaku auth login --url http://localhost:8080
+# Authenticate with the router OIDC proxy
+wanaku auth login \
+  --auth-server http://localhost:8080 \
+  --username alice \
+  --password
+
+# Or authenticate directly against Keycloak
+wanaku auth login \
+  --auth-server http://keycloak-host \
+  --realm wanaku \
+  --username alice \
+  --password
 
 # List available tools
 wanaku tools list


### PR DESCRIPTION
## Summary
- Update the CLI README login examples to use the current `wanaku auth login` flags
- Show both router OIDC proxy login and direct Keycloak login with `--realm`

## Notes
- This aligns the README with the 0.2.0 auth changes already documented in `docs/usage.md` and `docs/troubleshooting.md`

## Summary by Sourcery

Align CLI and operator documentation with current authentication flow and Camel route support.

Enhancements:
- Include WanakuCamelRoute alongside other CRDs in operator watch scope, resource management examples, and Helm configuration options.

Documentation:
- Update CLI README examples to reflect current `wanaku auth login` flags for router proxy and direct Keycloak authentication.
- Expand authentication usage docs with token get/set/clear commands and masked/unmasked token output behavior.
- Document WanakuCamelRoute as a first-class CRD in operator docs, including overview, commands, and reference to a dedicated guide.
- Describe optional `image` field in the WanakuCamelRoute CRD documentation for customizing the Camel Integration Capability image.