### PR TITLE
operator: Fix app label in WanakuCapability CIC

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
@@ -52,7 +52,8 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
         pvc.getMetadata().setName(createVolumeClaimName(serviceName));
         pvc.getMetadata().setNamespace(ns);
-        pvc.getMetadata().getLabels().put("app", deploymentName);
+        pvc.getMetadata().getLabels().put("app", serviceName);
+        pvc.getMetadata().getLabels().put("app.kubernetes.io/part-of", deploymentName);
         pvc.getMetadata().getLabels().put("component", "wanaku-services-storage");
 
         pvc.addOwnerReference(resource);
@@ -133,11 +134,12 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating internal service for capability: %s", serviceName);
         service.getMetadata().setName(serviceName);
         service.getMetadata().setNamespace(ns);
-        service.getMetadata().getLabels().put("app", parentName);
+        service.getMetadata().getLabels().put("app", serviceName);
+        service.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         service.getMetadata().getLabels().put("component", serviceName);
 
         ServiceSpec serviceSpec2 = service.getSpec();
-        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
+        serviceSpec2.setSelector(Map.of("app", serviceName));
 
         service.addOwnerReference(resource);
 
@@ -156,14 +158,15 @@ public final class CapabilityResourceFactory {
 
         desiredDeployment.getMetadata().setName(serviceName);
         desiredDeployment.getMetadata().setNamespace(ns);
-        desiredDeployment.getMetadata().getLabels().put("app", parentName);
+        desiredDeployment.getMetadata().getLabels().put("app", serviceName);
+        desiredDeployment.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         desiredDeployment.getMetadata().getLabels().put("component", serviceName);
 
         final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
 
-        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
-        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
-        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
+        deploymentSpec.getSelector().getMatchLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
         deploymentSpec
                 .getTemplate()

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
@@ -1,0 +1,137 @@
+package ai.wanaku.operator.util;
+
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertMetadataLabel;
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertServiceLabel;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapabilityResourceFactoryTest {
+
+    private static WanakuCapability makeCapability(String crName) {
+        WanakuCapability capability = new WanakuCapability();
+        capability.getMetadata().setName(crName);
+        capability.getMetadata().setNamespace("wanaku");
+        capability.getMetadata().setUid("test-uid");
+        capability.setSpec(new WanakuCapabilitySpec());
+        return capability;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = new WanakuCapabilitySpec.CapabilitiesSpec();
+        spec.setName(name);
+        spec.setImage("quay.io/wanaku/wanaku-tool-service-http:latest");
+        return spec;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCiCCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = makeCapabilityEntry(name);
+        spec.setImage("quay.io/wanaku/camel-integration-capability:latest");
+        spec.setType(OperatorConstants.CAMEL_INTEGRATION_CAPABILITY_TYPE);
+        return spec;
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void wanakuCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void cicCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void cicCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void cicCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void internalServiceSelectorUsesCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Service service = CapabilityResourceFactory.makeCapabilityInternalService(cr, entry);
+
+        assertEquals("cic-catalog-test", service.getSpec().getSelector().get("app"));
+        assertServiceLabel(service, "app", "cic-catalog-test");
+        assertServiceLabel(service, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void pvcUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+
+        PersistentVolumeClaim pvc = CapabilityResourceFactory.makeServicesVolumePVC(cr, "cic-catalog-test");
+
+        assertMetadataLabel(pvc, "app", "cic-catalog-test");
+        assertMetadataLabel(pvc, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+}


### PR DESCRIPTION
Fix https://github.com/wanaku-ai/wanaku/issues/1530

## Summary by Sourcery

Align Wanaku capability Kubernetes resources to consistently use the capability name for app identification and associate them with the parent capability set via standard labels.

Bug Fixes:
- Fix incorrect app labels and selectors on Wanaku capability deployments, services, and PVCs that prevented proper association and discovery in Kubernetes.

Enhancements:
- Add app.kubernetes.io/part-of labels to capability-related deployments, services, and PVCs to better group resources under their parent capability set.

Tests:
- Add unit tests covering label and selector configuration for Wanaku and CiC capability deployments, internal services, and PVCs to prevent regressions in Kubernetes labeling behavior.