### PR TITLE
Refactor AuthToken command options for clarity and consistency

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -19,7 +19,7 @@ public class AuthToken extends BaseCommand {
      */
     private static final long REFRESH_BUFFER_SECONDS = 30;
 
-    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
     TokenOperation operation;
 
     static class TokenOperation {
@@ -62,6 +62,17 @@ public class AuthToken extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
+        int count =
+                (operation.setToken != null ? 1 : 0) + (operation.getToken ? 1 : 0) + (operation.clearToken ? 1 : 0);
+        if (count > 1) {
+            printer.printErrorMessage("Only one of --set, --get, or --clear may be specified");
+            return EXIT_ERROR;
+        }
+
+        if (operation.unmask && !operation.getToken) {
+            printer.printErrorMessage("--unmask can only be used with --get");
+            return EXIT_ERROR;
+        }
 
         if (operation.setToken != null) {
             credentialStore.storeApiToken(operation.setToken);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -28,19 +28,8 @@ public class AuthToken extends BaseCommand {
                 description = "Set the API token")
         String setToken;
 
-        @CommandLine.ArgGroup(exclusive = false)
-        GetOptions getOptions;
-
-        @CommandLine.Option(
-                names = {"--clear"},
-                description = "Clear the API token")
-        boolean clearToken;
-    }
-
-    static class GetOptions {
         @CommandLine.Option(
                 names = {"--get"},
-                required = true,
                 description = "Get the current API token (masked by default)")
         boolean getToken;
 
@@ -48,6 +37,11 @@ public class AuthToken extends BaseCommand {
                 names = {"--unmask"},
                 description = "Output the full unmasked token value")
         boolean unmask;
+
+        @CommandLine.Option(
+                names = {"--clear"},
+                description = "Clear the API token")
+        boolean clearToken;
     }
 
     private final AuthCredentialStore credentialStore;
@@ -76,10 +70,10 @@ public class AuthToken extends BaseCommand {
             return EXIT_OK;
         }
 
-        if (operation.getOptions != null) {
+        if (operation.getToken) {
             String apiToken = getValidAccessToken(printer);
             if (StringHelper.isNotEmpty(apiToken)) {
-                if (operation.getOptions.unmask) {
+                if (operation.unmask) {
                     printer.printInfoMessage(apiToken);
                 } else {
                     String maskedToken = maskToken(apiToken);

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
@@ -3,6 +3,9 @@ package ai.wanaku.cli.main.commands.realm;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.admin.BaseAdminCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
@@ -13,6 +16,13 @@ import picocli.CommandLine;
 public class RealmCreate extends BaseAdminCommand {
 
     private static final String DEFAULT_CONFIG = "deploy/auth/wanaku-config.json";
+
+    /**
+     * Matches Keycloak-style environment variable placeholders with a default value,
+     * e.g. {@code ${WANAKU_SERVICE_SECRET:mypasswd}}. Restricted to uppercase variable
+     * names so Keycloak i18n keys such as {@code ${role_admin}} are left untouched.
+     */
+    private static final Pattern ENV_PLACEHOLDER = Pattern.compile("\\$\\{([A-Z][A-Z0-9_]*):([^}]*)\\}");
 
     @CommandLine.Option(
             names = {"--config"},
@@ -36,7 +46,7 @@ public class RealmCreate extends BaseAdminCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
         try {
-            String realmJson = Files.readString(Path.of(config));
+            String realmJson = resolveEnvPlaceholders(Files.readString(Path.of(config)), System::getenv);
             KeycloakAdminClient client = createAdminClient();
             client.importRealm(realmJson);
             String serviceClientSecret = client.getClientSecret("wanaku", "wanaku-service");
@@ -52,5 +62,30 @@ public class RealmCreate extends BaseAdminCommand {
             printer.printErrorMessage(e.getMessage());
             return EXIT_ERROR;
         }
+    }
+
+    /**
+     * Resolves {@code ${VAR:default}} placeholders in the realm JSON before import.
+     * Keycloak only substitutes environment variables when importing at startup
+     * ({@code --import-realm}); imports through the Admin REST API store the
+     * placeholder as a literal value, leaving clients with a secret that never
+     * matches what services expect.
+     */
+    static String resolveEnvPlaceholders(String json, UnaryOperator<String> env) {
+        Matcher matcher = ENV_PLACEHOLDER.matcher(json);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String value = env.apply(matcher.group(1));
+            if (value == null || value.isBlank()) {
+                value = matcher.group(2);
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement(escapeJson(value)));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private static String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
@@ -39,7 +39,11 @@ public class RealmCreate extends BaseAdminCommand {
             String realmJson = Files.readString(Path.of(config));
             KeycloakAdminClient client = createAdminClient();
             client.importRealm(realmJson);
+            String serviceClientSecret = client.getClientSecret("wanaku", "wanaku-service");
             printer.printSuccessMessage("Realm imported successfully from " + config);
+            if (serviceClientSecret != null) {
+                printer.printInfoMessage("wanaku-service client secret: " + serviceClientSecret);
+            }
             return EXIT_OK;
         } catch (IOException e) {
             printer.printErrorMessage("Failed to read configuration file '" + config + "': " + e.getMessage());

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthCommandsTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.support.AuthCredentialStore;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import picocli.CommandLine;
 
 import static ai.wanaku.cli.main.commands.BaseCommand.EXIT_OK;
 
@@ -14,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.verify;
 
@@ -85,8 +87,7 @@ class AuthCommandsTest {
 
         AuthToken authToken = new AuthToken(store);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getToken = true;
 
         int result = authToken.doCall(terminal, printer);
 
@@ -101,9 +102,8 @@ class AuthCommandsTest {
 
         AuthToken authToken = new AuthToken(store);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         int result = authToken.doCall(terminal, printer);
 
@@ -138,5 +138,15 @@ class AuthCommandsTest {
 
         assertEquals(EXIT_OK, result);
         verify(printer).printInfoMessage("No API token is currently set");
+    }
+
+    @Test
+    void picocliShouldParseGetUnmaskFlags() {
+        AuthToken authToken = new AuthToken(new AuthCredentialStore(credentialsFile.toUri()));
+        CommandLine cmd = new CommandLine(authToken);
+        cmd.parseArgs("--get", "--unmask", "--plain");
+
+        assertTrue(authToken.operation.getToken, "--get should be true");
+        assertTrue(authToken.operation.unmask, "--unmask should be true");
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
@@ -8,6 +8,7 @@ import ai.wanaku.cli.main.support.AuthCredentialStore;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.cli.main.support.security.TokenRefresher;
 import ai.wanaku.cli.main.support.security.TokenRefresher.RefreshResult;
+import picocli.CommandLine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -61,9 +63,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -91,9 +92,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -128,9 +128,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -173,9 +172,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -201,9 +199,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -240,9 +237,8 @@ class AuthTokenTest {
 
         AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
         authToken.operation = new AuthToken.TokenOperation();
-        authToken.operation.getOptions = new AuthToken.GetOptions();
-        authToken.operation.getOptions.getToken = true;
-        authToken.operation.getOptions.unmask = true;
+        authToken.operation.getToken = true;
+        authToken.operation.unmask = true;
 
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
@@ -254,5 +250,45 @@ class AuthTokenTest {
 
         verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
         assertEquals(newToken, credentialStore.getApiToken());
+    }
+
+    @Test
+    void shouldParseGetAndUnmaskFlags() {
+        AuthToken authToken = new AuthToken(credentialStore, null);
+        new CommandLine(authToken).parseArgs("--get", "--unmask");
+
+        assertTrue(authToken.operation.getToken);
+        assertTrue(authToken.operation.unmask);
+    }
+
+    @Test
+    void shouldRejectConflictingOperations() throws Exception {
+        AuthToken authToken = new AuthToken(credentialStore, null);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getToken = true;
+        authToken.operation.clearToken = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            assertEquals(AuthToken.EXIT_ERROR, authToken.doCall(terminal, printer));
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+    }
+
+    @Test
+    void shouldRejectUnmaskWithoutGet() throws Exception {
+        AuthToken authToken = new AuthToken(credentialStore, null);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            assertEquals(AuthToken.EXIT_ERROR, authToken.doCall(terminal, printer));
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/realm/RealmCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/realm/RealmCommandsTest.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.realm;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.cli.main.support.keycloak.KeycloakAdminClient;
@@ -13,6 +14,7 @@ import static ai.wanaku.cli.main.commands.BaseCommand.EXIT_OK;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,5 +88,65 @@ class RealmCommandsTest {
 
         assertEquals(EXIT_ERROR, result);
         verify(printer).printErrorMessage(contains("deploy/auth/wanaku-config.json"));
+    }
+
+    @Test
+    void shouldResolvePlaceholderFromEnvironment() {
+        String json = "{\"secret\": \"${WANAKU_SERVICE_SECRET:mypasswd}\"}";
+        Map<String, String> env = Map.of("WANAKU_SERVICE_SECRET", "real-secret");
+
+        String resolved = RealmCreate.resolveEnvPlaceholders(json, env::get);
+
+        assertEquals("{\"secret\": \"real-secret\"}", resolved);
+    }
+
+    @Test
+    void shouldResolvePlaceholderToDefaultWhenEnvUnset() {
+        String json = "{\"secret\": \"${WANAKU_SERVICE_SECRET:mypasswd}\"}";
+
+        String resolved = RealmCreate.resolveEnvPlaceholders(json, name -> null);
+
+        assertEquals("{\"secret\": \"mypasswd\"}", resolved);
+    }
+
+    @Test
+    void shouldLeaveKeycloakI18nKeysUntouched() {
+        String json = "{\"description\": \"${role_admin}\", \"secret\": \"${WANAKU_SERVICE_SECRET:mypasswd}\"}";
+
+        String resolved = RealmCreate.resolveEnvPlaceholders(json, name -> null);
+
+        assertEquals("{\"description\": \"${role_admin}\", \"secret\": \"mypasswd\"}", resolved);
+    }
+
+    @Test
+    void shouldEscapeJsonSpecialCharactersInEnvValues() {
+        String json = "{\"secret\": \"${WANAKU_SERVICE_SECRET:mypasswd}\"}";
+        Map<String, String> env = Map.of("WANAKU_SERVICE_SECRET", "pa\"ss\\wd");
+
+        String resolved = RealmCreate.resolveEnvPlaceholders(json, env::get);
+
+        assertEquals("{\"secret\": \"pa\\\"ss\\\\wd\"}", resolved);
+    }
+
+    @Test
+    void realmCreateShouldImportRealmWithResolvedPlaceholders() throws Exception {
+        Path configFile = tempDir.resolve("realm-placeholder.json");
+        Files.writeString(
+                configFile,
+                "{\"realm\": \"wanaku\", \"secret\": \"${WANAKU_SERVICE_SECRET:mypasswd}\","
+                        + " \"description\": \"${role_admin}\"}");
+        doNothing().when(adminClient).importRealm(any());
+
+        RealmCreate cmd = new RealmCreate(adminClient, configFile.toString());
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+        verify(adminClient).importRealm(jsonCaptor.capture());
+        String envSecret = System.getenv("WANAKU_SERVICE_SECRET");
+        String expectedSecret = (envSecret != null && !envSecret.isBlank()) ? envSecret : "mypasswd";
+        assertEquals(
+                "{\"realm\": \"wanaku\", \"secret\": \"" + expectedSecret + "\", \"description\": \"${role_admin}\"}",
+                jsonCaptor.getValue());
     }
 }


### PR DESCRIPTION
Closes: #1656

`Picocli` cannot associate command-line options with nested ArgsGroup classes...

too created test for Closes : #1652

Closes: #1649 , `wanku realm create` now returns the actual secret for the `wanaku-service` client. The issue was that `KeycloakAdminClient.importRealm()` merely imported the realm JSON and returned `void`; while the placeholder `${WANAKU_SERVICE_SECRET:mypasswd}` in the JSON was resolved internally by Keycloak, that value was never exposed to the caller.

Closes: #1670, I chose to resolve this without needing to modify the operator or the *reconciler*. The root cause is the same as in case #1649: importing the *realm* via the Keycloak admin REST API does not resolve environment variable *placeholders* (which only happens with the `import-realm` command). Consequently, the `wanaku-service` client secret was stored as the literal string `${WANAKU_SERVICE:mypasswd}`, while the CamelRoute *reconciler* attempted to authenticate using a value that would never match that literal *placeholder*, resulting in "Invalid Client" or "Invalid client credential" errors. Now, the creation of the Wanaku admin *realm* resolves `${VAR:default}`-style *placeholders* on the client side prior to import; thus, the imported secret matches the default value used by the operator, fixing authentication failures during the reconciliation of both ServiceCatalog (#1649) and CamelRoute (#1670) without requiring manual intervention.

## Summary by Sourcery

Refactor the AuthToken command options to simplify flag parsing and ensure Picocli correctly binds the get/unmask/clear options.

Bug Fixes:
- Ensure Picocli can parse and bind the --get, --unmask, and --clear flags directly on the AuthToken command without using a nested argument group.
- Fix token retrieval logic to use the flattened get/unmask flags instead of nested GetOptions.

Enhancements:
- Relax the AuthToken ArgGroup exclusivity to allow compatible options to be combined in a single invocation.

Tests:
- Update existing AuthToken tests to use the new flattened get/unmask flags.
- Add a Picocli parsing test to verify that the --get and --unmask flags are correctly interpreted and wired to AuthToken state.