### PR TITLE
docs: refresh 0.2.0 documentation

### DIFF
--- a/docs/camel-route-crd.md
+++ b/docs/camel-route-crd.md
@@ -25,6 +25,15 @@ spec:
   routerRef: my-router
 ```
 
+### `image` (optional)
+
+Container image used for the generated Camel Integration Capability deployment. If omitted, the operator uses `quay.io/wanaku/camel-integration-capability:latest`.
+
+```yaml
+spec:
+  image: quay.io/wanaku/camel-integration-capability:0.2.0
+```
+
 ### `route` (required)
 
 The Apache Camel route definition in YAML DSL. This is a free-form field that accepts any valid Camel YAML route structure.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -8,6 +8,7 @@ The Wanaku Operator manages three custom resource definitions (CRDs):
 
 - **WanakuRouter** — deploys and configures the MCP router gateway
 - **WanakuCapability** — deploys capability services (HTTP tools, Camel integrations, etc.) and connects them to a router
+- **WanakuCamelRoute** — packages inline Camel routes into service catalogs and deploys them to a router
 - **WanakuServiceCatalog** — deploys packaged service catalogs (Camel routes + Wanaku rules) to a router
 
 When you create these custom resources, the operator automatically provisions:
@@ -46,7 +47,7 @@ helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator 
   --set operatorNamespace=wanaku
 ```
 
-The operator watches for `WanakuRouter`, `WanakuCapability`, and `WanakuServiceCatalog` resources in the namespace specified by `operatorNamespace`. By default, it watches only the namespace where it's installed (current-namespace scope).
+The operator watches for `WanakuRouter`, `WanakuCapability`, `WanakuCamelRoute`, and `WanakuServiceCatalog` resources in the namespace specified by `operatorNamespace`. By default, it watches only the namespace where it's installed (current-namespace scope).
 
 To watch all namespaces, override the environment variables during Helm install:
 
