### PR TITLE
ci: dispatch integration tests after early-access build

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -88,3 +88,16 @@ jobs:
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
+
+  dispatch-integration-tests:
+    needs: pre-release-build-linux
+    runs-on: ubuntu-latest
+    if: github.repository == 'wanaku-ai/wanaku' && secrets.TESTS_DISPATCH_TOKEN != ''
+    steps:
+      - name: Dispatch integration tests
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.TESTS_DISPATCH_TOKEN }}
+          repository: wanaku-ai/wanaku-tests
+          event-type: wanaku-build-completed
+          client-payload: '{"version": "${{ github.event.inputs.currentDevelopmentVersion }}", "sha": "${{ github.sha }}", "ref": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

- Adds a `dispatch-integration-tests` job to the early-access workflow that triggers integration tests in `wanaku-ai/wanaku-tests` after snapshot artifacts are published
- Uses `peter-evans/repository-dispatch` to send a `wanaku-build-completed` event with the version from the workflow input
- Guarded with `secrets.TESTS_DISPATCH_TOKEN != ''` so forks skip this job gracefully
- Replaces the old Jenkins-based trigger for cross-repo integration testing

## Prerequisites

- A `TESTS_DISPATCH_TOKEN` secret must be added to this repo (fine-grained PAT or GitHub App token scoped to `wanaku-ai/wanaku-tests` with `Contents: Read and write`)
- The receiver workflow was merged in wanaku-ai/wanaku-tests#103

## Test plan

- [ ] Add the `TESTS_DISPATCH_TOKEN` secret
- [ ] Run the early-access workflow and verify the dispatch job triggers integration tests in wanaku-tests

## Summary by Sourcery

CI:
- Introduce a dispatch-integration-tests job in the early-access workflow to notify wanaku-tests via repository-dispatch when a build completes, gated by a dispatch token.