### PR TITLE
[backport 0.2.x] Fix #1724 and #1725: namespace CLI fixes

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
@@ -60,16 +60,6 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 
             return ret;
         }
-
-        public static AddressableNamespace defaultNs(String host) {
-            AddressableNamespace ret = new AddressableNamespace();
-            ret.setId("<default>");
-            ret.setPath("");
-            ret.setName("");
-            ret.host = host;
-
-            return ret;
-        }
     }
 
     @Override
@@ -80,10 +70,6 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
             WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
             List<AddressableNamespace> list =
                     response.data().stream().map(this::convertToAddressable).collect(Collectors.toList());
-
-            if (labelExpression == null || labelExpression.isBlank()) {
-                list.add(AddressableNamespace.defaultNs(host));
-            }
 
             printer.printTable(list, "id", "name", "path", "labels");
         } catch (WebApplicationException ex) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsAdd.java
@@ -21,6 +21,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
 
@@ -86,10 +87,13 @@ public class PromptsAdd extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
 
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
+
         PromptReference promptReference = new PromptReference();
         promptReference.setName(name);
         promptReference.setDescription(description);
-        promptReference.setNamespace(namespaceOptions.getNamespaceValue());
+        promptReference.setNamespace(namespaceName);
 
         // Parse messages
         List<PromptMessage> promptMessages = new ArrayList<>();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/prompts/PromptsEdit.java
@@ -19,6 +19,7 @@ import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.PromptsService;
 import picocli.CommandLine;
 
