### PR TITLE
Fix #1673: auto-refresh expired OIDC tokens in AuthToken --get

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -115,10 +115,8 @@ public class AuthToken extends BaseCommand {
             return null;
         }
 
-        if (isTokenExpiredOrExpiring()) {
-            if (tryRefreshToken(printer)) {
-                apiToken = credentialStore.getApiToken();
-            }
+        if (isTokenExpiredOrExpiring() && tryRefreshToken(printer)) {
+            apiToken = credentialStore.getApiToken();
         }
 
         return apiToken;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -1,14 +1,23 @@
 package ai.wanaku.cli.main.commands.auth;
 
+import java.time.Instant;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.AuthCredentialStore;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.cli.main.support.security.TokenRefresher;
+import ai.wanaku.cli.main.support.security.TokenRefresher.RefreshResult;
 import ai.wanaku.core.util.StringHelper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "token", description = "Manage API tokens")
 public class AuthToken extends BaseCommand {
+
+    /**
+     * Buffer time in seconds before token expiry to trigger refresh.
+     * Tokens will be refreshed when they are within this many seconds of expiring.
+     */
+    private static final long REFRESH_BUFFER_SECONDS = 30;
 
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     TokenOperation operation;
@@ -42,13 +51,19 @@ public class AuthToken extends BaseCommand {
     }
 
     private final AuthCredentialStore credentialStore;
+    private final TokenRefresher tokenRefresher;
 
     public AuthToken() {
-        this(new AuthCredentialStore());
+        this(new AuthCredentialStore(), null);
     }
 
     public AuthToken(AuthCredentialStore credentialStore) {
+        this(credentialStore, null);
+    }
+
+    AuthToken(AuthCredentialStore credentialStore, TokenRefresher tokenRefresher) {
         this.credentialStore = credentialStore;
+        this.tokenRefresher = tokenRefresher;
     }
 
     @Override
@@ -62,7 +77,7 @@ public class AuthToken extends BaseCommand {
         }
 
         if (operation.getOptions != null) {
-            String apiToken = credentialStore.getApiToken();
+            String apiToken = getValidAccessToken(printer);
             if (StringHelper.isNotEmpty(apiToken)) {
                 if (operation.getOptions.unmask) {
                     printer.printInfoMessage(apiToken);
@@ -86,6 +101,85 @@ public class AuthToken extends BaseCommand {
             }
         }
         return EXIT_OK;
+    }
+
+    /**
+     * Gets a valid access token, refreshing it if it is expired or about to expire.
+     *
+     * @param printer the printer for warning messages
+     * @return a valid access token, or null if unavailable
+     */
+    private String getValidAccessToken(WanakuPrinter printer) {
+        String apiToken = credentialStore.getApiToken();
+        if (StringHelper.isEmpty(apiToken)) {
+            return null;
+        }
+
+        if (isTokenExpiredOrExpiring()) {
+            if (tryRefreshToken(printer)) {
+                apiToken = credentialStore.getApiToken();
+            }
+        }
+
+        return apiToken;
+    }
+
+    /**
+     * Checks if the stored token is expired or about to expire.
+     *
+     * @return true if the token needs to be refreshed
+     */
+    private boolean isTokenExpiredOrExpiring() {
+        long expiryEpochSeconds = credentialStore.getTokenExpiry();
+        if (expiryEpochSeconds == 0) {
+            // No expiry stored - might be a token from before this feature
+            return false;
+        }
+
+        long currentEpochSeconds = Instant.now().getEpochSecond();
+        long secondsUntilExpiry = expiryEpochSeconds - currentEpochSeconds;
+
+        return secondsUntilExpiry <= REFRESH_BUFFER_SECONDS;
+    }
+
+    /**
+     * Attempts to refresh the access token using the stored refresh token.
+     *
+     * @param printer the printer for warning messages
+     * @return true if refresh was successful, false otherwise
+     */
+    private boolean tryRefreshToken(WanakuPrinter printer) {
+        String refreshToken = credentialStore.getRefreshToken();
+        String authServerUrl = credentialStore.getAuthServerUrl();
+        String clientId = credentialStore.getClientId();
+
+        if (StringHelper.isEmpty(refreshToken)) {
+            return false;
+        }
+
+        if (StringHelper.isEmpty(authServerUrl)) {
+            return false;
+        }
+
+        if (StringHelper.isEmpty(clientId)) {
+            clientId = "admin-cli";
+        }
+
+        String realm = credentialStore.getRealm();
+
+        try {
+            TokenRefresher refresher = tokenRefresher != null ? tokenRefresher : new TokenRefresher(insecure);
+            RefreshResult result = refresher.refresh(refreshToken, authServerUrl, clientId, realm);
+
+            credentialStore.storeApiToken(result.getAccessToken());
+            credentialStore.storeRefreshToken(result.getRefreshToken());
+            credentialStore.storeTokenExpiry(result.getExpiryEpochSeconds());
+
+            return true;
+        } catch (TokenRefresher.TokenRefreshException e) {
+            printer.printWarningMessage("Token refresh failed, returning existing token: " + e.getMessage());
+            return false;
+        }
     }
 
     private String maskToken(String token) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
@@ -1,0 +1,254 @@
+package ai.wanaku.cli.main.commands.auth;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.jline.terminal.Terminal;
+import ai.wanaku.cli.main.support.AuthCredentialStore;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.cli.main.support.security.TokenRefresher;
+import ai.wanaku.cli.main.support.security.TokenRefresher.RefreshResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockitoAnnotations;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisabledOnOs(OS.WINDOWS)
+class AuthTokenTest {
+
+    @TempDir
+    Path tempDir;
+
+    private AuthCredentialStore credentialStore;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        Path credentialsFile = tempDir.resolve("test-credentials");
+        URI credentialsUri = credentialsFile.toUri();
+        credentialStore = new AuthCredentialStore(credentialsUri);
+    }
+
+    @Test
+    void shouldRefreshExpiredTokenOnGet() throws Exception {
+        String oldToken = "old-expired-token";
+        String newToken = "new-refreshed-token";
+        String refreshToken = "my-refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expired 60 seconds ago
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
+        assertEquals(newToken, credentialStore.getApiToken());
+        assertEquals(newExpiry, credentialStore.getTokenExpiry());
+    }
+
+    @Test
+    void shouldNotRefreshValidTokenOnGet() throws Exception {
+        String token = "valid-token";
+
+        credentialStore.storeApiToken(token);
+        credentialStore.storeAuthMode("token");
+        // Token expires in 5 minutes
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 300);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        verify(mockRefresher, never()).refresh(any(), any(), any(), any());
+        assertEquals(token, credentialStore.getApiToken());
+    }
+
+    @Test
+    void shouldReturnExistingTokenWhenRefreshFails() throws Exception {
+        String oldToken = "old-token";
+        String refreshToken = "my-refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expired
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
+                .thenThrow(new TokenRefresher.TokenRefreshException("Refresh failed"));
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        // Should still have old token as fallback
+        assertEquals(oldToken, credentialStore.getApiToken());
+    }
+
+    @Test
+    void shouldRefreshTokenWithRealmOnGet() throws Exception {
+        String oldToken = "old-token";
+        String newToken = "new-token";
+        String refreshToken = "my-refresh-token";
+        String authServerUrl = "http://keycloak-host";
+        String clientId = "admin-cli";
+        String realm = "wanaku";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeRealm(realm);
+        credentialStore.storeAuthMode("token");
+        // Token expired
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() - 60);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, realm))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, realm);
+        assertEquals(newToken, credentialStore.getApiToken());
+    }
+
+    @Test
+    void shouldNotRefreshWhenNoExpiryStored() throws Exception {
+        String token = "legacy-token";
+
+        credentialStore.storeApiToken(token);
+        credentialStore.storeAuthMode("token");
+        // No expiry stored (legacy token)
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        verify(mockRefresher, never()).refresh(any(), any(), any(), any());
+        assertEquals(token, credentialStore.getApiToken());
+    }
+
+    @Test
+    void shouldRefreshTokenAboutToExpire() throws Exception {
+        String oldToken = "old-token";
+        String newToken = "new-token";
+        String refreshToken = "my-refresh-token";
+        String authServerUrl = "http://localhost:8080";
+        String clientId = "admin-cli";
+
+        credentialStore.storeApiToken(oldToken);
+        credentialStore.storeRefreshToken(refreshToken);
+        credentialStore.storeAuthServerUrl(authServerUrl);
+        credentialStore.storeClientId(clientId);
+        credentialStore.storeAuthMode("token");
+        // Token expires in 20 seconds (within 30 second buffer)
+        credentialStore.storeTokenExpiry(Instant.now().getEpochSecond() + 20);
+
+        TokenRefresher mockRefresher = mock(TokenRefresher.class);
+        long newExpiry = Instant.now().getEpochSecond() + 300;
+        when(mockRefresher.refresh(refreshToken, authServerUrl, clientId, null))
+                .thenReturn(new RefreshResult(newToken, refreshToken, newExpiry));
+
+        AuthToken authToken = new AuthToken(credentialStore, mockRefresher);
+        authToken.operation = new AuthToken.TokenOperation();
+        authToken.operation.getOptions = new AuthToken.GetOptions();
+        authToken.operation.getOptions.getToken = true;
+        authToken.operation.getOptions.unmask = true;
+
+        WanakuPrinter.setPlainMode(true);
+        try (Terminal terminal = WanakuPrinter.terminalInstance()) {
+            WanakuPrinter printer = new WanakuPrinter(null, terminal);
+            authToken.doCall(terminal, printer);
+        } finally {
+            WanakuPrinter.setPlainMode(false);
+        }
+
+        verify(mockRefresher).refresh(refreshToken, authServerUrl, clientId, null);
+        assertEquals(newToken, credentialStore.getApiToken());
+    }
+}

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -83,9 +83,39 @@ Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the 
 
 For direct REST API queries against the router (bypassing the `wanaku` CLI), retrieve the Bearer token stored by `wanaku auth login` (performed in Phase 3, Test 3.4 via [common/oidc-login-verification.md](common/oidc-login-verification.md)).
 
