### PR TITLE
Add AWS SQS tool

### DIFF
--- a/docs/service-templates.md
+++ b/docs/service-templates.md
@@ -255,6 +255,24 @@ A template for creating a Kafka-backed MCP tool with manual request/reply correl
 
 The request route sets a `wanakuCorrelationId` header from the Camel exchange id, and the response route uses that same header to match the reply to the original request.
 
+### `aws-sqs-tool`
+
+A template for creating an AWS SQS-backed MCP tool with manual request/reply correlation, Since SQS is a one-way messaging service, the template uses two queues:
+
+- A request route that sends a message to the request queue
+- A response route that consumes the response queue and forwards correlated replies back to the waiting request
+
+**Parameters:**
+
+- `aws.sqs.region`: AWS region (e.g., `us-east-1`)
+- `aws.sqs.accessKey`: AWS access key
+- `aws.sqs.secretKey`: AWS secret key
+- `aws.sqs.request.queue`: Queue used for outbound requests
+- `aws.sqs.response.queue`: Queue used for correlated replies
+- `aws.sqs.reply.timeout-ms`: How long to wait for a reply before failing, in milliseconds
+
+The request route sets a `wanakuCorrelationId` header, which the SQS component transfers as a message attribute. The service consuming the request queue must copy the `wanakuCorrelationId` message attribute from the request to its reply so the response route can match the reply to the original request.
+
 ### `github-pullrequest-source-tool`
 
 A template for creating a GitHub Pull Request tool service. This template allows agents to fetch pull request information on demand from a specified repository.

--- a/docs/service-templates.md
+++ b/docs/service-templates.md
@@ -255,7 +255,7 @@ A template for creating a Kafka-backed MCP tool with manual request/reply correl
 
 The request route sets a `wanakuCorrelationId` header from the Camel exchange id, and the response route uses that same header to match the reply to the original request.
 
-### `aws-sqs-tool`
+A template for creating an AWS SQS-backed MCP tool with manual request/reply correlation. Since SQS is a one-way messaging service, the template uses two queues:
 
 A template for creating an AWS SQS-backed MCP tool with manual request/reply correlation, Since SQS is a one-way messaging service, the template uses two queues:
 

