### PR TITLE
Fix #1672: cache REST client in operator reconcilers to avoid repeated connection setup

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -38,6 +38,7 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.smallrye.common.annotation.Blocking;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
@@ -94,6 +95,7 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
             RBACVerbs.PATCH,
             RBACVerbs.DELETE
         })
+@Blocking
 public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>, Cleaner<WanakuCamelRoute> {
     private static final Logger LOG = Logger.getLogger(WanakuCamelRouteReconciler.class);
 

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -38,7 +38,6 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
-import io.smallrye.common.annotation.Blocking;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
@@ -95,11 +94,13 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
             RBACVerbs.PATCH,
             RBACVerbs.DELETE
         })
-@Blocking
 public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>, Cleaner<WanakuCamelRoute> {
     private static final Logger LOG = Logger.getLogger(WanakuCamelRouteReconciler.class);
 
     private ServiceAuthenticator serviceAuthenticator;
+
+    private volatile ServiceCatalogService cachedClient;
+    private volatile String cachedBaseUri;
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -249,7 +250,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         dataStore.setData(data);
 
         try {
-            ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl, authSpec);
+            ServiceCatalogService service = getOrCreateClient(routerBaseUrl, authSpec);
             service.deploy(dataStore);
         } catch (WebApplicationException e) {
             throw new WanakuException(
@@ -263,34 +264,39 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
     }
 
     private void removeServiceCatalog(String routerBaseUrl, WanakuTypes.AuthSpec authSpec, String name) {
-        ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl, authSpec);
+        ServiceCatalogService service = getOrCreateClient(routerBaseUrl, authSpec);
         service.remove(name);
     }
 
-    private ServiceCatalogService createServiceCatalogClient(String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
+    private ServiceCatalogService getOrCreateClient(String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
+        if (cachedClient != null && routerBaseUrl.equals(cachedBaseUri)) {
+            return cachedClient;
+        }
+
         QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(routerBaseUrl));
 
         if (OperatorSecurityConfig.isAuthEnabled(authSpec)) {
             if (serviceAuthenticator == null) {
                 serviceAuthenticator = new ServiceAuthenticator(new OperatorSecurityConfig(authSpec));
             }
-            String token = serviceAuthenticator.currentValidAccessToken();
-            builder.register(new BearerTokenFilter(token));
+            builder.register(new BearerTokenFilter(serviceAuthenticator));
         }
 
-        return builder.build(ServiceCatalogService.class);
+        cachedClient = builder.build(ServiceCatalogService.class);
+        cachedBaseUri = routerBaseUrl;
+        return cachedClient;
     }
 
     private static class BearerTokenFilter implements ClientRequestFilter {
-        private final String token;
+        private final ServiceAuthenticator authenticator;
 
-        BearerTokenFilter(String token) {
-            this.token = token;
+        BearerTokenFilter(ServiceAuthenticator authenticator) {
+            this.authenticator = authenticator;
         }
 
         @Override
         public void filter(ClientRequestContext requestContext) {
-            requestContext.getHeaders().putSingle("Authorization", "Bearer " + token);
+            requestContext.getHeaders().putSingle("Authorization", "Bearer " + authenticator.currentValidAccessToken());
         }
     }
 

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
@@ -28,6 +28,7 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.smallrye.common.annotation.Blocking;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
@@ -49,6 +50,7 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
         apiGroups = "",
         resources = {"configmaps"},
         verbs = {RBACVerbs.GET, RBACVerbs.LIST, RBACVerbs.WATCH})
+@Blocking
 public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceCatalog>, Cleaner<WanakuServiceCatalog> {
     private static final Logger LOG = Logger.getLogger(WanakuServiceCatalogReconciler.class);
 

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
@@ -28,7 +28,6 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
-import io.smallrye.common.annotation.Blocking;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
@@ -50,13 +49,15 @@ import static ai.wanaku.operator.util.OperatorUtil.readyCondition;
         apiGroups = "",
         resources = {"configmaps"},
         verbs = {RBACVerbs.GET, RBACVerbs.LIST, RBACVerbs.WATCH})
