### PR TITLE
Fix #1726: accept Base64 data with newline characters in service catalog reconciler

### DIFF
--- a/core/core-services-api/src/main/java/ai/wanaku/core/services/api/SafeZip.java
+++ b/core/core-services-api/src/main/java/ai/wanaku/core/services/api/SafeZip.java
@@ -54,14 +54,16 @@ public final class SafeZip {
         if (base64Data == null) {
             throw new WanakuException("Missing archive data");
         }
+        // Strip whitespace that standard base64 encoders may insert (RFC 2045 line wrapping)
+        String cleaned = base64Data.replaceAll("\\s", "");
         // A Base64 string decodes to ~3/4 of its length; reject early, before allocating.
-        long approxDecoded = (long) (base64Data.length() / 4) * 3;
+        long approxDecoded = (long) (cleaned.length() / 4) * 3;
         if (approxDecoded > MAX_ARCHIVE_BYTES) {
             throw new WanakuException(
                     "Archive exceeds the maximum allowed size of %d bytes".formatted(MAX_ARCHIVE_BYTES));
         }
         try {
-            return Base64.getDecoder().decode(base64Data);
+            return Base64.getDecoder().decode(cleaned);
         } catch (IllegalArgumentException e) {
             throw new WanakuException("Invalid Base64 data: " + e.getMessage());
         }

--- a/core/core-services-api/src/test/java/ai/wanaku/core/services/api/SafeZipTest.java
+++ b/core/core-services-api/src/test/java/ai/wanaku/core/services/api/SafeZipTest.java
@@ -27,6 +27,7 @@ import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SafeZipTest {
 
@@ -42,6 +43,28 @@ class SafeZipTest {
         int tooLong = (int) (SafeZip.MAX_ARCHIVE_BYTES / 3 * 4) + 8;
         String b64 = "A".repeat(tooLong);
         assertThrows(WanakuException.class, () -> SafeZip.decodeArchive(b64));
+    }
+
+    @Test
+    void decodeArchiveAcceptsBase64WithNewlines() throws Exception {
+        byte[] data = "hello world".getBytes();
+        String encoded = Base64.getEncoder().encodeToString(data);
+        // Simulate line-wrapped base64 output (e.g. from 'base64' command with default 76-char wrapping)
+        String withNewlines = encoded + "\n";
+        assertArrayEquals(data, SafeZip.decodeArchive(withNewlines));
+    }
+
+    @Test
+    void decodeArchiveAcceptsBase64WithMimeLineWrapping() throws Exception {
+        // Create data large enough to produce multi-line base64 output (>76 chars)
+        byte[] data = new byte[100];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        // MIME encoder inserts \r\n every 76 chars, simulating default base64 command output
+        String encoded = Base64.getMimeEncoder().encodeToString(data);
+        assertTrue(encoded.contains("\r\n"), "MIME-encoded string should contain line breaks");
+        assertArrayEquals(data, SafeZip.decodeArchive(encoded));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1726

## Summary

The service catalog reconciler rejected Base64-encoded data containing newline characters. The standard `base64` command wraps output every 76 characters with newlines (per RFC 2045), causing the reconciler to fail with "Invalid Base64 data: Illegal character".

## Changes

- **`SafeZip.decodeArchive()`**: Strip whitespace characters from Base64 input before decoding, so line-wrapped Base64 output is accepted while still rejecting truly invalid Base64 data
- **`SafeZipTest`**: Added two tests covering trailing newlines and full MIME line-wrapped Base64 input

## Test plan

- [x] Unit tests pass (29/29 in core-services-api)
- [x] Full reactor build passes (unit tests)
- [ ] Integration tests: pre-existing infrastructure failures (Camel capability health check timeouts) affect all recent CI runs on main

## Summary by Sourcery

Allow service catalog archive decoding to accept Base64 input containing whitespace and line-wrapped data while preserving size validation and error handling.

Bug Fixes:
- Fix Base64 archive decoding to correctly handle input with newline and other whitespace characters instead of rejecting it as invalid.

Tests:
- Add unit tests verifying Base64 archive decoding succeeds with trailing newlines and MIME-style line-wrapped input.