### PR TITLE
Add comment-triggered integration test dispatch

### DIFF
--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -1,0 +1,85 @@
+name: Dispatch Integration Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+# Least-privilege defaults. issues:write is the minimum addition needed
+# so the GITHUB_TOKEN can add a reaction to the triggering comment.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: integration-tests-pr-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch Integration Tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'wanaku-ai/wanaku'
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '@wanaku-integration-tests test this')
+    steps:
+      - name: Check commenter permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERM=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" \
+            --jq '.permission')
+          if [[ "$PERM" != "admin" && "$PERM" != "write" ]]; then
+            echo "::error::User ${{ github.event.comment.user.login }} does not have write permission (has: $PERM)"
+            exit 1
+          fi
+
+      - name: Acknowledge comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='eyes'
+
+      - name: Fetch PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_JSON=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefName,headRepository)
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
+          if [[ -z "$HEAD_REF" || "$HEAD_REPO" == "/" || -z "$HEAD_REPO" ]]; then
+            echo "::error::Could not resolve PR head reference (fork may have been deleted)"
+            exit 1
+          fi
+          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+          echo "head_repo=${HEAD_REPO}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.INTEGRATION_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
+          owner: wanaku-ai
+          repositories: wanaku-tests
+
+      - name: Dispatch integration tests
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          gh workflow run full-integration-test.yml \
+            --repo wanaku-ai/wanaku-tests \
+            --ref main \
+            -f wanaku_repo="${HEAD_REPO}" \
+            -f wanaku_branch="${HEAD_REF}" \
+            -f pr_number="${PR_NUMBER}" \
+            -f source_repo="${SOURCE_REPO}"


### PR DESCRIPTION
## Summary

- Adds a new workflow that lets maintainers trigger integration tests by commenting `@wanaku-integration-tests test this` on a PR
- Uses the org-level `wanaku-integration-tests` GitHub App for cross-repo authentication (secrets: `INTEGRATION_APP_ID`, `INTEGRATION_APP_PRIVATE_KEY`)
- Dispatches `workflow_dispatch` to `wanaku-ai/wanaku-tests` `full-integration-test.yml` with the PR's head ref, repo, PR number, and source repo
- Includes permission check (write/admin only), concurrency control, and deleted-fork validation

## Required setup

- Store `INTEGRATION_APP_ID` and `INTEGRATION_APP_PRIVATE_KEY` as repo/org secrets
- GitHub App needs `actions: write` permission on `wanaku-ai/wanaku-tests`

## Companion PR

The `wanaku-ai/wanaku-tests` side (posting results back as a PR comment) is in a separate PR on that repo.

## Test plan

- [ ] Create a test PR touching router code
- [ ] Comment `@wanaku-integration-tests test this`
- [ ] Verify eyes reaction appears on the comment
- [ ] Verify workflow dispatches and runs green
- [ ] Verify `full-integration-test` run appears in wanaku-tests Actions tab

## Summary by Sourcery

Add a GitHub Actions workflow that allows maintainers to trigger cross-repo integration tests by posting a specific comment on pull requests, with permission checks and concurrency control.

New Features:
- Introduce a comment-driven workflow to dispatch full integration tests for pull requests via the wanaku-integration-tests GitHub App.

Enhancements:
- Enforce maintainer-only access, concurrency limits per pull request, and validation of PR head references before dispatching integration tests.