### PR TITLE
Fix #1605: handle null values in WanakuPrinter.printAsMap

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.stream.Collectors.toMap;
 import static org.jline.console.Printer.TableRows.EVEN;
 
 /**
@@ -309,9 +308,13 @@ public class WanakuPrinter extends DefaultPrinter {
         Map<String, Object> map = convertToMap(object);
         if (keys != null && keys.length > 0) {
             Set<String> keySet = Set.of(keys);
-            map = map.entrySet().stream()
-                    .filter(entry -> keySet.contains(entry.getKey()))
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, Object> filtered = new HashMap<>();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                if (keySet.contains(entry.getKey())) {
+                    filtered.put(entry.getKey(), entry.getValue());
+                }
+            }
+            map = filtered;
         }
 
         try {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -122,6 +122,9 @@ class WanakuPrinterPlainModeTest {
         String output = outputStream.toString();
         assertTrue(output.contains("ns-uuid-123"), "Output must contain non-null value 'ns-uuid-123'");
         assertTrue(output.contains("cleanup-target"), "Output must contain non-null value 'cleanup-target'");
+        // Null values are rendered as empty strings (Objects.toString(value, ""))
+        // so "name" key should appear followed by a tab but no "null" literal
+        assertFalse(output.contains("name\tnull"), "Null value must not be rendered as literal 'null'");
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.main.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -103,6 +105,23 @@ class WanakuPrinterPlainModeTest {
         assertFalse(output.isBlank(), "Plain-mode map output must not be blank");
         assertTrue(output.contains("my-capability"), "Output must contain value 'my-capability'");
         assertTrue(output.contains("localhost"), "Output must contain value 'localhost'");
+    }
+
+    @Test
+    void printAsMapHandlesNullValues() {
+        // Simulates a Namespace with null name (pre-allocated, no --name flag)
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", "ns-uuid-123");
+        data.put("name", null);
+        data.put("path", "cleanup-target");
+
+        assertDoesNotThrow(
+                () -> printer.printAsMap(data, "id", "name", "path"),
+                "printAsMap must not throw when map values are null");
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("ns-uuid-123"), "Output must contain non-null value 'ns-uuid-123'");
+        assertTrue(output.contains("cleanup-target"), "Output must contain non-null value 'cleanup-target'");
     }
 
     @Test


### PR DESCRIPTION
Fixes #1605

## Summary

`WanakuPrinter.printAsMap` used `Collectors.toMap()` to filter map entries by key, but that collector throws `NullPointerException` when any value is `null`. When creating a pre-allocated namespace without the `--name` flag, the `name` field is `null`, causing the NPE to propagate to the exception handler which prints "An error occurred: null" and exits with code 1 -- even though the namespace was created successfully server-side.

## Changes

- Replace the stream-based `Collectors.toMap()` with a plain `HashMap` loop that accepts null values
- Remove the now-unused `Collectors.toMap` static import
- Add a test case for `printAsMap` with null values

## Test plan

- [x] Unit tests pass (`WanakuPrinterPlainModeTest`, `NamespacesCreateTest`)
- [x] Integration tests: pre-existing failures on main, unrelated to this change

## Summary by Sourcery

Handle null map values in WanakuPrinter.printAsMap to prevent erroneous failures when printing filtered maps.

Bug Fixes:
- Prevent NullPointerException in printAsMap when input maps contain null values.

Tests:
- Add a unit test verifying printAsMap correctly handles maps with null values without throwing and still prints non-null entries.