### PR TITLE
Fix #1689: resolve OIDC client secret from K8s API to support rotation

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/clusterrole.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/clusterrole.yaml
@@ -158,6 +158,14 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -273,6 +281,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - get
       - list

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
                 secretKeyRef:
                   key: client-secret
                   name: {{ .Values.app.oidc.secretName }}
+            - name: WANAKU_OIDC_SECRET_NAME
+              value: {{ .Values.app.oidc.secretName }}
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES
               value: {{ .Values.app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAPABILITY_NAMESPACES | quote }}
             - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_WANAKU_CAMEL_ROUTE_NAMESPACES

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorSecurityConfig.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/OperatorSecurityConfig.java
@@ -1,5 +1,9 @@
 package ai.wanaku.operator.util;
 
+import java.util.Base64;
+import org.jboss.logging.Logger;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import ai.wanaku.capabilities.sdk.common.security.SecurityServiceConfig;
 import ai.wanaku.capabilities.sdk.security.TokenEndpoint;
 import ai.wanaku.operator.wanaku.WanakuTypes;
@@ -8,18 +12,50 @@ import ai.wanaku.operator.wanaku.WanakuTypes;
  * Adapts the operator's {@link WanakuTypes.AuthSpec} to the SDK's
  * {@link SecurityServiceConfig} interface so that {@code ServiceAuthenticator}
  * can be used for OIDC token acquisition.
