### PR TITLE
Add support for WANAKU_CREDENTIALS environment variable to customize credentials file path

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -38,6 +38,10 @@ public class AuthCredentialStore {
     }
 
     private static String getDefaultCredentialsFile() {
+        String envOverride = System.getenv("WANAKU_CREDENTIALS");
+        if (envOverride != null && !envOverride.isBlank()) {
+            return envOverride.trim();
+        }
         return WanakuHome.get() + File.separator + "credentials";
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -988,13 +988,22 @@ wanaku tools list --no-auth
 
 ### Credential Storage
 
-Authentication credentials are stored in:
+By default, credentials are stored in:
 
 ```text
 ~/.wanaku/credentials
 ```
 
-This file is a Java properties file containing:
+You can override this path with the `WANAKU_CREDENTIALS` environment variable to isolate credentials across contexts or concurrent sessions:
+
+```shell
+export WANAKU_CREDENTIALS=/tmp/my-isolated-credentials
+wanaku auth login --api-token <token>
+```
+
+This is useful when running multiple test plans or sessions in parallel, as it prevents token overwrites that would otherwise occur in the shared global file.
+
+The credentials file is a Java properties file containing:
 
 - `api.token`: The API bearer token
 - `refresh.token`: OAuth2 refresh token (when applicable)


### PR DESCRIPTION
Closes: #1665

## Summary by Sourcery

Add support for configuring the CLI credentials file path via an environment variable and document the new behavior.

Enhancements:
- Allow overriding the default credentials file location by reading the WANAKU_CREDENTIALS environment variable in the CLI credential store.

Documentation:
- Document the WANAKU_CREDENTIALS environment variable for overriding the default credentials file path and explain its use in parallel sessions.