### PR TITLE
refactor(AuthCredentialStore): move default credentials file path to a dedicated method

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -23,7 +23,6 @@ public class AuthCredentialStore {
 
     private static final Logger LOG = Logger.getLogger(AuthCredentialStore.class);
 
-    private static final String DEFAULT_CREDENTIALS_FILE = WanakuHome.get() + File.separator + "credentials";
     private static final String API_TOKEN_KEY = "api.token";
     private static final String REFRESH_TOKEN_KEY = "refresh.token";
     private static final String AUTH_MODE_KEY = "auth.mode";
@@ -35,7 +34,11 @@ public class AuthCredentialStore {
     private final URI credentialsUri;
 
     public AuthCredentialStore() {
-        this(resolveCredentialsPath(DEFAULT_CREDENTIALS_FILE));
+        this(resolveCredentialsPath(getDefaultCredentialsFile()));
+    }
+
+    private static String getDefaultCredentialsFile() {
+        return WanakuHome.get() + File.separator + "credentials";
     }
 
     public AuthCredentialStore(String credentialsPath) {


### PR DESCRIPTION
Closes: #1592

## Summary by Sourcery

Enhancements:
- Introduce a getDefaultCredentialsFile() helper to encapsulate construction of the default credentials file path used by AuthCredentialStore.