### PR TITLE
Add Prometheus metrics and Grafana dashboard support for Wanaku Operator

### DIFF
--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/README.md
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/README.md
@@ -24,6 +24,9 @@ The following table lists the configurable parameters and their default values.
 | `app.livenessProbe.periodSeconds` | The period in which the action should be called. | 10 |
 | `app.livenessProbe.successThreshold` | The success threshold to use. | 1 |
 | `app.livenessProbe.timeoutSeconds` | The amount of time to wait for each action. | 10 |
+| `app.metrics.grafanaDashboard.enabled` |   | false |
+| `app.metrics.serviceMonitor.enabled` |   | false |
+| `app.metrics.serviceMonitor.interval` |   | 30s |
 | `app.oidc.secretName` |   | wanaku-oidc |
 | `app.podSecurityContext.runAsNonRoot` | Require the pod to run as a non-root user. | true |
 | `app.podSecurityContext.seccompProfile.type` |   | RuntimeDefault |

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/dashboards/wanaku-operator-dashboard.json
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/dashboards/wanaku-operator-dashboard.json
@@ -122,21 +122,21 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Router reconciliations",
-      "description": "Rate of WanakuRouter reconciliations",
+      "title": "Reconciliations by controller",
+      "description": "Rate of reconciliations per controller",
       "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(wanaku_router_reconciliations_total[5m])",
-          "legendFormat": "reconciliations/s"
+          "expr": "sum by (controller) (rate(wanaku_reconciliations_total[5m]))",
+          "legendFormat": "{{controller}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 2,
@@ -147,28 +147,28 @@
         "overrides": []
       },
       "options": {
-        "legend": { "showLegend": false },
-        "tooltip": { "mode": "single" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
       }
     },
     {
       "id": 5,
       "type": "timeseries",
-      "title": "Router reconciliation errors",
-      "description": "Rate of failed WanakuRouter reconciliations",
+      "title": "Reconciliation errors by controller",
+      "description": "Rate of failed reconciliations per controller",
       "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(wanaku_router_reconciliation_errors_total[5m])",
-          "legendFormat": "errors/s"
+          "expr": "sum by (controller) (rate(wanaku_reconciliation_errors_total[5m]))",
+          "legendFormat": "{{controller}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "fixed", "fixedColor": "red" },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 2,
@@ -179,8 +179,8 @@
         "overrides": []
       },
       "options": {
-        "legend": { "showLegend": false },
-        "tooltip": { "mode": "single" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
       }
     }
   ]

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/dashboards/wanaku-operator-dashboard.json
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/dashboards/wanaku-operator-dashboard.json
@@ -1,0 +1,187 @@
+{
+  "title": "Wanaku Operator",
+  "uid": "wanaku-operator",
+  "tags": ["wanaku", "operator"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0,
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Routers",
+      "description": "WanakuRouter instances in the operator namespace",
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_router_instances",
+          "legendFormat": "routers"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Routers ready",
+      "description": "WanakuRouter instances whose Ready condition is True",
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_router_ready_instances",
+          "legendFormat": "ready"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Tool services",
+      "description": "WanakuCapability (tool service) instances in the operator namespace",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_toolservice_instances",
+          "legendFormat": "tool services"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Router reconciliations",
+      "description": "Rate of WanakuRouter reconciliations",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(wanaku_router_reconciliations_total[5m])",
+          "legendFormat": "reconciliations/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": false },
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Router reconciliation errors",
+      "description": "Rate of failed WanakuRouter reconciliations",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(wanaku_router_reconciliation_errors_total[5m])",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": false },
+        "tooltip": { "mode": "single" }
+      }
+    }
+  ]
+}

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   annotations:
     app.quarkus.io/quarkus-version: 3.33.2
     app.quarkus.io/build-timestamp: 2026-07-30 - 21:29:25 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8081"
+    prometheus.io/scheme: http
   labels:
     app.kubernetes.io/name: wanaku-operator
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
@@ -20,6 +24,10 @@ spec:
       annotations:
         app.quarkus.io/quarkus-version: 3.33.2
         app.quarkus.io/build-timestamp: 2026-07-30 - 21:29:25 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8081"
+        prometheus.io/scheme: http
       labels:
         app.kubernetes.io/managed-by: quarkus
         app.kubernetes.io/name: wanaku-operator

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/grafana-dashboard.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/grafana-dashboard.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.app.metrics.grafanaDashboard.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: wanaku-operator
+    grafana_dashboard: "1"
+  name: wanaku-operator-dashboard
+data:
+  wanaku-operator.json: |-
+    {{- .Files.Get "dashboards/wanaku-operator-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/service.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   annotations:
     app.quarkus.io/quarkus-version: 3.33.2
     app.quarkus.io/build-timestamp: 2026-07-30 - 21:29:25 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8081"
+    prometheus.io/scheme: http
   labels:
     app.kubernetes.io/name: wanaku-operator
     app.kubernetes.io/version: {{ .Chart.AppVersion }}

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/servicemonitor.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.app.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: wanaku-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/managed-by: quarkus
+  name: wanaku-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wanaku-operator
+  endpoints:
+    - scheme: http
+      targetPort: 8081
+      path: /metrics
+      interval: {{ .Values.app.metrics.serviceMonitor.interval }}
+      honorLabels: true
+
+{{- end }}

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/values.schema.json
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/values.schema.json
@@ -154,6 +154,30 @@
             }
           }
         },
