### PR TITLE
Fix #1697: set WANAKU_CREDENTIALS in all test plans for concurrent run isolation

### DIFF
--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -71,6 +71,8 @@ export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-
 export CIC_IMAGE="${CIC_IMAGE:-quay.io/wanaku/camel-integration-capability:latest}"
 # OIDC client secret for CIC-to-router authentication (defaults to "mypasswd")
 export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-${WANAKU_NAMESPACE}}"
 ```
 
 Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.

--- a/tests/plans/cli-auth-commands.md
+++ b/tests/plans/cli-auth-commands.md
@@ -54,7 +54,9 @@ export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-}"
 export WANAKU_TEST_USER="${WANAKU_TEST_USER:-alice}"
 export WANAKU_TEST_PASS="${WANAKU_TEST_PASS:-secretpass}"
 export WANAKU_REALM="${WANAKU_REALM:-wanaku}"
-export CREDENTIALS_FILE="${CREDENTIALS_FILE:-${HOME}/.wanaku/credentials}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-auth-$$}"
+export CREDENTIALS_FILE="${WANAKU_CREDENTIALS}"
 export TEST_USERNAME="${TEST_USERNAME:-testuser-811}"
 export TEST_PASSWORD="${TEST_PASSWORD:-TestPass123}"
 export TEST_EMAIL="${TEST_EMAIL:-testuser811@example.com}"
@@ -74,7 +76,8 @@ Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to 
 | `WANAKU_TEST_USER` | `alice` | Username for auth login tests (created by keycloak-setup.md) |
 | `WANAKU_TEST_PASS` | `secretpass` | Password for auth login tests |
 | `WANAKU_REALM` | `wanaku` | Keycloak realm name for direct login tests |
-| `CREDENTIALS_FILE` | `~/.wanaku/credentials` | Path to the CLI credentials file (Java Properties format) |
+| `WANAKU_CREDENTIALS` | `/tmp/wanaku-creds-auth-$$` | Isolated credentials file path (see [#1697](https://github.com/wanaku-ai/wanaku/issues/1697)) |
+| `CREDENTIALS_FILE` | `${WANAKU_CREDENTIALS}` | Alias for direct file access in test assertions |
 | `TEST_USERNAME` | `testuser-811` | Username for test user CRUD operations |
 | `TEST_PASSWORD` | `TestPass123` | Password for test user creation |
 | `TEST_EMAIL` | `testuser811@example.com` | Email for test user creation |

--- a/tests/plans/common/oidc-login-verification.md
+++ b/tests/plans/common/oidc-login-verification.md
@@ -13,6 +13,7 @@ The default test path below uses the router OIDC proxy; for direct Keycloak auth
 - WanakuRouter CR created and Ready
 - `WANAKU_ROUTER_URL` environment variable set (e.g. `http://<router-route-host>`)
 - `WANAKU_TEST_USER` and `WANAKU_TEST_PASS` environment variables set
