### PR TITLE
Fix #1683: ensure non-zero exit code for MCP tool call errors

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -8,6 +8,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.McpGetPromptResult;
 import dev.langchain4j.mcp.client.McpPromptMessage;
@@ -62,6 +63,13 @@ public class McpPrompt extends BaseCommand {
             }
 
             return EXIT_OK;
+        } catch (LangChain4jException e) {
+            String message = e.getMessage();
+            if (message == null || message.isBlank()) {
+                message = "Prompt call failed: " + name;
+            }
+            printer.printErrorMessage(message);
+            return EXIT_ERROR;
         } catch (Exception e) {
             printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -6,6 +6,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
+import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.McpReadResourceResult;
 import dev.langchain4j.mcp.client.McpResourceContents;
@@ -53,6 +54,13 @@ public class McpResource extends BaseCommand {
             }
 
             return EXIT_OK;
+        } catch (LangChain4jException e) {
+            String message = e.getMessage();
+            if (message == null || message.isBlank()) {
+                message = "Resource read failed: " + resourceUri;
+            }
+            printer.printErrorMessage(message);
+            return EXIT_ERROR;
         } catch (Exception e) {
             printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -9,6 +9,8 @@ import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import picocli.CommandLine;
@@ -61,6 +63,12 @@ public class McpTool extends BaseCommand {
 
             System.out.println(result.resultText());
             return EXIT_OK;
+        } catch (ToolArgumentsException e) {
+            printer.printErrorMessage(McpErrorHelper.friendlyToolCallMessage(e, name));
+            return EXIT_ERROR;
+        } catch (ToolExecutionException e) {
+            printer.printErrorMessage(McpErrorHelper.friendlyToolCallMessage(e, name));
+            return EXIT_ERROR;
         } catch (Exception e) {
             printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
@@ -3,6 +3,8 @@ package ai.wanaku.cli.main.support;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
 
 /**
  * Translates MCP client exceptions into user-friendly error messages.
@@ -16,6 +18,52 @@ import java.net.UnknownHostException;
 public final class McpErrorHelper {
 
     private McpErrorHelper() {}
+
+    /**
+     * Produces a user-friendly error message for a tool-call failure.
+     *
+     * <p>Handles MCP-specific exceptions that carry structured error information
+     * (error codes, tool names) and produces actionable messages.</p>
+     *
+     * @param ex the tool execution exception (either {@code ToolExecutionException}
+     *           or {@code ToolArgumentsException})
+     * @param toolName the name of the tool that was being called (may be null)
+     * @return a user-friendly error message
+     */
+    public static String friendlyToolCallMessage(ToolExecutionException ex, String toolName) {
+        return buildToolCallMessage(ex.getMessage(), ex.errorCode(), toolName);
+    }
+
+    /**
+     * Produces a user-friendly error message for a tool-arguments failure.
+     *
+     * @param ex the tool arguments exception
+     * @param toolName the name of the tool that was being called (may be null)
+     * @return a user-friendly error message
+     */
+    public static String friendlyToolCallMessage(ToolArgumentsException ex, String toolName) {
+        return buildToolCallMessage(ex.getMessage(), ex.errorCode(), toolName);
+    }
+
+    private static String buildToolCallMessage(String message, Integer errorCode, String toolName) {
+        StringBuilder sb = new StringBuilder();
+
+        if (message != null && !message.isBlank()) {
+            sb.append(message);
+        } else if (toolName != null) {
+            sb.append("Tool call failed: ").append(toolName);
+        } else {
+            sb.append("Tool call failed");
+        }
+
+        if (errorCode != null && errorCode == -32602) {
+            sb.append("\n\nPossible causes:\n");
+            sb.append("  - Tool name is not registered on the MCP server\n");
+            sb.append("  - Invalid tool arguments");
+        }
+
+        return sb.toString();
+    }
 
     /**
      * Produces a user-friendly error message for the given exception and

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -8,6 +8,8 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import picocli.CommandLine;
@@ -143,6 +145,35 @@ class McpToolTest {
         Integer result = command.doCall(null, printer);
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("Missing required option: --name");
+    }
+
+    @Test
+    @DisplayName("Should return error on ToolArgumentsException for invalid tool name")
+    void shouldReturnErrorOnToolArgumentsException() throws Exception {
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenThrow(new ToolArgumentsException("Invalid tool name: nonexistent", -32602));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(printer).printErrorMessage(captor.capture());
+        String message = captor.getValue();
+        assertTrue(message.contains("Invalid tool name"));
+    }
+
+    @Test
+    @DisplayName("Should return error on ToolExecutionException")
+    void shouldReturnErrorOnToolExecutionException() throws Exception {
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenThrow(new ToolExecutionException("Tool execution failed", -32603));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        verify(printer).printErrorMessage(any(String.class));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
@@ -4,6 +4,8 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.concurrent.ExecutionException;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -122,5 +124,34 @@ class McpErrorHelperTest {
         assertTrue(message.contains("Possible causes"));
         assertFalse(message.contains("ExecutionException"));
         assertFalse(message.contains("RuntimeException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for ToolArgumentsException with invalid tool name")
+    void shouldHandleToolArgumentsExceptionForInvalidTool() {
+        ToolArgumentsException ex = new ToolArgumentsException("Invalid tool name: nonexistent", -32602);
+        String message = McpErrorHelper.friendlyToolCallMessage(ex, "nonexistent");
+
+        assertTrue(message.contains("Invalid tool name"));
+        assertTrue(message.contains("Tool name is not registered"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for ToolExecutionException")
+    void shouldHandleToolExecutionException() {
+        ToolExecutionException ex = new ToolExecutionException("tool failed");
+        String message = McpErrorHelper.friendlyToolCallMessage(ex, "my-tool");
+
+        assertTrue(message.contains("tool failed"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for ToolExecutionException with null message")
+    void shouldHandleToolExecutionExceptionWithNullMessage() {
+        ToolExecutionException ex = new ToolExecutionException((String) null);
+        String message = McpErrorHelper.friendlyToolCallMessage(ex, "my-tool");
+
+        assertTrue(message.contains("Tool call failed"));
+        assertTrue(message.contains("my-tool"));
     }
 }


### PR DESCRIPTION
Fixes #1683

## Summary

The CLI returned exit code 0 when invoking a non-existent MCP tool, even though the output indicated the tool does not exist. This fix adds explicit handling for langchain4j MCP client exceptions (`ToolExecutionException` and `ToolArgumentsException`) in the `McpTool`, `McpPrompt`, and `McpResource` commands, ensuring the CLI always returns exit code 1 for tool call errors.

## Changes

- **McpTool**: Added specific catch clauses for `ToolExecutionException` and `ToolArgumentsException` before the generic `Exception` handler, with user-friendly error messages via `McpErrorHelper`
- **McpPrompt / McpResource**: Added catch clause for `LangChain4jException` (parent of both exception types) for consistency
- **McpErrorHelper**: Added `friendlyToolCallMessage` methods that produce actionable error messages for MCP-specific exceptions, including hints about possible causes for error code -32602 (invalid tool name / invalid arguments)
- **Tests**: Added unit tests covering the new exception handling paths

## Test plan

- [ ] Unit tests pass (`McpToolTest`, `McpErrorHelperTest`)
- [ ] Invoking a non-existent MCP tool returns exit code 1
- [ ] Error message includes the tool name and actionable guidance

## Integration test note

CI failures in `HttpToolCliITCase` and `CliResourceITCase` are pre-existing flaky tests (same tests pass in prior runs on main, and they fail with "Internal Server Error: Generic error" unrelated to this change).

## Summary by Sourcery

Ensure MCP CLI commands return a non-zero exit code and clearer error messages when MCP tool, prompt, or resource calls fail.

Bug Fixes:
- Ensure MCP tool invocations that fail with ToolArgumentsException or ToolExecutionException cause the CLI to exit with an error status instead of success.
- Handle LangChain4jException failures in MCP prompt and resource commands so these also exit with an error status and show an appropriate message.

Enhancements:
- Add McpErrorHelper helpers to generate user-friendly, actionable messages for MCP tool call failures, including guidance for invalid tool names or arguments.

Tests:
- Add unit tests for McpTool error handling on ToolArgumentsException and ToolExecutionException.
- Add unit tests verifying user-friendly messages produced by McpErrorHelper for MCP tool call exceptions.