### PR TITLE
docs: isolate OpenShift test plan namespaces

### DIFF
--- a/docs/contributing-test-plans.md
+++ b/docs/contributing-test-plans.md
@@ -10,6 +10,8 @@ A test plan has three layers:
 2. **Common steps** (`tests/plans/common/*.md`) — reusable procedures shared across plans (Keycloak setup, namespace creation, cleanup).
 3. **Environment variables** — all configurable values declared upfront so the same plan works across versions and clusters.
 
+For OpenShift-based plans, the namespace/project name must default to a unique value per run so multiple plans can execute in the same cluster without colliding. If a shared namespace is required, it should be set explicitly by the operator of the test run.
+
 ## Phases, not scripts
 
 Organize tests into numbered phases that run sequentially. Each phase groups related assertions. This makes it easy to skip phases, resume after failure, or run a subset.
@@ -129,6 +131,7 @@ Use `--ignore-not-found=true` on all delete commands and `2>/dev/null || true` o
 ## Checklist for new plans
 
 - [ ] All configurable values are environment variables with defaults
+- [ ] OpenShift namespace/project defaults are unique per run, not shared cluster-wide
 - [ ] Common procedures reference shared docs, not inline copies
 - [ ] Every step has a PASS/FAIL assertion
 - [ ] No fixed `sleep` — use `oc wait`, `oc rollout status`, or polling

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -66,14 +66,14 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-cic-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export CIC_IMAGE="${CIC_IMAGE:-quay.io/wanaku/camel-integration-capability:latest}"
 # OIDC client secret for CIC-to-router authentication (defaults to "mypasswd")
 export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
 ```
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.
 
 ### Helper: wait for resource deletion
 

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -66,7 +66,8 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-cic-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-cic-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export CIC_IMAGE="${CIC_IMAGE:-quay.io/wanaku/camel-integration-capability:latest}"
@@ -156,7 +157,7 @@ Follow [common/openshift-login.md](common/openshift-login.md) to log in to the t
 
 ### Step 1.1: Create namespace
 
-Follow [common/namespace-setup.md](common/namespace-setup.md) to create and verify the namespace. Use `WANAKU_NAMESPACE=wanaku-cic-test` (or the value from the environment variables above).
+Follow [common/namespace-setup.md](common/namespace-setup.md) to create and verify the namespace. Use the unique `WANAKU_NAMESPACE` value from the environment variables above, or override it if you need a specific namespace.
 
 ### Step 1.2: Deploy Keycloak
 

--- a/tests/plans/cli-auth-commands.md
+++ b/tests/plans/cli-auth-commands.md
@@ -47,8 +47,6 @@ echo "PASS: all prerequisites met"
 
 ```bash
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-auth-${WANAKU_TEST_RUN_ID}}"
 export KEYCLOAK_ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
 export KEYCLOAK_ADMIN_PASS="${KEYCLOAK_ADMIN_PASS:-admin}"
 export KEYCLOAK_URL="${KEYCLOAK_URL:-}"
@@ -63,10 +61,12 @@ export TEST_EMAIL="${TEST_EMAIL:-testuser811@example.com}"
 export TEST_CLIENT_ID="${TEST_CLIENT_ID:-test-service-811}"
 ```
 
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for the Keycloak deployment.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `WANAKU_REPO_ROOT` | `.` | Path to the wanaku repository root |
-| `WANAKU_NAMESPACE` | `wanaku-auth-<run-id>` | OpenShift namespace for Keycloak deployment |
+| `WANAKU_NAMESPACE` | `wanaku-auth-<run-id>` | OpenShift namespace for Keycloak deployment, set by [common/namespace-setup.md](common/namespace-setup.md) |
 | `KEYCLOAK_ADMIN_USER` | `admin` | Keycloak admin username |
 | `KEYCLOAK_ADMIN_PASS` | `admin` | Keycloak admin password |
 | `KEYCLOAK_URL` | _(set by setup)_ | Keycloak URL (set after Keycloak deployment) |

--- a/tests/plans/cli-auth-commands.md
+++ b/tests/plans/cli-auth-commands.md
@@ -47,7 +47,8 @@ echo "PASS: all prerequisites met"
 
 ```bash
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-auth-${WANAKU_TEST_RUN_ID}}"
 export KEYCLOAK_ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
 export KEYCLOAK_ADMIN_PASS="${KEYCLOAK_ADMIN_PASS:-admin}"
 export KEYCLOAK_URL="${KEYCLOAK_URL:-}"
