### PR TITLE
Fix #1717: add imageTag field to WanakuCamelRoute CRD spec

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/crds/wanakucamelroutes.wanaku.ai-v1.yml
@@ -25,6 +25,8 @@ spec:
                 - "Always"
                 - "IfNotPresent"
                 - "Never"
+              imageTag:
+                type: "string"
               mcp:
                 properties:
                   resources:

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpec.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpec.java
@@ -5,10 +5,12 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class WanakuCamelRouteSpec {
-    private static final String DEFAULT_CIC_IMAGE = "quay.io/wanaku/camel-integration-capability:latest";
+    static final String DEFAULT_CIC_IMAGE_REPO = "quay.io/wanaku/camel-integration-capability";
+    static final String DEFAULT_CIC_IMAGE_TAG = "latest";
 
     private String routerRef;
     private String image;
+    private String imageTag;
     private String imagePullPolicy;
     private JsonNode route;
     private McpSpec mcp;
@@ -22,12 +24,32 @@ public class WanakuCamelRouteSpec {
         this.routerRef = routerRef;
     }
 
+    /**
+     * Returns the CIC container image to use. Resolution order:
+     * <ol>
+     *   <li>If {@code image} is explicitly set, return it as-is (full override).</li>
+     *   <li>If only {@code imageTag} is set, combine the default repository with the tag.</li>
+     *   <li>Otherwise, return the default image with the {@code latest} tag.</li>
+     * </ol>
+     */
     public String getImage() {
-        return (image != null && !image.isBlank()) ? image : DEFAULT_CIC_IMAGE;
+        if (image != null && !image.isBlank()) {
+            return image;
+        }
+        String tag = (imageTag != null && !imageTag.isBlank()) ? imageTag : DEFAULT_CIC_IMAGE_TAG;
+        return DEFAULT_CIC_IMAGE_REPO + ":" + tag;
     }
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public String getImageTag() {
+        return imageTag;
+    }
+
+    public void setImageTag(String imageTag) {
+        this.imageTag = imageTag;
     }
 
     public String getImagePullPolicy() {

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpecTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuCamelRouteSpecTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.operator.wanaku;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class WanakuCamelRouteSpecTest {
 
@@ -29,10 +30,59 @@ class WanakuCamelRouteSpecTest {
     }
 
     @Test
+    void getImageUsesImageTagWhenImageNotSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImageTag("1.2.3");
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:1.2.3", spec.getImage());
+    }
+
+    @Test
+    void getImageUsesImageTagWhenImageIsBlank() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImage("  ");
+        spec.setImageTag("0.8.0");
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:0.8.0", spec.getImage());
+    }
+
+    @Test
+    void getImagePrefersFullImageOverImageTag() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImage("my-registry.io/custom-cic:2.0.0");
+        spec.setImageTag("1.0.0");
+
+        assertEquals("my-registry.io/custom-cic:2.0.0", spec.getImage());
+    }
+
+    @Test
+    void getImageIgnoresBlankImageTag() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImageTag("   ");
+
+        assertEquals("quay.io/wanaku/camel-integration-capability:latest", spec.getImage());
+    }
+
+    @Test
+    void getImageTagReturnsNullWhenNotSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+
+        assertNull(spec.getImageTag());
+    }
+
+    @Test
+    void getImageTagReturnsValueWhenSet() {
+        WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
+        spec.setImageTag("1.0.0");
+
+        assertEquals("1.0.0", spec.getImageTag());
+    }
+
+    @Test
     void getImagePullPolicyReturnsNullWhenNotSet() {
         WanakuCamelRouteSpec spec = new WanakuCamelRouteSpec();
 
-        assertEquals(null, spec.getImagePullPolicy());
+        assertNull(spec.getImagePullPolicy());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1717

Adds `spec.imageTag` to the WanakuCamelRoute CRD so users can pin the CIC container image version without specifying the full image path.

**Resolution order:**
1. `spec.image` -- full override (existing behavior, unchanged)
2. `spec.imageTag` -- combined with the default repository (`quay.io/wanaku/camel-integration-capability`)
3. Default: `latest` tag (existing behavior, unchanged)

**Changes:**
- `WanakuCamelRouteSpec`: split hardcoded `DEFAULT_CIC_IMAGE` constant into separate repo and tag constants, added `imageTag` field with getter/setter, updated `getImage()` resolution logic
- `WanakuCamelRouteSpecTest`: added 6 new tests covering all `imageTag` scenarios
- CRD manifest: added `imageTag` field to the schema, preserved existing `imagePullPolicy` enum constraint

**Note:** Integration tests show pre-existing CIC health check failures (all recent runs on main also fail with the same error -- unrelated to this change).

## Summary by Sourcery

Add support for specifying the CIC container image via an image tag on WanakuCamelRoute while preserving existing full image override behavior.

New Features:
- Introduce spec.imageTag on WanakuCamelRoute to allow pinning the CIC container image tag against the default repository.

Enhancements:
- Refine image resolution logic in WanakuCamelRouteSpec to prioritize explicit image, then imageTag, then the default latest image tag.

Tests:
- Extend WanakuCamelRouteSpecTest with coverage for imageTag behavior, preference ordering between image and imageTag, and null/blank handling.