### PR TITLE
Fix #1688: add imagePullPolicy support and image validation for WanakuCamelRoute CIC

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
@@ -19,6 +19,8 @@ spec:
             properties:
               image:
                 type: "string"
+              imagePullPolicy:
+                type: "string"
               mcp:
                 properties:
                   resources:

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
@@ -21,6 +21,10 @@ spec:
                 type: "string"
               imagePullPolicy:
                 type: "string"
+                enum:
+                - "Always"
+                - "IfNotPresent"
+                - "Never"
               mcp:
                 properties:
                   resources:

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -51,6 +51,8 @@ import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
 import static ai.wanaku.operator.util.OperatorUtil.findCondition;
 import static ai.wanaku.operator.util.OperatorUtil.getRouterBaseUrl;
 import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
+import static ai.wanaku.operator.util.OperatorUtil.resolveImagePullPolicy;
+import static ai.wanaku.operator.util.OperatorUtil.validateImageAllowed;
 
 @ControllerConfiguration(
         informer = @Informer(namespaces = Constants.WATCH_CURRENT_NAMESPACE),
@@ -159,6 +161,12 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
                     resource,
                     "DeploymentError",
                     "Failed to package CamelRoute '%s': %s".formatted(catalogName, e.getMessage()));
+        }
+
+        try {
+            validateImageAllowed(resource.getSpec().getImage());
+        } catch (IllegalArgumentException e) {
+            return setErrorStatus(resource, "ValidationError", e.getMessage());
         }
 
         try {
@@ -400,7 +408,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         Container container = spec.getTemplate().getSpec().getContainers().getFirst();
         container.setName(cicName);
         container.setImage(resource.getSpec().getImage());
-        container.setImagePullPolicy("Always");
+        container.setImagePullPolicy(resolveImagePullPolicy(resource.getSpec().getImagePullPolicy(), null));
         container.setEnv(buildCicEnvVars(crName, routerBaseUrl, authSpec));
 
         deployment.addOwnerReference(resource);

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -46,13 +46,12 @@ import ai.wanaku.operator.util.CamelRoutePackager;
 import ai.wanaku.operator.util.CapabilityResourceFactory;
 import ai.wanaku.operator.util.EnvironmentVariables;
 import ai.wanaku.operator.util.OperatorSecurityConfig;
+import ai.wanaku.operator.util.OperatorUtil;
 
 import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
 import static ai.wanaku.operator.util.OperatorUtil.findCondition;
 import static ai.wanaku.operator.util.OperatorUtil.getRouterBaseUrl;
 import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
-import static ai.wanaku.operator.util.OperatorUtil.resolveImagePullPolicy;
-import static ai.wanaku.operator.util.OperatorUtil.validateImageAllowed;
 
 @ControllerConfiguration(
         informer = @Informer(namespaces = Constants.WATCH_CURRENT_NAMESPACE),
@@ -164,7 +163,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         }
 
         try {
-            validateImageAllowed(resource.getSpec().getImage());
+            OperatorUtil.validateImageAllowed(resource.getSpec().getImage());
         } catch (IllegalArgumentException e) {
             return setErrorStatus(resource, "ValidationError", e.getMessage());
         }
@@ -408,7 +407,8 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         Container container = spec.getTemplate().getSpec().getContainers().getFirst();
         container.setName(cicName);
         container.setImage(resource.getSpec().getImage());
-        container.setImagePullPolicy(resolveImagePullPolicy(resource.getSpec().getImagePullPolicy(), null));
+        container.setImagePullPolicy(
+                OperatorUtil.resolveImagePullPolicy(resource.getSpec().getImagePullPolicy(), null));
         container.setEnv(buildCicEnvVars(crName, routerBaseUrl, authSpec));
 
         deployment.addOwnerReference(resource);

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpec.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpec.java
@@ -9,6 +9,7 @@ public class WanakuCamelRouteSpec {
 
     private String routerRef;
     private String image;
+    private String imagePullPolicy;
     private JsonNode route;
     private McpSpec mcp;
     private Map<String, String> properties;
@@ -27,6 +28,14 @@ public class WanakuCamelRouteSpec {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public String getImagePullPolicy() {
+        return imagePullPolicy;
+    }
+
+    public void setImagePullPolicy(String imagePullPolicy) {
+        this.imagePullPolicy = imagePullPolicy;
     }
 
     public JsonNode getRoute() {

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpecTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpecTest.java
@@ -1,0 +1,45 @@
+package ai.wanaku.operator.wanaku;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WanakuCamelRouteSpecTest {
+
+    @Test
+    void getImageReturnsDefaultWhenNull() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:latest", spec.getImage());
+    }
+
+    @Test
+    void getImageReturnsDefaultWhenBlank() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImage("   ");
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:latest", spec.getImage());
+    }
+
+    @Test
+    void getImageReturnsCustomImageWhenSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImage("quay.io/wanaku/camel-integration-capability:0.5.0");
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:0.5.0", spec.getImage());
+    }
+
+    @Test
+    void getImagePullPolicyReturnsNullWhenNotSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+
+        assertEquals(null, spec.getImagePullPolicy());
+    }
+
+    @Test
+    void getImagePullPolicyReturnsValueWhenSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImagePullPolicy("IfNotPresent");
+
+        assertEquals("IfNotPresent", spec.getImagePullPolicy());
+    }
+}


### PR DESCRIPTION
Fixes #1688

## Summary

The WanakuCamelRoute CRD was missing `imagePullPolicy` support and image validation, which are both available in the WanakuCapability path. This PR adds parity:

- **imagePullPolicy field**: Added to `WanakuCamelRouteSpec` and the CRD manifest. Uses `OperatorUtil.resolveImagePullPolicy()` with a default of `IfNotPresent` (previously hardcoded to `Always`).
- **Image validation**: The reconciler now calls `OperatorUtil.validateImageAllowed()` before deploying the CIC instance, matching the security check used by `CapabilityResourceFactory`.
- **Tests**: Added unit tests for image default/custom values and imagePullPolicy behavior.

## Test plan

- [x] Unit tests pass (`WanakuCamelRouteSpecTest`)
- [x] Full operator module build succeeds (`mvn verify`)
- [x] Integration tests: CIC-related tests pass (CamelBasicToolITCase, CamelFileResourceITCase, CamelMultiInstanceITCase, CamelPostgresToolITCase)
- [x] Pre-existing `RouterReconnectionITCase` failure in cross-capability-tests is unrelated (also fails on main)

## Summary by Sourcery

Add image pull policy support and image validation to WanakuCamelRoute to align CIC deployment behavior with existing capability resources.

New Features:
- Expose imagePullPolicy field in WanakuCamelRouteSpec and CRD to control CIC container image pull behavior.

Bug Fixes:
- Validate WanakuCamelRoute CIC images before deployment to prevent use of disallowed images.

Enhancements:
- Use configurable image pull policy instead of hardcoded Always when creating CIC deployments.
- Add unit tests covering default and custom image values and imagePullPolicy behavior for WanakuCamelRouteSpec.

Tests:
- Introduce WanakuCamelRouteSpecTest to verify image defaults and imagePullPolicy getters and setters.