+ *
+ * <p>When a {@link KubernetesClient} is provided, the client secret is resolved
+ * by reading the Kubernetes Secret directly via the API on each call to
+ * {@link #getSecret()}, allowing the operator to pick up secret rotations
+ * without a pod restart. Falls back to the {@code WANAKU_OIDC_CLIENT_SECRET}
+ * environment variable when the Kubernetes Secret cannot be read.</p>
  */
 public final class OperatorSecurityConfig implements SecurityServiceConfig {
+    private static final Logger LOG = Logger.getLogger(OperatorSecurityConfig.class);
+
     static final String CLIENT_SECRET_ENV = "WANAKU_OIDC_CLIENT_SECRET";
+    static final String SECRET_NAME_ENV = "WANAKU_OIDC_SECRET_NAME";
+    static final String DEFAULT_SECRET_NAME = "wanaku-oidc";
+    static final String SECRET_KEY = "client-secret";
     static final String DEFAULT_CLIENT_SECRET = "mypasswd";
     static final String CLIENT_ID = "wanaku-service";
 
     private final String tokenEndpoint;
-    private final String clientSecret;
+    private final KubernetesClient kubernetesClient;
+    private final String namespace;
 
+    /**
+     * Creates a config that resolves the client secret from the environment
+     * variable only (legacy behavior, no dynamic refresh).
+     *
+     * @param authSpec the auth specification from the WanakuRouter
+     */
     public OperatorSecurityConfig(WanakuTypes.AuthSpec authSpec) {
+        this(authSpec, null, null);
+    }
+
+    /**
+     * Creates a config that resolves the client secret from a Kubernetes Secret
+     * via the API on each call to {@link #getSecret()}, falling back to the
+     * environment variable when the API read fails.
+     *
+     * @param authSpec the auth specification from the WanakuRouter
+     * @param kubernetesClient the Kubernetes client for reading Secrets (may be null)
+     * @param namespace the namespace containing the OIDC secret (may be null)
+     */
+    public OperatorSecurityConfig(WanakuTypes.AuthSpec authSpec, KubernetesClient kubernetesClient, String namespace) {
         this.tokenEndpoint = buildTokenEndpoint(authSpec);
-        this.clientSecret = resolveClientSecret();
+        this.kubernetesClient = kubernetesClient;
+        this.namespace = namespace;
     }
 
     @Override
@@ -29,7 +65,13 @@ public final class OperatorSecurityConfig implements SecurityServiceConfig {
 
     @Override
     public String getSecret() {
-        return clientSecret;
+        if (kubernetesClient != null && namespace != null) {
+            String fromK8s = readSecretFromKubernetes();
+            if (fromK8s != null) {
+                return fromK8s;
+            }
+        }
+        return resolveClientSecret();
     }
 
     @Override
@@ -41,6 +83,49 @@ public final class OperatorSecurityConfig implements SecurityServiceConfig {
         return authSpec != null
                 && authSpec.getAuthServer() != null
                 && !authSpec.getAuthServer().isBlank();
+    }
+
+    /**
+     * Reads the OIDC client secret from a Kubernetes Secret via the API.
+     *
+     * @return the decoded secret value, or null if the secret cannot be read
+     */
+    private String readSecretFromKubernetes() {
+        String secretName = resolveSecretName();
+        try {
+            Secret secret = kubernetesClient
+                    .secrets()
+                    .inNamespace(namespace)
+                    .withName(secretName)
+                    .get();
+            if (secret != null && secret.getData() != null) {
+                String encoded = secret.getData().get(SECRET_KEY);
+                if (encoded != null && !encoded.isBlank()) {
+                    return new String(Base64.getDecoder().decode(encoded));
+                }
+            }
+            LOG.debugf(
+                    "Kubernetes Secret '%s' in namespace '%s' does not contain key '%s'",
+                    secretName, namespace, SECRET_KEY);
+        } catch (Exception e) {
+            LOG.warnf(
+                    "Failed to read OIDC secret '%s' from namespace '%s': %s. "
+                            + "Falling back to environment variable.",
+                    secretName, namespace, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the name of the Kubernetes Secret that contains the OIDC
+     * client secret, using the {@code WANAKU_OIDC_SECRET_NAME} environment
+     * variable or the default {@value #DEFAULT_SECRET_NAME}.
+     *
+     * @return the secret name
+     */
+    static String resolveSecretName() {
+        String name = System.getenv(SECRET_NAME_ENV);
+        return (name != null && !name.isBlank()) ? name : DEFAULT_SECRET_NAME;
     }
 
     private static String buildTokenEndpoint(WanakuTypes.AuthSpec authSpec) {

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -95,10 +95,12 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
             RBACVerbs.PATCH,
             RBACVerbs.DELETE
         })
+@RBACRule(
+        apiGroups = "",
+        resources = {"secrets"},
+        verbs = {RBACVerbs.GET, RBACVerbs.LIST, RBACVerbs.WATCH})
 public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>, Cleaner<WanakuCamelRoute> {
     private static final Logger LOG = Logger.getLogger(WanakuCamelRouteReconciler.class);
-
-    private ServiceAuthenticator serviceAuthenticator;
 
     private volatile ServiceCatalogService cachedClient;
     private volatile String cachedBaseUri;
@@ -283,10 +285,10 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(routerBaseUrl));
 
         if (OperatorSecurityConfig.isAuthEnabled(authSpec)) {
-            if (serviceAuthenticator == null) {
-                serviceAuthenticator = new ServiceAuthenticator(new OperatorSecurityConfig(authSpec));
-            }
-            builder.register(new BearerTokenFilter(serviceAuthenticator));
+            OperatorSecurityConfig config =
+                    new OperatorSecurityConfig(authSpec, kubernetesClient, kubernetesClient.getNamespace());
+            ServiceAuthenticator authenticator = new ServiceAuthenticator(config);
+            builder.register(new BearerTokenFilter(authenticator));
         }
 
         cachedClient = builder.build(ServiceCatalogService.class);
@@ -422,7 +424,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         deployment.addOwnerReference(resource);
     }
 
-    private static List<EnvVar> buildCicEnvVars(String crName, String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
+    private List<EnvVar> buildCicEnvVars(String crName, String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
         List<EnvVar> envVars = new ArrayList<>();
 
         envVars.add(new EnvVarBuilder()
@@ -463,13 +465,15 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
             if (realm == null || realm.isBlank()) {
                 realm = EnvironmentVariables.DEFAULT_AUTH_REALM;
             }
+            OperatorSecurityConfig config =
+                    new OperatorSecurityConfig(authSpec, kubernetesClient, kubernetesClient.getNamespace());
             envVars.add(new EnvVarBuilder()
                     .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_TOKEN_ENDPOINT)
                     .withValue(authSpec.getAuthServer() + "/realms/" + realm)
                     .build());
             envVars.add(new EnvVarBuilder()
                     .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_SECRET)
-                    .withValue(OperatorSecurityConfig.resolveClientSecret())
+                    .withValue(config.getSecret())
                     .build());
             envVars.add(new EnvVarBuilder()
                     .withName(EnvironmentVariables.CAMEL_INTEGRATION_CAPABILITY_CLIENT_ID)

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
@@ -49,12 +49,14 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
         apiGroups = "",
         resources = {"configmaps"},
         verbs = {RBACVerbs.GET, RBACVerbs.LIST, RBACVerbs.WATCH})
+@RBACRule(
+        apiGroups = "",
+        resources = {"secrets"},
+        verbs = {RBACVerbs.GET, RBACVerbs.LIST, RBACVerbs.WATCH})
 public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceCatalog>, Cleaner<WanakuServiceCatalog> {
     private static final Logger LOG = Logger.getLogger(WanakuServiceCatalogReconciler.class);
 
     private static final String CATALOG_DATA_KEY = "catalog.zip";
-
-    private ServiceAuthenticator serviceAuthenticator;
 
     private volatile ServiceCatalogService cachedClient;
     private volatile String cachedBaseUri;
@@ -253,10 +255,10 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
         QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(routerBaseUrl));
 
         if (OperatorSecurityConfig.isAuthEnabled(authSpec)) {
-            if (serviceAuthenticator == null) {
-                serviceAuthenticator = new ServiceAuthenticator(new OperatorSecurityConfig(authSpec));
-            }
-            builder.register(new BearerTokenFilter(serviceAuthenticator));
+            OperatorSecurityConfig config =
+                    new OperatorSecurityConfig(authSpec, kubernetesClient, kubernetesClient.getNamespace());
+            ServiceAuthenticator authenticator = new ServiceAuthenticator(config);
+            builder.register(new BearerTokenFilter(authenticator));
         }
 
         cachedClient = builder.build(ServiceCatalogService.class);

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorSecurityConfigTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/OperatorSecurityConfigTest.java
@@ -1,11 +1,21 @@
 package ai.wanaku.operator.util;
 
+import java.util.Base64;
+import java.util.Map;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import ai.wanaku.operator.wanaku.WanakuTypes;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OperatorSecurityConfigTest {
 
@@ -97,5 +107,87 @@ class OperatorSecurityConfigTest {
         OperatorSecurityConfig config = new OperatorSecurityConfig(authSpec);
 
         assertTrue(config.isAuthEnabled());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSecretReadFromKubernetesApi() {
+        WanakuTypes.AuthSpec authSpec = new WanakuTypes.AuthSpec();
+        authSpec.setAuthServer("http://keycloak:8080");
+
+        String expectedSecret = "my-rotated-secret";
+        Secret k8sSecret = new SecretBuilder()
+                .withData(Map.of(
+                        OperatorSecurityConfig.SECRET_KEY,
+                        Base64.getEncoder().encodeToString(expectedSecret.getBytes())))
+                .build();
+
+        KubernetesClient client = mock(KubernetesClient.class);
+        MixedOperation secretsOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        Resource secretResource = mock(Resource.class);
+
+        when(client.secrets()).thenReturn(secretsOp);
+        when(secretsOp.inNamespace("test-ns")).thenReturn(nsOp);
+        when(nsOp.withName(OperatorSecurityConfig.DEFAULT_SECRET_NAME)).thenReturn(secretResource);
+        when(secretResource.get()).thenReturn(k8sSecret);
+
+        OperatorSecurityConfig config = new OperatorSecurityConfig(authSpec, client, "test-ns");
+
+        assertEquals(expectedSecret, config.getSecret());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSecretFallsBackWhenKubernetesApiFails() {
+        WanakuTypes.AuthSpec authSpec = new WanakuTypes.AuthSpec();
+        authSpec.setAuthServer("http://keycloak:8080");
+
+        KubernetesClient client = mock(KubernetesClient.class);
+        when(client.secrets()).thenThrow(new RuntimeException("API unreachable"));
+
+        OperatorSecurityConfig config = new OperatorSecurityConfig(authSpec, client, "test-ns");
+
+        // Should fall back to env var / default without throwing
+        assertEquals(OperatorSecurityConfig.DEFAULT_CLIENT_SECRET, config.getSecret());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSecretFallsBackWhenK8sSecretMissing() {
+        WanakuTypes.AuthSpec authSpec = new WanakuTypes.AuthSpec();
+        authSpec.setAuthServer("http://keycloak:8080");
+
+        KubernetesClient client = mock(KubernetesClient.class);
+        MixedOperation secretsOp = mock(MixedOperation.class);
+        NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+        Resource secretResource = mock(Resource.class);
+
+        when(client.secrets()).thenReturn(secretsOp);
+        when(secretsOp.inNamespace("test-ns")).thenReturn(nsOp);
+        when(nsOp.withName(OperatorSecurityConfig.DEFAULT_SECRET_NAME)).thenReturn(secretResource);
+        when(secretResource.get()).thenReturn(null);
+
+        OperatorSecurityConfig config = new OperatorSecurityConfig(authSpec, client, "test-ns");
+
+        assertEquals(OperatorSecurityConfig.DEFAULT_CLIENT_SECRET, config.getSecret());
+    }
+
+    @Test
+    void testResolveSecretNameDefault() {
+        // When env var is not set, should return the default name
+        assertEquals(OperatorSecurityConfig.DEFAULT_SECRET_NAME, OperatorSecurityConfig.resolveSecretName());
+    }
+
+    @Test
+    void testLegacyConstructorFallsBackToEnvVar() {
+        WanakuTypes.AuthSpec authSpec = new WanakuTypes.AuthSpec();
+        authSpec.setAuthServer("http://keycloak:8080");
+
+        // Legacy constructor (no K8s client) should still work
+        OperatorSecurityConfig config = new OperatorSecurityConfig(authSpec);
+
+        // Should return default since no env var and no K8s client
+        assertEquals(OperatorSecurityConfig.DEFAULT_CLIENT_SECRET, config.getSecret());
     }
 }


### PR DESCRIPTION
Fixes #1689

## Summary

The operator cached the OIDC client secret from the `WANAKU_OIDC_CLIENT_SECRET` environment variable at pod startup and never refreshed it. When the Keycloak client secret was rotated and the Kubernetes Secret updated, the operator continued using the stale cached value until manually restarted.

### Changes

- **`OperatorSecurityConfig`**: Added a new constructor accepting `KubernetesClient` and namespace. `getSecret()` now reads the K8s Secret directly via the API on each call, falling back to the env var for backward compatibility.
- **`WanakuServiceCatalogReconciler`** and **`WanakuCamelRouteReconciler`**: No longer cache the `ServiceAuthenticator` across reconciliations. Each reconciliation creates a fresh authenticator with the current secret from the K8s API, ensuring rotated secrets are picked up immediately.
- **`buildCicEnvVars`**: Reads the current secret from the K8s API instead of the stale env var when setting environment variables for CIC deployments.
- **Helm chart**: Added `WANAKU_OIDC_SECRET_NAME` env var to deployment template. Added `secrets` RBAC access to `wanaku-service-catalog-cluster-role` and `wanaku-camel-route-cluster-role`.
- **Tests**: Added unit tests for K8s Secret reading, API failure fallback, and missing secret handling.

### Integration test note

The `RouterReconnectionITCase` timeout failure is a pre-existing flaky test that also fails on unrelated branches (confirmed on `quick-fix/cross-capability-missing-realm`).

## Summary by Sourcery

Resolve OIDC client secrets dynamically from Kubernetes Secrets to support secret rotation without restarting the operator.

New Features:
- Add support for resolving the OIDC client secret from a Kubernetes Secret via the API, with configurable secret name via environment variable.

Bug Fixes:
- Ensure the operator picks up rotated OIDC client secrets immediately instead of using a stale value cached at startup.

Enhancements:
- Refactor operator reconciler logic to construct a fresh ServiceAuthenticator and OperatorSecurityConfig per reconciliation, enabling dynamic secret resolution.
- Update CIC environment variable construction to read the current OIDC client secret from the Kubernetes API rather than a cached environment variable value.

Deployment:
- Extend Helm deployment to expose the OIDC secret name as an environment variable and grant RBAC permissions for reading secrets to relevant cluster roles.

Tests:
- Add unit tests covering Kubernetes Secret-based secret resolution, API failure fallback behavior, missing secret handling, and legacy constructor behavior.