### PR TITLE
Fix #1649: resolve property placeholders in realm JSON before REST API import

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/realm/RealmCreate.java
@@ -3,6 +3,8 @@ package ai.wanaku.cli.main.commands.realm;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.admin.BaseAdminCommand;
 import ai.wanaku.cli.main.support.WanakuPrinter;
@@ -13,6 +15,14 @@ import picocli.CommandLine;
 public class RealmCreate extends BaseAdminCommand {
 
     private static final String DEFAULT_CONFIG = "deploy/auth/wanaku-config.json";
+
+    /**
+     * Matches property placeholders with a default value, e.g.
+     * {@code ${VAR_NAME:default}}. Placeholders without a colon (such as
+     * Keycloak's localization keys like {@code ${client_account}}) are left
+     * untouched.
+     */
+    static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}:]+):([^}]*)\\}");
 
     @CommandLine.Option(
             names = {"--config"},
@@ -37,6 +47,7 @@ public class RealmCreate extends BaseAdminCommand {
     public Integer doCall(Terminal terminal, WanakuPrinter printer) {
         try {
             String realmJson = Files.readString(Path.of(config));
+            realmJson = resolvePropertyPlaceholders(realmJson);
             KeycloakAdminClient client = createAdminClient();
             client.importRealm(realmJson);
             printer.printSuccessMessage("Realm imported successfully from " + config);
@@ -48,5 +59,35 @@ public class RealmCreate extends BaseAdminCommand {
             printer.printErrorMessage(e.getMessage());
             return EXIT_ERROR;
         }
+    }
+
+    /**
+     * Resolves {@code ${VAR:default}} property placeholders in the realm JSON
+     * by looking up the named environment variable, falling back to the default
+     * value when the variable is not set or blank.
+     *
+     * <p>Keycloak's startup-based realm import ({@code --import-realm})
+     * resolves these automatically, but the Admin REST API does not. This
+     * method provides equivalent behavior for REST API imports so that the
+     * imported client secrets match what downstream services expect.</p>
+     *
+     * <p>Placeholders without a default (e.g. {@code ${client_account}}) are
+     * Keycloak localization keys and are intentionally left untouched.</p>
+     *
+     * @param json the raw realm configuration JSON
+     * @return the JSON with environment-variable placeholders resolved
+     */
+    static String resolvePropertyPlaceholders(String json) {
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(json);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String envVar = matcher.group(1);
+            String defaultValue = matcher.group(2);
+            String envValue = System.getenv(envVar);
+            String resolved = (envValue != null && !envValue.isBlank()) ? envValue : defaultValue;
+            matcher.appendReplacement(result, Matcher.quoteReplacement(resolved));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/realm/RealmCommandsTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/realm/RealmCommandsTest.java
@@ -13,9 +13,12 @@ import static ai.wanaku.cli.main.commands.BaseCommand.EXIT_OK;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.doNothing;
@@ -86,5 +89,57 @@ class RealmCommandsTest {
 
         assertEquals(EXIT_ERROR, result);
         verify(printer).printErrorMessage(contains("deploy/auth/wanaku-config.json"));
+    }
+
+    @Test
+    void resolvePropertyPlaceholdersShouldUseDefaultWhenEnvNotSet() {
+        String input = "{\"secret\": \"${WANAKU_TEST_NOT_SET_12345:mypasswd}\"}";
+        String result = RealmCreate.resolvePropertyPlaceholders(input);
+        assertEquals("{\"secret\": \"mypasswd\"}", result);
+    }
+
+    @Test
+    void resolvePropertyPlaceholdersShouldLeaveLocalizationKeysUntouched() {
+        String input = "{\"name\": \"${client_account}\", \"desc\": \"${role_uma_authorization}\"}";
+        String result = RealmCreate.resolvePropertyPlaceholders(input);
+        assertEquals(input, result, "Keycloak localization keys (without colon default) must not be changed");
+    }
+
+    @Test
+    void resolvePropertyPlaceholdersShouldHandleMultiplePlaceholders() {
+        String input = "{\"a\": \"${NOT_SET_A_12345:valA}\", \"b\": \"${NOT_SET_B_12345:valB}\"}";
+        String result = RealmCreate.resolvePropertyPlaceholders(input);
+        assertEquals("{\"a\": \"valA\", \"b\": \"valB\"}", result);
+    }
+
+    @Test
+    void resolvePropertyPlaceholdersShouldHandleEmptyDefault() {
+        String input = "{\"secret\": \"${NOT_SET_EMPTY_12345:}\"}";
+        String result = RealmCreate.resolvePropertyPlaceholders(input);
+        assertEquals("{\"secret\": \"\"}", result);
+    }
+
+    @Test
+    void resolvePropertyPlaceholdersShouldPreservePlainText() {
+        String input = "{\"realm\": \"wanaku\", \"enabled\": true}";
+        String result = RealmCreate.resolvePropertyPlaceholders(input);
+        assertEquals(input, result);
+    }
+
+    @Test
+    void realmCreateShouldResolvePlaceholdersBeforeImport() throws Exception {
+        Path configFile = tempDir.resolve("realm-with-placeholders.json");
+        Files.writeString(configFile, "{\"secret\": \"${WANAKU_TEST_NOT_SET_67890:resolved_secret}\"}");
+        doNothing().when(adminClient).importRealm(any());
+
+        RealmCreate cmd = new RealmCreate(adminClient, configFile.toString());
+        int result = cmd.doCall(terminal, printer);
+
+        assertEquals(EXIT_OK, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(adminClient).importRealm(captor.capture());
+        String importedJson = captor.getValue();
+        assertFalse(importedJson.contains("${"), "Placeholders should be resolved before import");
+        assertTrue(importedJson.contains("resolved_secret"), "Default value should be substituted");
     }
 }


### PR DESCRIPTION
Fixes #1649

## Summary

The Keycloak realm config file (`deploy/auth/wanaku-config.json`) uses `${WANAKU_SERVICE_SECRET:mypasswd}` placeholder syntax for the `wanaku-service` client secret. Keycloak resolves these placeholders automatically during startup-based realm import (`--import-realm`), but **not** when importing via the Admin REST API.

When `wanaku admin realm create` imports the realm via the REST API, the literal string `${WANAKU_SERVICE_SECRET:mypasswd}` was stored as the actual client secret. The operator then tries to authenticate with `mypasswd` (the resolved default), causing an "Invalid client or Invalid client credentials" error.

## Changes

- `RealmCreate` now resolves `${VAR:default}` property placeholders in the realm JSON before sending it to the Keycloak REST API
- Keycloak localization keys (e.g. `${client_account}`) that lack a colon+default are intentionally left untouched
- Added tests for placeholder resolution including edge cases

## CI Note

The `CapabilityResilienceITCase.shouldDetectCapabilityStoppage` test failure is a pre-existing flaky test (awaitility timeout) unrelated to this change.

## Summary by Sourcery

Resolve environment-variable placeholders in Keycloak realm JSON before REST API import to align behavior with startup-based imports.

Bug Fixes:
- Ensure realm client secrets use resolved environment-variable values instead of unresolved placeholder strings during REST-based imports.

Enhancements:
- Add placeholder resolution helper in RealmCreate that preserves Keycloak localization keys without defaults.

Tests:
- Add unit tests covering placeholder resolution behavior, including multiple placeholders, empty defaults, unchanged plain JSON, and end-to-end realm import.