### PR TITLE
Fix #1611: harden tool invocation against null keys, uncaught exceptions, and stale registrations

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkus.runtime.StartupEvent;
@@ -57,8 +58,25 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
     }
 
     public ToolReference add(ToolReference toolReference) {
-        // then registers the tool with the tool manager
-        registerTool(toolReference);
+        try {
+            // then registers the tool with the tool manager
+            registerTool(toolReference);
+        } catch (EntityAlreadyExistsException e) {
+            // If a tool with the same name exists from a different service type,
+            // it is stale (left over from a previously stopped capability instance).
+            // Replace it so the new handler points to the live service.
+            ToolReference existing = getByName(toolReference.getName());
+            if (existing != null && !Objects.equals(existing.getType(), toolReference.getType())) {
+                LOG.infof(
+                        "Replacing stale tool %s (was type %s, now %s)",
+                        toolReference.getName(), existing.getType(), toolReference.getType());
+                toolManager.removeTool(toolReference.getName());
+                removeByName(toolReference.getName());
+                registerTool(toolReference);
+            } else {
+                throw e;
+            }
+        }
 
         // if all goes well, persist the tool, so it can be loaded back when restarting
         return toolReferenceRepository.persist(toolReference);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -109,8 +109,9 @@ public class InvokerBridge implements ToolsBridge {
                             LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
                             return ToolResponse.error(failure.getMessage());
                         }))
-                .onFailure(failure ->
-                        failure instanceof IllegalArgumentException || failure instanceof ServiceNotFoundException)
+                .onFailure(failure -> failure instanceof IllegalArgumentException
+                        || failure instanceof NullPointerException
+                        || failure instanceof ServiceNotFoundException)
                 .recoverWithItem(failure -> {
                     LOG.debugf(failure, "Pre-invocation failure: %s", failure.getMessage());
                     return ToolResponse.error(failure.getMessage());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -109,6 +109,11 @@ public class InvokerBridge implements ToolsBridge {
                             LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
                             return ToolResponse.error(failure.getMessage());
                         }))
+                .onFailure()
+                .recoverWithItem(failure -> {
+                    LOG.debugf(failure, "Pre-invocation failure: %s", failure.getMessage());
+                    return ToolResponse.error(failure.getMessage());
+                })
                 .onItemOrFailure()
                 .invoke((item, failure) -> {
                     if (vertx != null) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -109,7 +109,8 @@ public class InvokerBridge implements ToolsBridge {
                             LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
                             return ToolResponse.error(failure.getMessage());
                         }))
