### PR TITLE
Add echo service template

### DIFF
--- a/services/service-templates/src/main/services/echo-tool/echo/service.properties
+++ b/services/service-templates/src/main/services/echo-tool/echo/service.properties
@@ -1,0 +1,2 @@
+tool.description=Echo back the input message duplicated with a configurable separator
+echo.separator=->

--- a/services/service-templates/src/main/services/echo-tool/echo/wanaku-echo-tool.camel.yaml
+++ b/services/service-templates/src/main/services/echo-tool/echo/wanaku-echo-tool.camel.yaml
@@ -1,0 +1,10 @@
+- route:
+    id: echo-tool
+    description: Echo back the input message duplicated with a configurable separator
+    from:
+      uri: direct:wanaku
+      steps:
+        - setBody:
+            expression:
+              simple:
+                expression: "${body}{{echo.separator}}${body}"

--- a/services/service-templates/src/main/services/echo-tool/echo/wanaku-echo-tool.rules.yaml
+++ b/services/service-templates/src/main/services/echo-tool/echo/wanaku-echo-tool.rules.yaml
@@ -1,0 +1,11 @@
+mcp:
+  tools:
+    - echo:
+        route:
+          id: "echo-tool"
+        description: "Echo back the input message duplicated with a separator"
+        properties:
+          - name: wanaku_body
+            type: string
+            description: The message to echo back
+            required: true

--- a/services/service-templates/src/main/services/echo-tool/index.properties
+++ b/services/service-templates/src/main/services/echo-tool/index.properties
@@ -1,0 +1,7 @@
+catalog.dependencies.echo=echo/echo.dependencies.txt
+catalog.description=Echo back the input message duplicated with a configurable separator
+catalog.name=echo-tool
+catalog.properties.echo=echo/service.properties
+catalog.routes.echo=echo/wanaku-echo-tool.camel.yaml
+catalog.rules.echo=echo/wanaku-echo-tool.rules.yaml
+catalog.services=echo


### PR DESCRIPTION
## Summary

- Adds a new `echo-tool` service template that receives a message and replies it back duplicated (e.g., input `AAA` produces `AAA->AAA`)
- The separator is configurable via the `echo.separator` property (default: `->`)
- Uses only Camel core features (`setBody` + `simple`), no external dependencies

## Test plan

- [ ] Build: `mvn verify` from root
- [ ] `wanaku start local` → `wanaku service template list` shows `echo-tool`
- [ ] Instantiate: `wanaku service template instantiate --name echo-tool`
- [ ] Invoke via MCP with `wanaku_body=AAA`, verify response is `AAA->AAA`
- [ ] Instantiate with custom separator: `--property echo.separator=::`, verify `AAA::AAA`

## Summary by Sourcery

Add a new echo-tool service template that duplicates an input message with a configurable separator and exposes it as an MCP tool.

New Features:
- Introduce an echo-tool service template that echoes back the input message duplicated with a separator.
- Expose the echo-tool as an MCP tool accepting a required wanaku_body string parameter.
- Add configuration for a customizable echo.separator property with a default value in service properties.

Enhancements:
- Register the echo-tool template in the service catalog with associated routes, rules, dependencies, and properties metadata.