### PR TITLE
Fix #1606: return HTTP 404 instead of 500 for non-existent toolset repos

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -149,7 +150,7 @@ public class ToolsetReposBean {
             throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         if (url != null && !url.isBlank()) {
@@ -206,7 +207,7 @@ public class ToolsetReposBean {
     public Map<String, Object> browse(String name) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         String url = resolveBaseUrl(ds);
@@ -242,7 +243,7 @@ public class ToolsetReposBean {
     public List<ToolReference> fetchToolset(String name, String toolsetName) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         validateToolsetName(toolsetName);

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanNotFoundTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanNotFoundTest.java
@@ -1,0 +1,61 @@
+package ai.wanaku.backend.api.v1.toolsetrepos;
+
+import java.util.Collections;
+import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ToolsetReposBean} returns HTTP-404-friendly exceptions
+ * when a toolset repository is not found, rather than a generic
+ * {@link ai.wanaku.capabilities.sdk.api.exceptions.WanakuException} (which maps to HTTP 500).
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolsetReposBeanNotFoundTest {
+
+    @Mock
+    DataStoreRepository dataStoreRepository;
+
+    private ToolsetReposBean bean;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        bean = new ToolsetReposBean();
+
+        // Inject the mock DataStoreRepository into the private field
+        var field = ToolsetReposBean.class.getDeclaredField("dataStoreRepository");
+        field.setAccessible(true);
+        field.set(bean, dataStoreRepository);
+    }
+
+    @Test
+    void browseNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(ResourceNotFoundException.class, () -> bean.browse("non-existent-repo"));
+    }
+
+    @Test
+    void updateNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> bean.update("non-existent-repo", "https://example.com", "desc", null, null));
+    }
+
+    @Test
+    void fetchToolsetFromNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(ResourceNotFoundException.class, () -> bean.fetchToolset("non-existent-repo", "my-toolset"));
+    }
+}


### PR DESCRIPTION
Fixes #1606

## Summary

When browsing, updating, or fetching a toolset from a non-existent toolset repository, the API was returning HTTP 500 (Internal Server Error) instead of HTTP 404 (Not Found). The root cause was that `ToolsetReposBean` threw `WanakuException` (which maps to HTTP 500) instead of `ResourceNotFoundException` (which maps to HTTP 404).

## Changes

- Changed `ToolsetReposBean.browse()`, `update()`, and `fetchToolset()` to throw `ResourceNotFoundException` instead of `WanakuException` when a repository is not found by name
- Added `ToolsetReposBeanNotFoundTest` unit test to verify all three methods throw `ResourceNotFoundException` for non-existent repositories

## Test plan

- [x] New unit tests pass (`ToolsetReposBeanNotFoundTest`)
- [x] Existing unit tests pass (`ToolsetReposBeanSsrfTest`)
- [x] Full `mvn verify` passes

## Summary by Sourcery

Return HTTP 404 instead of 500 when a toolset repository does not exist, and add tests to verify the behavior.

Bug Fixes:
- Map missing toolset repositories to ResourceNotFoundException so the API returns HTTP 404 instead of 500.

Tests:
- Add ToolsetReposBeanNotFoundTest to verify browse, update, and fetchToolset throw ResourceNotFoundException for non-existent repositories.