### PR TITLE
[backport 0.2.x] Namespace validation and error handling fixes

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.stream.Collectors.toMap;
 import static org.jline.console.Printer.TableRows.EVEN;
 
 /**
@@ -309,9 +308,13 @@ public class WanakuPrinter extends DefaultPrinter {
         Map<String, Object> map = convertToMap(object);
         if (keys != null && keys.length > 0) {
             Set<String> keySet = Set.of(keys);
-            map = map.entrySet().stream()
-                    .filter(entry -> keySet.contains(entry.getKey()))
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, Object> filtered = new HashMap<>();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                if (keySet.contains(entry.getKey())) {
+                    filtered.put(entry.getKey(), entry.getValue());
+                }
+            }
+            map = filtered;
         }
 
         try {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
@@ -80,4 +80,25 @@ public class NamespacesCreateTest {
         Namespace submitted = captor.getValue();
         assertNull(submitted.getName());
     }
+
+    @Test
+    @DisplayName("Should create pre-allocated namespace when name is omitted")
+    void shouldCreatePreallocatedNamespaceWhenNameOmitted() throws Exception {
+        Namespace created = new Namespace();
+        created.setId("ns-3");
+        created.setPath("ns-no-name");
+
+        when(namespacesService.create(any(Namespace.class))).thenReturn(new WanakuResponse<>(created));
+
+        command.path = "ns-no-name";
+        command.name = null;
+
+        Integer result = command.doCall(null, mock(WanakuPrinter.class));
+
+        assertEquals(0, result);
+        ArgumentCaptor<Namespace> captor = ArgumentCaptor.forClass(Namespace.class);
+        verify(namespacesService).create(captor.capture());
+        Namespace submitted = captor.getValue();
+        assertNull(submitted.getName());
+    }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.main.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
@@ -111,6 +112,21 @@ class WanakuPrinterPlainModeTest {
 
         String output = outputStream.toString();
         assertTrue(output.contains("Available service templates:"), "Info message must appear in plain-mode output");
+    }
+
+    @Test
+    void printAsMapHandlesNullValues() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", "ns-123");
+        data.put("name", null);
+        data.put("path", "my-path");
+
+        printer.printAsMap(data, "id", "name", "path");
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Map output with null values must not be blank");
+        assertTrue(output.contains("ns-123"), "Output must contain non-null value 'ns-123'");
+        assertTrue(output.contains("my-path"), "Output must contain non-null value 'my-path'");
     }
 
     @Test

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,34 @@
+package ai.wanaku.backend.api.v1.exceptions;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+
+/**
+ * Maps {@link IllegalArgumentException} to HTTP 400 (Bad Request) responses.
+ * This ensures that validation errors (e.g., invalid namespace names) return
+ * a proper client error status instead of a generic 500 error.
+ */
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    private static final Logger LOG = Logger.getLogger(IllegalArgumentExceptionMapper.class);
+
+    @APIResponse(
+            responseCode = "400",
+            description = "Bad request",
+            content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
+    @Override
+    public Response toResponse(IllegalArgumentException e) {
+        LOG.warnf("Bad request: %s", e.getMessage());
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new WanakuResponse<Void>(e.getMessage()))
+                .build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.WanakuRouterConfig;
 import ai.wanaku.backend.core.persistence.api.NamespaceRepository;
@@ -26,6 +27,12 @@ public class NamespacesBean {
     private static final String LABEL_ALLOCATED_AT = "wanaku.io/allocated-at";
     private static final String LABEL_EXPIRES_AT = "wanaku.io/expires-at";
     private static final Set<String> PROTECTED_NAMESPACES = Set.of("default", "public", "wanaku-internal");
+
+    /**
+     * Pattern for valid namespace names and paths: must start with an alphanumeric character,
+     * followed by zero or more alphanumeric characters or dashes.
+     */
+    private static final Pattern VALID_NAMESPACE_PATTERN = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]*$");
 
     @Inject
     Instance<NamespaceRepository> namespaceRepositoryInstance;
@@ -72,6 +79,8 @@ public class NamespacesBean {
     }
 
     public Namespace alocateNamespace(String name) {
+        validateNamespaceValue(name, "name");
+
         List<Namespace> byName = namespaceRepository.findByName(name);
         if (byName.isEmpty()) {
             final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(name);
@@ -106,6 +115,9 @@ public class NamespacesBean {
         if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         if (isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath())) {
             throw new IllegalArgumentException("Reserved namespace names cannot be created");
@@ -165,6 +177,9 @@ public class NamespacesBean {
         if (namespace == null) {
             return false;
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         Namespace existingNamespace = namespaceRepository.findById(id);
         if (existingNamespace == null) {
@@ -272,6 +287,27 @@ public class NamespacesBean {
 
     private boolean isProtectedNamespace(Namespace namespace) {
         return isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath());
+    }
+
+    /**
+     * Validates that a namespace value (name or path) contains only alphanumeric characters and dashes,
+     * and starts with an alphanumeric character. Null values are accepted (e.g., preallocated namespaces
+     * have null names).
+     *
+     * @param value the value to validate
+     * @param fieldName the field name for the error message (e.g., "name" or "path")
+     * @throws IllegalArgumentException if the value contains invalid characters
+     */
+    private void validateNamespaceValue(String value, String fieldName) {
+        if (value == null) {
+            return;
+        }
+
+        if (!VALID_NAMESPACE_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid namespace %s: '%s'. Only alphanumeric characters and dashes are allowed, and it must start with an alphanumeric character"
+                            .formatted(fieldName, value));
+        }
     }
 
     private boolean isProtectedNamespaceName(String value) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -116,6 +116,11 @@ public class InvokerBridge implements ToolsBridge {
                     } else {
                         RequestIdContext.clear();
                     }
+                })
+                .onFailure()
+                .recoverWithItem(failure -> {
+                    LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
+                    return ToolResponse.error(failure.getMessage());
                 });
     }
 

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
@@ -141,6 +141,34 @@ public abstract class AbstractNamespacesResourceTest extends WanakuRouterTest {
 
     @Order(6)
     @Test
+    public void testCreateNamespaceWithInvalidPathReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/invalid-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(7)
+    @Test
+    public void testCreateNamespaceWithLeadingDashReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-bad-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(8)
+    @Test
     public void testStaleNamespaceCleanup() {
         Namespace namespace = new Namespace();
         stalePath = "test-stale-ns-" + System.currentTimeMillis();

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
@@ -16,6 +16,7 @@ import static ai.wanaku.test.assertions.WanakuAssertions.assertNamespaceExists;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @QuarkusTest
 @TestProfile(NoOidcTestProfile.class)
@@ -227,6 +228,78 @@ public class NamespacesBeanTest {
         boolean result = namespacesBean.update(publicNamespace.getId(), updated);
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingSlashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpacesIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpecialCharsIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my_namespace!");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingDashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithInvalidNameIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-path");
+        namespace.setName("/invalid-name");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace name");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-namespace-123");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getPath()).isEqualTo("valid-namespace-123");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidNameAndPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my-path-" + System.currentTimeMillis());
+        namespace.setName("my-name");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getName()).isEqualTo("my-name");
     }
 
     @Test

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -3,7 +3,12 @@ package ai.wanaku.backend.bridge;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.capabilities.sdk.api.types.InputSchema;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -12,8 +17,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -460,5 +467,42 @@ class InvokerBridgeTest {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, null));
         assertTrue(ex.getMessage().contains("query"), "Should report 'query' as missing");
