### PR TITLE
[backport 0.2.x] Fix #1608: exclude default namespace from label-filtered namespace list

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
@@ -3,11 +3,9 @@ package ai.wanaku.cli.main.commands.namespaces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jline.terminal.Terminal;
-import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -36,7 +34,7 @@ For detailed information see the label expression manual page:
 Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 """
             })
-    private String labelExpression;
+    String labelExpression;
 
     NamespacesService namespacesService;
 
@@ -76,15 +74,16 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService =
-                QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host)).build(NamespacesService.class);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
             List<AddressableNamespace> list =
                     response.data().stream().map(this::convertToAddressable).collect(Collectors.toList());
 
-            list.add(AddressableNamespace.defaultNs(host));
+            if (labelExpression == null || labelExpression.isBlank()) {
+                list.add(AddressableNamespace.defaultNs(host));
+            }
 
             printer.printTable(list, "id", "name", "path", "labels");
         } catch (WebApplicationException ex) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
@@ -1,0 +1,114 @@
+package ai.wanaku.cli.main.commands.namespaces;
+
+import java.util.List;
+import java.util.Map;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NamespaceListTest {
+
+    @Mock
+    private NamespacesService namespacesService;
+
+    private NamespaceList command;
+
+    @BeforeEach
+    void setUp() {
+        command = new NamespaceList();
+        command.namespacesService = namespacesService;
+        command.host = "http://localhost:8080";
+    }
+
+    @Test
+    @DisplayName("Should include default namespace when no label expression is set")
+    @SuppressWarnings("unchecked")
+    void shouldIncludeDefaultNamespaceWhenNoLabelExpression() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+
+        when(namespacesService.list(null)).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        assertEquals(2, printed.size(), "Should contain the namespace plus the default namespace");
+    }
+
+    @Test
+    @DisplayName("Should exclude default namespace when label expression is set")
+    @SuppressWarnings("unchecked")
+    void shouldExcludeDefaultNamespaceWhenLabelExpressionSet() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+        ns.setLabels(Map.of("tier", "frontend"));
+
+        when(namespacesService.list("tier=frontend")).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        command.labelExpression = "tier=frontend";
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        assertEquals(1, printed.size(), "Should contain only the matched namespace, not the default");
+    }
+
+    @Test
+    @DisplayName("Should exclude default namespace when label expression is a blank string")
+    @SuppressWarnings("unchecked")
+    void shouldExcludeDefaultNamespaceWhenLabelExpressionBlank() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+
+        when(namespacesService.list("   ")).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        command.labelExpression = "   ";
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        // A blank label expression is effectively "no filter", so the default namespace should be excluded
+        // since the backend treats blank as "list all" and the client should not add a synthetic default
+        // Actually, blank means "no filter active" so default SHOULD be included
+        assertEquals(2, printed.size(), "Blank expression means no filter, so default namespace should be included");
+    }
+}


### PR DESCRIPTION
## Backport of #1625

Cherry-pick of #1625 onto `0.2.x`.

**Original PR:** #1625 - Fix #1608: exclude default namespace from label-filtered namespace list
**Original author:** @orpiske
**Target branch:** `0.2.x`

### Original description

Fixes #1608

## Summary
- The CLI `namespace list` command unconditionally appended the synthetic `<default>` namespace to every result, including when a label expression filter (`-e`) was active
- Wrapped the `<default>` namespace addition in a condition that checks whether a label expression is active
- Switched service initialization to use the authenticated helper (`initAuthenticatedServiceIfNeeded`) for consistent auth handling
- Added unit tests covering filtered and unfiltered namespace list behavior

### Backport validation

- Cherry-pick completed without conflicts.
- Build and tests intentionally skipped at the request of the maintainer.

Generated by Codex via OSS Helper

## Summary by Sourcery

Adjust CLI namespace listing behavior around the synthetic default namespace and align service initialization with authenticated access.

Bug Fixes:
- Exclude the synthetic default namespace from namespace list results when a label expression filter is active, while still including it for unfiltered or blank label queries.

Enhancements:
- Switch namespace listing to use the authenticated service initialization helper for consistent authentication handling.

Tests:
- Add unit tests covering namespace listing with no label expression, with an explicit label filter, and with a blank label expression to verify default-namespace behavior.