### PR TITLE
test: add ToolsetReposBeanNotFoundTest for #1606 fix verification

### DIFF
--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanNotFoundTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBeanNotFoundTest.java
@@ -1,0 +1,61 @@
+package ai.wanaku.backend.api.v1.toolsetrepos;
+
+import java.util.Collections;
+import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ToolsetReposBean} returns HTTP-404-friendly exceptions
+ * when a toolset repository is not found, rather than a generic
+ * {@link ai.wanaku.capabilities.sdk.api.exceptions.WanakuException} (which maps to HTTP 500).
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolsetReposBeanNotFoundTest {
+
+    @Mock
+    DataStoreRepository dataStoreRepository;
+
+    private ToolsetReposBean bean;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        bean = new ToolsetReposBean();
+
+        // Inject the mock DataStoreRepository into the private field
+        var field = ToolsetReposBean.class.getDeclaredField("dataStoreRepository");
+        field.setAccessible(true);
+        field.set(bean, dataStoreRepository);
+    }
+
+    @Test
+    void browseNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(ResourceNotFoundException.class, () -> bean.browse("non-existent-repo"));
+    }
+
+    @Test
+    void updateNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> bean.update("non-existent-repo", "https://example.com", "desc", null, null));
+    }
+
+    @Test
+    void fetchToolsetFromNonExistentRepoThrowsResourceNotFoundException() {
+        when(dataStoreRepository.findAllFilterByLabelExpression(anyString())).thenReturn(Collections.emptyList());
+
+        assertThrows(ResourceNotFoundException.class, () -> bean.fetchToolset("non-existent-repo", "my-toolset"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for the #1606 fix (merged in PR #1615) verifying that `browse()`, `update()`, and `fetchToolset()` throw `ResourceNotFoundException` (HTTP 404) instead of `WanakuException` (HTTP 500) when the toolset repository does not exist

## Test plan

- [x] 3 tests covering browse, update, and fetchToolset with non-existent repos

## Summary by Sourcery

Tests:
- Add unit tests for browse, update, and fetchToolset to ensure non-existent repositories result in ResourceNotFoundException instead of server errors.