### PR TITLE
Fix #1749: redirect CLI log output to stderr

### DIFF
--- a/apps/wanaku-cli/src/main/resources/application.properties
+++ b/apps/wanaku-cli/src/main/resources/application.properties
@@ -23,6 +23,7 @@ wanaku.cli.auth.credentials-file=~/.wanaku/credentials
 # Include documentation files in native image
 quarkus.native.resources.includes=docs/**
 
+quarkus.log.console.stderr=true
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
 quarkus.log.category."ai.wanaku.capabilities.sdk.common.ProcessRunner".level=WARNING


### PR DESCRIPTION
Fixes wanaku-ai/wanaku-barn#67

## Summary

- Adds `quarkus.log.console.stderr=true` to the CLI's `application.properties` so that all console log output (WARN, INFO, etc.) is directed to stderr instead of stdout.
- This prevents log messages (e.g. AuthCredentialStore filesystem permission warnings) from polluting stdout when `--plain` is used for programmatic token consumption.

## Test plan

- [x] All 367 CLI unit tests pass
- [x] Integration tests pass

## Summary by Sourcery

Enhancements:
- Configure Quarkus logging to send console output to stderr by default in the CLI application.