### PR TITLE
Fix #1706: return actual error details instead of generic message in BaseExceptionMapper

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
@@ -51,9 +51,13 @@ public final class ProvisioningHelper {
         ProvisioningReference provisioningReference = provisionerBridge.provision(
                 referenceName, payload.getConfigurationData(), payload.getSecretsData(), service);
 
-        uriSetter.accept(
-                provisioningReference.configurationURI().toString(),
-                provisioningReference.secretsURI().toString());
+        String configURI = provisioningReference.configurationURI() != null
+                ? provisioningReference.configurationURI().toString()
+                : "";
+        String secretsURI = provisioningReference.secretsURI() != null
+                ? provisioningReference.secretsURI().toString()
+                : "";
+        uriSetter.accept(configURI, secretsURI);
 
         return provisioningReference;
     }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/BaseExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/BaseExceptionMapper.java
@@ -12,23 +12,32 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 
 /**
  * A provider of a base exception mapper that converts exceptions to standardized responses.
+ * <p>
+ * This is the catch-all mapper for exceptions not handled by more specific mappers.
+ * It includes the actual exception message in the response so that clients receive
+ * actionable diagnostic information instead of a generic error.
  */
 @Provider
 public class BaseExceptionMapper implements ExceptionMapper<Exception> {
     private static final Logger LOG = Logger.getLogger(BaseExceptionMapper.class);
 
-    private static final String GENERIC_ERROR = "Generic error";
+    private static final String FALLBACK_MESSAGE = "Internal server error";
 
     @APIResponse(
             responseCode = "500",
-            description = "Generic error",
+            description = "Internal server error",
             content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
     @Override
     public Response toResponse(Exception e) {
         LOG.error(e.getMessage(), e);
 
+        String message = e.getMessage();
+        if (message == null || message.isBlank()) {
+            message = FALLBACK_MESSAGE;
+        }
+
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .entity(new WanakuResponse<Void>(GENERIC_ERROR))
+                .entity(new WanakuResponse<Void>(message))
                 .build();
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -86,11 +86,13 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
                 });
 
         final Map<String, PropertySchema> serviceProperties = provisioningReference.properties();
-        final Map<String, Property> clientProperties =
-                toolReference.getInputSchema().getProperties();
-        for (var serviceProperty : serviceProperties.entrySet()) {
-            clientProperties.computeIfAbsent(
-                    serviceProperty.getKey(), v -> toProperty(serviceProperty, serviceProperties));
+        if (serviceProperties != null && !serviceProperties.isEmpty() && toolReference.getInputSchema() != null) {
+            final Map<String, Property> clientProperties =
+                    toolReference.getInputSchema().getProperties();
+            for (var serviceProperty : serviceProperties.entrySet()) {
+                clientProperties.computeIfAbsent(
+                        serviceProperty.getKey(), v -> toProperty(serviceProperty, serviceProperties));
+            }
         }
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
@@ -35,7 +35,11 @@ public class ToolsHelper {
     }
 
     private static Class<?> toType(Property property) {
-        return switch (property.getType().toLowerCase()) {
+        String type = property.getType();
+        if (type == null || type.isBlank()) {
+            return String.class;
+        }
+        return switch (type.toLowerCase()) {
             case "string" -> String.class;
             case "int", "integer" -> Integer.class;
             case "boolean" -> Boolean.class;


### PR DESCRIPTION
Fixes #1706

## Summary

- **BaseExceptionMapper** was returning a hardcoded "Generic error" message for all unhandled exceptions, making CLI tool registration failures impossible to diagnose from the client side. Changed it to return the actual exception message, with a fallback to "Internal server error" when the message is null or blank.
- Added **null-safety guards** in the tool registration path to prevent `NullPointerException` from reaching the catch-all mapper:
  - `ToolsHelper.toType()`: handles null/blank property types by defaulting to `String.class`
  - `ProvisioningHelper.provision()`: handles null URIs from provisioning responses
  - `ToolsBean.provision()`: handles null property maps and input schemas

## Test plan

- [x] `HttpToolCliITCase.shouldRegisterHttpToolViaCli` now passes (was the failing test from the issue)
- [x] All 26 HTTP capability tests pass (0 failures, 0 errors)
- [x] Router backend unit tests pass
- [x] Camel test failures in CI are pre-existing and unrelated (same failures on baseline main branch)

## Summary by Sourcery

Improve error reporting for unhandled exceptions and harden tool provisioning against null values to make CLI tool registration failures diagnosable from the client side.

Bug Fixes:
- Return the actual exception message in the base exception mapper response, falling back to a generic internal server error when the message is unavailable.
- Guard tool provisioning and registration paths against null property types, null provisioning URIs, and null/empty property maps to avoid unexpected runtime exceptions.

Enhancements:
- Document the role of the base exception mapper as a catch-all that surfaces actionable diagnostic information to clients.