### PR TITLE
CLI: Document usage of a java truststore to connect to https servers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,45 @@ wanaku auth login \
 wanaku tools list --no-auth
 ```
 
+### CLI commands fail with: An error occurred: Failed to communicate with Keycloak
+
+**Symptoms:**
+
+- `wanaku` CLI commands fail to communicate with Keycloak
+
+Example:
+
+```shell
+An error occurred: Failed to communicate with Keycloak at https://127.0.0.1:8543
+
+Run with --verbose flag for more details
+
+```
+
+If you set `--verbose` and then shows the cause as:
+
+```shell
+sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+```
+
+**Why this happens:**
+
+The security code (JSSE) in wanaku-cli doesn't recognize the certificate that serves the Keycloak HTTPS endpoint.
+
+**Fix:**
+
+You have two options:
+
+- You can skip the certificate checks in wanaku-cli by using the `--insecure` parameter. In this case, it will show a warning `WARNING: TLS certificate verification is disabled. This is insecure and should only be used for development.`.
+
+- You can use the CA that signed the Keycloak HTTPS endpoint, by either importing it into the default Java truststore `$JAVA_HOME/lib/security/cacerts` or have a particular keystore file and use the `-Djavax.net.ssl.trustStore` and `-Djavax.net.ssl.trustStorePassword` parameters to refer to this custom truststore.
+
+NOTE: You can set these `-D` to the wanaku-cli as in this example:
+
+```shell
+java "-Djavax.net.ssl.trustStore=my-truststore.p12" "-Djavax.net.ssl.trustStorePassword=changeit" -jar quarkus-run.jar  admin credentials show --admin-username=admin --admin-password=admin --keycloak-url=https://keycloak.192.168.49.2.nip.io --show-secret --client-id wanaku-service
+```
+
 ### Token issuer mismatch causes 401 on OpenShift / Kubernetes
 
 **Symptoms:**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -357,6 +357,19 @@ Verify the installation:
 wanaku --version
 ```
 
+### Handling HTTPS connections
+
+Wanaku CLI may connect to either Keycloak or Wanaku MCP server, if their HTTP endpoints are protected by a server certificate (TLS) you may choose to skip the certificate checks or use the CA (Certificate Authority) that issued them on the wanaku-cli so the client can check the server certificate.
+
+1. In wanaku-cli you can skip the checks by using the `--insecure` parameter, and it's going to print a warning message about it.
+2. You can use the CA that signed the Keycloak HTTPS endpoint, by either importing it into the default Java truststore `$JAVA_HOME/lib/security/cacerts` or have a particular keystore file and use the `-Djavax.net.ssl.trustStore` and `-Djavax.net.ssl.trustStorePassword` parameters to refer to this custom truststore.
+
+NOTE: You can set these `-D` to the wanaku-cli as in this example:
+
+```shell
+java "-Djavax.net.ssl.trustStore=my-truststore.p12" "-Djavax.net.ssl.trustStorePassword=changeit" -jar quarkus-run.jar  admin credentials show --admin-username=admin --admin-password=admin --keycloak-url=https://keycloak.192.168.49.2.nip.io --show-secret --client-id wanaku-service
+```
+
 ## Installing and Running the Router
 
 There are three ways to run the router. They work similarly, with the distinction that some of them may come with more


### PR DESCRIPTION
https://github.com/wanaku-ai/wanaku/issues/1264

## Summary by Sourcery

Document CLI configuration for HTTPS connections using Java truststores and insecure mode when communicating with Keycloak and MCP servers.

Documentation:
- Add troubleshooting guidance for CLI failures communicating with Keycloak over HTTPS due to untrusted certificates and how to resolve them with Java truststores or insecure mode.
- Extend usage documentation with instructions on handling HTTPS connections for CLI targets using either insecure mode or Java truststore configuration.