### PR TITLE
chore: add wanakucamelcodeexecutionengines permissions to test SA

### DIFF
--- a/tests/plans/setup/create-service-account.sh
+++ b/tests/plans/setup/create-service-account.sh
@@ -74,7 +74,8 @@ rules:
     resources: ["wanakurouters", "wanakurouters/status", "wanakurouters/finalizers",
                  "wanakucapabilities", "wanakucapabilities/status", "wanakucapabilities/finalizers",
                  "wanakuservicecatalogs", "wanakuservicecatalogs/status", "wanakuservicecatalogs/finalizers",
-                 "wanakucamelroutes", "wanakucamelroutes/status", "wanakucamelroutes/finalizers"]
+                 "wanakucamelroutes", "wanakucamelroutes/status", "wanakucamelroutes/finalizers",
+                 "wanakucamelcodeexecutionengines", "wanakucamelcodeexecutionengines/status", "wanakucamelcodeexecutionengines/finalizers"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   # Self subject access review (oc auth can-i)


### PR DESCRIPTION
## Summary

- Add `wanakucamelcodeexecutionengines`, `wanakucamelcodeexecutionengines/status`, and `wanakucamelcodeexecutionengines/finalizers` to the `wanaku-test-runner` ClusterRole in the SA setup script
- The `WanakuCamelCodeExecutionEngine` CRD was added to the operator Helm chart but the test runner SA was not updated, causing Helm install to fail with RBAC escalation errors and the operator to crash with 403 Forbidden on the new CRD's informer

## Test plan

- Run `bash tests/plans/setup/create-service-account.sh` with cluster-admin credentials
- Verify `helm install wanaku-operator` succeeds in the test namespace
- Run the operator-basic-functionality test plan

## Summary by Sourcery

Tests:
- Update the wanaku-test-runner ClusterRole in the setup script to include WanakuCamelCodeExecutionEngine resources, status, and finalizers.