### PR TITLE
Fix #1722: add download progress bar for wanaku start local

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -4,6 +4,7 @@ import jakarta.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,8 @@ public class StartLocal extends StartBase {
 
     private static final String CAMEL_INTEGRATION = "camel-integration";
 
+    private PrintWriter outputWriter;
+
     @Override
     protected void startWanaku() {
         List<String> services;
@@ -114,7 +117,7 @@ public class StartLocal extends StartBase {
 
         environment.withFailFast(failFast);
 
-        LocalRunner localRunner = new LocalRunner(config, environment, insecure);
+        LocalRunner localRunner = new LocalRunner(config, environment, insecure, outputWriter);
         try {
             localRunner.start(services);
         } catch (WanakuException | IOException e) {
@@ -163,6 +166,7 @@ public class StartLocal extends StartBase {
             }
         }
         printer.printWarningMessage("Authentication is disabled in local mode");
+        this.outputWriter = terminal.writer();
         startWanaku();
         return EXIT_OK;
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/DownloadProgressBar.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/DownloadProgressBar.java
@@ -1,0 +1,69 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.PrintWriter;
+
+/**
+ * Renders a text-based progress bar for file downloads.
+ *
+ * <p>Overwrites the current terminal line using carriage return ({@code \r})
+ * to provide a live-updating progress display.  When the total size is known
+ * a percentage bar is shown; otherwise only the downloaded byte count is
+ * displayed.</p>
+ */
+public final class DownloadProgressBar implements DownloadProgressListener {
+
+    private static final int BAR_WIDTH = 30;
+
+    private final String label;
+    private final PrintWriter writer;
+
+    /**
+     * Creates a progress bar with the given label and writer.
+     *
+     * @param label  short name shown before the bar (e.g. component name)
+     * @param writer the writer to print progress to (typically terminal writer)
+     */
+    public DownloadProgressBar(String label, PrintWriter writer) {
+        this.label = label;
+        this.writer = writer;
+    }
+
+    @Override
+    public void onProgress(long bytesRead, long totalBytes) {
+        if (totalBytes > 0) {
+            int percent = (int) (bytesRead * 100 / totalBytes);
+            int filled = (int) (bytesRead * BAR_WIDTH / totalBytes);
+            int empty = BAR_WIDTH - filled;
+
+            writer.printf(
+                    "\r%-25s [%s%s] %3d%% (%s / %s)",
+                    label,
+                    "=".repeat(filled),
+                    " ".repeat(empty),
+                    percent,
+                    formatBytes(bytesRead),
+                    formatBytes(totalBytes));
+        } else {
+            writer.printf("\r%-25s  %s downloaded", label, formatBytes(bytesRead));
+        }
+        writer.flush();
+    }
+
+    /**
+     * Prints a newline to move past the progress bar after download completes.
+     */
+    public void finish() {
+        writer.println();
+        writer.flush();
+    }
+
+    static String formatBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        } else if (bytes < 1024 * 1024) {
+            return String.format("%.1f KB", bytes / 1024.0);
+        } else {
+            return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
+        }
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/DownloadProgressListener.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/DownloadProgressListener.java
@@ -1,0 +1,19 @@
+package ai.wanaku.cli.main.support;
+
+/**
+ * Callback interface for tracking download progress.
+ *
+ * <p>Implementations receive periodic updates as bytes are downloaded, allowing
+ * them to render progress bars, log messages, or other feedback.</p>
+ */
+@FunctionalInterface
+public interface DownloadProgressListener {
+
+    /**
+     * Called periodically during a download to report progress.
+     *
+     * @param bytesRead total bytes downloaded so far
+     * @param totalBytes total expected size in bytes, or {@code -1} if unknown
+     */
+    void onProgress(long bytesRead, long totalBytes);
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/Downloader.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/Downloader.java
@@ -7,13 +7,16 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 
 public class Downloader {
     private static final Logger LOG = Logger.getLogger(Downloader.class);
+    private static final int BUFFER_SIZE = 8192;
 
     private static String getFileNameFromUrl(String url) {
         int lastIndex = url.lastIndexOf("/");
@@ -23,7 +26,36 @@ public class Downloader {
         throw new WanakuException("Invalid url: " + url);
     }
 
+    /**
+     * Downloads a file from the given URL into the specified directory.
+     *
+     * <p>If the file already exists locally, the download is skipped and the
+     * existing file is returned immediately.</p>
+     *
+     * @param url       the URL to download from
+     * @param directory the local directory to save the file into
+     * @return the local file
+     * @throws MalformedURLException if the URL is invalid
+     */
     public static File downloadFile(String url, File directory) throws MalformedURLException {
+        return downloadFile(url, directory, null);
+    }
+
+    /**
+     * Downloads a file from the given URL into the specified directory,
+     * reporting progress to the supplied listener.
+     *
+     * <p>If the file already exists locally, the download is skipped and the
+     * existing file is returned immediately (the listener is not called).</p>
+     *
+     * @param url      the URL to download from
+     * @param directory the local directory to save the file into
+     * @param listener optional progress listener (may be {@code null})
+     * @return the local file
+     * @throws MalformedURLException if the URL is invalid
+     */
+    public static File downloadFile(String url, File directory, DownloadProgressListener listener)
+            throws MalformedURLException {
         String fileName = getFileNameFromUrl(url);
         File localFile = new File(directory, fileName);
         if (localFile.exists()) {
@@ -31,17 +63,52 @@ public class Downloader {
             return localFile;
         }
 
-        URL remoteFile = URI.create(url).toURL();
-
-        try (InputStream in = remoteFile.openStream()) {
+        try {
             File parentDir = localFile.getParentFile();
             Files.createDirectories(parentDir.toPath());
 
-            try (OutputStream out = new FileOutputStream(localFile)) {
-                in.transferTo(out);
+            HttpClient client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+
+            HttpRequest request =
+                    HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            int statusCode = response.statusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new WanakuException("Download failed with HTTP status " + statusCode + " for URL: " + url);
             }
 
+            long totalBytes =
+                    response.headers().firstValueAsLong("Content-Length").orElse(-1L);
+
+            try (InputStream in = response.body();
+                    OutputStream out = new FileOutputStream(localFile)) {
+
+                byte[] buffer = new byte[BUFFER_SIZE];
+                long bytesRead = 0;
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                    bytesRead += read;
+                    if (listener != null) {
+                        listener.onProgress(bytesRead, totalBytes);
+                    }
+                }
+            }
         } catch (IOException e) {
+            // Clean up partial file on failure
+            if (localFile.exists()) {
+                localFile.delete();
+            }
+            throw new WanakuException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (localFile.exists()) {
+                localFile.delete();
+            }
             throw new WanakuException(e);
         }
         LOG.infof("File downloaded successfully to: %s", localFile.getAbsolutePath());

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/runner/local/LocalRunner.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.runner.local;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -19,6 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.jboss.logging.Logger;
 import ai.wanaku.capabilities.sdk.common.ProcessRunner;
+import ai.wanaku.cli.main.support.DownloadProgressBar;
+import ai.wanaku.cli.main.support.DownloadProgressListener;
 import ai.wanaku.cli.main.support.Downloader;
 import ai.wanaku.cli.main.support.HttpUtil;
 import ai.wanaku.cli.main.support.RuntimeConstants;
@@ -37,6 +40,7 @@ public class LocalRunner {
     private final WanakuCliConfig config;
     private final HttpClient httpClient;
     private final URI routerReadinessUri;
+    private final PrintWriter outputWriter;
     private int activeServices = 0;
 
     public static class LocalRunnerEnvironment {
@@ -140,15 +144,30 @@ public class LocalRunner {
     private final LocalRunnerEnvironment environment;
 
     public LocalRunner(WanakuCliConfig config, LocalRunnerEnvironment environment, boolean insecure) {
-        this(config, environment, HttpUtil.newHttpClient(insecure), DEFAULT_ROUTER_READINESS_URI);
+        this(config, environment, HttpUtil.newHttpClient(insecure), DEFAULT_ROUTER_READINESS_URI, null);
+    }
+
+    public LocalRunner(
+            WanakuCliConfig config, LocalRunnerEnvironment environment, boolean insecure, PrintWriter outputWriter) {
+        this(config, environment, HttpUtil.newHttpClient(insecure), DEFAULT_ROUTER_READINESS_URI, outputWriter);
     }
 
     LocalRunner(
             WanakuCliConfig config, LocalRunnerEnvironment environment, HttpClient httpClient, URI routerReadinessUri) {
+        this(config, environment, httpClient, routerReadinessUri, null);
+    }
+
+    LocalRunner(
+            WanakuCliConfig config,
+            LocalRunnerEnvironment environment,
+            HttpClient httpClient,
+            URI routerReadinessUri,
+            PrintWriter outputWriter) {
         this.config = config;
         this.environment = environment;
         this.httpClient = httpClient;
         this.routerReadinessUri = routerReadinessUri;
+        this.outputWriter = outputWriter;
     }
 
     public void start(List<String> services) throws IOException {
@@ -427,7 +446,19 @@ public class LocalRunner {
 
             LOG.infof("Downloading %s", componentName);
             LOG.debugf("Download URL: %s", downloadUrl);
-            downloadedFile = Downloader.downloadFile(downloadUrl, destinationDir);
+
+            DownloadProgressBar progressBar = null;
+            DownloadProgressListener listener = null;
+            if (outputWriter != null) {
+                progressBar = new DownloadProgressBar(componentName, outputWriter);
+                listener = progressBar;
+            }
+
+            downloadedFile = Downloader.downloadFile(downloadUrl, destinationDir, listener);
+
+            if (progressBar != null) {
+                progressBar.finish();
+            }
         }
 
         if (isJarArtifact(downloadedFile.getName())) {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/DownloadProgressBarTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/DownloadProgressBarTest.java
@@ -1,0 +1,72 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadProgressBarTest {
+
+    @Test
+    void shouldShowPercentageWhenTotalIsKnown() {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        DownloadProgressBar bar = new DownloadProgressBar("test-component", pw);
+        bar.onProgress(50, 100);
+
+        String output = sw.toString();
+        assertTrue(output.contains("50%"), "Should contain 50%% but was: " + output);
+        assertTrue(output.contains("test-component"), "Should contain the label");
+    }
+
+    @Test
+    void shouldShowBytesWhenTotalIsUnknown() {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        DownloadProgressBar bar = new DownloadProgressBar("test-component", pw);
+        bar.onProgress(1024, -1);
+
+        String output = sw.toString();
+        assertTrue(output.contains("downloaded"), "Should indicate download progress");
+        assertTrue(output.contains("test-component"), "Should contain the label");
+    }
+
+    @Test
+    void shouldShowFullProgressAt100Percent() {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        DownloadProgressBar bar = new DownloadProgressBar("my-service", pw);
+        bar.onProgress(200, 200);
+
+        String output = sw.toString();
+        assertTrue(output.contains("100%"), "Should show 100%% but was: " + output);
+    }
+
+    @Test
+    void finishShouldAddNewline() {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        DownloadProgressBar bar = new DownloadProgressBar("test", pw);
+        bar.onProgress(100, 100);
+        bar.finish();
+
+        String output = sw.toString();
+        assertTrue(output.endsWith(System.lineSeparator()), "Should end with newline");
+    }
+
+    @Test
+    void formatBytesShouldFormatCorrectly() {
+        assertEquals("0 B", DownloadProgressBar.formatBytes(0));
+        assertEquals("512 B", DownloadProgressBar.formatBytes(512));
+        assertEquals("1.0 KB", DownloadProgressBar.formatBytes(1024));
+        assertEquals("1.5 KB", DownloadProgressBar.formatBytes(1536));
+        assertEquals("1.0 MB", DownloadProgressBar.formatBytes(1024 * 1024));
+        assertEquals("2.5 MB", DownloadProgressBar.formatBytes((long) (2.5 * 1024 * 1024)));
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/DownloaderTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/DownloaderTest.java
@@ -1,0 +1,129 @@
+package ai.wanaku.cli.main.support;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloaderTest {
+
+    private HttpServer server;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void shouldDownloadFileWithProgressReporting() throws Exception {
+        byte[] content = "Hello, World!".getBytes();
+        server.createContext("/test-file.txt", exchange -> {
+            exchange.getResponseHeaders().set("Content-Length", String.valueOf(content.length));
+            exchange.sendResponseHeaders(200, content.length);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        });
+        server.start();
+
+        String url = "http://localhost:%d/test-file.txt"
+                .formatted(server.getAddress().getPort());
+
+        AtomicLong lastBytesRead = new AtomicLong();
+        AtomicLong reportedTotal = new AtomicLong();
+        List<Long> progressUpdates = new ArrayList<>();
+
+        DownloadProgressListener listener = (bytesRead, totalBytes) -> {
+            lastBytesRead.set(bytesRead);
+            reportedTotal.set(totalBytes);
+            progressUpdates.add(bytesRead);
+        };
+
+        File result = Downloader.downloadFile(url, tempDir.toFile(), listener);
+
+        assertTrue(result.exists(), "Downloaded file should exist");
+        assertEquals("Hello, World!", Files.readString(result.toPath()));
+        assertEquals(content.length, lastBytesRead.get(), "Final bytes read should match content length");
+        assertEquals(content.length, reportedTotal.get(), "Reported total should match Content-Length");
+        assertFalse(progressUpdates.isEmpty(), "Progress should have been reported at least once");
+    }
+
+    @Test
+    void shouldDownloadWithoutListenerForBackwardCompatibility() throws Exception {
+        byte[] content = "test data".getBytes();
+        server.createContext("/compat-file.txt", exchange -> {
+            exchange.getResponseHeaders().set("Content-Length", String.valueOf(content.length));
+            exchange.sendResponseHeaders(200, content.length);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        });
+        server.start();
+
+        String url = "http://localhost:%d/compat-file.txt"
+                .formatted(server.getAddress().getPort());
+
+        File result = Downloader.downloadFile(url, tempDir.toFile());
+
+        assertTrue(result.exists(), "Downloaded file should exist");
+        assertEquals("test data", Files.readString(result.toPath()));
+    }
+
+    @Test
+    void shouldSkipDownloadWhenFileAlreadyExists() throws Exception {
+        File existingFile = tempDir.resolve("existing-file.txt").toFile();
+        Files.writeString(existingFile.toPath(), "already here");
+
+        AtomicLong callCount = new AtomicLong();
+        DownloadProgressListener listener = (bytesRead, totalBytes) -> callCount.incrementAndGet();
+
+        File result = Downloader.downloadFile("http://localhost/existing-file.txt", tempDir.toFile(), listener);
+
+        assertEquals(existingFile, result, "Should return existing file");
+        assertEquals(0, callCount.get(), "Progress listener should not be called for cached files");
+    }
+
+    @Test
+    void shouldHandleMissingContentLength() throws Exception {
+        byte[] content = "no content length".getBytes();
+        server.createContext("/no-length.txt", exchange -> {
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().write(content);
+            exchange.close();
+        });
+        server.start();
+
+        String url = "http://localhost:%d/no-length.txt"
+                .formatted(server.getAddress().getPort());
+
+        AtomicLong reportedTotal = new AtomicLong(999);
+
+        File result = Downloader.downloadFile(url, tempDir.toFile(), (bytesRead, totalBytes) -> {
+            reportedTotal.set(totalBytes);
+        });
+
+        assertTrue(result.exists(), "Downloaded file should exist");
+        assertEquals(-1, reportedTotal.get(), "Total should be -1 when Content-Length is absent");
+    }
+}


### PR DESCRIPTION
Fixes #1722

## Summary

- Added `DownloadProgressListener` functional interface for tracking download progress
- Added `DownloadProgressBar` that renders a live-updating text progress bar on the terminal
- Modified `Downloader` to use `HttpClient` instead of `URL.openStream()`, enabling chunked reading with `Content-Length` access for percentage display
- When `Content-Length` is unavailable (e.g. some CDN responses), falls back to showing bytes downloaded without percentage
- Wired progress display through `LocalRunner` using the terminal's `PrintWriter`
- Cached files (already downloaded) skip the progress bar entirely

## Test plan

- [x] `DownloadProgressBarTest` - verifies bar formatting, percentage display, unknown-total fallback, byte formatting
- [x] `DownloaderTest` - verifies download with progress, backward compatibility (no listener), cached file skip, missing Content-Length handling
- [x] `LocalRunnerTest` - existing tests continue to pass
- [x] Static analysis passes
- [x] Integration tests pass (CamelBasicToolITCase failures are pre-existing on main)

## Summary by Sourcery

Add terminal-backed download progress reporting to wanaku local service downloads.

New Features:
- Introduce DownloadProgressListener callback interface for reporting download progress.
- Add DownloadProgressBar to render live updating progress information in the terminal for service downloads.

Enhancements:
- Update Downloader to use HttpClient with chunked reads and optional progress listener while preserving cached-file behavior and cleaning up partial downloads.
- Extend LocalRunner and StartLocal to accept a PrintWriter from the terminal and wire download progress display into service artifact downloads.

Tests:
- Add DownloaderTest to cover progress reporting, backward compatibility, cache skipping, and missing Content-Length behavior.
- Add DownloadProgressBarTest to validate formatting, percentage display, unknown-total handling, completion newline, and byte unit formatting.