@@ -206,6 +207,12 @@ kubectl create configmap finance-catalog-data \
 > [!TIP]
 > See [Service Catalogs](usage.md#service-catalogs) and [Service Templates](service-templates.md) for details on creating and packaging catalogs.
 
+### WanakuCamelRoute (`wanaku.ai/v1alpha1`)
+
+Packages inline Camel routes and MCP metadata into a service catalog automatically, then deploys the resulting capability to a router.
+
+See the dedicated [WanakuCamelRoute CRD guide](camel-route-crd.md) for the full schema, examples, and troubleshooting notes.
+
 ## Deployment Examples
 
 ### Minimal Router + HTTP Capability
@@ -284,7 +291,7 @@ kubectl apply -f service-catalog.yaml -n wanaku
 **List all Wanaku resources:**
 
 ```shell
-kubectl get wanakurouter,wanakucapability,wanakuservicecatalog -n wanaku
+kubectl get wanakurouter,wanakucapability,wanakucamelroute,wanakuservicecatalog -n wanaku
 ```
 
 **Get detailed status:**
@@ -344,6 +351,7 @@ Delete the custom resources in reverse order (catalogs first, then capabilities,
 
 ```shell
 kubectl delete wanakuservicecatalog my-catalogs -n wanaku
+kubectl delete wanakucamelroute my-camel-route -n wanaku
 kubectl delete wanakucapability wanaku-capabilities -n wanaku
 kubectl delete wanakurouter wanaku-dev -n wanaku
 ```
@@ -363,7 +371,7 @@ helm uninstall wanaku-operator -n wanaku
 > kubectl delete wanakurouter --all -n wanaku
 > kubectl delete wanakucapability --all -n wanaku
 > kubectl delete wanakuservicecatalog --all -n wanaku
-> kubectl delete crd wanakurouters.wanaku.ai wanakucapabilities.wanaku.ai wanakuservicecatalogs.wanaku.ai
+> kubectl delete crd wanakurouters.wanaku.ai wanakucapabilities.wanaku.ai wanakucamelroutes.wanaku.ai wanakuservicecatalogs.wanaku.ai
 > ```
 
 ## Running Without Authentication
@@ -402,6 +410,7 @@ The operator's Helm chart exposes these key configuration options in `values.yam
 | `app.ports.http` | int | `8081` | HTTP port for operator's health and metrics endpoints. |
 | `app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_ROUTER_NAMESPACES` | string | `JOSDK_WATCH_CURRENT` | Watch scope for `WanakuRouter` resources (`JOSDK_WATCH_CURRENT` = current namespace only, `JOSDK_ALL_NAMESPACES` = cluster-wide). |
 | `app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES` | string | `JOSDK_WATCH_CURRENT` | Watch scope for `WanakuCapability` resources. |
+| `app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAMEL_ROUTE_NAMESPACES` | string | `JOSDK_WATCH_CURRENT` | Watch scope for `WanakuCamelRoute` resources. |
 | `app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_SERVICE_CATALOG_NAMESPACES` | string | `JOSDK_WATCH_CURRENT` | Watch scope for `WanakuServiceCatalog` resources. |
 
 **Example: customize operator image and watch all namespaces**
@@ -412,6 +421,7 @@ helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator 
   --set app.image=quay.io/myorg/wanaku-operator:1.0.0 \
   --set app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_ROUTER_NAMESPACES=JOSDK_ALL_NAMESPACES \
   --set app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES=JOSDK_ALL_NAMESPACES \
+  --set app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAMEL_ROUTE_NAMESPACES=JOSDK_ALL_NAMESPACES \
   --set app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_SERVICE_CATALOG_NAMESPACES=JOSDK_ALL_NAMESPACES
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -934,13 +934,24 @@ This command removes all authentication data from the local credentials file.
 
 #### Token Management
 
-Display the raw authentication token (useful for debugging or using with other tools):
+Manage the stored authentication token:
 
 ```shell
-wanaku auth token
+wanaku auth token --get
 ```
 
-This outputs the raw API token without masking.
+By default, `--get` masks the token value. Use `--unmask` to print the full token:
+
+```shell
+wanaku auth token --get --unmask
+```
+
+You can also set or clear the stored token directly:
+
+```shell
+wanaku auth token --set <token>
+wanaku auth token --clear
+```
 
 ### Using Authentication with Commands
 
@@ -3297,7 +3308,10 @@ This section provides solutions to common issues you may encounter while using W
 
    ```shell
    rm ~/.wanaku/credentials
-   wanaku auth login --url http://localhost:8080
+   wanaku auth login \
+     --auth-server http://localhost:8080 \
+     --username alice \
+     --password
    ```
 
 4. Verify the router can reach Keycloak:
@@ -3316,7 +3330,10 @@ This section provides solutions to common issues you may encounter while using W
 1. Re-authenticate with the router:
 
    ```shell
-   wanaku auth login --url http://localhost:8080
+   wanaku auth login \
+     --auth-server http://localhost:8080 \
+     --username alice \
+     --password
    ```
 
 2. Check token lifetime settings in Keycloak if tokens expire too quickly


### PR DESCRIPTION
## Summary
- Update auth documentation to match the current CLI syntax (`auth login --auth-server`, `auth token --get`, `--unmask`)
- Add the missing `WanakuCamelRoute` entry to the operator guide and Helm values reference
- Document the `WanakuCamelRoute.spec.image` override in the CRD guide

## Notes
- This is documentation-only and does not change runtime behavior.
- Verified with `git diff --check`.

## Summary by Sourcery

Refresh documentation to align with Wanaku 0.2.0 authentication and operator behavior.

Documentation:
- Update CLI authentication and token management examples to match current flags and workflows.
- Document WanakuCamelRoute as a managed CRD in the operator guide and Helm values reference, including namespace watch configuration.
- Describe the optional WanakuCamelRoute.spec.image override and its default image in the CRD guide.