### PR TITLE
chore: pass current branch to early-access workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ load-test: test-resources test-tools
 	$(WANAKU_CLI_CMD) targets tools list
 
 early-builds:
-	gh workflow run early-access -f currentDevelopmentVersion=$$(cat core/core-util/target/classes/version.txt)
+	gh workflow run early-access --ref $$(git rev-parse --abbrev-ref HEAD) -f currentDevelopmentVersion=$$(cat core/core-util/target/classes/version.txt)


### PR DESCRIPTION
## Summary
- The `early-builds` Makefile target now passes `--ref` with the current branch to `gh workflow run`, so the workflow runs on the correct branch instead of defaulting to the repo's default branch.

## Summary by Sourcery

Build:
- Update the early-builds Makefile target to invoke the GitHub early-access workflow with the current branch as the ref instead of relying on the default branch.