### PR TITLE
chore: upgrade Forage to 1.5.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
         <wanaku-capabilities-sdk.version>0.2.0</wanaku-capabilities-sdk.version>
-        <forage.version>1.3</forage.version>
+        <forage.version>1.5.0</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <operator-framework.version>5.3.4</operator-framework.version>


### PR DESCRIPTION
## Summary
- Backport: upgrades Forage from 1.3 to 1.5.0 in `parent/pom.xml`

## Test plan
- [ ] Verify project builds successfully with the new Forage version