### PR TITLE
[#1518] Local mode should warn about disabled authentication

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -162,6 +162,7 @@ public class StartLocal extends StartBase {
                 return EXIT_OK;
             }
         }
+        printer.printWarningMessage("Authentication is disabled in local mode");
         startWanaku();
         return EXIT_OK;
     }


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1518

Backport of https://github.com/wanaku-ai/wanaku/pull/1587

## Summary by Sourcery

Enhancements:
- Add a CLI warning message indicating that authentication is disabled in local mode.