### PR TITLE
Fix #1654: exclude JVM -XX: flags from operator log error filter

### DIFF
--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -1495,6 +1495,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
   | grep -iv "this-configmap-does-not-exist" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1510,6 +1511,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
     | grep -iv "this-configmap-does-not-exist" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -1268,6 +1268,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "not found in namespace" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1282,6 +1283,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "not found in namespace" \
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"


### PR DESCRIPTION
## Summary

- Exclude all JVM `-XX:` flag lines from the operator log error detection grep in test plans
- Fixes false positive where `ExitOnOutOfMemoryError` JVM flag matched the `error|exception` pattern
- Uses `grep -v "\-XX:"` to filter the entire category of JVM flags rather than individual flag names

## Test plan

- [ ] Run `operator-camel-route` test plan and verify Test 10.3 no longer flags `ExitOnOutOfMemoryError`
- [ ] Run `camel-integration-capability` test plan and verify Test 9.3 no longer flags JVM flags

## Summary by Sourcery

Tests:
- Update operator log grep filters in camel-integration-capability and operator-camel-route test plans to ignore JVM -XX: options when counting unexpected errors.