### PR TITLE
Fix dispatch workflow permissions for PR comment reactions

### DIFF
--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -4,11 +4,9 @@ on:
   issue_comment:
     types: [created]
 
-# Least-privilege defaults. issues:write is the minimum addition needed
-# so the GITHUB_TOKEN can add a reaction to the triggering comment.
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

- Reactions on PR comments require `pull-requests: write`, not just `issues: write`
- The `Acknowledge comment` step was failing with HTTP 403 because the GITHUB_TOKEN lacked write access to pull request resources

## Test plan

- [ ] Merge this, then re-test on PR #1733 by commenting `@wanaku-integration-tests test this`
- [ ] Verify the eyes reaction appears

## Summary by Sourcery

Build:
- Adjust GitHub Actions workflow permissions so the GITHUB_TOKEN has write access to pull request resources for comment reactions.