### PR TITLE
Fix wanaku-ai/wanaku-tests#155: use 0-based indexing for namespace preallocation

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -52,7 +52,7 @@ public class NamespacesBean {
     public synchronized void preload() {
         // Preload data
         if (namespaceRepository.size() < maxNamespaces) {
-            for (int i = 1; i <= maxNamespaces; i++) {
+            for (int i = 0; i < maxNamespaces; i++) {
                 final String namespacePath = String.format("ns-%d", i);
                 Namespace namespace = new Namespace();
                 namespace.setPath(namespacePath);


### PR DESCRIPTION
## Summary

- Changed `NamespacesBean.preload()` loop from `for (int i = 1; i <= maxNamespaces; i++)` to `for (int i = 0; i < maxNamespaces; i++)`
- Namespace paths now created as `ns-0` through `ns-9`, matching the MCP server naming convention established in commit 7758890 and `NamespaceTenantConfigResolver` (`MAX_NAMESPACES = 10`, valid range `0..9`)
- Previously, `ns-10` was created but had no MCP server, causing `IllegalStateException: Invalid server name: ns-10` when `alocateNamespace` assigned that slot

## Test plan

- [ ] Verify router creates `ns-0` through `ns-9` at startup (not `ns-1` through `ns-10`)
- [ ] Verify `HttpToolCliITCase.shouldRegisterHttpToolViaCli` passes
- [ ] Verify `CliResourceITCase.shouldExposeResourceViaCli` passes
- [ ] Verify existing namespace OIDC tests still pass (they reference `ns-1` which exists in both ranges)

## Summary by Sourcery

Bug Fixes:
- Prevent allocation of an invalid ns-10 namespace by matching preallocated namespaces to the configured 0..(maxNamespaces-1) server range.