### PR TITLE
Fix #1639: add --namespace-name as a PicoCLI alias for --namespace

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -33,7 +33,7 @@ public class NamespaceOptions {
             "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
 
     @Option(
-            names = {"-N", "--namespace"},
+            names = {"-N", "--namespace", "--namespace-name"},
             description = "The namespace name associated with this entity")
     String namespace;
 


### PR DESCRIPTION
Fixes #1639

Adds `--namespace-name` as a PicoCLI alias for the `--namespace` option in the shared `NamespaceOptions` class. This restores backward compatibility for CLI commands (including `forwards add`) that previously accepted `--namespace-name`.

The fix is a single-line change to the `@Option` annotation's `names` array.

Integration test `ForwardsCliITCase.shouldAddForwardViaCli` now passes (was failing on main).

## Summary by Sourcery

New Features:
- Introduce `--namespace-name` as an alias for the existing `--namespace` CLI option to support legacy usage.