### PR TITLE
Add PR auto-labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,52 @@
+needs-review:
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/**
+          - apps/**
+          - apps/wanaku-router-backend/**
+          - capabilities/**
+          - capabilities-quarkus-sdk/**
+          - archetypes/**
+          - docs/**
+          - '**/*.md'
+          - services/**
+
+needs-test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/wanaku-cli/**
+          - apps/wanaku-router-backend/**
+          - capabilities-quarkus-sdk/**
+          - capabilities/tools/wanaku-tool-service-http/**
+
+needs-e2e-test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/wanaku-operator/**
+
+UI:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/ui/**
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - '**/*.adoc'
+          - '**/*.md'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+services:
+  - changed-files:
+      - any-glob-to-any-file:
+          - services/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/pom.xml'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: Label pull request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Add `actions/labeler@v7.0.0` (pinned by commit hash) workflow triggered on `pull_request_target`
- Labels PRs based on changed file paths: `needs-review`, `needs-test`, `needs-e2e-test`, `UI`, `documentation`, `ci`, `services`, `dependencies`
- Uses `sync-labels: true` to remove labels when files no longer match

## Test plan
- [ ] Merge to `main`, then open a test PR touching `core/` — verify `needs-review` label is applied
- [ ] Push a change to `apps/ui/` — verify `UI` label is added
- [ ] Verify `sync-labels` removes labels when changed files are reverted

## Summary by Sourcery

Introduce an automated workflow to label pull requests based on changed file paths.

New Features:
- Add a label configuration file mapping paths to labels such as review, testing, UI, documentation, CI, services, and dependencies.
- Add a GitHub Actions workflow that runs on pull_request_target events and synchronizes labels on pull requests.