+- `WANAKU_CREDENTIALS` exported to a per-run path (see [#1697](https://github.com/wanaku-ai/wanaku/issues/1697)) to isolate credential storage across concurrent test runs
 
 ## Steps
 

--- a/tests/plans/mcp-cli-commands.md
+++ b/tests/plans/mcp-cli-commands.md
@@ -393,6 +393,8 @@ export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
 export WANAKU_PROVIDER_STATIC_FILE_IMAGE="${WANAKU_PROVIDER_STATIC_FILE_IMAGE:-quay.io/wanaku/wanaku-provider-performance-static-file:latest}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-${WANAKU_NAMESPACE}}"
 ```
 
 Follow [common/namespace-setup.md](common/namespace-setup.md) before Part 2 to derive a unique `WANAKU_NAMESPACE` for the OpenShift environment.

--- a/tests/plans/observability-tracing.md
+++ b/tests/plans/observability-tracing.md
@@ -70,6 +70,8 @@ export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
 export OTEL_COLLECTOR_IMAGE="${OTEL_COLLECTOR_IMAGE:-otel/opentelemetry-collector-contrib:0.127.0}"
 export JAEGER_IMAGE="${JAEGER_IMAGE:-jaegertracing/jaeger:latest}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-${WANAKU_NAMESPACE}}"
 ```
 
 Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.

--- a/tests/plans/operator-basic-functionality.md
+++ b/tests/plans/operator-basic-functionality.md
@@ -64,6 +64,8 @@ Set these before running the plan. All image tags default to `latest` but can be
 export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 export WANAKU_CAPABILITY_HTTP_IMAGE="${WANAKU_CAPABILITY_HTTP_IMAGE:-quay.io/wanaku/wanaku-tool-service-http:latest}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-${WANAKU_NAMESPACE}}"
 ```
 
 Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -65,6 +65,8 @@ export WANAKU_REPO_ROOT="${WANAKU_REPO_ROOT:-.}"
 export WANAKU_ROUTER_IMAGE="${WANAKU_ROUTER_IMAGE:-quay.io/wanaku/wanaku-router-backend:latest}"
 # OIDC client secret for operator-to-router authentication (defaults to "mypasswd")
 export WANAKU_OIDC_CLIENT_SECRET="${WANAKU_OIDC_CLIENT_SECRET:-mypasswd}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-${WANAKU_NAMESPACE}}"
 ```
 
 Follow [common/namespace-setup.md](common/namespace-setup.md) before Phase 1 to derive a unique `WANAKU_NAMESPACE` for this run.

--- a/tests/plans/performance-testing-local.md
+++ b/tests/plans/performance-testing-local.md
@@ -51,6 +51,8 @@ export KEYCLOAK_ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
 export KEYCLOAK_ADMIN_PASS="${KEYCLOAK_ADMIN_PASS:-admin}"
 export KEYCLOAK_REALM="${KEYCLOAK_REALM:-wanaku}"
 export ROUTER_HOST="${ROUTER_HOST:-${KEYCLOAK_HOST}}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-perf-$$}"
 export VU_LEVELS="${VU_LEVELS:-1 10 500 1000 2000 30000}"
 export TEST_DURATION="${TEST_DURATION:-30s}"
 export TEST_BASE_DIR="${TEST_BASE_DIR:-$HOME/perf-results}"

--- a/tests/plans/wanaku-home-resolution.md
+++ b/tests/plans/wanaku-home-resolution.md
@@ -44,6 +44,8 @@ export WANAKU_ROUTER_URL="${WANAKU_ROUTER_URL:-http://localhost:8080}"
 export MCP_SERVER_URI="${MCP_SERVER_URI:-http://localhost:8080/public/mcp/sse}"
 export CUSTOM_HOME_DIR="${CUSTOM_HOME_DIR:-/tmp/wanaku-test-home-$$}"
 export CUSTOM_HOME_DIR_SYSPROP="${CUSTOM_HOME_DIR_SYSPROP:-/tmp/wanaku-test-sysprop-$$}"
+# Isolate credentials per test run to avoid contention (see #1697)
+export WANAKU_CREDENTIALS="${WANAKU_CREDENTIALS:-/tmp/wanaku-creds-home-$$}"
 ```
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

- Add `WANAKU_CREDENTIALS` export to all 8 test plans that use CLI auth commands, preventing credential file contention when plans run in parallel
- Update `common/oidc-login-verification.md` prerequisites to document the requirement
- Fix `cli-auth-commands.md` variable reference table to reflect the new default path
- Use defaulting pattern (`${WANAKU_CREDENTIALS:-...}`) consistently across all plans so user overrides are respected

## Test plan

- [x] Verified all 8 affected plans have unique credential paths (OpenShift: `${WANAKU_NAMESPACE}`, local: `$$` + plan prefix)
- [x] Verified 25 unaffected plans correctly excluded (no auth commands)
- [x] Verified `cli-auth-commands.md` CREDENTIALS_FILE alias stays in sync with WANAKU_CREDENTIALS

## Summary by Sourcery

Improve operator and CLI authentication robustness and make test plans safe to run concurrently by isolating credential storage and supporting dynamically rotated secrets.

New Features:
- Support resolving the operator OIDC client secret from a Kubernetes Secret at runtime, falling back to an environment variable when needed.
- Allow the WANAKU CLI to override the credentials file path via a system property for per-process credential isolation.
- Gate Camel Integration Capability deployment readiness on its Kubernetes Deployment status before marking the route ready.

Bug Fixes:
- Prevent concurrent WANAKU CLI processes from corrupting the credentials file by using file locking for reads and writes.
- Ensure expired tokens that cannot be refreshed are not reused, allowing callers to trigger a full re-login instead of sending invalid tokens.

Enhancements:
- Refactor operator reconcilers to use the new dynamic OperatorSecurityConfig in both service catalog and Camel route clients.
- Expose helper methods to check Kubernetes Deployment readiness for CIC and cover them with unit tests.
- Improve logging around Kubernetes secret resolution for OIDC client secrets in the operator.

Build:
- Inject the OIDC secret name into the operator deployment via environment variables so it can be used when resolving secrets dynamically.

CI:
- Configure an automatic PR labeler workflow and label rules to categorize pull requests by area and testing requirements.

Documentation:
- Update OIDC login and CLI auth test documentation to describe isolated credential paths and the new WANAKU_CREDENTIALS variable.
- Adjust CLI auth command documentation to reflect the new default credentials file path and aliasing via WANAKU_CREDENTIALS.

Tests:
- Add unit tests for dynamic Kubernetes secret resolution and fallback behavior in OperatorSecurityConfig.
- Add unit tests verifying CIC deployment readiness checks in the Camel route reconciler.
- Extend CLI credential store tests to cover system property overrides and per-run file isolation.
- Update and add test plan steps to export WANAKU_CREDENTIALS uniquely per run across multiple plans using CLI auth commands.

Chores:
- Introduce a GitHub PR labeler configuration to automatically apply area and testing-related labels based on changed files.