@@ -65,7 +66,7 @@ export TEST_CLIENT_ID="${TEST_CLIENT_ID:-test-service-811}"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `WANAKU_REPO_ROOT` | `.` | Path to the wanaku repository root |
-| `WANAKU_NAMESPACE` | `wanaku-test` | OpenShift namespace for Keycloak deployment |
+| `WANAKU_NAMESPACE` | `wanaku-auth-<run-id>` | OpenShift namespace for Keycloak deployment |
 | `KEYCLOAK_ADMIN_USER` | `admin` | Keycloak admin username |
 | `KEYCLOAK_ADMIN_PASS` | `admin` | Keycloak admin password |
 | `KEYCLOAK_URL` | _(set by setup)_ | Keycloak URL (set after Keycloak deployment) |

--- a/tests/plans/common/cleanup.md
+++ b/tests/plans/common/cleanup.md
@@ -92,7 +92,7 @@ echo "SKIP: CRD deletion (uncomment to enable)"
 
 ### 9. Delete the namespace (optional)
 
-The test service account lives in `wanaku-test-infra`, not in `${WANAKU_NAMESPACE}`, so deleting the test namespace does not affect the shared test infrastructure. Only delete the namespace when it was created for this specific run.
+The test service account lives in `wanaku-test-infra`, not in `${WANAKU_NAMESPACE}`, so deleting the test namespace does not affect the shared test infrastructure. Only delete the namespace when it was created for this specific run. If you intentionally reuse a shared namespace, leave the deletion commented out and skip namespace cleanup for that shared environment.
 
 ```bash
 # WARNING: This deletes everything in the namespace.

--- a/tests/plans/common/cleanup.md
+++ b/tests/plans/common/cleanup.md
@@ -4,7 +4,7 @@ Reusable steps for cleaning up all Wanaku test resources from OpenShift.
 
 ## Prerequisites
 
-- `WANAKU_NAMESPACE` environment variable set
+- `WANAKU_NAMESPACE` environment variable set to the namespace created for this test run
 
 ## Steps
 
@@ -92,7 +92,7 @@ echo "SKIP: CRD deletion (uncomment to enable)"
 
 ### 9. Delete the namespace (optional)
 
-The test service account lives in `wanaku-test-infra`, not in `${WANAKU_NAMESPACE}`, so deleting the test namespace does not affect the service account or its RBAC.
+The test service account lives in `wanaku-test-infra`, not in `${WANAKU_NAMESPACE}`, so deleting the test namespace does not affect the shared test infrastructure. Only delete the namespace when it was created for this specific run.
 
 ```bash
 # WARNING: This deletes everything in the namespace.

--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -15,7 +15,7 @@ Reusable steps for deploying and configuring Keycloak as the OIDC provider for W
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-20260716-043000` |
+| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-<run-id>` |
 | `WANAKU_REPO_ROOT` | Path to the wanaku repository root | `.` |
 | `WANAKU_CLI` | Command to invoke the Wanaku CLI (see step 1) | `wanaku` |
 | `KEYCLOAK_ADMIN_USER` | Keycloak admin username | `admin` |

--- a/tests/plans/common/keycloak-setup.md
+++ b/tests/plans/common/keycloak-setup.md
@@ -15,7 +15,7 @@ Reusable steps for deploying and configuring Keycloak as the OIDC provider for W
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `WANAKU_NAMESPACE` | Target namespace | `wanaku-test` |
+| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-20260716-043000` |
 | `WANAKU_REPO_ROOT` | Path to the wanaku repository root | `.` |
 | `WANAKU_CLI` | Command to invoke the Wanaku CLI (see step 1) | `wanaku` |
 | `KEYCLOAK_ADMIN_USER` | Keycloak admin username | `admin` |

--- a/tests/plans/common/namespace-setup.md
+++ b/tests/plans/common/namespace-setup.md
@@ -6,15 +6,21 @@ Reusable steps for creating and configuring the test namespace on OpenShift.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `WANAKU_NAMESPACE` | Target namespace for all Wanaku resources | `wanaku-test` |
+| `WANAKU_NAMESPACE_PREFIX` | Prefix used to derive a per-run namespace when one is not provided | `wanaku-test` |
+| `WANAKU_TEST_RUN_ID` | Unique suffix for the namespace when one is not provided | `20260716-043000` |
+| `WANAKU_NAMESPACE` | Target namespace for all Wanaku resources | `wanaku-test-20260716-043000` |
 
 ## Steps
 
 ### 1. Export the namespace variable
 
 ```bash
