### PR TITLE
chore: add jline CLibrary native classes to GraalVM runtime init list

### DIFF
--- a/apps/wanaku-cli/pom.xml
+++ b/apps/wanaku-cli/pom.xml
@@ -264,7 +264,9 @@
                     --initialize-at-run-time=org.jline.nativ.Kernel32$MENU_EVENT_RECORD,
                     --initialize-at-run-time=org.jline.nativ.JLineLibrary,
                     --initialize-at-run-time=com.nimbusds.oauth2.sdk.http.HTTPRequest,
-                    -H:ReflectionConfigurationFiles=reflection-config.json,
+		    --initialize-at-run-time=org.jline.nativ.CLibrary$Termios,
+		    --initialize-at-run-time=org.jline.nativ.CLibrary$WinSize,
+			-H:ReflectionConfigurationFiles=reflection-config.json,
                     -H:IncludeResourceBundles=consoleui_messages,
                     -H:ResourceConfigurationFiles=resources-config.json
                 </quarkus.native.additional-build-args>


### PR DESCRIPTION
## Summary
- Add `--initialize-at-run-time` entries for `org.jline.nativ.CLibrary$Termios` and `org.jline.nativ.CLibrary$WinSize` to the native image build args
- Fixes native CLI build failure on Fedora 43 with GCC 15 where the linker fails due to missing runtime initialization for these jline native classes

## Test plan
- [x] Native build completes successfully with `make cli-native`