@@ -99,7 +100,8 @@ public class PromptsEdit extends BaseCommand {
 
         // Update only the fields that were provided
         if (namespaceOptions != null) {
-            String ns = namespaceOptions.getNamespaceValue();
+            NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+            String ns = namespaceOptions.resolveNamespaceName(namespacesService);
             if (ns != null) {
                 existingPrompt.setNamespace(ns);
             }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/resources/ResourcesExpose.java
@@ -13,6 +13,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ResourcesService;
 import picocli.CommandLine;
 
@@ -114,13 +115,16 @@ public class ResourcesExpose extends BaseCommand {
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
         resourcesService = initAuthenticatedService(ResourcesService.class, host);
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
+
         ResourceReference resource = new ResourceReference();
         resource.setLocation(location);
         resource.setType(type);
         resource.setName(name);
         resource.setDescription(description);
         resource.setMimeType(mimeType);
-        resource.setNamespace(namespaceOptions.getNamespaceValue());
+        resource.setNamespace(namespaceName);
         resource.setLabels(labels);
 
         ResourcePayload resourcePayload = new ResourcePayload();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsAdd.java
@@ -17,6 +17,7 @@ import ai.wanaku.cli.main.support.FileHelper;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.PropertyHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ToolsService;
 import picocli.CommandLine;
 
@@ -116,13 +117,15 @@ public class ToolsAdd extends BaseCommand {
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
+        NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+        String namespaceName = namespaceOptions.resolveNamespaceName(namespacesService);
 
         ToolReference toolReference = new ToolReference();
         toolReference.setName(name);
         toolReference.setDescription(description);
         toolReference.setUri(uri);
         toolReference.setType(type);
-        toolReference.setNamespace(namespaceOptions.getNamespaceValue());
+        toolReference.setNamespace(namespaceName);
         toolReference.setLabels(labels);
 
         InputSchema inputSchema = new InputSchema();

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/tools/ToolsImport.java
@@ -9,6 +9,7 @@ import ai.wanaku.cli.main.commands.BaseCommand;
 import ai.wanaku.cli.main.converter.URLConverter;
 import ai.wanaku.cli.main.support.NamespaceOptions;
 import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
 import ai.wanaku.core.services.api.ToolsService;
 import ai.wanaku.core.util.ToolsetIndexHelper;
 import picocli.CommandLine;
@@ -44,7 +45,8 @@ public class ToolsImport extends BaseCommand {
 
             // Apply default namespace to tools that don't have one
             if (namespaceOptions != null) {
-                String ns = namespaceOptions.getNamespaceValue();
+                NamespacesService namespacesService = initAuthenticatedService(NamespacesService.class, host);
+                String ns = namespaceOptions.resolveNamespaceName(namespacesService);
                 if (ns != null && !ns.isEmpty()) {
                     for (ToolReference toolReference : toolReferences) {
                         if (toolReference.getNamespace() == null

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -121,4 +121,51 @@ public class NamespaceOptions {
             throw ex;
         }
     }
+
+    /**
+     * Resolves the namespace to its human-readable name.
+     * <p>
+     * If {@code --namespace} was provided, returns the name directly.
+     * If {@code --namespace-id} was provided, queries the server to look up the name by UUID.
+     * </p>
+     * <p>
+     * This method should be used by commands whose backends resolve namespaces by name
+     * (e.g., tools, prompts, resources) rather than by ID (e.g., forwards).
+     * </p>
+     *
+     * @param namespacesService the service to use for looking up namespace by ID
+     * @return the namespace name
+     * @throws Exception if the lookup fails or no matching namespace is found
+     */
+    public String resolveNamespaceName(NamespacesService namespacesService) throws Exception {
+        if (namespace != null) {
+            return namespace;
+        }
+
+        if (namespaceId == null || namespaceId.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Either --namespace or --namespace-id must be provided with a non-blank value.");
+        }
+
+        try {
+            WanakuResponse<Namespace> response = namespacesService.getById(namespaceId);
+            Namespace ns = response.data();
+            if (ns == null) {
+                throw new IllegalArgumentException(
+                        "No namespace found with ID '%s'. Use 'wanaku namespaces list' to see available namespaces."
+                                .formatted(namespaceId));
+            }
+
+            String name = ns.getName();
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException(
+                        "Namespace with ID '%s' has no name assigned. Use --namespace with a name instead, or assign a name to the namespace first."
+                                .formatted(namespaceId));
+            }
+            return name;
+        } catch (WebApplicationException ex) {
+            commonResponseErrorHandler(ex.getResponse());
+            throw ex;
+        }
+    }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
@@ -36,9 +36,8 @@ public class NamespaceListTest {
     }
 
     @Test
-    @DisplayName("Should include default namespace when no label expression is set")
-    @SuppressWarnings("unchecked")
-    void shouldIncludeDefaultNamespaceWhenNoLabelExpression() throws Exception {
+    @DisplayName("Should list namespaces from backend without adding synthetic default")
+    void shouldListNamespacesWithoutSyntheticDefault() throws Exception {
         Namespace ns = new Namespace();
         ns.setId("ns-1");
         ns.setPath("ns-team");
@@ -55,7 +54,7 @@ public class NamespaceListTest {
         verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
 
         List<?> printed = captor.getValue();
-        assertEquals(2, printed.size(), "Should contain the namespace plus the default namespace");
+        assertEquals(1, printed.size(), "Should contain only the namespace from the backend");
     }
 
     @Test
@@ -85,9 +84,9 @@ public class NamespaceListTest {
     }
 
     @Test
-    @DisplayName("Should exclude default namespace when label expression is a blank string")
+    @DisplayName("Should list namespaces from backend when label expression is blank")
     @SuppressWarnings("unchecked")
-    void shouldExcludeDefaultNamespaceWhenLabelExpressionBlank() throws Exception {
+    void shouldListNamespacesWhenLabelExpressionBlank() throws Exception {
         Namespace ns = new Namespace();
         ns.setId("ns-1");
         ns.setPath("ns-team");
@@ -106,9 +105,6 @@ public class NamespaceListTest {
         verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
 
         List<?> printed = captor.getValue();
-        // A blank label expression is effectively "no filter", so the default namespace should be excluded
-        // since the backend treats blank as "list all" and the client should not add a synthetic default
-        // Actually, blank means "no filter active" so default SHOULD be included
-        assertEquals(2, printed.size(), "Blank expression means no filter, so default namespace should be included");
+        assertEquals(1, printed.size(), "Should contain only the namespace from the backend");
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/NamespaceOptionsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/NamespaceOptionsTest.java
@@ -1,0 +1,116 @@
+package ai.wanaku.cli.main.support;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.core.services.api.NamespacesService;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NamespaceOptionsTest {
+
+    private NamespaceOptions createWithNamespace(String name) throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        Field field = NamespaceOptions.class.getDeclaredField("namespace");
+        field.setAccessible(true);
+        field.set(options, name);
+        return options;
+    }
+
+    private NamespaceOptions createWithNamespaceId(String id) throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        Field field = NamespaceOptions.class.getDeclaredField("namespaceId");
+        field.setAccessible(true);
+        field.set(options, id);
+        return options;
+    }
+
+    @Test
+    void resolveNamespaceNameReturnsNameWhenNamespaceProvided() throws Exception {
+        NamespaceOptions options = createWithNamespace("default");
+        NamespacesService service = mock(NamespacesService.class);
+
+        String result = options.resolveNamespaceName(service);
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void resolveNamespaceNameLooksUpByIdWhenNamespaceIdProvided() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setName("default");
+        ns.setPath("default");
+
+        when(service.getById("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63")).thenReturn(new WanakuResponse<>(ns));
+
+        String result = options.resolveNamespaceName(service);
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNamespaceIdNotFound() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("nonexistent-id");
+        NamespacesService service = mock(NamespacesService.class);
+
+        when(service.getById("nonexistent-id")).thenReturn(new WanakuResponse<>((Namespace) null));
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNamespaceHasNoName() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("preallocated-id");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setName(null);
+        ns.setPath("ns-1");
+
+        when(service.getById("preallocated-id")).thenReturn(new WanakuResponse<>(ns));
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceNameThrowsWhenNeitherProvided() throws Exception {
+        NamespaceOptions options = new NamespaceOptions();
+        NamespacesService service = mock(NamespacesService.class);
+
+        assertThrows(IllegalArgumentException.class, () -> options.resolveNamespaceName(service));
+    }
+
+    @Test
+    void resolveNamespaceIdReturnsIdDirectlyWhenNamespaceIdProvided() throws Exception {
+        NamespaceOptions options = createWithNamespaceId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        NamespacesService service = mock(NamespacesService.class);
+
+        String result = options.resolveNamespaceId(service);
+
+        assertEquals("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63", result);
+    }
+
+    @Test
+    void resolveNamespaceIdLooksUpByNameWhenNamespaceProvided() throws Exception {
+        NamespaceOptions options = createWithNamespace("default");
+        NamespacesService service = mock(NamespacesService.class);
+
+        Namespace ns = new Namespace();
+        ns.setId("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63");
+        ns.setName("default");
+
+        when(service.list()).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        String result = options.resolveNamespaceId(service);
+
+        assertEquals("4ff7507f-a88c-47a7-b6e0-4a09e11b0a63", result);
+    }
+}


### PR DESCRIPTION
## Backport of #1730 and #1729

Cherry-pick of #1730 and #1729 onto `0.2.x`.

**Original PRs:**
- #1730 - Fix #1724: resolve namespace ID to name in CLI commands (@orpiske)
- #1729 - Fix #1725: remove duplicated default namespace from CLI list (@orpiske)

**Target branch:** `0.2.x`

### Original descriptions

**#1730:** Resolves namespace ID to human-readable name in CLI commands (tools add, tools import, prompts add, prompts edit, resources expose).

**#1729:** Removes the synthetic default namespace that was being added client-side in CLI list output, since the backend already includes it.

## Summary by Sourcery

Backport CLI namespace handling fixes to the 0.2.x branch to align behavior with backend expectations.

Bug Fixes:
- Resolve namespace IDs to human-readable names for CLI commands that require namespace names (tools add/import, prompts add/edit, resources expose).
- Stop adding a synthetic default namespace in CLI namespace list output so it mirrors the backend response.

Enhancements:
- Introduce NamespaceOptions.resolveNamespaceName helper to centralize resolution of namespace IDs to names.
- Tighten validation and error reporting when resolving namespaces by name or ID in CLI commands.

Tests:
- Adjust namespace list tests to assert that only backend-provided namespaces are printed, including when label expressions are blank.
- Add unit tests for NamespaceOptions namespace name/ID resolution behavior, including success and failure scenarios.