+The `wanaku auth token --get` command automatically refreshes expired tokens using the stored refresh token. If the refresh token has also expired, `ensure_valid_token` re-authenticates from scratch.
+
 ```bash
 get_router_token() {
   wanaku auth token --get --unmask --plain 2>/dev/null
+}
+```
+
+### Helper: ensure a valid OIDC token is available
+
+Call this before phases that use `get_router_token()` or `wanaku` CLI commands to prevent 401 errors from expired tokens. The `wanaku auth token --get` command auto-refreshes, but if the refresh token itself has expired, a full re-login is performed.
+
+```bash
+ensure_valid_token() {
+  local TOKEN
+  TOKEN=$(get_router_token)
+  if [ -n "${TOKEN}" ] && [ "${TOKEN}" != "null" ]; then
+    return 0
+  fi
+
+  echo "INFO: token refresh failed, performing full re-login"
+  echo "${WANAKU_TEST_PASS}" | ${WANAKU_CLI:-wanaku} auth login \
+    --auth-server "${WANAKU_ROUTER_URL}" \
+    --username "${WANAKU_TEST_USER}" \
+    --password \
+    --plain 2>&1
+
+  TOKEN=$(get_router_token)
+  if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+    echo "FAIL: unable to obtain a valid token after re-login"
+    return 1
+  fi
+  return 0
 }
 ```
 
