### PR TITLE
Use client-id for create-github-app-token v3

### DIFF
--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.INTEGRATION_APP_ID }}
+          client-id: ${{ secrets.INTEGRATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
           owner: wanaku-ai
           repositories: wanaku-tests


### PR DESCRIPTION
## Summary

- `create-github-app-token` v3.x deprecated `app-id` in favor of `client-id`
- The secret should be `INTEGRATION_APP_CLIENT_ID` containing the GitHub App Client ID string (starts with `Iv`)

## Test plan

- [ ] Merge, then test with `/wanaku-integration-tests` on a PR

## Summary by Sourcery

CI:
- Switch integration test workflow token generation from app-id to client-id using the INTEGRATION_APP_CLIENT_ID secret.