### PR TITLE
Fix #1607: return HTTP 404 instead of 500 for non-existent forward refresh

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -29,6 +29,7 @@ import ai.wanaku.backend.core.mcp.util.LabelExpressionParser;
 import ai.wanaku.backend.core.persistence.api.ForwardReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.WanakuRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
@@ -332,7 +333,8 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
     public void refresh(ForwardReference forwardReferenceHint) {
         List<ForwardReference> references = forwardReferenceRepository.findByName(forwardReferenceHint.getName());
         if (references.isEmpty()) {
-            throw new WanakuException("Forward reference not found: %s".formatted(forwardReferenceHint.getName()));
+            throw new ResourceNotFoundException(
+                    "Forward reference not found: %s".formatted(forwardReferenceHint.getName()));
         }
 
         ForwardReference forwardReference = references.getFirst();


### PR DESCRIPTION
## Summary

- Change `ForwardsBean.refresh()` to throw `ResourceNotFoundException` instead of `WanakuException` when a forward reference is not found
- The API now returns HTTP 404 instead of HTTP 500

## Test plan

- [x] Existing tests pass

## Summary by Sourcery

Bug Fixes:
- Map missing forward refresh operations to ResourceNotFoundException so the API responds with HTTP 404 instead of HTTP 500.