### PR TITLE
chore: address review feedback from PR #1708

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/common/ProvisioningHelper.java
@@ -53,10 +53,10 @@ public final class ProvisioningHelper {
 
         String configURI = provisioningReference.configurationURI() != null
                 ? provisioningReference.configurationURI().toString()
-                : "";
+                : null;
         String secretsURI = provisioningReference.secretsURI() != null
                 ? provisioningReference.secretsURI().toString()
-                : "";
+                : null;
         uriSetter.accept(configURI, secretsURI);
 
         return provisioningReference;

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/BaseExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/BaseExceptionMapper.java
@@ -14,8 +14,8 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
  * A provider of a base exception mapper that converts exceptions to standardized responses.
  * <p>
  * This is the catch-all mapper for exceptions not handled by more specific mappers.
- * It includes the actual exception message in the response so that clients receive
- * actionable diagnostic information instead of a generic error.
+ * It returns a generic error message to avoid leaking internal implementation details;
+ * the full exception message and stack trace are logged server-side for diagnostics.
  */
 @Provider
 public class BaseExceptionMapper implements ExceptionMapper<Exception> {
@@ -31,13 +31,8 @@ public class BaseExceptionMapper implements ExceptionMapper<Exception> {
     public Response toResponse(Exception e) {
         LOG.error(e.getMessage(), e);
 
-        String message = e.getMessage();
-        if (message == null || message.isBlank()) {
-            message = FALLBACK_MESSAGE;
-        }
-
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .entity(new WanakuResponse<Void>(message))
+                .entity(new WanakuResponse<Void>(FALLBACK_MESSAGE))
                 .build();
     }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/tools/ToolsBean.java
@@ -86,7 +86,10 @@ public class ToolsBean extends LabelsAwareWanakuEntityBean<ToolReference> {
                 });
 
         final Map<String, PropertySchema> serviceProperties = provisioningReference.properties();
-        if (serviceProperties != null && !serviceProperties.isEmpty() && toolReference.getInputSchema() != null) {
+        if (serviceProperties != null
+                && !serviceProperties.isEmpty()
+                && toolReference.getInputSchema() != null
+                && toolReference.getInputSchema().getProperties() != null) {
             final Map<String, Property> clientProperties =
                     toolReference.getInputSchema().getProperties();
             for (var serviceProperty : serviceProperties.entrySet()) {


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #1708:

- **BaseExceptionMapper**: always return generic "Internal server error" to clients to avoid leaking internal implementation details (database errors, hostnames, etc.). Full exception details remain in server logs for diagnostics.
- **ProvisioningHelper**: use `null` instead of empty string `""` when `configurationURI` or `secretsURI` are absent, preserving "unset" vs "empty" semantics for downstream consumers.
- **ToolsBean**: add null guard for `getInputSchema().getProperties()` to prevent `NullPointerException` when `InputSchema` exists but its properties map is uninitialized.

## Test plan

- [x] `mvn compile -pl apps/wanaku-router-backend -am` passes
- [x] `mvn test -pl apps/wanaku-router-backend` passes
- [x] Adversarial code review passed

## Summary by Sourcery

Align error handling and provisioning behavior with review feedback to improve security and robustness.

Bug Fixes:
- Prevent potential NullPointerException in ToolsBean when the input schema exists but its properties map is uninitialized.

Enhancements:
- Return a generic internal server error message from the BaseExceptionMapper while keeping detailed exception information in server logs.
- Treat absent configuration and secrets URIs as null in ProvisioningHelper to preserve unset vs empty semantics for downstream consumers.