### PR TITLE
Fix #1699: return null for expired tokens when refresh fails

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/auth/AuthToken.java
@@ -105,9 +105,12 @@ public class AuthToken extends BaseCommand {
 
     /**
      * Gets a valid access token, refreshing it if it is expired or about to expire.
+     * Returns null when the token is expired and cannot be refreshed, so that callers
+     * (such as the test plan's {@code ensure_valid_token} helper) can detect the failure
+     * and perform a full re-login instead of sending an expired token.
      *
      * @param printer the printer for warning messages
-     * @return a valid access token, or null if unavailable
+     * @return a valid access token, or null if unavailable or expired beyond recovery
      */
     private String getValidAccessToken(WanakuPrinter printer) {
         String apiToken = credentialStore.getApiToken();
@@ -115,8 +118,12 @@ public class AuthToken extends BaseCommand {
             return null;
         }
 
-        if (isTokenExpiredOrExpiring() && tryRefreshToken(printer)) {
-            apiToken = credentialStore.getApiToken();
+        if (isTokenExpiredOrExpiring()) {
+            if (tryRefreshToken(printer)) {
+                apiToken = credentialStore.getApiToken();
+            } else {
+                return null;
+            }
         }
 
         return apiToken;

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/auth/AuthTokenTest.java
@@ -108,7 +108,7 @@ class AuthTokenTest {
     }
 
     @Test
-    void shouldReturnExistingTokenWhenRefreshFails() throws Exception {
+    void shouldReturnNullWhenRefreshFails() throws Exception {
         String oldToken = "old-token";
         String refreshToken = "my-refresh-token";
         String authServerUrl = "http://localhost:8080";
@@ -135,12 +135,16 @@ class AuthTokenTest {
         WanakuPrinter.setPlainMode(true);
         try (Terminal terminal = WanakuPrinter.terminalInstance()) {
             WanakuPrinter printer = new WanakuPrinter(null, terminal);
-            authToken.doCall(terminal, printer);
+            Integer exitCode = authToken.doCall(terminal, printer);
+            assertEquals(0, exitCode);
         } finally {
             WanakuPrinter.setPlainMode(false);
         }
 
-        // Should still have old token as fallback
+        // The expired token is still in the credential store (not cleared), but
+        // getValidAccessToken returns null so the CLI outputs "No API token is
+        // currently set" instead of the expired token. This lets the test plan's
+        // ensure_valid_token helper detect the failure and perform a full re-login.
         assertEquals(oldToken, credentialStore.getApiToken());
     }
 


### PR DESCRIPTION
Fixes #1699

When `getValidAccessToken()` detected an expired token and `tryRefreshToken()` failed, it returned the expired token anyway. This caused the test plan's `ensure_valid_token` helper to see a non-empty token and skip re-login, which then led to 401 errors in tests 4.10 and 7.5.

Now returns null when the token is expired and cannot be refreshed, letting the test plan detect the failure and perform a full re-login.

## Summary by Sourcery

Return null instead of an expired access token when refresh fails, allowing callers to detect the failure and trigger a full re-login.

Bug Fixes:
- Ensure getValidAccessToken returns null when an expired token cannot be refreshed, instead of returning the expired token.

Tests:
- Update authentication token tests to assert null is returned on refresh failure while preserving the stored expired token.