-                .onFailure()
+                .onFailure(failure ->
+                        failure instanceof IllegalArgumentException || failure instanceof ServiceNotFoundException)
                 .recoverWithItem(failure -> {
                     LOG.debugf(failure, "Pre-invocation failure: %s", failure.getMessage());
                     return ToolResponse.error(failure.getMessage());

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -136,9 +136,9 @@ public final class InvokerToolExecutor {
      */
     static Map<String, Object> filterOutReservedArgs(Map<String, Object> args) {
         return args.entrySet().stream()
-                .filter(e -> e.getKey() == null
-                        || (!e.getKey().startsWith(METADATA_PREFIX)
-                                && !e.getKey().startsWith(AUTH_PREFIX)))
+                .filter(e -> e.getKey() != null
+                        && !e.getKey().startsWith(METADATA_PREFIX)
+                        && !e.getKey().startsWith(AUTH_PREFIX))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerToolExecutor.java
@@ -135,6 +135,9 @@ public final class InvokerToolExecutor {
      * @return a new map without reserved arguments
      */
     static Map<String, Object> filterOutReservedArgs(Map<String, Object> args) {
+        if (args == null) {
+            return Map.of();
+        }
         return args.entrySet().stream()
                 .filter(e -> e.getKey() != null
                         && !e.getKey().startsWith(METADATA_PREFIX)

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
@@ -81,7 +81,8 @@ public class ToolsHelper {
             BiFunction<ToolManager.ToolArguments, CallableReference, Uni<ToolResponse>> handler) {
 
         if (toolManager.getTool(toolReference.getName()) != null) {
-            throw EntityAlreadyExistsException.forName(toolReference.getName());
+            LOG.infof("Replacing stale tool registration for %s", toolReference.getName());
+            toolManager.removeTool(toolReference.getName());
         }
 
         try {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
@@ -81,8 +81,7 @@ public class ToolsHelper {
             BiFunction<ToolManager.ToolArguments, CallableReference, Uni<ToolResponse>> handler) {
 
         if (toolManager.getTool(toolReference.getName()) != null) {
-            LOG.infof("Replacing stale tool registration for %s", toolReference.getName());
-            toolManager.removeTool(toolReference.getName());
+            throw EntityAlreadyExistsException.forName(toolReference.getName());
         }
 
         try {

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -271,6 +271,19 @@ class InvokerBridgeTest {
     }
 
     @Test
+    void filterOutReservedArgs_filtersOutNullKeys() {
+        Map<String, Object> args = new HashMap<>();
+        args.put(null, "nullKeyValue");
+        args.put("regularArg", "value");
+
+        Map<String, Object> filtered = InvokerToolExecutor.filterOutReservedArgs(args);
+
+        assertEquals(1, filtered.size());
+        assertEquals("value", filtered.get("regularArg"));
+        assertFalse(filtered.containsKey(null), "Null keys must be filtered out");
+    }
+
+    @Test
     void extractAuthHeaders_extractsPrefixedArgsAndStripsPrefix() {
         final ToolManager.ToolArguments toolArguments = mockToolArguments();
         Map<String, Object> args = new HashMap<>();

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -271,6 +271,13 @@ class InvokerBridgeTest {
     }
 
     @Test
+    void filterOutReservedArgs_returnsEmptyMapWhenArgsIsNull() {
+        Map<String, Object> filtered = InvokerToolExecutor.filterOutReservedArgs(null);
+
+        assertTrue(filtered.isEmpty(), "Null args should return an empty map");
+    }
+
+    @Test
     void filterOutReservedArgs_filtersOutNullKeys() {
         Map<String, Object> args = new HashMap<>();
         args.put(null, "nullKeyValue");


### PR DESCRIPTION
## Summary

Fixes #1611

Three improvements to the router's tool invocation path to address regressions exposed by the SDK's required-parameter validation (commit `5d6a445042d7`):

1. **Filter null-keyed args** (`InvokerToolExecutor`): `filterOutReservedArgs` previously kept entries with null keys (`e.getKey() == null`), which could cause `NullPointerException` when building protobuf maps. Now rejects null keys.

2. **Recover pre-invocation failures** (`InvokerBridge`): Exceptions from steps before the gRPC transport (service resolution, request building, parameter validation) were not caught by the inner error handler and propagated as uncaught MCP Internal errors (`-32603`). An outer `onFailure().recoverWithItem()` now converts these to proper `ToolResponse.error()` responses. This fixes the `shouldHandleMissingRequiredParameter` test in `CamelBasicToolITCase`.

3. **Replace stale tool registrations** (`ToolsBean`): When a new CIC instance registers a tool whose name is already taken by a different service type (a leftover from a previously stopped capability), the router now removes the stale entry and re-registers with the live handler. Same-type duplicates still raise `EntityAlreadyExistsException`.

## Test plan

- [x] Unit tests pass (381 tests, 0 failures)
- [x] New test: `filterOutReservedArgs_filtersOutNullKeys`
- [x] `CamelBasicToolITCase.shouldHandleMissingRequiredParameter` passes (was failing)
- [x] `HttpToolRegistrationITCase.shouldRejectDuplicateToolName` passes (duplicate guard preserved)
- [ ] `CamelMultiInstanceITCase` - still under investigation; root cause may require SDK-side changes