+    }
+
+    @Test
+    void execute_returnsErrorResponseOnValidationFailure() {
+        // Set up a tool reference with a required parameter
+        Map<String, Property> props = new HashMap<>();
+        props.put("city", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.setType("http");
+        ref.getInputSchema().setRequired(List.of("city"));
+
+        // Mock ToolArguments with empty args (missing required 'city')
+        ToolManager.ToolArguments toolArguments = mock(ToolManager.ToolArguments.class);
+        when(toolArguments.args()).thenReturn(Map.of());
+        McpConnection connection = mock(McpConnection.class);
+        when(connection.id()).thenReturn("test-connection");
+        when(toolArguments.connection()).thenReturn(connection);
+        when(toolArguments.requestId()).thenReturn(new RequestId("test-request-1"));
+
+        // Mock dependencies -- ServiceResolver must return a non-null target
+        // so we get past resolveService and into buildToolInvokeRequest
+        ServiceResolver serviceResolver = mock(ServiceResolver.class);
+        when(serviceResolver.resolve(anyString(), anyString()))
+                .thenReturn(mock(ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget.class));
+
+        WanakuBridgeTransport transport = mock(WanakuBridgeTransport.class);
+
+        InvokerBridge bridge = new InvokerBridge(serviceResolver, transport, null, null);
+
+        // Execute should return ToolResponse.error instead of propagating the exception
+        ToolResponse response = bridge.execute(toolArguments, ref).await().indefinitely();
+
+        assertNotNull(response, "Response should not be null");
+        assertTrue(response.isError(), "Response should be an error");
+        TextContent textContent = response.firstContent().asText();
+        assertTrue(textContent.text().contains("city"), "Error message should mention the missing parameter 'city'");
     }
 }


### PR DESCRIPTION
## Backport to 0.2.x

Cherry-pick of 3 namespace-related fixes from `main` onto `0.2.x`.

### Commits included

1. **Fix #1605: fix spurious null error in namespaces create without --name** (`64fc55d1`)
2. **Fix #1637: validate namespace names to reject non-alphanumeric/dash characters** (`82e281be`)
3. **Fix #1638: surface validation error details instead of generic -32603** (`1268331a`)

### Notes

- No conflicts encountered
- No prerequisites needed
- Sanity build passes (`mvn verify -DskipTests`)

## Summary by Sourcery

Backport namespace validation and error handling improvements across backend and CLI components.

New Features:
- Enforce strict validation rules for namespace names and paths, rejecting invalid characters and formats.
- Map IllegalArgumentException to HTTP 400 responses with structured WanakuResponse payloads for client-visible validation errors.
- Ensure CLI namespace creation treats omitted names as pre-allocated namespaces while preserving path.
- Allow the CLI plain-mode printer to render maps containing null-valued fields without failing.

Bug Fixes:
- Prevent spurious null errors when creating namespaces without a provided name.
- Return tool execution validation failures as ToolResponse error objects instead of propagating exceptions from InvokerBridge.

Tests:
- Add backend and REST API tests covering namespace validation for various invalid and valid name/path combinations and HTTP 400 responses.
- Add bridge tests verifying that missing required tool parameters yield error ToolResponses mentioning the offending field.
- Extend CLI tests for namespace creation without name and for plain-mode map printing with null values.