-export WANAKU_NAMESPACE="wanaku-test"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE_PREFIX="${WANAKU_NAMESPACE_PREFIX:-wanaku-test}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-${WANAKU_NAMESPACE_PREFIX}-${WANAKU_TEST_RUN_ID}}"
 ```
+
+This keeps each test run isolated by default while still allowing callers to override `WANAKU_NAMESPACE` when they intentionally want to reuse a namespace.
 
 ### 2. Create the namespace (project)
 

--- a/tests/plans/common/namespace-setup.md
+++ b/tests/plans/common/namespace-setup.md
@@ -1,6 +1,7 @@
 # Common: Namespace Setup
 
 Reusable steps for creating and configuring the test namespace on OpenShift.
+Use this shared setup from each OpenShift plan instead of re-defining the namespace derivation inline.
 
 ## Variables
 
@@ -8,7 +9,7 @@ Reusable steps for creating and configuring the test namespace on OpenShift.
 |----------|-------------|---------|
 | `WANAKU_NAMESPACE_PREFIX` | Prefix used to derive a per-run namespace when one is not provided | `wanaku-test` |
 | `WANAKU_TEST_RUN_ID` | Unique suffix for the namespace when one is not provided | `20260716-043000` |
-| `WANAKU_NAMESPACE` | Target namespace for all Wanaku resources | `wanaku-test-20260716-043000` |
+| `WANAKU_NAMESPACE` | Target namespace for all Wanaku resources | `wanaku-test-<run-id>` |
 
 ## Steps
 

--- a/tests/plans/common/operator-deployment.md
+++ b/tests/plans/common/operator-deployment.md
@@ -13,7 +13,7 @@ Reusable steps for installing the Wanaku operator on OpenShift using Helm.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `WANAKU_NAMESPACE` | Target namespace | `wanaku-test` |
+| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-20260716-043000` |
 | `WANAKU_REPO_ROOT` | Path to the wanaku repository root | `/path/to/wanaku` |
 | `WANAKU_OPERATOR_IMAGE` | Operator container image (optional override) | `quay.io/wanaku/wanaku-operator:latest` |
 

--- a/tests/plans/common/operator-deployment.md
+++ b/tests/plans/common/operator-deployment.md
@@ -13,7 +13,7 @@ Reusable steps for installing the Wanaku operator on OpenShift using Helm.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-20260716-043000` |
+| `WANAKU_NAMESPACE` | Target namespace created for this run | `wanaku-test-<run-id>` |
 | `WANAKU_REPO_ROOT` | Path to the wanaku repository root | `/path/to/wanaku` |
 | `WANAKU_OPERATOR_IMAGE` | Operator container image (optional override) | `quay.io/wanaku/wanaku-operator:latest` |
 

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -389,7 +389,8 @@ The first `oc login` step is manual; everything else is automatable.
 ### Environment variables
 
 ```bash
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-mcp-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-mcp-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -389,13 +389,13 @@ The first `oc login` step is manual; everything else is automatable.
 ### Environment variables
 
 ```bash
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-mcp-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
 export WANAKU_PROVIDER_STATIC_FILE_IMAGE="${WANAKU_PROVIDER_STATIC_FILE_IMAGE:-quay.io/wanaku/wanaku-provider-performance-static-file:latest}"
 ```
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Part 2 to derive a unique `WANAKU_NAMESPACE` for the OpenShift environment.
 
 ### Helper: wait for resource deletion
 

