### PR TITLE
Fix #1593: replace quarkus-oidc-proxy with null-safe WanakuOidcProxy

### DIFF
--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -112,7 +112,7 @@ jobs:
       run: >
         java -Dquarkus.launch.rebuild=true
         -Dquarkus.oidc.enabled=false
-        -Dquarkus.oidc-proxy.enabled=false
+        -Dwanaku.oidc-proxy.enabled=false
         -jar apps/wanaku-router-backend/target/quarkus-app/quarkus-run.jar
 
     - name: Start Router Backend

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -167,7 +167,7 @@ public class LocalRunner {
                 RuntimeConstants.WANAKU_ROUTER_BACKEND,
                 wanakuHomeOpt(),
                 "-Dquarkus.oidc.enabled=false",
-                "-Dquarkus.oidc-proxy.enabled=false");
+                "-Dwanaku.oidc-proxy.enabled=false");
 
         for (Map.Entry<String, String> component : components.entrySet()) {
             if (isEnabled(services, component)) {

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -180,11 +180,9 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-authorization</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.oidc-proxy</groupId>
-            <artifactId>quarkus-oidc-proxy</artifactId>
-            <version>${quarkus-oidc-proxy.version}</version>
-        </dependency>
+        <!-- quarkus-oidc-proxy removed: its OidcProxy constructor NPEs when the
+             OIDC provider is unavailable at startup (wanaku-ai/wanaku#1593).
+             WanakuOidcProxy replaces it with lazy, null-safe initialization. -->
 
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResource.java
@@ -14,7 +14,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("/.well-known")
 @Produces(MediaType.APPLICATION_JSON)
 public class OAuthAuthorizationServerWellKnownResource {
-    @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    @ConfigProperty(name = "wanaku.oidc-proxy.root-path", defaultValue = "/q/oidc")
     String oidcProxyRootPath;
 
     @ConfigProperty(name = "auth.proxy", defaultValue = "http://localhost:8080")

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResource.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Produces(MediaType.APPLICATION_JSON)
 public class OAuthProtectedResourceWellKnownResource {
 
-    @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    @ConfigProperty(name = "wanaku.oidc-proxy.root-path", defaultValue = "/q/oidc")
     String oidcProxyRootPath;
 
     @Context

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/AuthConfigSource.java
@@ -72,7 +72,7 @@ public class AuthConfigSource implements ConfigSource {
             props.put("quarkus.oidc.mcp.enabled", "false");
             props.put("quarkus.oidc.mcp.discovery-enabled", "false");
             props.put("quarkus.oidc.mcp.resource-metadata.enabled", "false");
-            props.put("quarkus.oidc-proxy.enabled", "false");
+            props.put("wanaku.oidc-proxy.enabled", "false");
             props.put("quarkus.http.auth.permission.authenticated.policy", "permit");
             props.put("quarkus.http.auth.permission.mcp-authenticated.policy", "permit");
             props.put("quarkus.http.auth.permission.web.policy", "permit");

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
@@ -26,7 +26,7 @@ public class NamespaceTenantConfigResolver implements TenantConfigResolver {
     @ConfigProperty(name = "auth.proxy")
     String authProxy;
 
-    @ConfigProperty(name = "quarkus.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    @ConfigProperty(name = "wanaku.oidc-proxy.root-path", defaultValue = "/q/oidc")
     String oidcProxyRootPath;
 
     @Override

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/WanakuOidcProxy.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/WanakuOidcProxy.java
@@ -1,0 +1,367 @@
+package ai.wanaku.backend.support;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import java.net.URI;
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.quarkus.oidc.OidcConfigurationMetadata;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.quarkus.oidc.runtime.TenantConfigContext;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+@ApplicationScoped
+public class WanakuOidcProxy {
+    private static final Logger LOG = Logger.getLogger(WanakuOidcProxy.class);
+
+    private static final String RESPONSE_TYPES_SUPPORTED = "response_types_supported";
+    private static final String SUBJECT_TYPES_SUPPORTED = "subject_types_supported";
+    private static final String SCOPES_SUPPORTED = "scopes_supported";
+    private static final String ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED = "id_token_signing_alg_values_supported";
+    private static final String CODE_CHALLENGE_METHODS_SUPPORTED = "code_challenge_methods_supported";
+
+    @ConfigProperty(name = "wanaku.oidc-proxy.root-path", defaultValue = "/q/oidc")
+    String rootPath;
+
+    @ConfigProperty(name = "wanaku.oidc-proxy.tenant-id", defaultValue = "")
+    String tenantId;
+
+    @ConfigProperty(name = "wanaku.oidc-proxy.enabled", defaultValue = "true")
+    boolean enabled;
+
+    @ConfigProperty(name = "wanaku.http.auth", defaultValue = "keycloak")
+    String authMode;
+
+    @Inject
+    Instance<TenantConfigBean> tenantConfigBeanInstance;
+
+    private volatile WebClient client;
+    private volatile OidcConfigurationMetadata oidcMetadata;
+    private volatile OidcTenantConfig oidcTenantConfig;
+    private volatile boolean initialized;
+
+    void setupRoutes(@Observes Router router) {
+        if (!enabled || "none".equalsIgnoreCase(authMode)) {
+            return;
+        }
+
+        tryInitialize();
+
+        String metadataPath = rootPath + "/.well-known/openid-configuration";
+        router.get(metadataPath).handler(this::wellKnownConfig);
+        router.get(rootPath + "/authorize").handler(this::authorize);
+        router.post(rootPath + "/token").handler(this::token);
+        router.get(rootPath + "/jwks").handler(this::jwks);
+        router.get(rootPath + "/userinfo").handler(this::userinfo);
+        router.get(rootPath + "/logout").handler(this::endSession);
+        router.post(rootPath + "/register").handler(this::clientRegistration);
+
+        if (initialized) {
+            LOG.infof("OIDC proxy routes registered at %s (provider available)", rootPath);
+        } else {
+            LOG.warnf(
+                    "OIDC proxy routes registered at %s in degraded mode — provider unavailable, endpoints will return 503",
+                    rootPath);
+        }
+    }
+
+    private void tryInitialize() {
+        if (initialized) {
+            return;
+        }
+
+        if (!tenantConfigBeanInstance.isResolvable()) {
+            LOG.warn("TenantConfigBean not available — OIDC is likely disabled");
+            return;
+        }
+
+        TenantConfigBean tenantConfigBean = tenantConfigBeanInstance.get();
+        TenantConfigContext ctx = (tenantId == null || tenantId.isEmpty())
+                ? tenantConfigBean.getDefaultTenant()
+                : tenantConfigBean.getStaticTenantsConfig().get(tenantId);
+
+        if (ctx == null) {
+            LOG.warn("OIDC proxy tenant config not found — operating in degraded mode");
+            return;
+        }
+
+        if (ctx.getOidcProviderClient() == null) {
+            LOG.warn("OIDC provider client unavailable — proxy operating in degraded mode");
+            return;
+        }
+
+        this.oidcTenantConfig = ctx.getOidcTenantConfig();
+        this.oidcMetadata = ctx.getOidcMetadata();
+        this.client = ctx.getOidcProviderClient().getWebClient();
+        this.initialized = true;
+    }
+
+    private void wellKnownConfig(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        JsonObject json = new JsonObject();
+        json.put(OidcConfigurationMetadata.AUTHORIZATION_ENDPOINT, buildUri(context, rootPath + "/authorize"));
+        json.put(OidcConfigurationMetadata.TOKEN_ENDPOINT, buildUri(context, rootPath + "/token"));
+
+        if (oidcMetadata.getJsonWebKeySetUri() != null) {
+            json.put(OidcConfigurationMetadata.JWKS_ENDPOINT, buildUri(context, rootPath + "/jwks"));
+        }
+        if (oidcMetadata.getEndSessionUri() != null) {
+            json.put(OidcConfigurationMetadata.END_SESSION_ENDPOINT, buildUri(context, rootPath + "/logout"));
+        }
+        if (oidcMetadata.getUserInfoUri() != null) {
+            json.put(OidcConfigurationMetadata.USERINFO_ENDPOINT, buildUri(context, rootPath + "/userinfo"));
+        }
+        if (oidcMetadata.getRegistrationUri() != null) {
+            json.put("registration_endpoint", buildUri(context, rootPath + "/register"));
+        }
+        if (oidcMetadata.getIssuer() != null) {
+            json.put(OidcConfigurationMetadata.ISSUER, oidcMetadata.getIssuer());
+        }
+
+        addListProperty(json, RESPONSE_TYPES_SUPPORTED);
+        addListProperty(json, SUBJECT_TYPES_SUPPORTED);
+        addListProperty(json, SCOPES_SUPPORTED);
+        addListProperty(json, CODE_CHALLENGE_METHODS_SUPPORTED);
+        addListProperty(json, ID_TOKEN_SIGNING_ALGORITHMS_SUPPORTED);
+
+        endJsonResponse(context, json.toString());
+    }
+
+    private void authorize(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        MultiMap queryParams = context.queryParams();
+        StringBuilder location = new StringBuilder(oidcMetadata.getAuthorizationUri());
+        boolean first = true;
+
+        first = appendParam(location, first, OidcConstants.CODE_FLOW_RESPONSE_TYPE, OidcConstants.CODE_FLOW_CODE);
+
+        String clientId = queryParams.get(OidcConstants.CLIENT_ID);
+        if (clientId == null) {
+            badRequest(context);
+            return;
+        }
+        first = appendParam(location, first, OidcConstants.CLIENT_ID, OidcCommonUtils.urlEncode(clientId));
+
+        String scope = queryParams.get(OidcConstants.TOKEN_SCOPE);
+        if (scope != null) {
+            first = appendParam(location, first, OidcConstants.TOKEN_SCOPE, OidcCommonUtils.urlEncode(scope));
+        }
+
+        String redirectUri = queryParams.get(OidcConstants.CODE_FLOW_REDIRECT_URI);
+        if (redirectUri == null) {
+            badRequest(context);
+            return;
+        }
+        first = appendParam(
+                location, first, OidcConstants.CODE_FLOW_REDIRECT_URI, OidcCommonUtils.urlEncode(redirectUri));
+
+        String state = queryParams.get(OidcConstants.CODE_FLOW_STATE);
+        if (state != null) {
+            first = appendParam(location, first, OidcConstants.CODE_FLOW_STATE, state);
+        }
+
+        String codeChallenge = queryParams.get("code_challenge");
+        if (codeChallenge != null) {
+            first = appendParam(location, first, "code_challenge", codeChallenge);
+            String codeChallengeMethod = queryParams.get("code_challenge_method");
+            if (codeChallengeMethod != null) {
+                appendParam(location, first, "code_challenge_method", codeChallengeMethod);
+            }
+        }
+
+        context.response().setStatusCode(HttpResponseStatus.FOUND.code());
+        context.response().putHeader(HttpHeaders.LOCATION, location.toString());
+        context.response().end();
+    }
+
+    private void token(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        OidcUtils.getFormUrlEncodedData(context)
+                .onItem()
+                .transformToUni(requestParams -> {
+                    var request = client.postAbs(oidcMetadata.getTokenUri());
+                    request.putHeader(
+                            String.valueOf(HttpHeaders.CONTENT_TYPE),
+                            String.valueOf(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED));
+                    request.putHeader(String.valueOf(HttpHeaders.ACCEPT), "application/json");
+
+                    Buffer buffer = Buffer.buffer();
+
+                    for (String key : requestParams.names()) {
+                        for (String value : requestParams.getAll(key)) {
+                            encodeForm(buffer, key, value);
+                        }
+                    }
+
+                    String authHeader = context.request().getHeader(HttpHeaderNames.AUTHORIZATION);
+                    if (authHeader != null) {
+                        request.putHeader(String.valueOf(HttpHeaders.AUTHORIZATION), authHeader);
+                    }
+
+                    return request.sendBuffer(buffer).onItem().transformToUni(response -> {
+                        endJsonResponse(context, response.bodyAsString());
+                        return io.smallrye.mutiny.Uni.createFrom().voidItem();
+                    });
+                })
+                .subscribe()
+                .with(v -> {}, err -> {
+                    LOG.errorf(err, "Token exchange failed");
+                    context.response().setStatusCode(502).end();
+                });
+    }
+
+    private void jwks(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        client.getAbs(oidcMetadata.getJsonWebKeySetUri())
+                .putHeader(String.valueOf(HttpHeaders.ACCEPT), "application/json")
+                .send()
+                .subscribe()
+                .with(response -> endJsonResponse(context, response.bodyAsString()));
+    }
+
+    private void userinfo(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        String authHeader = context.request().getHeader(HttpHeaderNames.AUTHORIZATION);
+        if (authHeader == null) {
+            badRequest(context);
+            return;
+        }
+
+        client.getAbs(oidcMetadata.getUserInfoUri())
+                .putHeader(String.valueOf(HttpHeaderNames.AUTHORIZATION), authHeader)
+                .putHeader(String.valueOf(HttpHeaders.ACCEPT), "application/json")
+                .send()
+                .subscribe()
+                .with(response -> endJsonResponse(context, response.bodyAsString()));
+    }
+
+    private void endSession(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        if (oidcMetadata.getEndSessionUri() == null) {
+            context.response().setStatusCode(404).end();
+            return;
+        }
+
+        StringBuilder location = new StringBuilder(oidcMetadata.getEndSessionUri());
+        boolean first = true;
+        for (var entry : context.queryParams()) {
+            first = appendParam(location, first, entry.getKey(), entry.getValue());
+        }
+
+        context.response().setStatusCode(HttpResponseStatus.FOUND.code());
+        context.response().putHeader(HttpHeaders.LOCATION, location.toString());
+        context.response().end();
+    }
+
+    private void clientRegistration(RoutingContext context) {
+        if (!ensureAvailable(context)) {
+            return;
+        }
+
+        if (oidcMetadata.getRegistrationUri() == null) {
+            context.response().setStatusCode(404).end();
+            return;
+        }
+
+        context.request().bodyHandler(body -> {
+            var request = client.postAbs(oidcMetadata.getRegistrationUri());
+            String authHeader = context.request().getHeader(HttpHeaderNames.AUTHORIZATION);
+            if (authHeader != null) {
+                request.putHeader(String.valueOf(HttpHeaderNames.AUTHORIZATION), authHeader);
+            }
+            request.putHeader(String.valueOf(HttpHeaders.CONTENT_TYPE), "application/json");
+            request.putHeader(String.valueOf(HttpHeaders.ACCEPT), "application/json");
+
+            request.sendJson(body.toJsonObject())
+                    .subscribe()
+                    .with(response -> endJsonResponse(context, response.bodyAsString()));
+        });
+        context.request().resume();
+    }
+
+    private boolean ensureAvailable(RoutingContext context) {
+        if (!initialized) {
+            tryInitialize();
+        }
+        if (!initialized) {
+            context.response().setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code());
+            context.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            context.end("{\"error\":\"oidc_provider_unavailable\","
+                    + "\"error_description\":\"OIDC proxy is not available because the identity provider"
+                    + " was unreachable at startup\"}");
+            return false;
+        }
+        return true;
+    }
+
+    private void addListProperty(JsonObject json, String propertyName) {
+        List<String> values = oidcMetadata.getStringList(propertyName);
+        if (values != null) {
+            json.put(propertyName, values);
+        }
+    }
+
+    private String buildUri(RoutingContext context, String path) {
+        String authority = URI.create(context.request().absoluteURI()).getAuthority();
+        String scheme = context.request().scheme();
+        return scheme + "://" + authority + path;
+    }
+
+    private static boolean appendParam(StringBuilder sb, boolean first, String name, String value) {
+        sb.append(first ? '?' : '&').append(name).append('=').append(value);
+        return false;
+    }
+
+    private static void encodeForm(Buffer buffer, String name, String value) {
+        if (buffer.length() != 0) {
+            buffer.appendByte((byte) '&');
+        }
+        buffer.appendString(name);
+        buffer.appendByte((byte) '=');
+        buffer.appendString(OidcCommonUtils.urlEncode(value));
+    }
+
+    private static void endJsonResponse(RoutingContext context, String jsonResponse) {
+        context.response().setStatusCode(HttpResponseStatus.OK.code());
+        context.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        context.end(jsonResponse);
+    }
+
+    private static void badRequest(RoutingContext context) {
+        context.response().setStatusCode(400).end();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -111,10 +111,8 @@ quarkus.oidc.mcp.connection-delay=60S
 # dynamically by NamespaceTenantConfigResolver to avoid sequential startup
 # discovery delays and OidcProxy NPE when the OIDC server is slow.
 
-quarkus.oidc-proxy.enabled=true
-quarkus.oidc-proxy.root-path=/q/oidc
-# Make sure to use the configurations for the MCP tenant instead of the default ones
-quarkus.oidc-proxy.tenant-id=mcp
+wanaku.oidc-proxy.root-path=/q/oidc
+wanaku.oidc-proxy.tenant-id=mcp
 
 # Paths used by the OIDC Proxy, which need to be public
 quarkus.http.auth.permission.oidcproxy.paths=/.well-known/oauth-protected-resource/*, /.well-known/oauth-authorization-server/*, /q/oidc/*

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceIT.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthAuthorizationServerWellKnownResourceIT.java
@@ -36,9 +36,9 @@ class OAuthAuthorizationServerWellKnownResourceIT {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "quarkus.oidc-proxy.enabled", "false",
+                    "wanaku.oidc-proxy.enabled", "false",
                     "quarkus.oidc.enabled", "false",
-                    "quarkus.oidc-proxy.root-path", "/test-oidc");
+                    "wanaku.oidc-proxy.root-path", "/test-oidc");
         }
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResourceIT.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OAuthProtectedResourceWellKnownResourceIT.java
@@ -58,9 +58,9 @@ class OAuthProtectedResourceWellKnownResourceIT {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                     "wanaku.http.auth", "none",
-                    "quarkus.oidc-proxy.enabled", "false",
+                    "wanaku.oidc-proxy.enabled", "false",
                     "quarkus.oidc.enabled", "false",
-                    "quarkus.oidc-proxy.root-path", "/q/oidc");
+                    "wanaku.oidc-proxy.root-path", "/q/oidc");
         }
     }
 }

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OidcDegradedStartupTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/oidc/OidcDegradedStartupTest.java
@@ -1,0 +1,33 @@
+package ai.wanaku.backend.api.v1.oidc;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import ai.wanaku.backend.support.DegradedOidcTestProfile;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(DegradedOidcTestProfile.class)
+class OidcDegradedStartupTest {
+
+    @Test
+    void metadataEndpointReturns503WhenOidcProviderUnavailable() {
+        given().when().get("/q/oidc/.well-known/openid-configuration").then().statusCode(503);
+    }
+
+    @Test
+    void tokenEndpointReturns503WhenOidcProviderUnavailable() {
+        given().contentType("application/x-www-form-urlencoded")
+                .when()
+                .post("/q/oidc/token")
+                .then()
+                .statusCode(503);
+    }
+
+    @Test
+    void authorizationEndpointReturns503WhenOidcProviderUnavailable() {
+        given().when().get("/q/oidc/authorize").then().statusCode(503);
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/AuthConfigSourceTest.java
@@ -63,7 +63,7 @@ class AuthConfigSourceTest {
         Map<String, String> props = configSource.getProperties();
         assertNotNull(props);
         assertEquals("false", props.get("quarkus.oidc.enabled"));
-        assertEquals("false", props.get("quarkus.oidc-proxy.enabled"));
+        assertEquals("false", props.get("wanaku.oidc-proxy.enabled"));
         assertEquals("false", props.get("quarkus.oidc.discovery-enabled"));
         assertEquals("false", props.get("quarkus.oidc.resource-metadata.enabled"));
         assertEquals("false", props.get("quarkus.oidc.mcp.enabled"));
@@ -83,7 +83,7 @@ class AuthConfigSourceTest {
     void getValue_returnsNoAuthValue_whenAuthSetToNone() {
         System.setProperty(AUTH_PROPERTY, "none");
         assertEquals("false", configSource.getValue("quarkus.oidc.enabled"));
-        assertEquals("false", configSource.getValue("quarkus.oidc-proxy.enabled"));
+        assertEquals("false", configSource.getValue("wanaku.oidc-proxy.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.discovery-enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.resource-metadata.enabled"));
         assertEquals("false", configSource.getValue("quarkus.oidc.mcp.enabled"));

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/DegradedOidcTestProfile.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/DegradedOidcTestProfile.java
@@ -1,0 +1,19 @@
+package ai.wanaku.backend.support;
+
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DegradedOidcTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "wanaku.http.auth", "keycloak",
+                "quarkus.oidc.enabled", "true",
+                "quarkus.oidc.auth-server-url", "http://localhost:1/realms/nonexistent",
+                "quarkus.oidc.mcp.auth-server-url", "http://localhost:1/realms/nonexistent",
+                "auth.server", "http://localhost:1",
+                "quarkus.oidc.connection-delay", "1S",
+                "quarkus.oidc.mcp.connection-delay", "1S");
+    }
+}

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NoOidcTestProfile.java
@@ -10,6 +10,6 @@ public class NoOidcTestProfile implements QuarkusTestProfile {
         return Map.of(
                 "wanaku.http.auth", "none",
                 "quarkus.oidc.enabled", "false",
-                "quarkus.oidc-proxy.enabled", "false");
+                "wanaku.oidc-proxy.enabled", "false");
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,7 +49,6 @@
         <jackson.version>2.21.2</jackson.version>
         <junit-jupiter.version>6.1.0</junit-jupiter.version>
         <quarkus-mcp-server.version>1.13.1</quarkus-mcp-server.version>
-        <quarkus-oidc-proxy.version>0.5.0</quarkus-oidc-proxy.version>
         <camel.version>4.18.1</camel.version>
         <picocli.version>4.7.7</picocli.version>
         <langchain4j.version>1.16.3</langchain4j.version>


### PR DESCRIPTION
## Summary

- Removed the `quarkus-oidc-proxy` extension which crashes with NPE when the OIDC provider (Keycloak) is unavailable at startup
- Replaced it with `WanakuOidcProxy`, a CDI-managed bean that lazily initializes the OIDC provider connection
- When the provider is unavailable, the proxy returns HTTP 503 with a clear error message instead of crashing
- Migrated all `quarkus.oidc-proxy.*` config properties to `wanaku.oidc-proxy.*` namespace

## Test plan

- [x] `OidcDegradedStartupTest` verifies the router starts without NPE when the OIDC provider is unreachable
- [x] Metadata, token, and authorization endpoints return 503 in degraded mode
- [x] All existing tests pass (383 unit + 69 integration, 0 failures)
- [ ] Manual verification with Keycloak available — OIDC proxy routes function normally
- [ ] Manual verification with Keycloak down — router starts, health check reports "not ready", proxy returns 503

## Summary by Sourcery

Replace the quarkus-oidc-proxy extension with an application-scoped WanakuOidcProxy that lazily proxies OIDC endpoints and degrades gracefully when the provider is unavailable.

New Features:
- Introduce WanakuOidcProxy CDI bean to expose OIDC metadata, token, authorization, and related endpoints via Vert.x routes.

Bug Fixes:
- Prevent startup NPEs when the OIDC provider is unreachable by lazily initializing the OIDC proxy and returning HTTP 503 in degraded mode.

Enhancements:
- Migrate configuration from quarkus.oidc-proxy.* to wanaku.oidc-proxy.* across application, tests, and tooling.
- Simplify parent and backend POMs by removing the quarkus-oidc-proxy dependency and its version property.

Tests:
- Add DegradedOidcTestProfile and OidcDegradedStartupTest to verify the router starts and OIDC endpoints return 503 when the provider is unavailable.
- Update existing tests and CI/e2e configurations to use the new wanaku.oidc-proxy.* configuration namespace.