### PR TITLE
[backport 0.2.x] Fix #1606: return HTTP 404 instead of 500 for non-existent toolset repo

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -149,7 +150,7 @@ public class ToolsetReposBean {
             throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         if (url != null && !url.isBlank()) {
@@ -206,7 +207,7 @@ public class ToolsetReposBean {
     public Map<String, Object> browse(String name) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         String url = resolveBaseUrl(ds);
@@ -242,7 +243,7 @@ public class ToolsetReposBean {
     public List<ToolReference> fetchToolset(String name, String toolsetName) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         validateToolsetName(toolsetName);


### PR DESCRIPTION
## Backport of #1615

Cherry-pick of #1615 onto `0.2.x`.

**Original PR:** #1615 - Fix #1606: return HTTP 404 instead of 500 for non-existent toolset repo
**Original author:** @orpiske
**Target branch:** `0.2.x`

### Original description

- Change `ToolsetReposBean` to throw `ResourceNotFoundException` instead of `WanakuException` when a repository is not found
- The API now returns HTTP 404 instead of HTTP 500

## Summary by Sourcery

Bug Fixes:
- Ensure operations on non-existent toolset repositories throw a ResourceNotFoundException so the API responds with HTTP 404 instead of HTTP 500.