### PR TITLE
Fix #1606: return HTTP 404 instead of 500 for non-existent toolset repo

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -149,7 +150,7 @@ public class ToolsetReposBean {
             throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         if (url != null && !url.isBlank()) {
@@ -206,7 +207,7 @@ public class ToolsetReposBean {
     public Map<String, Object> browse(String name) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         String url = resolveBaseUrl(ds);
@@ -242,7 +243,7 @@ public class ToolsetReposBean {
     public List<ToolReference> fetchToolset(String name, String toolsetName) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         validateToolsetName(toolsetName);

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposResourceTest.java
@@ -1,0 +1,37 @@
+package ai.wanaku.backend.api.v1.toolsetrepos;
+
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ToolsetReposResourceTest {
+
+    @Mock
+    ToolsetReposBean toolsetReposBean;
+
+    @InjectMocks
+    ToolsetReposResource resource;
+
+    @Test
+    void browseNonExistentRepoThrowsResourceNotFound() {
+        when(toolsetReposBean.browse("non-existent-repo"))
+                .thenThrow(new ResourceNotFoundException("Toolset repository not found: non-existent-repo"));
+
+        assertThrows(ResourceNotFoundException.class, () -> resource.browse("non-existent-repo"));
+    }
+
+    @Test
+    void fetchToolsetFromNonExistentRepoThrowsResourceNotFound() {
+        when(toolsetReposBean.fetchToolset("non-existent-repo", "some-toolset"))
+                .thenThrow(new ResourceNotFoundException("Toolset repository not found: non-existent-repo"));
+
+        assertThrows(ResourceNotFoundException.class, () -> resource.fetchToolset("non-existent-repo", "some-toolset"));
+    }
+}


### PR DESCRIPTION
Fixes #1606

Change `ToolsetReposBean` to throw `ResourceNotFoundException` instead of `WanakuException` when a toolset repository is not found in `browse()`, `fetchToolset()`, and `update()` methods. The `ResourceNotFoundException` is mapped to HTTP 404 by the existing `ResourceNotFoundExceptionMapper`.

Integration test failure is pre-existing and unrelated (HttpToolCliITCase.shouldRegisterHttpToolViaCli fails on main as well).

## Summary by Sourcery

Return HTTP 404 for operations on non-existent toolset repositories instead of a generic server error.

Bug Fixes:
- Map missing toolset repositories to ResourceNotFoundException so they are exposed as HTTP 404 responses.

Tests:
- Add unit tests ensuring ToolsetReposResource propagates ResourceNotFoundException for browse and fetchToolset on non-existent repositories.