### PR TITLE
Fix #1773: enhance error handling in NamespacesBean and add tests for extractErrorMessage in ResponseHelper

### DIFF
--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ResponseHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/ResponseHelper.java
@@ -6,8 +6,12 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class ResponseHelper {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private ResponseHelper() {}
 
     public static int handleNotFound(
@@ -38,6 +42,7 @@ public final class ResponseHelper {
             } catch (Exception ignored) {
                 // Ignore if we can't read the body
             }
+            responseBody = extractErrorMessage(responseBody);
 
             if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                 message = String.format(
@@ -60,5 +65,27 @@ public final class ResponseHelper {
                 printer.printErrorMessage(message);
             }
         }
+    }
+
+    /**
+     * Extracts the error message from a {@code WanakuResponse} JSON body
+     * (e.g. {@code {"error":{"message":"..."},"data":null}}), falling back
+     * to the raw body when it does not match that shape.
+     */
+    static String extractErrorMessage(String responseBody) {
+        if (responseBody == null || responseBody.isEmpty()) {
+            return "";
+        }
+        try {
+            JsonNode error = MAPPER.readTree(responseBody).path("error");
+            String message =
+                    error.isTextual() ? error.asText() : error.path("message").asText(null);
+            if (message != null && !message.isEmpty()) {
+                return message;
+            }
+        } catch (Exception ignored) {
+            // Not a JSON body; fall through to the raw body
+        }
+        return responseBody;
     }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ResponseHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/ResponseHelperTest.java
@@ -35,4 +35,24 @@ class ResponseHelperTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
     }
+
+    @Test
+    void extractErrorMessageReadsWanakuResponseError() {
+        String body = "{\"error\":{\"message\":\"Cannot update protected namespace 'ns-6'\"},\"data\":null}";
+        assertEquals("Cannot update protected namespace 'ns-6'", ResponseHelper.extractErrorMessage(body));
+    }
+
+    @Test
+    void extractErrorMessageReadsTextualError() {
+        String body = "{\"error\":\"something went wrong\",\"data\":null}";
+        assertEquals("something went wrong", ResponseHelper.extractErrorMessage(body));
+    }
+
+    @Test
+    void extractErrorMessageFallsBackToRawBody() {
+        assertEquals("plain text error", ResponseHelper.extractErrorMessage("plain text error"));
+        assertEquals("", ResponseHelper.extractErrorMessage(""));
+        assertEquals("", ResponseHelper.extractErrorMessage(null));
+        assertEquals("{\"data\":null}", ResponseHelper.extractErrorMessage("{\"data\":null}"));
+    }
 }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -190,7 +190,8 @@ public class NamespacesBean {
                 || isProtectedNamespaceName(namespace.getName())
                 || isProtectedNamespaceName(namespace.getPath())) {
             LOG.warnf("Refusing to update protected namespace %s", existingNamespace.getPath());
-            return false;
+            throw new IllegalArgumentException(
+                    "Cannot update protected namespace '%s'".formatted(existingNamespace.getPath()));
         }
 
         return namespaceRepository.update(id, namespace);

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
@@ -205,9 +205,9 @@ public class NamespacesBeanTest {
         updated.setPath(defaultNamespace.getPath());
         updated.setLabels(defaultNamespace.getLabels());
 
-        boolean result = namespacesBean.update(defaultNamespace.getId(), updated);
-
-        assertThat(result).isFalse();
+        assertThatThrownBy(() -> namespacesBean.update(defaultNamespace.getId(), updated))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("protected namespace");
     }
 
     @Test
@@ -225,9 +225,9 @@ public class NamespacesBeanTest {
         updated.setPath(publicNamespace.getPath());
         updated.setLabels(publicNamespace.getLabels());
 
-        boolean result = namespacesBean.update(publicNamespace.getId(), updated);
-
-        assertThat(result).isFalse();
+        assertThatThrownBy(() -> namespacesBean.update(publicNamespace.getId(), updated))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("protected namespace");
     }
 
     @Test


### PR DESCRIPTION
Fixes: #1773

## Summary by Sourcery

Enhance error reporting for protected namespace updates and CLI response handling, ensuring clearer error messages and aligned behavior between backend and client.

Bug Fixes:
- Change protected namespace update attempts to throw an IllegalArgumentException with a descriptive message instead of returning false.

Enhancements:
- Add ResponseHelper.extractErrorMessage to parse WanakuResponse JSON bodies and surface the embedded error message in CLI output.

Tests:
- Add unit tests for ResponseHelper.extractErrorMessage covering structured JSON, textual error fields, and non-JSON fallbacks.
- Update NamespacesBean tests to assert that protected namespace updates now fail with an IllegalArgumentException containing an appropriate message.