### PR TITLE
Fix #1651: wait for CIC readiness before reporting CamelRoute as Ready

### DIFF
--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.client.ClientRequestFilter;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -175,6 +176,22 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         status.setDeployedCatalogName(catalogName);
         status.setRegisteredTools(extractToolNames(resource.getSpec()));
         status.setRegisteredResources(extractResourceNames(resource.getSpec()));
+
+        if (!isCicReady(crName + "-cic", namespace)) {
+            LOG.infof("CIC instance '%s-cic' is not yet ready, rescheduling reconciliation", crName);
+            Condition condition = new ConditionBuilder()
+                    .withType(READY_CONDITION)
+                    .withStatus("False")
+                    .withObservedGeneration(resource.getMetadata().getGeneration())
+                    .withLastTransitionTime(OffsetDateTime.now(ZoneOffset.UTC).toString())
+                    .withReason("CICNotReady")
+                    .withMessage("Waiting for CIC instance to become ready")
+                    .build();
+            status.setConditions(List.of(condition));
+            resource.setStatus(status);
+            return UpdateControl.patchStatus(resource).rescheduleAfter(Duration.ofSeconds(5));
+        }
+
         final Condition previousReadyCondition = findCondition(
                 resource.getStatus() != null ? resource.getStatus().getConditions() : null, READY_CONDITION);
         status.setConditions(List.of(readyCondition(
@@ -290,6 +307,24 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         public void filter(ClientRequestContext requestContext) {
             requestContext.getHeaders().putSingle("Authorization", "Bearer " + token);
         }
+    }
+
+    private boolean isCicReady(String cicName, String namespace) {
+        Deployment cicDeployment = kubernetesClient
+                .apps()
+                .deployments()
+                .inNamespace(namespace)
+                .withName(cicName)
+                .get();
+        return isDeploymentReady(cicDeployment);
+    }
+
+    static boolean isDeploymentReady(Deployment deployment) {
+        if (deployment == null || deployment.getStatus() == null) {
+            return false;
+        }
+        Integer readyReplicas = deployment.getStatus().getReadyReplicas();
+        return readyReplicas != null && readyReplicas > 0;
     }
 
     private static final int CIC_GRPC_PORT = 9190;

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -177,8 +177,9 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         status.setRegisteredTools(extractToolNames(resource.getSpec()));
         status.setRegisteredResources(extractResourceNames(resource.getSpec()));
 
-        if (!isCicReady(crName + "-cic", namespace)) {
-            LOG.infof("CIC instance '%s-cic' is not yet ready, rescheduling reconciliation", crName);
+        final String cicName = crName + "-cic";
+        if (!isCicReady(cicName, namespace)) {
+            LOG.infof("CIC instance '%s' is not yet ready, rescheduling reconciliation", cicName);
             Condition condition = new ConditionBuilder()
                     .withType(READY_CONDITION)
                     .withStatus("False")
@@ -309,7 +310,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
         }
     }
 
-    private boolean isCicReady(String cicName, String namespace) {
+    boolean isCicReady(String cicName, String namespace) {
         Deployment cicDeployment = kubernetesClient
                 .apps()
                 .deployments()

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconcilerTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconcilerTest.java
@@ -1,0 +1,49 @@
+package ai.wanaku.operator.wanaku;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WanakuCamelRouteReconcilerTest {
+
+    @Test
+    void isDeploymentReadyReturnsFalseWhenDeploymentIsNull() {
+        assertFalse(WanakuCamelRouteReconciler.isDeploymentReady(null));
+    }
+
+    @Test
+    void isDeploymentReadyReturnsFalseWhenStatusIsNull() {
+        Deployment deployment = new Deployment();
+        assertFalse(WanakuCamelRouteReconciler.isDeploymentReady(deployment));
+    }
+
+    @Test
+    void isDeploymentReadyReturnsFalseWhenReadyReplicasIsNull() {
+        Deployment deployment = new Deployment();
+        DeploymentStatus status = new DeploymentStatus();
+        status.setReadyReplicas(null);
+        deployment.setStatus(status);
+        assertFalse(WanakuCamelRouteReconciler.isDeploymentReady(deployment));
+    }
+
+    @Test
+    void isDeploymentReadyReturnsFalseWhenReadyReplicasIsZero() {
+        Deployment deployment = new Deployment();
+        DeploymentStatus status = new DeploymentStatus();
+        status.setReadyReplicas(0);
+        deployment.setStatus(status);
+        assertFalse(WanakuCamelRouteReconciler.isDeploymentReady(deployment));
+    }
+
+    @Test
+    void isDeploymentReadyReturnsTrueWhenReadyReplicasIsPositive() {
+        Deployment deployment = new Deployment();
+        DeploymentStatus status = new DeploymentStatus();
+        status.setReadyReplicas(1);
+        deployment.setStatus(status);
+        assertTrue(WanakuCamelRouteReconciler.isDeploymentReady(deployment));
+    }
+}

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconcilerTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconcilerTest.java
@@ -1,11 +1,18 @@
 package ai.wanaku.operator.wanaku;
 
+import java.lang.reflect.Field;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class WanakuCamelRouteReconcilerTest {
 
@@ -45,5 +52,68 @@ class WanakuCamelRouteReconcilerTest {
         status.setReadyReplicas(1);
         deployment.setStatus(status);
         assertTrue(WanakuCamelRouteReconciler.isDeploymentReady(deployment));
+    }
+
+    @Test
+    void isCicReadyReturnsFalseWhenDeploymentNotFound() throws Exception {
+        WanakuCamelRouteReconciler reconciler = new WanakuCamelRouteReconciler();
+        KubernetesClient mockClient = mockKubernetesClient("test-ns", "test-cic", null);
+        setKubernetesClient(reconciler, mockClient);
+
+        assertFalse(reconciler.isCicReady("test-cic", "test-ns"));
+    }
+
+    @Test
+    void isCicReadyReturnsFalseWhenDeploymentNotReady() throws Exception {
+        WanakuCamelRouteReconciler reconciler = new WanakuCamelRouteReconciler();
+
+        Deployment deployment = new Deployment();
+        DeploymentStatus status = new DeploymentStatus();
+        status.setReadyReplicas(0);
+        deployment.setStatus(status);
+
+        KubernetesClient mockClient = mockKubernetesClient("test-ns", "test-cic", deployment);
+        setKubernetesClient(reconciler, mockClient);
+
+        assertFalse(reconciler.isCicReady("test-cic", "test-ns"));
+    }
+
+    @Test
+    void isCicReadyReturnsTrueWhenDeploymentReady() throws Exception {
+        WanakuCamelRouteReconciler reconciler = new WanakuCamelRouteReconciler();
+
+        Deployment deployment = new Deployment();
+        DeploymentStatus status = new DeploymentStatus();
+        status.setReadyReplicas(1);
+        deployment.setStatus(status);
+
+        KubernetesClient mockClient = mockKubernetesClient("test-ns", "test-cic", deployment);
+        setKubernetesClient(reconciler, mockClient);
+
+        assertTrue(reconciler.isCicReady("test-cic", "test-ns"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KubernetesClient mockKubernetesClient(String namespace, String name, Deployment result) {
+        KubernetesClient client = mock(KubernetesClient.class);
+        AppsAPIGroupDSL apps = mock(AppsAPIGroupDSL.class);
+        MixedOperation deployments = mock(MixedOperation.class);
+        MixedOperation namespacedDeployments = mock(MixedOperation.class);
+        RollableScalableResource namedResource = mock(RollableScalableResource.class);
+
+        when(client.apps()).thenReturn(apps);
+        when(apps.deployments()).thenReturn(deployments);
+        when(deployments.inNamespace(namespace)).thenReturn(namespacedDeployments);
+        when(namespacedDeployments.withName(name)).thenReturn(namedResource);
+        when(namedResource.get()).thenReturn(result);
+
+        return client;
+    }
+
+    private static void setKubernetesClient(WanakuCamelRouteReconciler reconciler, KubernetesClient client)
+            throws Exception {
+        Field field = WanakuCamelRouteReconciler.class.getDeclaredField("kubernetesClient");
+        field.setAccessible(true);
+        field.set(reconciler, client);
     }
 }


### PR DESCRIPTION
Fixes #1651

## Summary

The `WanakuCamelRouteReconciler` was marking the CR as Ready immediately after creating the CIC Deployment object, before the CIC pod was actually running. This caused the MCP endpoint to return no tools when queried right after the CR reached Ready state.

## Changes

- Added CIC Deployment readiness check: the reconciler now verifies that the CIC Deployment has at least one ready replica before setting Ready=True on the CR
- When the CIC is not yet ready, the reconciler sets Ready=False with reason `CICNotReady` and reschedules reconciliation after 5 seconds
- Added unit tests for the deployment readiness check logic

## Summary by Sourcery

Ensure WanakuCamelRoute resources are only marked Ready after the associated CIC deployment has at least one ready replica, delaying readiness when CIC is not yet available.

Bug Fixes:
- Prevent WanakuCamelRoute CRs from being marked Ready before the CIC deployment has a running pod, avoiding empty MCP tool responses immediately after readiness.

Enhancements:
- Add a readiness check helper for CIC deployments based on deployment status and ready replicas count.

Tests:
- Add unit tests covering the deployment readiness helper behavior for null deployment, missing status, missing ready replicas, zero replicas, and positive replicas.