+        "metrics" : {
+          "type" : "object",
+          "properties" : {
+            "grafanaDashboard" : {
+              "type" : "object",
+              "properties" : {
+                "enabled" : {
+                  "type" : "boolean"
+                }
+              }
+            },
+            "serviceMonitor" : {
+              "type" : "object",
+              "properties" : {
+                "interval" : {
+                  "type" : "string"
+                },
+                "enabled" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          }
+        },
         "startupProbe" : {
           "type" : "object",
           "properties" : {
@@ -206,33 +230,6 @@
           "properties" : {
             "secretName" : {
               "type" : "string"
-            }
-          }
-        },
-        "metrics" : {
-          "type" : "object",
-          "properties" : {
-            "grafanaDashboard" : {
-              "type" : "object",
-              "properties" : {
-                "enabled" : {
-                  "description" : "Create a ConfigMap with the operator Grafana dashboard, discoverable by the Grafana sidecar.",
-                  "type" : "boolean"
-                }
-              }
-            },
-            "serviceMonitor" : {
-              "type" : "object",
-              "properties" : {
-                "enabled" : {
-                  "description" : "Create a Prometheus ServiceMonitor for the operator metrics endpoint.",
-                  "type" : "boolean"
-                },
-                "interval" : {
-                  "description" : "Scrape interval for the ServiceMonitor.",
-                  "type" : "string"
-                }
-              }
             }
           }
         }

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/values.schema.json
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/values.schema.json
@@ -208,6 +208,33 @@
               "type" : "string"
             }
           }
+        },
+        "metrics" : {
+          "type" : "object",
+          "properties" : {
+            "grafanaDashboard" : {
+              "type" : "object",
+              "properties" : {
+                "enabled" : {
+                  "description" : "Create a ConfigMap with the operator Grafana dashboard, discoverable by the Grafana sidecar.",
+                  "type" : "boolean"
+                }
+              }
+            },
+            "serviceMonitor" : {
+              "type" : "object",
+              "properties" : {
+                "enabled" : {
+                  "description" : "Create a Prometheus ServiceMonitor for the operator metrics endpoint.",
+                  "type" : "boolean"
+                },
+                "interval" : {
+                  "description" : "Scrape interval for the ServiceMonitor.",
+                  "type" : "string"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
@@ -16,6 +16,12 @@ app:
       version: ""
   image: quay.io/wanaku/wanaku-operator:latest
   imagePullPolicy: IfNotPresent
+  metrics:
+    grafanaDashboard:
+      enabled: false
+    serviceMonitor:
+      enabled: false
+      interval: 30s
   livenessProbe:
     failureThreshold: 3
     httpGet:

--- a/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
+++ b/apps/wanaku-operator/deploy/helm/wanaku-operator/values.yaml
@@ -16,12 +16,6 @@ app:
       version: ""
   image: quay.io/wanaku/wanaku-operator:latest
   imagePullPolicy: IfNotPresent
-  metrics:
-    grafanaDashboard:
-      enabled: false
-    serviceMonitor:
-      enabled: false
-      interval: 30s
   livenessProbe:
     failureThreshold: 3
     httpGet:
@@ -31,6 +25,12 @@ app:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 10
+  metrics:
+    grafanaDashboard:
+      enabled: false
+    serviceMonitor:
+      enabled: false
+      interval: 30s
   oidc:
     secretName: wanaku-oidc
   podSecurityContext:

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -148,6 +148,10 @@
                                 <copy todir="${project.build.directory}/helm/kubernetes/wanaku-operator/dashboards" overwrite="true">
                                     <fileset dir="${project.basedir}/src/main/helm/dashboards" />
                                 </copy>
+                                <!-- Strip the commit-id annotation so the local clone's HEAD does not leak into the chart -->
+                                <replaceregexp flags="g" match="\r?\n\s*app\.quarkus\.io/commit-id: [^\r\n]*" replace="">
+                                    <fileset dir="${helm.templates}" includes="*.yaml" />
+                                </replaceregexp>
                                 <!-- Prefix roleRef names to match namespace-prefixed ClusterRoles -->
                                 <replace dir="${helm.templates}" includes="*-crd-role-binding.yaml" token="name: wanaku-capability-cluster-role" value="name: {{ $.Release.Namespace }}-wanaku-capability-cluster-role" />
                                 <replace dir="${helm.templates}" includes="*-crd-role-binding.yaml" token="name: wanaku-router-cluster-role" value="name: {{ $.Release.Namespace }}-wanaku-router-cluster-role" />

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -69,6 +69,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-openshift-client</artifactId>
         </dependency>
 
@@ -122,7 +127,10 @@
                     AdditionalHelmTemplateBuildItem pipeline).
                  2. Add security-context fields not yet supported by the quarkus-kubernetes
                     extension (seccompProfile, allowPrivilegeEscalation, capabilities.drop)
-                    and template them as configurable Helm values. -->
+                    and template them as configurable Helm values.
+                 3. Copy the Grafana dashboard overlay (template + dashboards/ dir) into the
+                    chart; quarkus-helm does not carry over non-template dirs nor templates
+                    using .Files.Get. -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
@@ -135,6 +143,11 @@
                         <configuration>
                             <target>
                                 <property name="helm.templates" value="${project.build.directory}/helm/kubernetes/wanaku-operator/templates" />
+                                <!-- Copy the Grafana dashboard template and JSON into the chart -->
+                                <copy file="${project.basedir}/src/main/helm/templates/grafana-dashboard.yaml" todir="${helm.templates}" overwrite="true" />
+                                <copy todir="${project.build.directory}/helm/kubernetes/wanaku-operator/dashboards" overwrite="true">
+                                    <fileset dir="${project.basedir}/src/main/helm/dashboards" />
+                                </copy>
                                 <!-- Prefix roleRef names to match namespace-prefixed ClusterRoles -->
                                 <replace dir="${helm.templates}" includes="*-crd-role-binding.yaml" token="name: wanaku-capability-cluster-role" value="name: {{ $.Release.Namespace }}-wanaku-capability-cluster-role" />
                                 <replace dir="${helm.templates}" includes="*-crd-role-binding.yaml" token="name: wanaku-router-cluster-role" value="name: {{ $.Release.Namespace }}-wanaku-router-cluster-role" />

--- a/apps/wanaku-operator/src/main/helm/dashboards/wanaku-operator-dashboard.json
+++ b/apps/wanaku-operator/src/main/helm/dashboards/wanaku-operator-dashboard.json
@@ -122,21 +122,21 @@
     {
       "id": 4,
       "type": "timeseries",
-      "title": "Router reconciliations",
-      "description": "Rate of WanakuRouter reconciliations",
+      "title": "Reconciliations by controller",
+      "description": "Rate of reconciliations per controller",
       "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(wanaku_router_reconciliations_total[5m])",
-          "legendFormat": "reconciliations/s"
+          "expr": "sum by (controller) (rate(wanaku_reconciliations_total[5m]))",
+          "legendFormat": "{{controller}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 2,
@@ -147,28 +147,28 @@
         "overrides": []
       },
       "options": {
-        "legend": { "showLegend": false },
-        "tooltip": { "mode": "single" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
       }
     },
     {
       "id": 5,
       "type": "timeseries",
-      "title": "Router reconciliation errors",
-      "description": "Rate of failed WanakuRouter reconciliations",
+      "title": "Reconciliation errors by controller",
+      "description": "Rate of failed reconciliations per controller",
       "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "refId": "A",
-          "expr": "rate(wanaku_router_reconciliation_errors_total[5m])",
-          "legendFormat": "errors/s"
+          "expr": "sum by (controller) (rate(wanaku_reconciliation_errors_total[5m]))",
+          "legendFormat": "{{controller}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "fixed", "fixedColor": "red" },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 2,
@@ -179,8 +179,8 @@
         "overrides": []
       },
       "options": {
-        "legend": { "showLegend": false },
-        "tooltip": { "mode": "single" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
       }
     }
   ]

--- a/apps/wanaku-operator/src/main/helm/dashboards/wanaku-operator-dashboard.json
+++ b/apps/wanaku-operator/src/main/helm/dashboards/wanaku-operator-dashboard.json
@@ -1,0 +1,187 @@
+{
+  "title": "Wanaku Operator",
+  "uid": "wanaku-operator",
+  "tags": ["wanaku", "operator"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0,
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Routers",
+      "description": "WanakuRouter instances in the operator namespace",
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_router_instances",
+          "legendFormat": "routers"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Routers ready",
+      "description": "WanakuRouter instances whose Ready condition is True",
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_router_ready_instances",
+          "legendFormat": "ready"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Tool services",
+      "description": "WanakuCapability (tool service) instances in the operator namespace",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "wanaku_toolservice_instances",
+          "legendFormat": "tool services"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Router reconciliations",
+      "description": "Rate of WanakuRouter reconciliations",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(wanaku_router_reconciliations_total[5m])",
+          "legendFormat": "reconciliations/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": false },
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Router reconciliation errors",
+      "description": "Rate of failed WanakuRouter reconciliations",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(wanaku_router_reconciliation_errors_total[5m])",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": false },
+        "tooltip": { "mode": "single" }
+      }
+    }
+  ]
+}