@@ -463,6 +493,8 @@ fi
 ### Test 4.10: Verify catalog exists in router
 
 ```bash
+ensure_valid_token
+
 CATALOG_RESPONSE=$(query_router_api /api/v1/service-catalog)
 
 if echo "${CATALOG_RESPONSE}" | jq -e '.data' > /dev/null 2>&1; then
@@ -485,6 +517,7 @@ fi
 **Description:** After the operator deploys the catalog and starts the CIC, the sends-greeting tool should appear in the router's tool list.
 
 ```bash
+ensure_valid_token
 start_port_forward
 
 MAX_RETRIES=12
@@ -534,6 +567,7 @@ oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" | grep -q "Successfully deplo
 **Description:** Use the `wanaku tools list` command to confirm the sends-greeting tool is registered.
 
 ```bash
+ensure_valid_token
 start_port_forward
 
 TOOLS_OUTPUT=$(wanaku tools list --host "${WANAKU_HOST}" --plain 2>&1)
@@ -769,6 +803,7 @@ echo "promote-cic-service-exists=$?"
 ### Test 6.6: Verify both tools are registered in router
 
 ```bash
+ensure_valid_token
 start_port_forward
 
 MAX_RETRIES=12
@@ -801,6 +836,8 @@ stop_port_forward
 ### Test 6.7: Verify resource is registered in router
 
 ```bash
+ensure_valid_token
+
 RESOURCES_RESPONSE=$(query_router_api /api/v1/resources)
 echo "Router resources:"
 echo "${RESOURCES_RESPONSE}"
@@ -959,6 +996,8 @@ fi
 ### Test 7.5: Verify catalog deployed to router via REST API
 
 ```bash
+ensure_valid_token
+
 CATALOG_RESPONSE=$(query_router_api /api/v1/service-catalog)
 
 if echo "${CATALOG_RESPONSE}" | jq -e '.data[] | select(.name == "hello-system")' > /dev/null 2>&1; then


### PR DESCRIPTION
Fixes #1673

## Summary

- `wanaku auth token --get` now checks token expiry and automatically refreshes
  using the stored refresh token before returning the access token. Previously it
  returned the raw stored token, which caused 401 Unauthorized errors in long-running
  test sequences when the 300-second OIDC token expired.
- Adds `ensure_valid_token` helper to the camel-integration-capability test plan that
  performs a full re-login when the refresh token has also expired.
- Adds `ensure_valid_token` calls before tests 4.10, 4.11, 5.1, 6.6, 6.7, and 7.5.
- 6 new unit tests covering token refresh on get, no-refresh for valid tokens,
  fallback on refresh failure, realm-aware refresh, legacy tokens without expiry,
  and near-expiry buffer refresh.

## Summary by Sourcery

Auto-refresh OIDC access tokens returned by `wanaku auth token --get` and strengthen test coverage and integration test helpers to avoid 401s from expired tokens.

New Features:
- Add automatic refresh of stored OIDC access tokens when running `wanaku auth token --get`, including near-expiry buffering and realm-aware refresh.

Enhancements:
- Introduce a camel-integration-capability test helper `ensure_valid_token` that performs a full re-login when token refresh cannot provide a valid access token.
- Update camel-integration-capability tests to invoke `ensure_valid_token` before router and CLI interactions that rely on a valid token.

Tests:
- Add unit test suite for `AuthToken` covering refresh behavior, valid-token no-op, refresh failure fallback, realm handling, legacy tokens without expiry, and near-expiry buffer refresh.