### PR TITLE
[backport 0.2.x] Operator fixes, CLI improvements, and namespace guard

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -33,7 +33,7 @@ public class NamespaceOptions {
             "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
 
     @Option(
-            names = {"-N", "--namespace"},
+            names = {"-N", "--namespace", "--namespace-name"},
             description = "The namespace name associated with this entity")
     String namespace;
 

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -94,6 +94,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
@@ -52,7 +52,8 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
         pvc.getMetadata().setName(createVolumeClaimName(serviceName));
         pvc.getMetadata().setNamespace(ns);
-        pvc.getMetadata().getLabels().put("app", deploymentName);
+        pvc.getMetadata().getLabels().put("app", serviceName);
+        pvc.getMetadata().getLabels().put("app.kubernetes.io/part-of", deploymentName);
         pvc.getMetadata().getLabels().put("component", "wanaku-services-storage");
 
         pvc.addOwnerReference(resource);
@@ -133,11 +134,12 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating internal service for capability: %s", serviceName);
         service.getMetadata().setName(serviceName);
         service.getMetadata().setNamespace(ns);
-        service.getMetadata().getLabels().put("app", parentName);
+        service.getMetadata().getLabels().put("app", serviceName);
+        service.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         service.getMetadata().getLabels().put("component", serviceName);
 
         ServiceSpec serviceSpec2 = service.getSpec();
-        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
+        serviceSpec2.setSelector(Map.of("app", serviceName));
 
         service.addOwnerReference(resource);
 
@@ -156,14 +158,15 @@ public final class CapabilityResourceFactory {
 
         desiredDeployment.getMetadata().setName(serviceName);
         desiredDeployment.getMetadata().setNamespace(ns);
-        desiredDeployment.getMetadata().getLabels().put("app", parentName);
+        desiredDeployment.getMetadata().getLabels().put("app", serviceName);
+        desiredDeployment.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         desiredDeployment.getMetadata().getLabels().put("component", serviceName);
 
         final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
 
-        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
-        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
-        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
+        deploymentSpec.getSelector().getMatchLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
         deploymentSpec
                 .getTemplate()

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/assertions/OperatorAssertions.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/assertions/OperatorAssertions.java
@@ -1,0 +1,65 @@
+package ai.wanaku.operator.assertions;
+
+import org.assertj.core.api.Assertions;
+import io.fabric8.kubernetes.api.model.Condition;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+
+/**
+ * Custom assertions for Wanaku operator testing.
+ * Provides Kubernetes-specific assertions with clear failure messages.
+ */
+public final class OperatorAssertions {
+
+    private OperatorAssertions() {}
+
+    // ========== Condition Assertions ==========
+
+    public static void assertCondition(
+            Condition condition, String expectedType, String expectedStatus, Long expectedObservedGeneration) {
+        Assertions.assertThat(condition).isNotNull();
+        Assertions.assertThat(condition.getType()).isEqualTo(expectedType);
+        Assertions.assertThat(condition.getStatus()).isEqualTo(expectedStatus);
+        Assertions.assertThat(condition.getObservedGeneration()).isEqualTo(expectedObservedGeneration);
+    }
+
+    // ========== Service Assertions ==========
+
+    public static void assertServiceLabel(Service service, String labelKey, String expectedValue) {
+        Assertions.assertThat(service).isNotNull();
+        Assertions.assertThat(service.getMetadata().getLabels()).containsEntry(labelKey, expectedValue);
+    }
+
+    public static void assertServicePort(Service service, int expectedPort) {
+        Assertions.assertThat(service).isNotNull();
+        Assertions.assertThat(service.getSpec().getPorts()).isNotEmpty();
+        Assertions.assertThat(service.getSpec().getPorts().getFirst().getPort()).isEqualTo(expectedPort);
+    }
+
+    // ========== Metadata Assertions ==========
+
+    public static void assertMetadataLabel(HasMetadata resource, String labelKey, String expectedValue) {
+        Assertions.assertThat(resource).isNotNull();
+        Assertions.assertThat(resource.getMetadata().getLabels()).containsEntry(labelKey, expectedValue);
+    }
+
+    // ========== Endpoint Assertions ==========
+
+    public static void assertEndpointTarget(Endpoints endpoints, String expectedHost, int expectedPort) {
+        Assertions.assertThat(endpoints).isNotNull();
+        Assertions.assertThat(endpoints.getSubsets()).isNotEmpty();
+        Assertions.assertThat(endpoints.getSubsets().getFirst().getAddresses()).isNotEmpty();
+        Assertions.assertThat(endpoints.getSubsets().getFirst().getPorts()).isNotEmpty();
+        Assertions.assertThat(endpoints
+                        .getSubsets()
+                        .getFirst()
+                        .getAddresses()
+                        .getFirst()
+                        .getHostname())
+                .isEqualTo(expectedHost);
+        Assertions.assertThat(
+                        endpoints.getSubsets().getFirst().getPorts().getFirst().getPort())
+                .isEqualTo(expectedPort);
+    }
+}

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
@@ -1,0 +1,137 @@
+package ai.wanaku.operator.util;
+
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertMetadataLabel;
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertServiceLabel;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapabilityResourceFactoryTest {
+
+    private static WanakuCapability makeCapability(String crName) {
+        WanakuCapability capability = new WanakuCapability();
+        capability.getMetadata().setName(crName);
+        capability.getMetadata().setNamespace("wanaku");
+        capability.getMetadata().setUid("test-uid");
+        capability.setSpec(new WanakuCapabilitySpec());
+        return capability;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = new WanakuCapabilitySpec.CapabilitiesSpec();
+        spec.setName(name);
+        spec.setImage("quay.io/wanaku/wanaku-tool-service-http:latest");
+        return spec;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCiCCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = makeCapabilityEntry(name);
+        spec.setImage("quay.io/wanaku/camel-integration-capability:latest");
+        spec.setType(OperatorConstants.CAMEL_INTEGRATION_CAPABILITY_TYPE);
+        return spec;
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void wanakuCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void cicCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void cicCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void cicCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void internalServiceSelectorUsesCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Service service = CapabilityResourceFactory.makeCapabilityInternalService(cr, entry);
+
+        assertEquals("cic-catalog-test", service.getSpec().getSelector().get("app"));
+        assertServiceLabel(service, "app", "cic-catalog-test");
+        assertServiceLabel(service, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void pvcUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+
+        PersistentVolumeClaim pvc = CapabilityResourceFactory.makeServicesVolumePVC(cr, "cic-catalog-test");
+
+        assertMetadataLabel(pvc, "app", "cic-catalog-test");
+        assertMetadataLabel(pvc, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -97,6 +97,12 @@ public class NamespacesBean {
             throw new IllegalArgumentException("Namespace cannot be null");
         }
 
+        // Path must be provided
+        if (namespace.getPath() == null || StringHelper.isBlank(namespace.getPath())) {
+            throw new IllegalArgumentException("Path cannot be null");
+        }
+
+        // Name can be null if we are resetting/de-allocating the NS
         if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -1494,6 +1494,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
   | grep -iv "this-configmap-does-not-exist" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1509,6 +1510,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
     | grep -iv "this-configmap-does-not-exist" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -1267,6 +1267,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "not found in namespace" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1281,6 +1282,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "not found in namespace" \
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"


### PR DESCRIPTION
## Backport to 0.2.x

Cherry-pick of 5 commits from `main` onto `0.2.x`.

### Commits included

1. **operator: Fix app label in WanakuCapability CIC** (`93d26e1f`) — @claudio-claudius
2. **Fix #1654: exclude JVM -XX: flags from operator log error filter** (`a1b702df`)
3. **CLI: Document usage of a java truststore to connect to https servers** (`46d6726f`) — *skipped: already in 0.2.x*
4. **Prevent code from trying to create namespaces with null paths** (`23af2444`)
5. **Fix #1639: add --namespace-name as a PicoCLI alias for --namespace** (`30c0b8f0`)

### Prerequisites added

- `OperatorAssertions.java` test utility (from main) + `assertj-core` test dependency — required by the backported operator test

### Notes

- 1 commit skipped (docs change already present on 0.2.x)
- No conflicts encountered
- Sanity build passes (`mvn verify -DskipTests`)

## Summary by Sourcery

Backport operator label fixes, namespace validation guardrails, CLI namespace option alias, and related test and log-filter updates to the 0.2.x branch.

New Features:
- Add --namespace-name as a CLI alias for --namespace to support alternative flag naming.

Bug Fixes:
- Correct Kubernetes app labels and selectors for capability deployments, services, and PVCs so they use the capability name and carry part-of metadata.
- Prevent namespaces from being created with a null or blank path value in the router backend API.
- Exclude JVM -XX: options from operator log error filtering to avoid counting normal JVM flags as unexpected errors.

Enhancements:
- Introduce OperatorAssertions test utility and add AssertJ as a test dependency to improve operator test readability and robustness.
- Add focused unit tests for CapabilityResourceFactory to verify labeling and selector behavior for Wanaku capabilities and CIC deployments.

Tests:
- Update operator test plans to ignore JVM -XX: flags when checking for unexpected errors in logs.