### PR TITLE
Fix head repo extraction in dispatch workflow

### DIFF
--- a/.github/workflows/dispatch-integration-tests.yml
+++ b/.github/workflows/dispatch-integration-tests.yml
@@ -49,8 +49,8 @@ jobs:
             --repo "${{ github.repository }}" \
             --json headRefName,headRepository)
           HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
-          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
-          if [[ -z "$HEAD_REF" || "$HEAD_REPO" == "/" || -z "$HEAD_REPO" ]]; then
+          HEAD_REPO=$(echo "$PR_JSON" | jq -r '.headRepository.nameWithOwner')
+          if [[ -z "$HEAD_REF" || -z "$HEAD_REPO" || "$HEAD_REPO" == "null" ]]; then
             echo "::error::Could not resolve PR head reference (fork may have been deleted)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Use `headRepository.nameWithOwner` instead of `headRepository.owner.login + "/" + headRepository.name`
- The `owner` field is not nested inside `headRepository` in `gh pr view` JSON output, causing the repo to resolve as `/wanaku` instead of `orpiske/wanaku`

## Test plan

- [ ] Merge, then test with `/wanaku-integration-tests` on a PR from a fork

## Summary by Sourcery

Fix extraction of the PR head repository in the dispatch integration tests workflow to correctly handle forked repositories.

Bug Fixes:
- Use the GraphQL nameWithOwner field for headRepository to avoid incorrect or empty repository paths when triggering integration tests from forks.
- Treat missing or null headRepository values as errors to prevent dispatching tests with an unresolved head repo.