### PR TITLE
chore: update leftover 0.2.0 version references to 0.3.0

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/Chart.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/Chart.yaml
@@ -1,4 +1,4 @@
 ---
 name: wanaku-operator
-version: 0.2.0-SNAPSHOT
+version: 0.3.0-SNAPSHOT
 apiVersion: v2

--- a/docs/camel-route-crd.md
+++ b/docs/camel-route-crd.md
@@ -31,7 +31,7 @@ Container image used for the generated Camel Integration Capability deployment. 
 
 ```yaml
 spec:
-  image: quay.io/wanaku/camel-integration-capability:0.2.0
+  image: quay.io/wanaku/camel-integration-capability:0.3.0
 ```
 
 ### `route` (required)

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -8,17 +8,17 @@ Releases are cut from release branches following the `X.Y.x` naming convention (
 
 ```shell
 git checkout main
-git checkout -b 0.2.x
-git push origin 0.2.x
+git checkout -b 0.3.x
+git push origin 0.3.x
 ```
 
 ### Set the versions
 
 ```shell
-export RELEASE_BRANCH=0.2.x
-export PREVIOUS_VERSION=0.1.0
-export CURRENT_DEVELOPMENT_VERSION=0.2.0
-export NEXT_DEVELOPMENT_VERSION=0.2.1
+export RELEASE_BRANCH=0.3.x
+export PREVIOUS_VERSION=0.2.0
+export CURRENT_DEVELOPMENT_VERSION=0.3.0
+export NEXT_DEVELOPMENT_VERSION=0.3.1
 ```
 
 ### Trigger the release
@@ -81,11 +81,11 @@ gpg --list-public-keys --keyid-format LONG
 Repeat this for every machine to be used for the release. Make sure you are on the release branch.
 
 ```shell
-export RELEASE_BRANCH=0.2.x
+export RELEASE_BRANCH=0.3.x
 git checkout ${RELEASE_BRANCH}
-export PREVIOUS_VERSION=0.1.0
-export CURRENT_DEVELOPMENT_VERSION=0.2.0
-export NEXT_DEVELOPMENT_VERSION=0.2.1
+export PREVIOUS_VERSION=0.2.0
+export CURRENT_DEVELOPMENT_VERSION=0.3.0
+export NEXT_DEVELOPMENT_VERSION=0.3.1
 ```
 
 > [!NOTE]

--- a/docs/testing-wanaku-start-local.md
+++ b/docs/testing-wanaku-start-local.md
@@ -26,7 +26,7 @@ version=$(cat core/core-util/target/classes/version.txt)
 java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
   --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip \
   --local-dist apps/wanaku-tool-service-http/target/distributions/wanaku-tool-service-http-${version}.zip \
-  --local-dist /path/to/camel-integration-capability-main-0.2.0-SNAPSHOT-jar-with-dependencies.jar \
+  --local-dist /path/to/camel-integration-capability-main-0.3.0-SNAPSHOT-jar-with-dependencies.jar \
   --camel-routes file:///path/to/routes.camel.yaml \
   --camel-rules file:///path/to/rules.yaml
 ```
@@ -37,7 +37,7 @@ java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
 version=$(cat core/core-util/target/classes/version.txt)
 java -jar apps/wanaku-cli/target/quarkus-app/quarkus-run.jar start local \
   --local-dist apps/wanaku-router-backend/target/distributions/wanaku-router-backend-${version}.zip \
-  --local-dist /path/to/camel-integration-capability-main-0.2.0-SNAPSHOT-jar-with-dependencies.jar \
+  --local-dist /path/to/camel-integration-capability-main-0.3.0-SNAPSHOT-jar-with-dependencies.jar \
   --service-catalog my-catalog \
   --service-catalog-system ftp
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3136,8 +3136,8 @@ open http://localhost:8080
 
 ```shell
 mvn -B archetype:generate -DarchetypeGroupId=ai.wanaku -DarchetypeArtifactId=wanaku-mcp-servers-archetype \
-  -DarchetypeVersion=0.2.0 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
-  -Dname=S3 -Dwanaku-version=0.2.0 -Dwanaku-capability-type=camel
+  -DarchetypeVersion=0.3.0 -DgroupId=ai.wanaku -Dpackage=ai.wanaku.mcp.servers.s3 -DartifactId=wanaku-mcp-servers-s3 \
+  -Dname=S3 -Dwanaku-version=0.3.0 -Dwanaku-capability-type=camel
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary
- Update Helm chart version from `0.2.0-SNAPSHOT` to `0.3.0-SNAPSHOT`
- Update documentation examples (usage, release guide, CRD docs, testing guide) from `0.2.0` to `0.3.0`
- Update test run report version reference

**Note:** `wanaku-capabilities-sdk.version` in `parent/pom.xml` is intentionally kept at `0.2.0-SNAPSHOT` as the SDK has not been released yet.

## Test plan
- [ ] Verify `mvn verify` still passes
- [ ] Verify docs render correctly

## Summary by Sourcery

Align project references with the 0.3.0 development line and record an automated test run report.

Enhancements:
- Bump wanaku-operator Helm chart version metadata to 0.3.0-SNAPSHOT.
- Add a markdown report summarizing the results of an automated end-to-end test run.

Documentation:
- Update release, usage, CRD, and local testing documentation to reference version 0.3.0 instead of 0.2.0.