### PR TITLE
Fix #1697: isolate credential storage for concurrent test runs

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -2,12 +2,14 @@ package ai.wanaku.cli.main.support;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Properties;
@@ -31,6 +33,14 @@ public class AuthCredentialStore {
     private static final String CLIENT_ID_KEY = "client.id";
     private static final String REALM_KEY = "auth.realm";
 
+    /**
+     * System property that, when set, overrides the default credentials file path. This allows
+     * Quarkus configuration ({@code wanaku.cli.auth.credentials-file}) or a JVM flag
+     * ({@code -Dwanaku.cli.auth.credentials-file=...}) to isolate credential storage per
+     * process, preventing contention when multiple CLI invocations run concurrently.
+     */
+    static final String CREDENTIALS_FILE_SYS_PROP = "wanaku.cli.auth.credentials-file";
+
     private final URI credentialsUri;
 
     public AuthCredentialStore() {
@@ -42,6 +52,12 @@ public class AuthCredentialStore {
         if (envOverride != null && !envOverride.isBlank()) {
             return envOverride.trim();
         }
+
+        String sysPropOverride = System.getProperty(CREDENTIALS_FILE_SYS_PROP);
+        if (sysPropOverride != null && !sysPropOverride.isBlank()) {
+            return sysPropOverride.trim();
+        }
+
         return WanakuHome.get() + File.separator + "credentials";
     }
 
@@ -228,7 +244,12 @@ public class AuthCredentialStore {
         try {
             Path credentialsPath = Paths.get(credentialsUri);
             if (Files.exists(credentialsPath)) {
-                props.load(Files.newInputStream(credentialsPath));
+                // Use a shared (read) lock so concurrent readers do not block each other
+                // but writers are excluded while the read is in progress.
+                try (FileChannel channel = FileChannel.open(credentialsPath, StandardOpenOption.READ);
+                        FileLock ignored = channel.lock(0, Long.MAX_VALUE, true)) {
+                    props.load(java.nio.channels.Channels.newInputStream(channel));
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to load credentials", e);
@@ -242,10 +263,19 @@ public class AuthCredentialStore {
             if (!Files.exists(credentialsPath)) {
                 return;
             }
-            Properties props = loadProperties();
-            props.remove(key);
-            try (OutputStream out = Files.newOutputStream(credentialsPath)) {
-                props.store(out, "Wanaku CLI Authentication Credentials");
+
+            ensureSecureFile(credentialsPath);
+            // Use file locking to prevent concurrent processes from corrupting the properties file.
+            try (FileChannel channel =
+                            FileChannel.open(credentialsPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                    FileLock ignored = channel.lock()) {
+                Properties props = new Properties();
+                props.load(java.nio.channels.Channels.newInputStream(channel));
+                props.remove(key);
+                channel.truncate(0);
+                channel.position(0);
+                props.store(
+                        java.nio.channels.Channels.newOutputStream(channel), "Wanaku CLI Authentication Credentials");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to clear credential: " + key, e);
@@ -255,15 +285,22 @@ public class AuthCredentialStore {
     private void storeCredential(String key, String value) {
         try {
             Path credentialsPath = Paths.get(credentialsUri);
-            Properties props = loadProperties();
-
-            props.setProperty(key, value);
 
             // Make sure the file exists with owner-only permissions BEFORE writing secrets to it,
             // so access and refresh tokens are never momentarily world-readable.
             ensureSecureFile(credentialsPath);
-            try (OutputStream out = Files.newOutputStream(credentialsPath)) {
-                props.store(out, "Wanaku CLI Authentication Credentials");
+
+            // Use file locking to prevent concurrent processes from corrupting the properties file.
+            try (FileChannel channel =
+                            FileChannel.open(credentialsPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                    FileLock ignored = channel.lock()) {
+                Properties props = new Properties();
+                props.load(java.nio.channels.Channels.newInputStream(channel));
+                props.setProperty(key, value);
+                channel.truncate(0);
+                channel.position(0);
+                props.store(
+                        java.nio.channels.Channels.newOutputStream(channel), "Wanaku CLI Authentication Credentials");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to store credential: " + key, e);

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/AuthCredentialStoreTest.java
@@ -194,6 +194,36 @@ class AuthCredentialStoreTest {
                 "Credentials directory must not be accessible by group or others");
     }
 
+    @Test
+    void shouldUseSystemPropertyForCredentialsFile() {
+        Path customPath = tempDir.resolve("sysprop-credentials");
+        System.setProperty(AuthCredentialStore.CREDENTIALS_FILE_SYS_PROP, customPath.toString());
+        try {
+            AuthCredentialStore store = new AuthCredentialStore();
+            store.storeApiToken("sysprop-test-token");
+
+            assertEquals("sysprop-test-token", store.getApiToken());
+            assertTrue(customPath.toFile().exists(), "Credentials file should exist at custom path");
+        } finally {
+            System.clearProperty(AuthCredentialStore.CREDENTIALS_FILE_SYS_PROP);
+        }
+    }
+
+    @Test
+    void concurrentTestRunsShouldUseIsolatedFiles() {
+        Path file1 = tempDir.resolve("run-1-credentials");
+        Path file2 = tempDir.resolve("run-2-credentials");
+
+        AuthCredentialStore store1 = new AuthCredentialStore(file1.toUri());
+        AuthCredentialStore store2 = new AuthCredentialStore(file2.toUri());
+
+        store1.storeApiToken("token-for-run-1");
+        store2.storeApiToken("token-for-run-2");
+
+        assertEquals("token-for-run-1", store1.getApiToken(), "Run 1 should have its own token");
+        assertEquals("token-for-run-2", store2.getApiToken(), "Run 2 should have its own token");
+    }
+
     private static void assumePosixFileSystem() {
         Assumptions.assumeTrue(
                 FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),

--- a/tests/plans/common/oidc-login-verification.md
+++ b/tests/plans/common/oidc-login-verification.md
@@ -13,8 +13,19 @@ The default test path below uses the router OIDC proxy; for direct Keycloak auth
 - WanakuRouter CR created and Ready
 - `WANAKU_ROUTER_URL` environment variable set (e.g. `http://<router-route-host>`)
 - `WANAKU_TEST_USER` and `WANAKU_TEST_PASS` environment variables set
+- `WANAKU_TEST_RUN_ID` set (derived automatically by [namespace-setup.md](namespace-setup.md))
 
 ## Steps
+
+### 0. Isolate credential storage for this test run
+
+Concurrent test runs must not share the same credentials file. Derive a unique path
+from `WANAKU_TEST_RUN_ID` so that each run writes to its own file.
+
+```bash
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-${TMPDIR:-/tmp}/wanaku-credentials-${WANAKU_TEST_RUN_ID:-$$}}"
+echo "Using isolated credentials file: ${WANAKU_CREDENTIALS}"
+```
 
 ### 1. Verify the OIDC login works
 


### PR DESCRIPTION
Fixes #1697

## Summary

The wanaku CLI stores credentials at `~/.wanaku/credentials`, which is shared across all concurrent test runs. When multiple test agents run simultaneously, credential writes from one agent can overwrite or corrupt credentials used by another.

This PR fixes the contention by:

- Adding system property support (`wanaku.cli.auth.credentials-file`) to `AuthCredentialStore` so each CLI process can use an isolated credentials file via Quarkus config or JVM flag
- Adding file locking (shared read locks, exclusive write locks) to `loadProperties`, `storeCredential`, and `clearCredential` to prevent concurrent write corruption
- Updating the `oidc-login-verification` test plan to derive a unique `WANAKU_CREDENTIALS` path per test run using `WANAKU_TEST_RUN_ID`

## Test plan

- [x] Existing `AuthCredentialStoreTest` tests pass (18 tests, 0 failures)
- [x] New `shouldUseSystemPropertyForCredentialsFile` test verifies system property override
- [x] New `concurrentTestRunsShouldUseIsolatedFiles` test verifies isolation between stores
- [x] Full `wanaku-cli` module build and test: 351 tests pass, 0 failures

## CI note

The integration test failure is in `http-capability-tests`, which also fails on the baseline run against main (run ID 30039678383). This is a pre-existing flaky test unrelated to credential storage changes.

## Summary by Sourcery

Isolate Wanaku CLI credential storage between concurrent processes and strengthen file access coordination to prevent corruption.

New Features:
- Allow overriding the default Wanaku CLI credentials file path via a system property for per-process isolation.

Bug Fixes:
- Prevent concurrent reads and writes from corrupting the shared credentials file by adding file locking around credential load, update, and clear operations.

Enhancements:
- Update OIDC login verification test plan to derive a unique credentials file path per test run using the test run identifier.

Tests:
- Extend AuthCredentialStore tests to cover system property overrides and isolated credential files for concurrent test runs.