### PR TITLE
Fix #1687: disable JWT introspection for public Keycloak client

### DIFF
--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/support/NamespaceTenantConfigResolver.java
@@ -57,6 +57,7 @@ public class NamespaceTenantConfigResolver implements TenantConfigResolver {
                 .tenantId(tenantId)
                 .token()
                 .audience("wanaku-mcp-client")
+                .allowJwtIntrospection(false)
                 .end()
                 .resourceMetadata()
                 .enabled()

--- a/apps/wanaku-router-backend/src/main/resources/application.properties
+++ b/apps/wanaku-router-backend/src/main/resources/application.properties
@@ -88,6 +88,10 @@ quarkus.oidc.application-type=hybrid
 quarkus.oidc.logout.path=/logout
 quarkus.oidc.discovery-enabled=true
 quarkus.oidc.authentication.pkce-required=true
+# Verify bearer tokens locally via JWKS instead of calling the introspection endpoint.
+# The wanaku-mcp-router Keycloak client is public and therefore not authorized
+# to use the introspection endpoint (Keycloak returns 403).
+quarkus.oidc.token.allow-jwt-introspection=false
 quarkus.oidc.connection-delay=60S
 quarkus.oidc.resource-metadata.enabled=true
 
@@ -102,6 +106,7 @@ quarkus.oidc.mcp.resource-metadata.authorization-server=${auth.proxy}/q/oidc
 quarkus.oidc.mcp.auth-server-url=${auth.server}/realms/${auth.realm}
 quarkus.oidc.mcp.tenant-paths=/mcp/*
 quarkus.oidc.mcp.token.audience=wanaku-mcp-client
+quarkus.oidc.mcp.token.allow-jwt-introspection=false
 quarkus.oidc.mcp.resource-metadata.enabled=true
 quarkus.oidc.mcp.resource-metadata.resource=mcp
 quarkus.oidc.mcp.resource-metadata.force-https-scheme=false

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/support/NamespaceTenantConfigResolverTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -111,6 +112,15 @@ class NamespaceTenantConfigResolverTest {
         assertEquals(
                 "http://localhost:8080/q/oidc",
                 config.resourceMetadata().authorizationServer().orElse(null));
+    }
+
+    @Test
+    void disablesJwtIntrospection() {
+        RoutingContext ctx = mockContext("/ns-0/mcp/sse");
+        OidcTenantConfig config = resolver.resolve(ctx, null).await().indefinitely();
+
+        assertNotNull(config);
+        assertFalse(config.token().allowJwtIntrospection());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1687

## Summary

The router's REST API rejected valid bearer tokens (HTTP 401) because Quarkus OIDC was attempting to call the Keycloak token introspection endpoint to validate them. Since the `wanaku-mcp-router` client is configured as a public client, Keycloak denied the introspection request with a 403 ("Client not allowed.").

## Changes

- Added `quarkus.oidc.token.allow-jwt-introspection=false` for the default OIDC tenant, so bearer tokens are verified locally via JWKS instead of calling the introspection endpoint
- Added the same setting for the `mcp` tenant configuration
- Updated `NamespaceTenantConfigResolver` to set `allowJwtIntrospection(false)` on dynamically created namespace tenant configs
- Added a unit test verifying the namespace tenant disables JWT introspection

## How it works

Keycloak issues JWT access tokens that can be verified locally using the JWKS endpoint (public keys). By setting `allow-jwt-introspection=false`, Quarkus OIDC no longer attempts to call the introspection endpoint (which requires client credentials that a public client does not have) and instead verifies JWT signatures locally.

## Test results

- All 395 unit tests pass
- Full reactor build succeeds
- Integration tests: all router tests pass (51/51), including AuthenticationITCase. Pre-existing Camel capability health check failures are unrelated.

## Summary by Sourcery

Disable JWT introspection for router OIDC tenants so bearer tokens are validated locally and avoid Keycloak 403 errors for the public client.

Bug Fixes:
- Prevent router REST API from rejecting valid bearer tokens due to unauthorized JWT introspection requests against Keycloak for the public client.

Enhancements:
- Configure default and MCP OIDC tenants to validate JWT access tokens locally via JWKS instead of using the introspection endpoint.
- Ensure dynamically created namespace OIDC tenant configurations disable JWT introspection for consistency across namespaces.

Tests:
- Add a unit test verifying that namespace-resolved OIDC tenant configurations have JWT introspection disabled.