### PR TITLE
Fix #1607: return HTTP 404 instead of 500 for non-existent forward refresh

### DIFF
--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/forwards/ForwardsBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/forwards/ForwardsBeanTest.java
@@ -1,0 +1,35 @@
+package ai.wanaku.backend.api.v1.forwards;
+
+import java.util.Collections;
+import ai.wanaku.backend.core.persistence.api.ForwardReferenceRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ForwardsBeanTest {
+
+    @Mock
+    ForwardReferenceRepository forwardReferenceRepository;
+
+    @InjectMocks
+    ForwardsBean forwardsBean;
+
+    @Test
+    void refreshNonExistentForwardThrowsResourceNotFoundException() {
+        String name = "does-not-exist";
+        when(forwardReferenceRepository.findByName(name)).thenReturn(Collections.emptyList());
+
+        ForwardReference hint = new ForwardReference();
+        hint.setName(name);
+
+        assertThrows(ResourceNotFoundException.class, () -> forwardsBean.refresh(hint));
+    }
+}


### PR DESCRIPTION
Fixes #1607

## Summary

When refreshing a forward that does not exist, the API was returning HTTP 500 instead of HTTP 404 because `ForwardsBean.refresh()` was throwing the generic `WanakuException` instead of `ResourceNotFoundException`. Changed the thrown exception to `ResourceNotFoundException`, which the existing exception mapper correctly maps to HTTP 404.

## Changes

- `ForwardsBean.refresh()`: Changed `throw new WanakuException(...)` to `throw new ResourceNotFoundException(...)` when the forward reference is not found
- Added unit test `ForwardsBeanTest.refreshNonExistentForwardThrowsResourceNotFoundException()` to verify the correct exception type is thrown

## Summary by Sourcery

Return a resource-not-found error when refreshing a non-existent forward reference and add coverage for this behavior.

Bug Fixes:
- Change forward refresh to throw ResourceNotFoundException instead of a generic WanakuException when the referenced forward does not exist.

Tests:
- Add a unit test for ForwardsBean.refresh to verify that refreshing a non-existent forward throws ResourceNotFoundException.