--- a/apps/wanaku-operator/src/main/helm/templates/grafana-dashboard.yaml
+++ b/apps/wanaku-operator/src/main/helm/templates/grafana-dashboard.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.app.metrics.grafanaDashboard.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: wanaku-operator
+    grafana_dashboard: "1"
+  name: wanaku-operator-dashboard
+data:
+  wanaku-operator.json: |-
+    {{- .Files.Get "dashboards/wanaku-operator-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/apps/wanaku-operator/src/main/helm/values.yaml
+++ b/apps/wanaku-operator/src/main/helm/values.yaml
@@ -10,3 +10,9 @@ app:
         - ALL
   oidc:
     secretName: wanaku-oidc
+  metrics:
+    grafanaDashboard:
+      enabled: false
+    serviceMonitor:
+      enabled: false
+      interval: 30s

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/metrics/OperatorMetrics.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/metrics/OperatorMetrics.java
@@ -1,0 +1,106 @@
+package ai.wanaku.operator.metrics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+import io.fabric8.kubernetes.api.model.Condition;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.runtime.StartupEvent;
+import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuRouter;
+
+/**
+ * Registers the Wanaku operator metrics in the Micrometer registry, exposed in Prometheus
+ * format at the {@code /metrics} endpoint:
+ *
+ * <ul>
+ *   <li>{@code wanaku_router_reconciliations_total} - total WanakuRouter reconciliations</li>
+ *   <li>{@code wanaku_router_reconciliation_errors_total} - failed WanakuRouter reconciliations</li>
+ *   <li>{@code wanaku_router_instances} - WanakuRouter instances in the operator namespace</li>
+ *   <li>{@code wanaku_router_ready_instances} - WanakuRouter instances whose Ready condition is True</li>
+ *   <li>{@code wanaku_toolservice_instances} - WanakuCapability (tool service) instances in the operator namespace</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class OperatorMetrics {
+    private static final Logger LOG = Logger.getLogger(OperatorMetrics.class);
+
+    private final Counter routerReconciliations;
+    private final Counter routerReconciliationErrors;
+
+    @Inject
+    public OperatorMetrics(MeterRegistry registry, KubernetesClient kubernetesClient) {
+        routerReconciliations = Counter.builder("wanaku.router.reconciliations")
+                .description("Total number of WanakuRouter reconciliations")
+                .register(registry);
+
+        routerReconciliationErrors = Counter.builder("wanaku.router.reconciliation.errors")
+                .description("Total number of failed WanakuRouter reconciliations")
+                .register(registry);
+
+        Gauge.builder("wanaku.router.instances", () -> countInstances(kubernetesClient, WanakuRouter.class))
+                .description("Number of WanakuRouter instances in the operator namespace")
+                .register(registry);
+
+        Gauge.builder("wanaku.router.ready.instances", () -> countReadyRouters(kubernetesClient))
+                .description("Number of WanakuRouter instances whose Ready condition is True")
+                .register(registry);
+
+        Gauge.builder("wanaku.toolservice.instances", () -> countInstances(kubernetesClient, WanakuCapability.class))
+                .description("Number of WanakuCapability (tool service) instances in the operator namespace")
+                .register(registry);
+    }
+
+    void onStart(@Observes StartupEvent event) {
+        // Forces eager instantiation so the gauges are registered before the first scrape
+    }
+
+    public void countRouterReconciliation() {
+        routerReconciliations.increment();
+    }
+
+    public void countRouterReconciliationError() {
+        routerReconciliationErrors.increment();
+    }
+
+    private static <T extends HasMetadata> double countInstances(KubernetesClient client, Class<T> resourceType) {
+        try {
+            return client.resources(resourceType)
+                    .inNamespace(client.getNamespace())
+                    .list()
+                    .getItems()
+                    .size();
+        } catch (Exception e) {
+            LOG.debugf(e, "Unable to count %s instances", resourceType.getSimpleName());
+            return Double.NaN;
+        }
+    }
+
+    private static double countReadyRouters(KubernetesClient client) {
+        try {
+            return client.resources(WanakuRouter.class).inNamespace(client.getNamespace()).list().getItems().stream()
+                    .filter(OperatorMetrics::isReady)
+                    .count();
+        } catch (Exception e) {
+            LOG.debugf(e, "Unable to count ready WanakuRouter instances");
+            return Double.NaN;
+        }
+    }
+
+    static boolean isReady(WanakuRouter router) {
+        if (router.getStatus() == null) {
+            return false;
+        }
+
+        final Condition readyCondition =
+                OperatorUtil.findCondition(router.getStatus().getConditions(), OperatorUtil.READY_CONDITION);
+        return readyCondition != null && OperatorUtil.CONDITION_STATUS_TRUE.equals(readyCondition.getStatus());
+    }
+}

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/metrics/OperatorMetrics.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/metrics/OperatorMetrics.java
@@ -4,6 +4,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -13,30 +15,73 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.runtime.StartupEvent;
 import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.wanaku.WanakuCamelCodeExecutionEngine;
+import ai.wanaku.operator.wanaku.WanakuCamelRoute;
 import ai.wanaku.operator.wanaku.WanakuCapability;
 import ai.wanaku.operator.wanaku.WanakuRouter;
+import ai.wanaku.operator.wanaku.WanakuServiceCatalog;
 
 /**
  * Registers the Wanaku operator metrics in the Micrometer registry, exposed in Prometheus
  * format at the {@code /metrics} endpoint:
  *
  * <ul>
- *   <li>{@code wanaku_router_reconciliations_total} - total WanakuRouter reconciliations</li>
- *   <li>{@code wanaku_router_reconciliation_errors_total} - failed WanakuRouter reconciliations</li>
+ *   <li>{@code wanaku_reconciliations_total} - reconciliations, labeled by {@code controller}</li>
+ *   <li>{@code wanaku_reconciliation_errors_total} - failed reconciliations (thrown or resolved
+ *       to an error status), labeled by {@code controller}</li>
+ *   <li>{@code wanaku_router_reconciliations_total} - total WanakuRouter reconciliations
+ *       (kept for compatibility; equivalent to {@code controller="wanaku-router"})</li>
+ *   <li>{@code wanaku_router_reconciliation_errors_total} - failed WanakuRouter reconciliations
+ *       (kept for compatibility)</li>
  *   <li>{@code wanaku_router_instances} - WanakuRouter instances in the operator namespace</li>
  *   <li>{@code wanaku_router_ready_instances} - WanakuRouter instances whose Ready condition is True</li>
  *   <li>{@code wanaku_toolservice_instances} - WanakuCapability (tool service) instances in the operator namespace</li>
+ *   <li>{@code wanaku_servicecatalog_instances} - WanakuServiceCatalog instances in the operator namespace</li>
+ *   <li>{@code wanaku_camelroute_instances} - WanakuCamelRoute instances in the operator namespace</li>
+ *   <li>{@code wanaku_codeexecutionengine_instances} - WanakuCamelCodeExecutionEngine instances in the operator
+ *       namespace</li>
  * </ul>
+ *
+ * <p>Collection can be turned off with {@code wanaku.operator.metrics.enabled=false} (default {@code true}),
+ * in which case no Wanaku meter is registered and the gauges never query the Kubernetes API.</p>
  */
 @ApplicationScoped
 public class OperatorMetrics {
     private static final Logger LOG = Logger.getLogger(OperatorMetrics.class);
 
+    public static final String CONTROLLER_ROUTER = "wanaku-router";
+    public static final String CONTROLLER_CAPABILITY = "wanaku-capability";
+    public static final String CONTROLLER_SERVICE_CATALOG = "wanaku-service-catalog";
+    public static final String CONTROLLER_CAMEL_ROUTE = "wanaku-camel-route";
+    public static final String CONTROLLER_CODE_EXECUTION_ENGINE = "camel-code-execution-engine";
+
+    private static final List<String> CONTROLLERS = List.of(
+            CONTROLLER_ROUTER,
+            CONTROLLER_CAPABILITY,
+            CONTROLLER_SERVICE_CATALOG,
+            CONTROLLER_CAMEL_ROUTE,
+            CONTROLLER_CODE_EXECUTION_ENGINE);
+
+    private final MeterRegistry registry;
+    private final boolean enabled;
     private final Counter routerReconciliations;
     private final Counter routerReconciliationErrors;
 
     @Inject
-    public OperatorMetrics(MeterRegistry registry, KubernetesClient kubernetesClient) {
+    public OperatorMetrics(
+            MeterRegistry registry,
+            KubernetesClient kubernetesClient,
+            @ConfigProperty(name = "wanaku.operator.metrics.enabled", defaultValue = "true") boolean enabled) {
+        this.registry = registry;
+        this.enabled = enabled;
+
+        if (!enabled) {
+            LOG.info("Wanaku operator metrics are disabled (wanaku.operator.metrics.enabled=false)");
+            routerReconciliations = null;
+            routerReconciliationErrors = null;
+            return;
+        }
+
         routerReconciliations = Counter.builder("wanaku.router.reconciliations")
                 .description("Total number of WanakuRouter reconciliations")
                 .register(registry);
@@ -44,6 +89,12 @@ public class OperatorMetrics {
         routerReconciliationErrors = Counter.builder("wanaku.router.reconciliation.errors")
                 .description("Total number of failed WanakuRouter reconciliations")
                 .register(registry);
+
+        // Eagerly register the per-controller counters so all series appear from the first scrape
+        for (String controller : CONTROLLERS) {
+            reconciliations(controller);
+            reconciliationErrors(controller);
+        }
 
         Gauge.builder("wanaku.router.instances", () -> countInstances(kubernetesClient, WanakuRouter.class))
                 .description("Number of WanakuRouter instances in the operator namespace")
@@ -56,18 +107,70 @@ public class OperatorMetrics {
         Gauge.builder("wanaku.toolservice.instances", () -> countInstances(kubernetesClient, WanakuCapability.class))
                 .description("Number of WanakuCapability (tool service) instances in the operator namespace")
                 .register(registry);
+
+        Gauge.builder(
+                        "wanaku.servicecatalog.instances",
+                        () -> countInstances(kubernetesClient, WanakuServiceCatalog.class))
+                .description("Number of WanakuServiceCatalog instances in the operator namespace")
+                .register(registry);
+
+        Gauge.builder("wanaku.camelroute.instances", () -> countInstances(kubernetesClient, WanakuCamelRoute.class))
+                .description("Number of WanakuCamelRoute instances in the operator namespace")
+                .register(registry);
+
+        Gauge.builder(
+                        "wanaku.codeexecutionengine.instances",
+                        () -> countInstances(kubernetesClient, WanakuCamelCodeExecutionEngine.class))
+                .description("Number of WanakuCamelCodeExecutionEngine instances in the operator namespace")
+                .register(registry);
     }
 
     void onStart(@Observes StartupEvent event) {
         // Forces eager instantiation so the gauges are registered before the first scrape
     }
 
+    public void countReconciliation(String controller) {
+        if (!enabled) {
+            return;
+        }
+        reconciliations(controller).increment();
+    }
+
+    public void countReconciliationError(String controller) {
+        if (!enabled) {
+            return;
+        }
+        reconciliationErrors(controller).increment();
+    }
+
     public void countRouterReconciliation() {
+        if (!enabled) {
+            return;
+        }
         routerReconciliations.increment();
+        countReconciliation(CONTROLLER_ROUTER);
     }
 
     public void countRouterReconciliationError() {
+        if (!enabled) {
+            return;
+        }
         routerReconciliationErrors.increment();
+        countReconciliationError(CONTROLLER_ROUTER);
+    }
+
+    private Counter reconciliations(String controller) {
+        return Counter.builder("wanaku.reconciliations")
+                .description("Total number of reconciliations per controller")
+                .tag("controller", controller)
+                .register(registry);
+    }
+
+    private Counter reconciliationErrors(String controller) {
+        return Counter.builder("wanaku.reconciliation.errors")
+                .description("Total number of failed reconciliations per controller")
+                .tag("controller", controller)
+                .register(registry);
     }
 
     private static <T extends HasMetadata> double countInstances(KubernetesClient client, Class<T> resourceType) {

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelCodeExecutionEngineReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelCodeExecutionEngineReconciler.java
@@ -24,6 +24,7 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 import ai.wanaku.operator.util.OperatorUtil;
 
 import static ai.wanaku.operator.util.CodeExecutionEngineResourceFactory.makeCodeExecutionEngineInternalService;
@@ -67,6 +68,9 @@ public class WanakuCamelCodeExecutionEngineReconciler implements Reconciler<Wana
     @Inject
     KubernetesClient kubernetesClient;
 
+    @Inject
+    OperatorMetrics metrics;
+
     @Override
     public UpdateControl<WanakuCamelCodeExecutionEngine> reconcile(
             WanakuCamelCodeExecutionEngine resource, Context<WanakuCamelCodeExecutionEngine> context) throws Exception {
@@ -74,6 +78,8 @@ public class WanakuCamelCodeExecutionEngineReconciler implements Reconciler<Wana
         LOG.infof(
                 "Starting code execution engine reconciliation for %s",
                 resource.getMetadata().getName());
+
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CODE_EXECUTION_ENGINE);
 
         ValidateSpecResult validation = validateSpec(resource);
         if (!validation.valid) {
@@ -315,6 +321,7 @@ public class WanakuCamelCodeExecutionEngineReconciler implements Reconciler<Wana
         LOG.warnf(
                 "WanakuCamelCodeExecutionEngine '%s' error (%s): %s",
                 resource.getMetadata().getName(), reason, message);
+        metrics.countReconciliationError(OperatorMetrics.CONTROLLER_CODE_EXECUTION_ENGINE);
 
         WanakuCamelCodeExecutionEngineStatus status = new WanakuCamelCodeExecutionEngineStatus();
         Condition condition = new ConditionBuilder()

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCamelRouteReconciler.java
@@ -43,6 +43,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
 import ai.wanaku.core.services.api.ServiceCatalogService;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 import ai.wanaku.operator.util.CamelRoutePackager;
 import ai.wanaku.operator.util.CapabilityResourceFactory;
 import ai.wanaku.operator.util.EnvironmentVariableHelper;
@@ -110,10 +111,15 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
     @Inject
     KubernetesClient kubernetesClient;
 
+    @Inject
+    OperatorMetrics metrics;
+
     @Override
     public UpdateControl<WanakuCamelRoute> reconcile(WanakuCamelRoute resource, Context<WanakuCamelRoute> context) {
         String crName = resource.getMetadata().getName();
         LOG.infof("Starting camel route reconciliation for %s", crName);
+
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CAMEL_ROUTE);
 
         final String namespace = resource.getMetadata().getNamespace();
 
@@ -255,6 +261,7 @@ public class WanakuCamelRouteReconciler implements Reconciler<WanakuCamelRoute>,
 
     private UpdateControl<WanakuCamelRoute> setErrorStatus(WanakuCamelRoute resource, String reason, String message) {
         LOG.warnf("WanakuCamelRoute '%s' error (%s): %s", resource.getMetadata().getName(), reason, message);
+        metrics.countReconciliationError(OperatorMetrics.CONTROLLER_CAMEL_ROUTE);
 
         final WanakuCamelRouteStatus status = new WanakuCamelRouteStatus();
         Condition condition = new ConditionBuilder()

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuCapabilityReconciler.java
@@ -23,6 +23,7 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 import ai.wanaku.operator.util.CapabilityResourceFactory;
 import ai.wanaku.operator.util.OperatorConstants;
 import ai.wanaku.operator.util.OperatorUtil;
@@ -63,12 +64,16 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
     @Inject
     KubernetesClient kubernetesClient;
 
+    @Inject
+    OperatorMetrics metrics;
+
     @Override
     public UpdateControl<WanakuCapability> reconcile(WanakuCapability resource, Context<WanakuCapability> context) {
         LOG.infof(
                 "Starting capability reconciliation for %s",
                 resource.getMetadata().getName());
 
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CAPABILITY);
         try {
             final String namespace = resource.getMetadata().getNamespace();
 
@@ -205,6 +210,7 @@ public class WanakuCapabilityReconciler implements Reconciler<WanakuCapability> 
 
     private UpdateControl<WanakuCapability> setErrorStatus(WanakuCapability resource, String reason, String message) {
         LOG.warnf("WanakuCapability '%s' error (%s): %s", resource.getMetadata().getName(), reason, message);
+        metrics.countReconciliationError(OperatorMetrics.CONTROLLER_CAPABILITY);
 
         WanakuCapabilityStatus status = new WanakuCapabilityStatus();
         Condition condition = new ConditionBuilder()

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -28,6 +28,7 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
 import ai.wanaku.core.util.StringHelper;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 import ai.wanaku.operator.util.OperatorUtil;
 import ai.wanaku.operator.util.RouterResourceFactory;
 
@@ -101,38 +102,53 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
     @Inject
     KubernetesClient kubernetesClient;
 
+    @Inject
+    OperatorMetrics metrics;
+
     @Override
     public UpdateControl<WanakuRouter> reconcile(WanakuRouter resource, Context<WanakuRouter> context) {
         LOG.infof(
                 "Starting router reconciliation for %s", resource.getMetadata().getName());
 
-        ValidateSpecResult validation = validateSpec(resource);
-        if (!validation.valid) {
-            return setErrorStatus(resource, "ValidationError", validation.errorMessage);
+        metrics.countRouterReconciliation();
+        try {
+            ValidateSpecResult validation = validateSpec(resource);
+            if (!validation.valid) {
+                return setErrorStatus(resource, "ValidationError", validation.errorMessage);
+            }
+
+            WanakuTypes.ExposureSpec exposureSpec = resource.getSpec().getExposure();
+            if (exposureSpec != null
+                    && exposureSpec.getType() == WanakuTypes.ExposureType.ROUTE
+                    && !isOpenShiftCluster()) {
+                LOG.errorf(
+                        "WanakuRouter '%s' requests type=Route but the cluster does not have the"
+                                + " OpenShift Route API (route.openshift.io)",
+                        resource.getMetadata().getName());
+                return setErrorStatus(
+                        resource,
+                        "ValidationError",
+                        "spec.exposure.type is Route but this is not an OpenShift cluster");
+            }
+
+            final String namespace = resource.getMetadata().getNamespace();
+            final WanakuRouterStatus wanakuStatus = new WanakuRouterStatus();
+            deployRouter(resource, context, namespace, wanakuStatus);
+
+            final Condition previousReadyCondition = OperatorUtil.findCondition(
+                    resource.getStatus() != null ? resource.getStatus().getConditions() : null,
+                    OperatorUtil.READY_CONDITION);
+            wanakuStatus.setConditions(List.of(OperatorUtil.readyCondition(
+                    resource.getMetadata().getGeneration(),
+                    previousReadyCondition,
+                    "WanakuRouter deployment is ready")));
+
+            resource.setStatus(wanakuStatus);
+            return UpdateControl.patchStatus(resource);
+        } catch (RuntimeException e) {
+            metrics.countRouterReconciliationError();
+            throw e;
         }
-
-        WanakuTypes.ExposureSpec exposureSpec = resource.getSpec().getExposure();
-        if (exposureSpec != null && exposureSpec.getType() == WanakuTypes.ExposureType.ROUTE && !isOpenShiftCluster()) {
-            LOG.errorf(
-                    "WanakuRouter '%s' requests type=Route but the cluster does not have the"
-                            + " OpenShift Route API (route.openshift.io)",
-                    resource.getMetadata().getName());
-            return setErrorStatus(
-                    resource, "ValidationError", "spec.exposure.type is Route but this is not an OpenShift cluster");
-        }
-
-        final String namespace = resource.getMetadata().getNamespace();
-        final WanakuRouterStatus wanakuStatus = new WanakuRouterStatus();
-        deployRouter(resource, context, namespace, wanakuStatus);
-
-        final Condition previousReadyCondition = OperatorUtil.findCondition(
-                resource.getStatus() != null ? resource.getStatus().getConditions() : null,
-                OperatorUtil.READY_CONDITION);
-        wanakuStatus.setConditions(List.of(OperatorUtil.readyCondition(
-                resource.getMetadata().getGeneration(), previousReadyCondition, "WanakuRouter deployment is ready")));
-
-        resource.setStatus(wanakuStatus);
-        return UpdateControl.patchStatus(resource);
     }
 
     private void deployRouter(

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuRouterReconciler.java
@@ -309,6 +309,7 @@ public class WanakuRouterReconciler implements Reconciler<WanakuRouter> {
 
     private UpdateControl<WanakuRouter> setErrorStatus(WanakuRouter resource, String reason, String message) {
         LOG.warnf("WanakuRouter '%s' error (%s): %s", resource.getMetadata().getName(), reason, message);
+        metrics.countRouterReconciliationError();
         WanakuRouterStatus status = new WanakuRouterStatus();
         Condition condition = new ConditionBuilder()
                 .withType(OperatorUtil.READY_CONDITION)

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/wanaku/WanakuServiceCatalogReconciler.java
@@ -32,6 +32,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.security.ServiceAuthenticator;
 import ai.wanaku.core.services.api.ServiceCatalogService;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 import ai.wanaku.operator.util.OperatorSecurityConfig;
 
 import static ai.wanaku.operator.util.OperatorUtil.READY_CONDITION;
@@ -64,6 +65,9 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
     @Inject
     KubernetesClient kubernetesClient;
 
+    @Inject
+    OperatorMetrics metrics;
+
     @Override
     public UpdateControl<WanakuServiceCatalog> reconcile(
             WanakuServiceCatalog resource, Context<WanakuServiceCatalog> context) {
@@ -71,6 +75,7 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
                 "Starting service catalog reconciliation for %s",
                 resource.getMetadata().getName());
 
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_SERVICE_CATALOG);
         final String namespace = resource.getMetadata().getNamespace();
 
         final String routerRef = resource.getSpec().getRouterRef();
@@ -162,6 +167,7 @@ public class WanakuServiceCatalogReconciler implements Reconciler<WanakuServiceC
         LOG.warnf(
                 "WanakuServiceCatalog '%s' error (%s): %s",
                 resource.getMetadata().getName(), reason, message);
+        metrics.countReconciliationError(OperatorMetrics.CONTROLLER_SERVICE_CATALOG);
 
         final WanakuServiceCatalogStatus status = new WanakuServiceCatalogStatus();
         Condition condition = new ConditionBuilder()

--- a/apps/wanaku-operator/src/main/resources/application.properties
+++ b/apps/wanaku-operator/src/main/resources/application.properties
@@ -9,6 +9,18 @@
 quarkus.http.port=8081
 quarkus.devservices.enabled=false
 
+# Metrics Configuration (Prometheus exposition at /metrics)
+quarkus.micrometer.export.prometheus.path=/metrics
+
+# Gate the generated ServiceMonitor behind a Helm value (disabled by default) and
+# make its scrape interval configurable
+quarkus.helm.add-if-statement.service-monitor.on-resource-kind=ServiceMonitor
+quarkus.helm.add-if-statement.service-monitor.property=metrics.serviceMonitor.enabled
+quarkus.helm.add-if-statement.service-monitor.with-default-value=false
+quarkus.helm.add-if-statement.service-monitor.description=Create a ServiceMonitor for the operator metrics endpoint.
+quarkus.helm.expressions.17.path=(kind == ServiceMonitor).spec.endpoints.interval
+quarkus.helm.expressions.17.expression={{ .Values.app.metrics.serviceMonitor.interval }}
+
 # Logging Configuration
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO

--- a/apps/wanaku-operator/src/main/resources/application.properties
+++ b/apps/wanaku-operator/src/main/resources/application.properties
@@ -11,6 +11,9 @@ quarkus.devservices.enabled=false
 
 # Metrics Configuration (Prometheus exposition at /metrics)
 quarkus.micrometer.export.prometheus.path=/metrics
+# Set to false to disable the Wanaku operator metrics (reconciliation counters and
+# instance gauges) when they are not going to be consumed
+wanaku.operator.metrics.enabled=true
 
 # Gate the generated ServiceMonitor behind a Helm value (disabled by default) and
 # make its scrape interval configurable
@@ -31,6 +34,7 @@ quarkus.operator-sdk.crd.apply=true
 # Kubernetes Configuration
 quarkus.kubernetes.image-pull-policy=if-not-present
 quarkus.kubernetes.add-version-to-label-selectors=false
+quarkus.kubernetes.vcs-uri.enabled=false
 
 # Helm Configuration
 quarkus.helm.app-version=${project.version}

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/metrics/OperatorMetricsTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/metrics/OperatorMetricsTest.java
@@ -10,9 +10,12 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.wanaku.WanakuCamelCodeExecutionEngine;
+import ai.wanaku.operator.wanaku.WanakuCamelRoute;
 import ai.wanaku.operator.wanaku.WanakuCapability;
 import ai.wanaku.operator.wanaku.WanakuRouter;
 import ai.wanaku.operator.wanaku.WanakuRouterStatus;
+import ai.wanaku.operator.wanaku.WanakuServiceCatalog;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +37,7 @@ class OperatorMetricsTest {
         kubernetesClient = mock(KubernetesClient.class);
         when(kubernetesClient.getNamespace()).thenReturn(NAMESPACE);
         registry = new SimpleMeterRegistry();
-        metrics = new OperatorMetrics(registry, kubernetesClient);
+        metrics = new OperatorMetrics(registry, kubernetesClient, true);
     }
 
     @SuppressWarnings("unchecked")
@@ -64,6 +67,75 @@ class OperatorMetricsTest {
     }
 
     @Test
+    void taggedCountersIncrementPerController() {
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CAPABILITY);
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CAPABILITY);
+        metrics.countReconciliation(OperatorMetrics.CONTROLLER_CAMEL_ROUTE);
+        metrics.countReconciliationError(OperatorMetrics.CONTROLLER_CAPABILITY);
+
+        assertEquals(
+                2.0,
+                registry.get("wanaku.reconciliations")
+                        .tag("controller", OperatorMetrics.CONTROLLER_CAPABILITY)
+                        .counter()
+                        .count());
+        assertEquals(
+                1.0,
+                registry.get("wanaku.reconciliations")
+                        .tag("controller", OperatorMetrics.CONTROLLER_CAMEL_ROUTE)
+                        .counter()
+                        .count());
+        assertEquals(
+                1.0,
+                registry.get("wanaku.reconciliation.errors")
+                        .tag("controller", OperatorMetrics.CONTROLLER_CAPABILITY)
+                        .counter()
+                        .count());
+    }
+
+    @Test
+    void routerCountersAlsoIncrementTaggedCounters() {
+        metrics.countRouterReconciliation();
+        metrics.countRouterReconciliationError();
+
+        assertEquals(
+                1.0,
+                registry.get("wanaku.reconciliations")
+                        .tag("controller", OperatorMetrics.CONTROLLER_ROUTER)
+                        .counter()
+                        .count());
+        assertEquals(
+                1.0,
+                registry.get("wanaku.reconciliation.errors")
+                        .tag("controller", OperatorMetrics.CONTROLLER_ROUTER)
+                        .counter()
+                        .count());
+    }
+
+    @Test
+    void taggedCountersAreRegisteredEagerlyForAllControllers() {
+        for (String controller : List.of(
+                OperatorMetrics.CONTROLLER_ROUTER,
+                OperatorMetrics.CONTROLLER_CAPABILITY,
+                OperatorMetrics.CONTROLLER_SERVICE_CATALOG,
+                OperatorMetrics.CONTROLLER_CAMEL_ROUTE,
+                OperatorMetrics.CONTROLLER_CODE_EXECUTION_ENGINE)) {
+            assertEquals(
+                    0.0,
+                    registry.get("wanaku.reconciliations")
+                            .tag("controller", controller)
+                            .counter()
+                            .count());
+            assertEquals(
+                    0.0,
+                    registry.get("wanaku.reconciliation.errors")
+                            .tag("controller", controller)
+                            .counter()
+                            .count());
+        }
+    }
+
+    @Test
     void routerGaugesCountInstancesAndReadyInstances() {
         mockResourceList(WanakuRouter.class, List.of(router(true), router(false), new WanakuRouter()));
 
@@ -79,12 +151,39 @@ class OperatorMetricsTest {
     }
 
     @Test
+    void remainingCrGaugesCountInstances() {
+        mockResourceList(WanakuServiceCatalog.class, List.of(new WanakuServiceCatalog()));
+        mockResourceList(WanakuCamelRoute.class, List.of(new WanakuCamelRoute(), new WanakuCamelRoute()));
+        mockResourceList(WanakuCamelCodeExecutionEngine.class, List.of());
+
+        assertEquals(
+                1.0, registry.get("wanaku.servicecatalog.instances").gauge().value());
+        assertEquals(2.0, registry.get("wanaku.camelroute.instances").gauge().value());
+        assertEquals(
+                0.0,
+                registry.get("wanaku.codeexecutionengine.instances").gauge().value());
+    }
+
+    @Test
     void gaugesReturnNaNWhenTheApiIsUnavailable() {
         when(kubernetesClient.resources(WanakuRouter.class)).thenThrow(new RuntimeException("API unavailable"));
 
         assertTrue(Double.isNaN(registry.get("wanaku.router.instances").gauge().value()));
         assertTrue(Double.isNaN(
                 registry.get("wanaku.router.ready.instances").gauge().value()));
+    }
+
+    @Test
+    void disabledMetricsRegisterNothingAndCountersAreNoOps() {
+        SimpleMeterRegistry emptyRegistry = new SimpleMeterRegistry();
+        OperatorMetrics disabled = new OperatorMetrics(emptyRegistry, kubernetesClient, false);
+
+        disabled.countRouterReconciliation();
+        disabled.countRouterReconciliationError();
+        disabled.countReconciliation(OperatorMetrics.CONTROLLER_CAPABILITY);
+        disabled.countReconciliationError(OperatorMetrics.CONTROLLER_CAPABILITY);
+
+        assertTrue(emptyRegistry.getMeters().isEmpty());
     }
 
     @Test

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/metrics/OperatorMetricsTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/metrics/OperatorMetricsTest.java
@@ -1,0 +1,107 @@
+package ai.wanaku.operator.metrics;
+
+import java.util.List;
+import io.fabric8.kubernetes.api.model.ConditionBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import ai.wanaku.operator.util.OperatorUtil;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuRouter;
+import ai.wanaku.operator.wanaku.WanakuRouterStatus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OperatorMetricsTest {
+    private static final String NAMESPACE = "test-ns";
+
+    private KubernetesClient kubernetesClient;
+    private SimpleMeterRegistry registry;
+    private OperatorMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        kubernetesClient = mock(KubernetesClient.class);
+        when(kubernetesClient.getNamespace()).thenReturn(NAMESPACE);
+        registry = new SimpleMeterRegistry();
+        metrics = new OperatorMetrics(registry, kubernetesClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends HasMetadata> void mockResourceList(Class<T> resourceType, List<T> items) {
+        MixedOperation<T, KubernetesResourceList<T>, Resource<T>> operation = mock(MixedOperation.class);
+        NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> namespacedOperation =
+                mock(NonNamespaceOperation.class);
+        KubernetesResourceList<T> resourceList = mock(KubernetesResourceList.class);
+
+        when(kubernetesClient.resources(resourceType)).thenReturn(operation);
+        when(operation.inNamespace(NAMESPACE)).thenReturn(namespacedOperation);
+        when(namespacedOperation.list()).thenReturn(resourceList);
+        when(resourceList.getItems()).thenReturn(items);
+    }
+
+    @Test
+    void reconciliationCountersIncrement() {
+        metrics.countRouterReconciliation();
+        metrics.countRouterReconciliation();
+        metrics.countRouterReconciliationError();
+
+        assertEquals(
+                2.0, registry.get("wanaku.router.reconciliations").counter().count());
+        assertEquals(
+                1.0,
+                registry.get("wanaku.router.reconciliation.errors").counter().count());
+    }
+
+    @Test
+    void routerGaugesCountInstancesAndReadyInstances() {
+        mockResourceList(WanakuRouter.class, List.of(router(true), router(false), new WanakuRouter()));
+
+        assertEquals(3.0, registry.get("wanaku.router.instances").gauge().value());
+        assertEquals(1.0, registry.get("wanaku.router.ready.instances").gauge().value());
+    }
+
+    @Test
+    void toolServiceGaugeCountsCapabilities() {
+        mockResourceList(WanakuCapability.class, List.of(new WanakuCapability(), new WanakuCapability()));
+
+        assertEquals(2.0, registry.get("wanaku.toolservice.instances").gauge().value());
+    }
+
+    @Test
+    void gaugesReturnNaNWhenTheApiIsUnavailable() {
+        when(kubernetesClient.resources(WanakuRouter.class)).thenThrow(new RuntimeException("API unavailable"));
+
+        assertTrue(Double.isNaN(registry.get("wanaku.router.instances").gauge().value()));
+        assertTrue(Double.isNaN(
+                registry.get("wanaku.router.ready.instances").gauge().value()));
+    }
+
+    @Test
+    void isReadyChecksTheReadyCondition() {
+        assertTrue(OperatorMetrics.isReady(router(true)));
+        assertFalse(OperatorMetrics.isReady(router(false)));
+        assertFalse(OperatorMetrics.isReady(new WanakuRouter()));
+    }
+
+    private static WanakuRouter router(boolean ready) {
+        WanakuRouter router = new WanakuRouter();
+        WanakuRouterStatus status = new WanakuRouterStatus();
+        status.setConditions(List.of(new ConditionBuilder()
+                .withType(OperatorUtil.READY_CONDITION)
+                .withStatus(ready ? OperatorUtil.CONDITION_STATUS_TRUE : OperatorUtil.CONDITION_STATUS_FALSE)
+                .build()));
+        router.setStatus(status);
+        return router;
+    }
+}

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuRouterReconcilerTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/wanaku/WanakuRouterReconcilerTest.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.Condition;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import ai.wanaku.operator.metrics.OperatorMetrics;
 
 import static ai.wanaku.operator.assertions.OperatorAssertions.assertCondition;
 
@@ -25,6 +26,9 @@ class WanakuRouterReconcilerTest {
 
     @Mock
     KubernetesClient kubernetesClient;
+
+    @Mock
+    OperatorMetrics metrics;
 
     @InjectMocks
     WanakuRouterReconciler reconciler;

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -793,15 +793,30 @@ The operator exposes metrics in Prometheus format at `/metrics` on the operator'
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `wanaku_router_reconciliations_total` | counter | Total number of `WanakuRouter` reconciliations. |
-| `wanaku_router_reconciliation_errors_total` | counter | Total number of failed `WanakuRouter` reconciliations. |
+| `wanaku_reconciliations_total` | counter | Total number of reconciliations, labeled by `controller` (`wanaku-router`, `wanaku-capability`, `wanaku-service-catalog`, `wanaku-camel-route`, `camel-code-execution-engine`). |
+| `wanaku_reconciliation_errors_total` | counter | Total number of failed reconciliations (thrown errors or reconciliations that resolved to an error status), labeled by `controller`. |
+| `wanaku_router_reconciliations_total` | counter | Total number of `WanakuRouter` reconciliations. Equivalent to `wanaku_reconciliations_total{controller="wanaku-router"}`, kept for compatibility. |
+| `wanaku_router_reconciliation_errors_total` | counter | Total number of failed `WanakuRouter` reconciliations. Equivalent to the labeled counter, kept for compatibility. |
 | `wanaku_router_instances` | gauge | Number of `WanakuRouter` instances in the operator namespace. |
 | `wanaku_router_ready_instances` | gauge | Number of `WanakuRouter` instances whose `Ready` condition is `True`. |
 | `wanaku_toolservice_instances` | gauge | Number of `WanakuCapability` (tool service) instances in the operator namespace. |
+| `wanaku_servicecatalog_instances` | gauge | Number of `WanakuServiceCatalog` instances in the operator namespace. |
+| `wanaku_camelroute_instances` | gauge | Number of `WanakuCamelRoute` instances in the operator namespace. |
+| `wanaku_codeexecutionengine_instances` | gauge | Number of `WanakuCamelCodeExecutionEngine` instances in the operator namespace. |
 
 In addition to the Wanaku-specific metrics, the endpoint also exposes the standard
 [Java Operator SDK metrics](https://javaoperatorsdk.io/docs/features/#micrometer-implementation)
 (reconciliation timings, event counts, retries per controller) and JVM/HTTP metrics provided by Quarkus.
+
+The Wanaku-specific metrics can be disabled with `wanaku.operator.metrics.enabled=false`
+(default `true`) when they are not going to be consumed — the instance gauges then never
+query the Kubernetes API. With the Helm chart, set it through an environment variable:
+
+```shell
+helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator \
+  --namespace wanaku \
+  --set app.envs.WANAKU_OPERATOR_METRICS_ENABLED=false
+```
 
 **Quick check with port-forward:**
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -785,6 +785,74 @@ helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator 
   --set app.envs.QUARKUS_OPERATOR_SDK_CONTROLLERS_CAMEL_CODE_EXECUTION_ENGINE_NAMESPACES=JOSDK_ALL_NAMESPACES
 ```
 
+## Monitoring
+
+The operator exposes metrics in Prometheus format at `/metrics` on the operator's HTTP port (`8081` by default).
+
+### Available Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `wanaku_router_reconciliations_total` | counter | Total number of `WanakuRouter` reconciliations. |
+| `wanaku_router_reconciliation_errors_total` | counter | Total number of failed `WanakuRouter` reconciliations. |
+| `wanaku_router_instances` | gauge | Number of `WanakuRouter` instances in the operator namespace. |
+| `wanaku_router_ready_instances` | gauge | Number of `WanakuRouter` instances whose `Ready` condition is `True`. |
+| `wanaku_toolservice_instances` | gauge | Number of `WanakuCapability` (tool service) instances in the operator namespace. |
+
+In addition to the Wanaku-specific metrics, the endpoint also exposes the standard
+[Java Operator SDK metrics](https://javaoperatorsdk.io/docs/features/#micrometer-implementation)
+(reconciliation timings, event counts, retries per controller) and JVM/HTTP metrics provided by Quarkus.
+
+**Quick check with port-forward:**
+
+```shell
+kubectl port-forward deployment/wanaku-operator 8081:8081 --namespace wanaku
+curl -s http://localhost:8081/metrics | grep wanaku_
+```
+
+### Prometheus ServiceMonitor
+
+On clusters running the Prometheus Operator (including OpenShift with user workload monitoring enabled),
+the Helm chart can create a `ServiceMonitor` that scrapes the operator metrics endpoint:
+
+```shell
+helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator \
+  --namespace wanaku \
+  --set app.metrics.serviceMonitor.enabled=true
+```
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `app.metrics.serviceMonitor.enabled` | boolean | `false` | Create a `ServiceMonitor` for the operator metrics endpoint. |
+| `app.metrics.serviceMonitor.interval` | string | `30s` | Scrape interval for the `ServiceMonitor`. |
+
+> [!NOTE]
+> On OpenShift, enable [monitoring for user-defined projects](https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html)
+> so the cluster Prometheus picks up the `ServiceMonitor`.
+
+### Grafana Dashboard
+
+The Helm chart ships a Grafana dashboard with panels for all operator metrics
+(router/tool service instance counts, reconciliation and error rates). There are two ways to use it:
+
+**Automatic provisioning (Grafana sidecar).** If Grafana runs with the dashboard sidecar
+(the default in [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)),
+the chart can create a ConfigMap labeled `grafana_dashboard: "1"` that the sidecar discovers and loads automatically:
+
+```shell
+helm install wanaku-operator ./apps/wanaku-operator/deploy/helm/wanaku-operator \
+  --namespace wanaku \
+  --set app.metrics.serviceMonitor.enabled=true \
+  --set app.metrics.grafanaDashboard.enabled=true
+```
+
+**Manual import.** Import `apps/wanaku-operator/deploy/helm/wanaku-operator/dashboards/wanaku-operator-dashboard.json`
+in the Grafana UI (Dashboards → New → Import) and select your Prometheus data source.
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `app.metrics.grafanaDashboard.enabled` | boolean | `false` | Create a ConfigMap with the operator Grafana dashboard, discoverable by the Grafana sidecar. |
+
 ## Troubleshooting
 
 ### Operator pod not starting


### PR DESCRIPTION
Closes: wanaku-ai/wanaku-barn#36 



- Implement OperatorMetrics class to register metrics for router reconciliations and instances.
- Create Grafana dashboard JSON and ConfigMap template for automatic provisioning.
- Add ServiceMonitor configuration to expose metrics endpoint.
- Update values.yaml and values.schema.json to include metrics settings.
- Enhance documentation with monitoring and metrics details.

## Summary by Sourcery

Add Prometheus-based metrics and optional Grafana dashboard support for the Wanaku Operator, including Helm integration and documentation.

New Features:
- Expose operator and Wanaku-specific metrics via Micrometer Prometheus registry at the /metrics HTTP endpoint.
- Provide a Helm-managed ServiceMonitor resource to enable Prometheus scraping of operator metrics when enabled by values.
- Ship a preconfigured Grafana dashboard and optional ConfigMap for automatic dashboard provisioning via Grafana sidecars.

Enhancements:
- Introduce an OperatorMetrics component to track router reconciliations, errors, and Wanaku resource instance counts.
- Extend the Helm build to package Grafana dashboard assets and templates into the generated chart.

Documentation:
- Document operator monitoring, available metrics, Prometheus ServiceMonitor configuration, and Grafana dashboard usage.

Tests:
- Add unit tests for OperatorMetrics to validate counters, gauges, readiness derivation, and API failure handling.

Closes: wanaku-ai/wanaku-barn#66

-  I simply followed the requested follow-up pattern and made minor changes to the dashboard.