-@Blocking
 public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceCatalog>, Cleaner<WanakuServiceCatalog> {
     private static final Logger LOG = Logger.getLogger(WanakuServiceCatalogReconciler.class);
 
     private static final String CATALOG_DATA_KEY = "catalog.zip";
 
     private ServiceAuthenticator serviceAuthenticator;
+
+    private volatile ServiceCatalogService cachedClient;
+    private volatile String cachedBaseUri;
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -226,7 +227,7 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
         dataStore.setData(data);
 
         try {
-            ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl, authSpec);
+            ServiceCatalogService service = getOrCreateClient(routerBaseUrl, authSpec);
             service.deploy(dataStore);
         } catch (WebApplicationException e) {
             throw new WanakuException(
@@ -240,34 +241,39 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
     }
 
     private void removeServiceCatalog(String routerBaseUrl, WanakuTypes.AuthSpec authSpec, String name) {
-        ServiceCatalogService service = createServiceCatalogClient(routerBaseUrl, authSpec);
+        ServiceCatalogService service = getOrCreateClient(routerBaseUrl, authSpec);
         service.remove(name);
     }
 
-    private ServiceCatalogService createServiceCatalogClient(String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
+    private ServiceCatalogService getOrCreateClient(String routerBaseUrl, WanakuTypes.AuthSpec authSpec) {
+        if (cachedClient != null && routerBaseUrl.equals(cachedBaseUri)) {
+            return cachedClient;
+        }
+
         QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(routerBaseUrl));
 
         if (OperatorSecurityConfig.isAuthEnabled(authSpec)) {
             if (serviceAuthenticator == null) {
                 serviceAuthenticator = new ServiceAuthenticator(new OperatorSecurityConfig(authSpec));
             }
-            String token = serviceAuthenticator.currentValidAccessToken();
-            builder.register(new BearerTokenFilter(token));
+            builder.register(new BearerTokenFilter(serviceAuthenticator));
         }
 
-        return builder.build(ServiceCatalogService.class);
+        cachedClient = builder.build(ServiceCatalogService.class);
+        cachedBaseUri = routerBaseUrl;
+        return cachedClient;
     }
 
     private static class BearerTokenFilter implements ClientRequestFilter {
-        private final String token;
+        private final ServiceAuthenticator authenticator;
 
-        BearerTokenFilter(String token) {
-            this.token = token;
+        BearerTokenFilter(ServiceAuthenticator authenticator) {
+            this.authenticator = authenticator;
         }
 
         @Override
         public void filter(ClientRequestContext requestContext) {
-            requestContext.getHeaders().putSingle("Authorization", "Bearer " + token);
+            requestContext.getHeaders().putSingle("Authorization", "Bearer " + authenticator.currentValidAccessToken());
         }
     }
 }


### PR DESCRIPTION
Fixes #1672

## Summary

The `WanakuServiceCatalogReconciler` and `WanakuCamelRouteReconciler` were rebuilding a `QuarkusRestClientBuilder` REST client on every reconciliation call, causing repeated Netty channel bootstrap and connection setup overhead.

This PR:
- **Removes the `@Blocking` annotations** that were added previously. They are no-ops on JOSDK reconcilers, which already run on their own thread pool, not the Vert.x event loop.
- **Caches the REST client instance** per base URI in both reconcilers. The client is only rebuilt when the target router URI changes.
- **Makes `BearerTokenFilter` dynamic** so that cached clients still use valid OIDC tokens. The filter now calls `ServiceAuthenticator.currentValidAccessToken()` on each request instead of capturing a fixed token at client creation time.

## Changes

- `WanakuServiceCatalogReconciler`: removed `@Blocking`, added `cachedClient`/`cachedBaseUri` fields, renamed `createServiceCatalogClient` to `getOrCreateClient` with caching, updated `BearerTokenFilter` to use `ServiceAuthenticator` directly.
- `WanakuCamelRouteReconciler`: same changes as above.

## Test plan

- [x] `mvn verify -pl apps/wanaku-operator -am` passes
- [x] No functional changes to reconciliation logic or auth flow