### PR TITLE
ci: fix early-access workflow secrets reference in job-level if

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -92,10 +92,13 @@ jobs:
   dispatch-integration-tests:
     needs: pre-release-build-linux
     runs-on: ubuntu-latest
-    if: github.repository == 'wanaku-ai/wanaku' && secrets.TESTS_DISPATCH_TOKEN != ''
+    if: github.repository == 'wanaku-ai/wanaku'
     steps:
       - name: Dispatch integration tests
+        if: env.DISPATCH_TOKEN != ''
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        env:
+          DISPATCH_TOKEN: ${{ secrets.TESTS_DISPATCH_TOKEN }}
         with:
           token: ${{ secrets.TESTS_DISPATCH_TOKEN }}
           repository: wanaku-ai/wanaku-tests


### PR DESCRIPTION
## CI Fix

**Failed runs:**
- https://github.com/wanaku-ai/wanaku/actions/runs/29524723114
- https://github.com/wanaku-ai/wanaku/actions/runs/29499929406

### Errors Fixed
- `secrets` context used in job-level `if:` expression (line 95), which is not supported by GitHub Actions. This makes the entire workflow file invalid, causing all push-triggered runs to fail with: `Unrecognized named-value: 'secrets'`

### Fix
Moved the `secrets.TESTS_DISPATCH_TOKEN` check from the job-level `if:` to a step-level `if:` using an `env` mapping, which does support the `secrets` context.

## Summary by Sourcery

CI:
- Adjust the early-access workflow to avoid using secrets in job-level conditions, gating the integration test dispatch step via environment-based checks instead.