### PR TITLE
Fix #1675: add token refresh to operator-camel-route test plan

### DIFF
--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -79,15 +79,45 @@ Follow [common/wait-for-deletion.md](common/wait-for-deletion.md) to define the 
 
 The router has OIDC auth enabled, so all API requests (even from inside the pod) require a Bearer token. This helper retrieves the token stored by `wanaku auth login` (performed in Phase 3, Test 3.4 via [common/oidc-login-verification.md](common/oidc-login-verification.md)). The `--unmask` flag outputs the full token value for use in `curl` headers.
 
+The `wanaku auth token --get` command automatically refreshes expired tokens using the stored refresh token. If the refresh token has also expired, `ensure_valid_token` re-authenticates from scratch.
+
 ```bash
 get_router_token() {
   wanaku auth token --get --unmask --plain 2>/dev/null
 }
 ```
 
+### Helper: ensure a valid OIDC token is available
+
+Call this before phases that use `get_router_token()` or `wanaku` CLI commands to prevent 401 errors from expired tokens. The `wanaku auth token --get` command auto-refreshes, but if the refresh token itself has expired, a full re-login is performed.
+
+```bash
+ensure_valid_token() {
+  local TOKEN
+  TOKEN=$(get_router_token)
+  if [ -n "${TOKEN}" ] && [ "${TOKEN}" != "null" ]; then
+    return 0
+  fi
+
+  echo "INFO: token refresh failed, performing full re-login"
+  echo "${WANAKU_TEST_PASS}" | ${WANAKU_CLI:-wanaku} auth login \
+    --auth-server "${WANAKU_ROUTER_URL}" \
+    --username "${WANAKU_TEST_USER}" \
+    --password \
+    --plain 2>&1
+
+  TOKEN=$(get_router_token)
+  if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+    echo "FAIL: unable to obtain a valid token after re-login"
+    return 1
+  fi
+  return 0
+}
+```
+
 ### Helper: query router REST API via oc exec
 
-Uses `oc exec` into the router pod with a Bearer token obtained from Keycloak. Health endpoints (`/q/health/*`) do not require auth and are queried without a token.
+Uses `oc exec` into the router pod with a Bearer token obtained from Keycloak. Health endpoints (`/q/health/*`) do not require auth and are queried without a token. Calls `ensure_valid_token` before each request to prevent 401 errors from expired tokens.
 
 ```bash
 query_router_api() {
@@ -95,6 +125,8 @@ query_router_api() {
   local ROUTER_POD
   ROUTER_POD=$(oc get pods -l app=wanaku-test-router-mcp-router \
     -n "${WANAKU_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}')
+
+  ensure_valid_token || return 1
 
   local TOKEN
   TOKEN=$(get_router_token)


### PR DESCRIPTION
Fixes #1675

The OIDC bearer token has a 300-second lifetime and expires before REST API verification tests complete in the operator-camel-route test plan. Tests 4.6, 5.5, 5.6, 6.4, 6.5, 9.1, and 9.2 fail with authentication errors because the `query_router_api` helper does not refresh expired tokens.

## Changes

- Added `ensure_valid_token()` helper function to the operator-camel-route test plan (already present in camel-integration-capability plan since #1673)
- Updated `query_router_api()` to call `ensure_valid_token` before each request, automatically refreshing expired tokens or performing a full re-login when the refresh token has also expired
- Updated helper documentation to describe the auto-refresh behavior

## Notes

Integration test failures in CI are pre-existing infrastructure issues (Camel capability health check timeouts, MCP forwarding skip threshold) unrelated to this documentation-only change. All recent main branch runs show the same failures.

## Summary by Sourcery

Documentation:
- Extend the operator-camel-route test plan with an ensure_valid_token helper and usage notes so OIDC tokens are refreshed or re-acquired before router API calls.