### PR TITLE
Fix #1725: remove duplicated default namespace from CLI list

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
@@ -60,16 +60,6 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 
             return ret;
         }
-
-        public static AddressableNamespace defaultNs(String host) {
-            AddressableNamespace ret = new AddressableNamespace();
-            ret.setId("<default>");
-            ret.setPath("");
-            ret.setName("");
-            ret.host = host;
-
-            return ret;
-        }
     }
 
     @Override
@@ -80,10 +70,6 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
             WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
             List<AddressableNamespace> list =
                     response.data().stream().map(this::convertToAddressable).collect(Collectors.toList());
-
-            if (labelExpression == null || labelExpression.isBlank()) {
-                list.add(AddressableNamespace.defaultNs(host));
-            }
 
             printer.printTable(list, "id", "name", "path", "labels");
         } catch (WebApplicationException ex) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
@@ -41,8 +41,8 @@ class NamespaceListTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    @DisplayName("Should include default namespace when no label filter is specified")
-    void shouldIncludeDefaultNamespaceWithoutFilter() throws Exception {
+    @DisplayName("Should list namespaces from backend without adding synthetic default")
+    void shouldListNamespacesWithoutSyntheticDefault() throws Exception {
         Namespace ns = new Namespace();
         ns.setId("ns-1");
         ns.setPath("my-ns");
@@ -58,7 +58,7 @@ class NamespaceListTest {
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
         List<?> printed = captor.getValue();
-        assertEquals(2, printed.size(), "Should contain the namespace plus the default entry");
+        assertEquals(1, printed.size(), "Should contain only the namespace from the backend");
     }
 
     @SuppressWarnings("unchecked")
@@ -108,9 +108,9 @@ class NamespaceListTest {
     }
 
     @Test
-    @DisplayName("Should include default namespace when label expression is a blank string")
+    @DisplayName("Should list namespaces from backend when label expression is blank")
     @SuppressWarnings("unchecked")
-    void shouldIncludeDefaultNamespaceWhenLabelExpressionBlank() throws Exception {
+    void shouldListNamespacesWhenLabelExpressionBlank() throws Exception {
         Namespace ns = new Namespace();
         ns.setId("ns-1");
         ns.setPath("ns-team");
@@ -129,6 +129,6 @@ class NamespaceListTest {
         verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
 
         List<?> printed = captor.getValue();
-        assertEquals(2, printed.size(), "Blank expression means no filter, so default namespace should be included");
+        assertEquals(1, printed.size(), "Should contain only the namespace from the backend");
     }
 }


### PR DESCRIPTION
Fixes #1725

The CLI's `namespaces list` command was appending a synthetic `<default>` namespace entry with an empty path, producing a broken double-slash URL (`http://localhost:8080//mcp/sse`). Since the backend already ensures a proper "default" namespace exists via `ensureDefaultNamespace()`, this synthetic entry was redundant and caused the duplication reported in the issue.

**Changes:**
- Remove the synthetic `<default>` namespace addition from `NamespaceList.doCall()`
- Remove the unused `AddressableNamespace.defaultNs()` factory method
- Update CLI tests to reflect that the default namespace now comes from the backend only

## Summary by Sourcery

Stop adding a synthetic default namespace entry in the CLI namespaces list so only backend-provided namespaces are shown.

Bug Fixes:
- Prevent duplicate and malformed default namespace entries in the CLI namespaces list output.

Enhancements:
- Remove the unused factory for synthetic default namespaces from the CLI code.

Tests:
- Update namespace listing CLI tests to expect only backend-provided namespaces and no synthetic default entry.