### PR TITLE
Fix #1724: resolve namespace ID to name in CLI commands

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
@@ -20,6 +20,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
 
@@ -85,10 +86,13 @@ public class PromptsAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
+
         PromptReference promptReference = new PromptReference();
         promptReference.setName(name);
         promptReference.setDescription(description);
-        promptReference.setNamespace(namespaceOptions.getNamespaceValue());
+        promptReference.setNamespace(namespaceName);
 
         // Parse messages
         List<PromptMessage> promptMessages = new ArrayList<>();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
@@ -19,6 +19,7 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
 
@@ -99,7 +100,8 @@ public class PromptsEdit extends BaseCommand {
 
         // Update only the fields that were provided
         if (namespaceOptions != null) {
-            String ns = namespaceOptions.getNamespaceValue();
+            NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+            String ns = namespaceOptions.resolveNamespaceName(namespacesService);
             if (ns != null) {
                 existingPrompt.setNamespace(ns);
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
@@ -13,6 +13,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
 
@@ -114,13 +115,16 @@ public class ResourcesExpose extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         resourcesService = initAuthenticatedService(ResourcesService.class, host);
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
+
         ResourceReference resource = new ResourceReference();
         resource.setLocation(location);
         resource.setType(type);
         resource.setName(name);
         resource.setDescription(description);
         resource.setMimeType(mimeType);
-        resource.setNamespace(namespaceOptions.getNamespaceValue());
+        resource.setNamespace(namespaceName);
         resource.setLabels(labels);
 
         ResourcePayload resourcePayload = new ResourcePayload();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
@@ -16,6 +16,7 @@ import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.PropertyHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ToolsService;
 import picocli.CommandLine;
 
@@ -115,13 +116,15 @@ public class ToolsAdd extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
 
         ToolReference toolReference = new ToolReference();
         toolReference.setName(name);
         toolReference.setDescription(description);
         toolReference.setUri(uri);
         toolReference.setType(type);
-        toolReference.setNamespace(namespaceOptions.getNamespaceValue());
+        toolReference.setNamespace(namespaceName);
         toolReference.setLabels(labels);
 
         InputSchema inputSchema = new InputSchema();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
@@ -9,6 +9,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.converter.URLConverter;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ToolsService;
 import ai.wanaku.core.util.ToolsetIndexHelper;
 import picocli.CommandLine;
@@ -44,7 +45,8 @@ public class ToolsImport extends BaseCommand {
 
             // Apply default namespace to tools that don't have one
             if (namespaceOptions != null) {
-                String ns = namespaceOptions.getNamespaceValue();
+                NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+                String ns = namespaceOptions.resolveNamespaceName(namespacesService);
                 if (ns != null && !ns.isEmpty()) {
                     for (ToolReference toolReference : toolReferences) {
                         if (toolReference.getNamespace() == null

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -121,4 +121,51 @@ public class NamespaceOptions {
             throw ex;
         }
     }
+
+    /**
+     * Resolves the namespace to its human-readable name.
+     * <p>
+     * If {@code --namespace} was provided, returns the name directly.
+     * If {@code --namespace-id} was provided, queries the server to look up the name by UUID.
+     * </p>
+     * <p>
+     * This method should be used by commands whose backends resolve namespaces by name
+     * (e.g., tools, prompts, resources) rather than by ID (e.g., forwards).
+     * </p>
+     *
+     * @param namespacesService the service to use for looking up namespace by ID
+     * @return the namespace name
+     * @throws Exception if the lookup fails or no matching namespace is found
+     */
+    public String resolveNamespaceName(NamespacesService namespacesService) throws Exception {
+        if (namespace != null) {
+            return namespace;
+        }
+
+        if (namespaceId == null || namespaceId.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Either --namespace or --namespace-id must be provided with a non-blank value.");
+        }
+
+        try {
+            WanakuResponse<Namespace> response = namespacesService.getById(namespaceId);
+            Namespace ns = response.data();
+            if (ns == null) {
+                throw new IllegalArgumentException(
+                        "No namespace found with ID '%s'. Use 'wanaku namespaces list' to see available namespaces."
+                                .formatted(namespaceId));
+            }
+
+            String name = ns.getName();
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException(
+                        "Namespace with ID '%s' has no name assigned. Use --namespace with a name instead, or assign a name to the namespace first."
+                                .formatted(namespaceId));
+            }
+            return name;
+        } catch (WebApplicationException ex) {
+            commonResponseErrorHandler(ex.getResponse());
+            throw ex;
+        }
+    }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/NamespaceOptionsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/NamespaceOptionsTest.java
@@ -1,0 +1,116 @@
+package ai.wanaku.cli.main.support;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.core.services.api.NamespacesService;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NamespaceOptionsTest {
+
+    private NamespaceOptions createWithNamespace(String name) throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        Field field = NamespaceOptions.class.getDeclaredField("namespace");
+        field.setAccessible(true);
+        field.set(options, name);
+        return options;
+    }
+
+    private NamespaceOptions createWithNamespaceId(String id) throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        Field field = NamespaceOptions.class.getDeclaredField("namespaceId");
+        field.setAccessible(true);
+        field.set(options, id);
+        return options;
+    }
+
+    @Test
+    void resolveNamespaceNameReturnsNameWhenNamespaceProvided() throws Exception {
+        NamespaceOptions options = createWithNamespace("default");
+        NamespacesService service = mock(NamespacesService.class);
+
+        String result = options.resolveNamespaceName(service);
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void resolveNamespaceNameLooksUpByIdWhenNamespaceIdProvided() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setName("default");
+        ns.setPath("default");
+
+        when(service.getById("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63")).thenReturn(new WanakuResponse<>(ns));
+
+        String result = options.resolveNamespaceName(service);
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNamespaceIdNotFound() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("nonexistent-id");
+        NamespacesService service = mock(NamespacesService.class);
+
+        when(service.getById("nonexistent-id")).thenReturn(new WanakuResponse<>((Namespace) null));
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNamespaceHasNoName() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("preallocated-id");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setName(null);
+        ns.setPath("ns-1");
+
+        when(service.getById("preallocated-id")).thenReturn(new WanakuResponse<>(ns));
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNeitherProvided() throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        NamespacesService service = mock(NamespacesService.class);
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceIdReturnsIdDirectlyWhenNamespaceIdProvided() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        NamespacesService service = mock(NamespacesService.class);
+
+        String result = options.resolveNamespaceId(service);
+
+        assertEquals("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63", result);
+    }
+
+    @Test
+    void resolveNamespaceIdLooksUpByNameWhenNamespaceProvided() throws Exception {
+        NamespaceOptions options = createWithNamespace("default");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        ns.setName("default");
+
+        when(service.list()).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        String result = options.resolveNamespaceId(service);
+
+        assertEquals("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63", result);
+    }
+}


### PR DESCRIPTION
Fixes #1724

## Summary

When `--namespace-id` was used with CLI commands like `tools add`, `prompts add`, `resources expose`,
`tools import`, or `prompts edit`, the namespace UUID was passed directly to the backend which treated
it as a namespace **name** rather than an ID. This caused the UUID to be assigned as the name of a
random preallocated namespace instead of associating the entity with the correct namespace.

## Changes

- Added `resolveNamespaceName(NamespacesService)` to `NamespaceOptions` that looks up a namespace by
  ID and returns its name when `--namespace-id` is used, or returns the name directly when `--namespace`
  is used
- Updated `ToolsAdd`, `PromptsAdd`, `ResourcesExpose`, `ToolsImport`, and `PromptsEdit` to use
  `resolveNamespaceName()` instead of `getNamespaceValue()`
- Added unit tests for `resolveNamespaceName()` covering: name passthrough, ID-to-name resolution,
  not-found error, unnamed namespace error, and missing-arguments error

## Note

`ServiceExpose` was not updated because it generates local YAML files without a server connection,
making namespace resolution impractical there.

## Summary by Sourcery

Ensure CLI commands resolve namespaces by human-readable name when given either a namespace name or ID.

Bug Fixes:
- Fix tools, prompts, and resources CLI commands incorrectly treating --namespace-id as a namespace name when sending requests to the backend.

Enhancements:
- Add NamespaceOptions.resolveNamespaceName to centralize namespace name resolution from either --namespace or --namespace-id and surface clear errors for invalid input or unnamed namespaces.

Tests:
- Add unit tests for NamespaceOptions covering namespace name passthrough, ID-to-name resolution, and error cases for missing, not-found, or unnamed namespaces.