### PR TITLE
Update create-github-app-token to v3.2.0

### DIFF
--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     if: >-
       github.repository == 'wanaku-ai/wanaku'
       && github.event.issue.pull_request
-      && contains(github.event.comment.body, '@wanaku-integration-tests test this')
+      && contains(github.event.comment.body, '/test-integration')
     steps:
       - name: Check commenter permission
         env:

--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.INTEGRATION_APP_ID }}
           private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}

--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
     if: >-
       github.repository == 'wanaku-ai/wanaku'
       && github.event.issue.pull_request
-      && contains(github.event.comment.body, '/test-integration')
+      && contains(github.event.comment.body, '/wanaku-integration-tests')
     steps:
       - name: Check commenter permission
         env:


### PR DESCRIPTION
## Summary

- Update `actions/create-github-app-token` from v2.2.2 to v3.2.0
- Node 20 is deprecated on GitHub Actions runners; v3.2.0 supports Node 24

## Test plan

- [ ] Merge and re-test on PR #1735

## Summary by Sourcery

CI:
- Bump actions/create-github-app-token in the dispatch-integration-tests workflow from v2.2.2 to v3.2.0.