### PR TITLE
Fix #1637: validate namespace names to reject non-alphanumeric/dash characters

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,34 @@
+package ai.wanaku.backend.api.v1.exceptions;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+
+/**
+ * Maps {@link IllegalArgumentException} to HTTP 400 (Bad Request) responses.
+ * This ensures that validation errors (e.g., invalid namespace names) return
+ * a proper client error status instead of a generic 500 error.
+ */
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    private static final Logger LOG = Logger.getLogger(IllegalArgumentExceptionMapper.class);
+
+    @APIResponse(
+            responseCode = "400",
+            description = "Bad request",
+            content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
+    @Override
+    public Response toResponse(IllegalArgumentException e) {
+        LOG.warnf("Bad request: %s", e.getMessage());
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new WanakuResponse<Void>(e.getMessage()))
+                .build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.WanakuRouterConfig;
 import ai.wanaku.backend.core.persistence.api.NamespaceRepository;
@@ -26,6 +27,12 @@ public class NamespacesBean {
     private static final String LABEL_ALLOCATED_AT = "wanaku.io/allocated-at";
     private static final String LABEL_EXPIRES_AT = "wanaku.io/expires-at";
     private static final Set<String> PROTECTED_NAMESPACES = Set.of("default", "public", "wanaku-internal");
+
+    /**
+     * Pattern for valid namespace names and paths: must start with an alphanumeric character,
+     * followed by zero or more alphanumeric characters or dashes.
+     */
+    private static final Pattern VALID_NAMESPACE_PATTERN = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]*$");
 
     @Inject
     Instance<NamespaceRepository> namespaceRepositoryInstance;
@@ -72,6 +79,8 @@ public class NamespacesBean {
     }
 
     public Namespace alocateNamespace(String name) {
+        validateNamespaceValue(name, "name");
+
         List<Namespace> byName = namespaceRepository.findByName(name);
         if (byName.isEmpty()) {
             final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(name);
@@ -100,6 +109,9 @@ public class NamespacesBean {
         if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         if (isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath())) {
             throw new IllegalArgumentException("Reserved namespace names cannot be created");
@@ -159,6 +171,9 @@ public class NamespacesBean {
         if (namespace == null) {
             return false;
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         Namespace existingNamespace = namespaceRepository.findById(id);
         if (existingNamespace == null) {
@@ -266,6 +281,27 @@ public class NamespacesBean {
 
     private boolean isProtectedNamespace(Namespace namespace) {
         return isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath());
+    }
+
+    /**
+     * Validates that a namespace value (name or path) contains only alphanumeric characters and dashes,
+     * and starts with an alphanumeric character. Null values are accepted (e.g., preallocated namespaces
+     * have null names).
+     *
+     * @param value the value to validate
+     * @param fieldName the field name for the error message (e.g., "name" or "path")
+     * @throws IllegalArgumentException if the value contains invalid characters
+     */
+    private void validateNamespaceValue(String value, String fieldName) {
+        if (value == null) {
+            return;
+        }
+
+        if (!VALID_NAMESPACE_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid namespace %s: '%s'. Only alphanumeric characters and dashes are allowed, and it must start with an alphanumeric character"
+                            .formatted(fieldName, value));
+        }
     }
 
     private boolean isProtectedNamespaceName(String value) {

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
@@ -141,6 +141,34 @@ public abstract class AbstractNamespacesResourceTest extends WanakuRouterTest {
 
     @Order(6)
     @Test
+    public void testCreateNamespaceWithInvalidPathReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/invalid-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(7)
+    @Test
+    public void testCreateNamespaceWithLeadingDashReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-bad-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(8)
+    @Test
     public void testStaleNamespaceCleanup() {
         Namespace namespace = new Namespace();
         stalePath = "test-stale-ns-" + System.currentTimeMillis();

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
@@ -16,6 +16,7 @@ import static ai.wanaku.test.assertions.WanakuAssertions.assertNamespaceExists;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @QuarkusTest
 @TestProfile(NoOidcTestProfile.class)
@@ -227,6 +228,78 @@ public class NamespacesBeanTest {
         boolean result = namespacesBean.update(publicNamespace.getId(), updated);
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingSlashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpacesIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpecialCharsIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my_namespace!");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingDashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithInvalidNameIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-path");
+        namespace.setName("/invalid-name");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace name");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-namespace-123");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getPath()).isEqualTo("valid-namespace-123");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidNameAndPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my-path-" + System.currentTimeMillis());
+        namespace.setName("my-name");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getName()).isEqualTo("my-name");
     }
 
     @Test


### PR DESCRIPTION
Fixes #1637

## Summary

- Added input validation for namespace names and paths in the router backend. Namespace values must now match `^[a-zA-Z0-9][a-zA-Z0-9-]*$` (start with an alphanumeric character, followed by alphanumeric characters or dashes).
- Created `IllegalArgumentExceptionMapper` to return HTTP 400 for validation errors instead of generic 500 errors.
- Validation is applied in `create()`, `update()`, and `alocateNamespace()` methods of `NamespacesBean`.

## Test plan

- [x] Unit tests for rejected invalid paths (leading slash, spaces, special chars, leading dash)
- [x] Unit tests for rejected invalid names
- [x] Unit tests for accepted valid paths and names
- [x] REST-level tests verifying HTTP 400 responses for invalid namespace paths
- [x] All 389 existing unit tests pass
- [x] Integration tests: namespace-specific tests (`NamespaceCliITCase`, `NamespaceCrudITCase`) pass; pre-existing failures in unrelated tests are unchanged

## Summary by Sourcery

Enforce strict validation of namespace names and paths and surface validation failures as HTTP 400 responses.

Bug Fixes:
- Reject namespace names and paths containing non-alphanumeric or non-dash characters, including leading slashes, spaces, special characters, and leading dashes.

Enhancements:
- Introduce centralized namespace value validation logic in NamespacesBean using a shared regex pattern for names and paths.
- Add an IllegalArgumentException JAX-RS mapper so backend validation errors produce structured HTTP 400 (Bad Request) responses instead of generic server errors.

Tests:
- Extend unit and REST-level tests to cover invalid and valid namespace names/paths and to verify HTTP 400 responses from the API for bad input.