### PR TITLE
1506 React rules-of-hooks violation in ImportToolsetTable.tsx

### DIFF
--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetModal.tsx
@@ -9,7 +9,7 @@ import {
   TextArea,
   TextInput
 } from "@carbon/react"
-import React, {useRef, useState} from "react"
+import React, {useState} from "react"
 import {ToolReference} from "../../models"
 import {ToolParserError, Tools} from "./tools"
 import {ImportToolsetTable} from "./ImportToolsetTable"
@@ -37,11 +37,11 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
   const [contentSwitcherEnabled, setContentSwitcherEnabled] = useState(true)
   const [viewMode, setViewMode] = useState(VIEW_MODE_TABLE)
   const [fetchError, setFetchError] = useState<string | null>(null)
-  const selectedTools = useRef<ToolReference[]>([])
+  const [selectedTools, setSelectedTools] = useState<ToolReference[]>([])
 
   
-  function setSelectedTools(tools: ToolReference[]) {
-    selectedTools.current = tools
+  function selectTools(tools: ToolReference[]) {
+    setSelectedTools(tools)
     setToolsetJson(tools.length > 0 ? Tools.stringify(tools) : undefined)
   }
   
@@ -71,7 +71,7 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
     if (response.ok) {
       const tools = await response.json()
       setToolset(tools)
-      setSelectedTools(tools)
+      selectTools(tools)
     } else {
       throw new Error(`Error fetching toolset from ${toolsetUrl}: ${response.status}`)
     }
@@ -174,9 +174,9 @@ export const ImportToolsetModal: React.FC<ImportToolsetModalProps> = ({ onSubmit
             {viewMode === VIEW_MODE_TABLE && (
               <ImportToolsetTable
                 tools={toolset}
-                selectedTools={selectedTools.current}
+                selectedTools={selectedTools}
                 onSelectionChange={(tools: ToolReference[]) => {
-                  setSelectedTools(tools)
+                  selectTools(tools)
                 }}
               />
             )}

--- a/apps/ui/admin/src/Pages/Tools/ImportToolsetTable.tsx
+++ b/apps/ui/admin/src/Pages/Tools/ImportToolsetTable.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react"
+import React from "react"
 import {ToolReference} from "../../models"
 import {
   DataTable,
@@ -21,8 +21,16 @@ interface ImportToolsetTableProps {
 
 export const ImportToolsetTable: React.FC<ImportToolsetTableProps> = ({ tools, selectedTools, onSelectionChange }) => {
   
-  function findTool(rowId: string) {
-    return tools.find(item => item.name === rowId)
+  function addTool(tool: ToolReference): void {
+    if (!selectedTools.includes(tool)) {
+      onSelectionChange([...selectedTools, tool])
+    }
+  }
+  
+  function removeTool(tool: ToolReference): void {
+    if (selectedTools.includes(tool)) {
+      onSelectionChange(selectedTools.filter(item => item !== tool))
+    }
   }
   
   return (
@@ -41,22 +49,29 @@ export const ImportToolsetTable: React.FC<ImportToolsetTableProps> = ({ tools, s
       headers,
       rows,
       selectedRows,
+      selectAll,
       getTableProps,
       getHeaderProps,
       getRowProps,
       getSelectionProps
     }) => {
-      
-      // synchronize row selection with parent component
-      useEffect(() => {
-        onSelectionChange(selectedRows.map(row => findTool(row.id)!))
-      }, [selectedRows])
-      
+
       return (
         <Table {...getTableProps()}>
           <TableHead>
             <TableRow>
-              <TableSelectAll {...getSelectionProps()} />
+              <TableSelectAll {...getSelectionProps()}
+                onSelect={() => {
+                  const isChecked = selectedRows.length === rows.length
+                  const isIndeterminate = selectedRows.length > 0 && selectedRows.length < rows.length
+                  if (isChecked || isIndeterminate) {
+                    onSelectionChange([])
+                  } else {
+                    onSelectionChange(tools)
+                  }
+                  selectAll()
+                }}
+              />
               {headers.map((header) => (
                 <TableHeader {...getHeaderProps({header})}>
                   {header.header}
@@ -69,7 +84,15 @@ export const ImportToolsetTable: React.FC<ImportToolsetTableProps> = ({ tools, s
               const tool = tools.find(item => item.name === row.id)!
               return (
                 <TableRow {...getRowProps({ row })} key={tool.name}>
-                  <TableSelectRow {...getSelectionProps({ row })} />
+                  <TableSelectRow {...getSelectionProps({ row })}
+                    onChange={value => {
+                      if (value) {
+                        addTool(tool)
+                      } else {
+                        removeTool(tool)
+                      }
+                    }}
+                  />
                   <TableCell>{tool.name}</TableCell>
                   <TableCell>{tool.description}</TableCell>
                 </TableRow>


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1506

A backport of https://github.com/wanaku-ai/wanaku/pull/1574

## Summary by Sourcery

Align tool selection state handling between ImportToolsetTable and ImportToolsetModal to resolve React hooks usage issues and ensure consistent selection synchronization.

Bug Fixes:
- Fix tool selection synchronization by replacing useEffect-based updates with explicit add/remove and select-all callbacks tied to parent state.

Enhancements:
- Refactor ImportToolsetModal to store selected tools in React state instead of refs for clearer and more predictable UI state management.
- Update table row and header selection handlers to directly drive the selected tools list and JSON representation.