--- a/tests/plans/observability-tracing.md
+++ b/tests/plans/observability-tracing.md
@@ -65,14 +65,14 @@ echo "PASS: all prerequisites met"
 ### Environment variables
 
 ```bash
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-observability-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
 export OTEL_COLLECTOR_IMAGE="${OTEL_COLLECTOR_IMAGE:-otel/opentelemetry-collector-contrib:0.127.0}"
 export JAEGER_IMAGE="${JAEGER_IMAGE:-jaegertracing/jaeger:latest}"
 ```
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.
 
 ### Helper: wait for resource deletion
 

--- a/tests/plans/observability-tracing.md
+++ b/tests/plans/observability-tracing.md
@@ -65,7 +65,8 @@ echo "PASS: all prerequisites met"
 ### Environment variables
 
 ```bash
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-observability-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -61,7 +61,8 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -61,12 +61,12 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
 ```
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.
 
 ### Helper: wait for resource deletion
 

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -61,13 +61,13 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-camel-route-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 # OIDC client secret for operator-to-router authentication (defaults to "mypasswd")
 export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
 ```
+
+Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.
 
 ### Helper: wait for resource deletion
 

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -61,7 +61,8 @@ echo "PASS: all prerequisites met"
 Set these before running the plan. All image tags default to `latest` but can be overridden to test specific versions.
 
 ```bash
-export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-test}"
+export WANAKU_TEST_RUN_ID="${WANAKU_TEST_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+export WANAKU_NAMESPACE="${WANAKU_NAMESPACE:-wanaku-camel-route-${WANAKU_TEST_RUN_ID}}"
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 # OIDC client secret for operator-to-router authentication (defaults to "mypasswd")

--- a/tests/plans/setup/service-account-setup.md
+++ b/tests/plans/setup/service-account-setup.md
@@ -4,6 +4,8 @@ Running operator test plans with your personal (admin) credentials is dangerous.
 
 The service account lives in a shared `wanaku-test-infra` namespace, separate from the per-run namespace where each test plan executes. This keeps the test infrastructure stable while allowing multiple plans to reuse the same cluster without sharing a test namespace.
 
+No permission change is needed for that split: the service account already has cluster-scoped access to create and delete per-run namespaces/projects, plus the namespaced permissions the plans use inside those namespaces.
+
 ## Prerequisites
 
 - `oc` CLI logged in as a cluster admin (one-time setup)

--- a/tests/plans/setup/service-account-setup.md
+++ b/tests/plans/setup/service-account-setup.md
@@ -2,7 +2,7 @@
 
 Running operator test plans with your personal (admin) credentials is dangerous. This guide creates a dedicated service account with only the permissions the test plans require.
 
-The service account lives in a dedicated `wanaku-test-infra` namespace, separate from the `wanaku-test` namespace where tests run. This ensures the service account survives test cleanup and namespace deletion across test executions.
+The service account lives in a shared `wanaku-test-infra` namespace, separate from the per-run namespace where each test plan executes. This keeps the test infrastructure stable while allowing multiple plans to reuse the same cluster without sharing a test namespace.
 
 ## Prerequisites
 
@@ -41,7 +41,7 @@ oc whoami
 
 ## Token Management
 
-The `create-service-account.sh` script prints a token valid for 1 year. For CI systems, store it as a secret (e.g., GitHub Actions `OPENSHIFT_SA_TOKEN`).
+The `create-service-account.sh` script prints a token valid for 1 year. For CI systems, store it as a secret (e.g., GitHub Actions `OPENSHIFT_SA_TOKEN`). Reuse the same service-account namespace across runs unless you intentionally want to recreate the infrastructure.
 
 To rotate the token:
 


### PR DESCRIPTION
## Summary\n- make OpenShift test-plan namespaces default to a unique per-run value\n- update shared setup/cleanup docs to match the per-run namespace model\n- remove stale single-project wording from the plan instructions\n\n## Notes\n- refreshed the work from upstream main before branching\n

## Summary by Sourcery

Document per-run unique OpenShift namespaces for Wanaku test plans and align shared setup/cleanup guidance with the new isolation model.

Documentation:
- Update common namespace, Keycloak, and operator deployment docs to describe per-run, uniquely derived OpenShift namespaces and new environment variables.
- Revise individual plan docs to default namespaces to run-scoped values and clarify when operators may override them for shared use.
- Extend contributor guidelines and checklist to require unique-per-run OpenShift namespace defaults for all new test plans.