--- a/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.camel.yaml
+++ b/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.camel.yaml
@@ -1,0 +1,86 @@
+- route:
+    id: aws-sqs-request-reply
+    description: Send an AWS SQS request and wait for the correlated reply
+    from:
+      uri: direct:wanaku
+      steps:
+        - setExchangePattern:
+            pattern: InOut
+        - setProperty:
+            name: wanakuCorrelationId
+            expression:
+              simple:
+                expression: "${exchangeId}"
+        - setHeader:
+            name: wanakuCorrelationId
+            expression:
+              simple:
+                expression: "${exchangeProperty.wanakuCorrelationId}"
+        - log:
+            message: "Sending AWS SQS request with correlation id ${header.wanakuCorrelationId}"
+        - to:
+            uri: aws2-sqs:{{aws.sqs.request.queue}}
+            parameters:
+              region: "{{aws.sqs.region}}"
+              accessKey: "{{aws.sqs.accessKey}}"
+              secretKey: "{{aws.sqs.secretKey}}"
+        - pollEnrich:
+            timeout: "{{aws.sqs.reply.timeout-ms}}"
+            expression:
+              simple:
+                expression: "seda:aws-sqs-replies"
+        - choice:
+            when:
+              - simple: "${header.wanakuSqsReplyReceived} != 'true'"
+                steps:
+                  - log:
+                      message: "AWS SQS reply timed out after {{aws.sqs.reply.timeout-ms}} ms for correlation id ${exchangeProperty.wanakuCorrelationId}"
+                  - throwException:
+                      exceptionType: java.util.concurrent.TimeoutException
+                      message: "AWS SQS reply timed out after {{aws.sqs.reply.timeout-ms}} ms for correlation id ${exchangeProperty.wanakuCorrelationId}"
+              - simple: "${exchangeProperty.wanakuCorrelationId} != ${header.wanakuReplyCorrelationId}"
+                steps:
+                  - log:
+                      message: "AWS SQS reply correlation mismatch for ${exchangeProperty.wanakuCorrelationId}: received ${header.wanakuReplyCorrelationId}"
+                  - throwException:
+                      exceptionType: java.lang.IllegalStateException
+                      message: "AWS SQS reply correlation mismatch for ${exchangeProperty.wanakuCorrelationId}"
+            otherwise:
+              steps:
+                - log:
+                    message: "Received AWS SQS reply for ${exchangeProperty.wanakuCorrelationId}: ${body}"
+
+- route:
+    id: aws-sqs-response-reply
+    description: Correlate AWS SQS replies back to the waiting request
+    from:
+      uri: aws2-sqs:{{aws.sqs.response.queue}}
+      parameters:
+        region: "{{aws.sqs.region}}"
+        accessKey: "{{aws.sqs.accessKey}}"
+        secretKey: "{{aws.sqs.secretKey}}"
+        messageAttributeNames: All
+        waitTimeSeconds: 20
+      steps:
+        - filter:
+            simple: "${header.wanakuCorrelationId} != null"
+            steps:
+              - log:
+                  message: "Routing AWS SQS reply for ${header.wanakuCorrelationId}"
+              - setHeader:
+                  name: wanakuReplyCorrelationId
+                  expression:
+                    simple:
+                      expression: "${header.wanakuCorrelationId}"
+              - setHeader:
+                  name: wanakuSqsReplyReceived
+                  expression:
+                    simple:
+                      expression: "true"
+              - to:
+                  uri: seda:aws-sqs-replies
+        - filter:
+            simple: "${header.wanakuCorrelationId} == null"
+            steps:
+              - log:
+                  message: "Dropping AWS SQS reply without correlation id: ${body}"

--- a/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.dependencies.txt
+++ b/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.dependencies.txt
@@ -1,0 +1,1 @@
+org.apache.camel:camel-aws2-sqs

--- a/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.rules.yaml
+++ b/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/aws-sqs.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - send-message-to-aws-sqs:
+        route:
+          id: "aws-sqs-request-reply"
+        description: "{{tool.description}}"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The message to send to AWS SQS
+            required: true

--- a/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/service.properties
+++ b/services/service-templates/src/main/services/aws-sqs-tool/aws-sqs/service.properties
@@ -1,0 +1,7 @@
+tool.description=Send a message to AWS SQS and wait for the correlated reply
+aws.sqs.region={{aws.sqs.region}}
+aws.sqs.accessKey={{aws.sqs.accessKey}}
+aws.sqs.secretKey={{aws.sqs.secretKey}}
+aws.sqs.request.queue={{aws.sqs.request.queue}}
+aws.sqs.response.queue={{aws.sqs.response.queue}}
+aws.sqs.reply.timeout-ms={{aws.sqs.reply.timeout-ms}}

--- a/services/service-templates/src/main/services/aws-sqs-tool/index.properties
+++ b/services/service-templates/src/main/services/aws-sqs-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.aws-sqs=aws-sqs/aws-sqs.dependencies.txt
+catalog.description=Send and receive correlated messages via AWS SQS
+catalog.name=aws-sqs-tool
+catalog.properties.aws-sqs=aws-sqs/service.properties
+catalog.routes.aws-sqs=aws-sqs/aws-sqs.camel.yaml
+catalog.rules.aws-sqs=aws-sqs/aws-sqs.rules.yaml
+catalog.services=aws-sqs


### PR DESCRIPTION
Closes : #1186

## Summary by Sourcery

Introduce an AWS SQS-backed service template that supports request/response correlation for MCP tools.

New Features:
- Add aws-sqs-tool service template to send messages to an AWS SQS request queue and await correlated replies from a response queue.

Enhancements:
- Document the aws-sqs-tool template and its configuration parameters in the service-templates guide.