### PR TITLE
fix:  environment variables for Camel integration capability routes

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -433,6 +433,14 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
                 .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_SERVICE_CATALOG_SYSTEM)
                 .withValue(crName)
                 .build());
+        envVars.add(new EnvVarBuilder()
+                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_ROUTES_PATH)
+                .withValue(crName)
+                .build());
+        envVars.add(new EnvVarBuilder()
+                .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_ROUTES_RULES)
+                .withValue(crName)
+                .build());
 
         if (OperatorSecurityConfig.isAuthEnabled(authSpec)) {
             String realm = authSpec.getAuthRealm();


### PR DESCRIPTION
Fixes: #1636

## Summary by Sourcery

New Features:
- Expose CAMEL_INTEGRATION_CAPABILITY_ROUTES_PATH and CAMEL_INTEGRATION_CAPABILITY_ROUTES_RULES as environment variables for Camel integration capability routes.