### PR TITLE
[backport 0.2.x] Fix #1609: replace raw Java exception class names with user-friendly MCP error messages

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -62,7 +63,7 @@ public class McpPrompt extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -35,7 +36,7 @@ public class McpPromptList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -53,7 +54,7 @@ public class McpResource extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -37,7 +38,7 @@ public class McpResourceList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.jline.terminal.Terminal;
 import io.vertx.core.json.JsonObject;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -61,7 +62,7 @@ public class McpTool extends BaseCommand {
             System.out.println(result.resultText());
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -36,7 +37,7 @@ public class McpToolList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
@@ -1,0 +1,114 @@
+package ai.wanaku.cli.main.support;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * Translates MCP client exceptions into user-friendly error messages.
+ *
+ * <p>MCP client operations often throw wrapped exceptions (e.g.,
+ * {@code ExecutionException} wrapping {@code ConnectException}) whose default
+ * messages expose raw Java class names. This helper unwraps the cause chain
+ * and produces concise, actionable messages consistent with the rest of
+ * the Wanaku CLI.</p>
+ */
+public final class McpErrorHelper {
+
+    private McpErrorHelper() {}
+
+    /**
+     * Produces a user-friendly error message for the given exception and
+     * MCP server URI.
+     *
+     * @param ex the exception thrown during MCP client operations
+     * @param uri the MCP server URI the command was targeting (may be null)
+     * @return a user-friendly error message
+     */
+    public static String friendlyMessage(Exception ex, String uri) {
+        Throwable root = rootCause(ex);
+
+        if (root instanceof ConnectException) {
+            return connectionRefusedMessage(uri);
+        }
+
+        if (root instanceof UnknownHostException) {
+            return unknownHostMessage(root);
+        }
+
+        if (root instanceof SocketTimeoutException) {
+            return timeoutMessage(uri);
+        }
+
+        if (root instanceof IllegalArgumentException) {
+            String msg = root.getMessage();
+            if (msg != null && (msg.contains("URI") || msg.contains("scheme") || msg.contains("url"))) {
+                return invalidUriMessage(uri);
+            }
+        }
+
+        // For any other exception, return the root cause message without class name prefixes
+        String message = root.getMessage();
+        if (message == null || message.isBlank()) {
+            message = ex.getMessage();
+        }
+        if (message == null || message.isBlank()) {
+            return "An unexpected error occurred. Run with --verbose for more details";
+        }
+        return message;
+    }
+
+    private static String connectionRefusedMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Connection refused");
+        if (uri != null) {
+            sb.append(": could not connect to ").append(uri);
+        }
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - MCP server is not running\n");
+        sb.append("  - Incorrect --uri value\n");
+        sb.append("  - Network connectivity issues");
+        return sb.toString();
+    }
+
+    private static String unknownHostMessage(Throwable root) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Unable to resolve host: ").append(root.getMessage());
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - Invalid hostname in --uri option\n");
+        sb.append("  - DNS resolution failure\n");
+        sb.append("  - Network connectivity issues");
+        return sb.toString();
+    }
+
+    private static String timeoutMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Request timed out");
+        if (uri != null) {
+            sb.append(" connecting to ").append(uri);
+        }
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - MCP server is not responding\n");
+        sb.append("  - Network latency issues\n");
+        sb.append("  - Firewall blocking the connection");
+        return sb.toString();
+    }
+
+    private static String invalidUriMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Invalid URI");
+        if (uri != null) {
+            sb.append(": '").append(uri).append("' is not a valid MCP server URI");
+        }
+        sb.append("\n\nExpected format: http://<host>:<port>/path or https://<host>:<port>/path");
+        return sb.toString();
+    }
+
+    private static Throwable rootCause(Throwable ex) {
+        Throwable current = ex;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -90,6 +91,25 @@ class McpToolListTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should show user-friendly message for wrapped ConnectException")
+    void shouldShowFriendlyMessageForConnectException() throws Exception {
+        java.net.ConnectException cause = new java.net.ConnectException("Connection refused");
+        RuntimeException ex = new RuntimeException("java.net.ConnectException: Connection refused", cause);
+        when(mcpClient.listTools()).thenThrow(ex);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(printer).printErrorMessage(captor.capture());
+        String message = captor.getValue();
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:3001/mcp"));
+        assertTrue(message.contains("MCP server is not running"));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -92,6 +93,24 @@ class McpToolTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should show user-friendly message for invalid URI")
+    void shouldShowFriendlyMessageForInvalidUri() throws Exception {
+        command.uri = "not-a-valid-uri";
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenThrow(new IllegalArgumentException("URI with undefined scheme"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(printer).printErrorMessage(captor.capture());
+        String message = captor.getValue();
+        assertTrue(message.contains("Invalid URI"));
+        assertTrue(message.contains("not-a-valid-uri"));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
@@ -1,0 +1,126 @@
+package ai.wanaku.cli.main.support;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpErrorHelperTest {
+
+    @Test
+    @DisplayName("Should produce friendly message for ConnectException")
+    void shouldHandleConnectException() {
+        Exception ex = new ConnectException("Connection refused");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:59999/mcp"));
+        assertTrue(message.contains("MCP server is not running"));
+        assertFalse(message.contains("java.net.ConnectException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for wrapped ConnectException")
+    void shouldHandleWrappedConnectException() {
+        ConnectException cause = new ConnectException("Connection refused");
+        Exception ex = new ExecutionException("java.net.ConnectException: Connection refused", cause);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:59999/mcp"));
+        assertTrue(message.contains("Possible causes"));
+        assertFalse(message.contains("ExecutionException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for IllegalArgumentException with URI issue")
+    void shouldHandleInvalidUri() {
+        Exception ex = new IllegalArgumentException("URI with undefined scheme");
+        String message = McpErrorHelper.friendlyMessage(ex, "not-a-valid-uri");
+
+        assertTrue(message.contains("Invalid URI"));
+        assertTrue(message.contains("not-a-valid-uri"));
+        assertTrue(message.contains("not a valid MCP server URI"));
+        assertFalse(message.contains("IllegalArgumentException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for UnknownHostException")
+    void shouldHandleUnknownHost() {
+        Exception ex = new UnknownHostException("nonexistent.host.example");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://nonexistent.host.example:8080/mcp");
+
+        assertTrue(message.contains("Unable to resolve host"));
+        assertTrue(message.contains("nonexistent.host.example"));
+        assertTrue(message.contains("DNS resolution failure"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for wrapped UnknownHostException")
+    void shouldHandleWrappedUnknownHost() {
+        UnknownHostException cause = new UnknownHostException("badhost.example");
+        Exception ex = new ExecutionException("lookup failed", cause);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://badhost.example:8080/mcp");
+
+        assertTrue(message.contains("Unable to resolve host"));
+        assertTrue(message.contains("badhost.example"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for SocketTimeoutException")
+    void shouldHandleTimeout() {
+        Exception ex = new SocketTimeoutException("Read timed out");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("Request timed out"));
+        assertTrue(message.contains("http://localhost:8080/mcp"));
+        assertTrue(message.contains("MCP server is not responding"));
+    }
+
+    @Test
+    @DisplayName("Should pass through plain message for unrecognized exceptions")
+    void shouldPassThroughGenericException() {
+        Exception ex = new RuntimeException("something went wrong");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("something went wrong"));
+    }
+
+    @Test
+    @DisplayName("Should handle exception with null message")
+    void shouldHandleNullMessage() {
+        Exception ex = new RuntimeException((String) null);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("unexpected error"));
+    }
+
+    @Test
+    @DisplayName("Should handle ConnectException with null URI")
+    void shouldHandleConnectExceptionWithNullUri() {
+        Exception ex = new ConnectException("Connection refused");
+        String message = McpErrorHelper.friendlyMessage(ex, null);
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("MCP server is not running"));
+    }
+
+    @Test
+    @DisplayName("Should handle deeply wrapped ConnectException")
+    void shouldHandleDeeplyWrappedConnectException() {
+        ConnectException root = new ConnectException("Connection refused");
+        Exception mid = new ExecutionException("inner", root);
+        Exception outer = new RuntimeException("outer", mid);
+        String message = McpErrorHelper.friendlyMessage(outer, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("Possible causes"));
+        assertFalse(message.contains("ExecutionException"));
+        assertFalse(message.contains("RuntimeException"));
+    }
+}


### PR DESCRIPTION
## Backport of #1612

Cherry-pick of #1612 onto `0.2.x`.

**Original PR:** #1612 - Fix #1609: replace raw Java exception class names with user-friendly MCP error messages
**Original author:** @orpiske
**Target branch:** `0.2.x`

### Original description

- Add `McpErrorHelper` utility that walks exception cause chains and maps `ConnectException`, `UnknownHostException`, `SocketTimeoutException`, and URI-related exceptions to actionable messages with troubleshooting hints
- Update all 6 MCP CLI commands (`McpTool`, `McpToolList`, `McpResource`, `McpResourceList`, `McpPrompt`, `McpPromptList`) to use `McpErrorHelper.friendlyMessage()` instead of raw `e.getMessage()`
- Add 12 new tests covering direct exceptions, wrapped exception chains, null URIs, and deeply nested causes

## Summary by Sourcery

Improve MCP CLI error reporting by translating low-level Java exceptions into user-friendly messages.

Bug Fixes:
- Replace raw Java exception messages from MCP client failures with clearer, actionable error messages for connection, DNS, timeout, and URI issues.

Enhancements:
- Introduce McpErrorHelper to normalize and simplify MCP-related error messages across all MCP CLI commands.

Tests:
- Add unit tests for McpErrorHelper covering various network and URI error scenarios and deeply wrapped causes.
- Extend MCP tool and tool-list command tests to verify user-friendly error messages are displayed for wrapped connection and invalid URI errors.