### PR TITLE
Fix #1605: fix spurious null error in namespaces create without --name

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.stream.Collectors.toMap;
 import static org.jline.console.Printer.TableRows.EVEN;
 
 /**
@@ -309,9 +308,13 @@ public class WanakuPrinter extends DefaultPrinter {
         Map<String, Object> map = convertToMap(object);
         if (keys != null && keys.length > 0) {
             Set<String> keySet = Set.of(keys);
-            map = map.entrySet().stream()
-                    .filter(entry -> keySet.contains(entry.getKey()))
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, Object> filtered = new HashMap<>();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                if (keySet.contains(entry.getKey())) {
+                    filtered.put(entry.getKey(), entry.getValue());
+                }
+            }
+            map = filtered;
         }
 
         try {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
@@ -80,4 +80,25 @@ public class NamespacesCreateTest {
         Namespace submitted = captor.getValue();
         assertNull(submitted.getName());
     }
+
+    @Test
+    @DisplayName("Should create pre-allocated namespace when name is omitted")
+    void shouldCreatePreallocatedNamespaceWhenNameOmitted() throws Exception {
+        Namespace created = new Namespace();
+        created.setId("ns-3");
+        created.setPath("ns-no-name");
+
+        when(namespacesService.create(any(Namespace.class))).thenReturn(new WanakuResponse<>(created));
+
+        command.path = "ns-no-name";
+        command.name = null;
+
+        Integer result = command.doCall(null, mock(WanakuPrinter.class));
+
+        assertEquals(0, result);
+        ArgumentCaptor<Namespace> captor = ArgumentCaptor.forClass(Namespace.class);
+        verify(namespacesService).create(captor.capture());
+        Namespace submitted = captor.getValue();
+        assertNull(submitted.getName());
+    }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -121,12 +122,15 @@ class WanakuPrinterPlainModeTest {
         data.put("name", null);
         data.put("path", "my-path");
 
-        printer.printAsMap(data, "id", "name", "path");
+        assertDoesNotThrow(
+                () -> printer.printAsMap(data, "id", "name", "path"),
+                "printAsMap must not throw when map values are null");
 
         String output = outputStream.toString();
         assertFalse(output.isBlank(), "Map output with null values must not be blank");
         assertTrue(output.contains("ns-123"), "Output must contain non-null value 'ns-123'");
         assertTrue(output.contains("my-path"), "Output must contain non-null value 'my-path'");
+        assertFalse(output.contains("name\tnull"), "Null value must not be rendered as literal 'null'");
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.main.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
@@ -111,6 +112,21 @@ class WanakuPrinterPlainModeTest {
 
         String output = outputStream.toString();
         assertTrue(output.contains("Available service templates:"), "Info message must appear in plain-mode output");
+    }
+
+    @Test
+    void printAsMapHandlesNullValues() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", "ns-123");
+        data.put("name", null);
+        data.put("path", "my-path");
+
+        printer.printAsMap(data, "id", "name", "path");
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Map output with null values must not be blank");
+        assertTrue(output.contains("ns-123"), "Output must contain non-null value 'ns-123'");
+        assertTrue(output.contains("my-path"), "Output must contain non-null value 'my-path'");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` in `WanakuPrinter.printAsMap()` when map values contain null entries
- The key-filtering logic now handles null values gracefully instead of throwing

## Test plan

- [x] New `WanakuPrinterPlainModeTest` covering null value scenarios
- [x] New `NamespacesCreateTest` verifying the create-without-name flow

## Summary by Sourcery

Handle null values safely in CLI map printing and ensure namespace creation works when name is omitted.

Bug Fixes:
- Prevent NullPointerException in WanakuPrinter.printAsMap when maps contain null values.
- Ensure namespaces can be created without specifying a name in the CLI command.

Tests:
- Add WanakuPrinterPlainModeTest coverage for printing maps containing null values.
- Extend NamespacesCreateTest to cover create-without-name flow.