### PR TITLE
Rewrite README to match main project standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The first `cargo build` automatically builds the admin UI via `yarn` if `ui/admi
 
 The easiest way to learn Wanaku is by following the **[guided tutorial](https://wanaku.ai/docs/demos/)**.
 
-The reference documentation, including the complete installation and configuration instructions, is available on the [usage guide](https://wanaku.ai/docs/version/).
+The reference documentation, including the complete installation and configuration instructions, is available in the [usage guide](https://wanaku.ai/docs/version/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,36 @@
-# Wanaku Praxis
+# Wanaku - An MCP Router that connects everything
 
-A Rust-based MCP router built on the [Praxis](https://github.com/praxis-proxy/praxis) proxy framework. Think of it as the proof-of-concept sibling to [Wanaku](https://github.com/opiske/wanaku)—same routing logic, different runtime, zero JVM overhead.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Build](https://img.shields.io/github/actions/workflow/status/wanaku-ai/wanaku/main-build.yml?branch=main)](https://github.com/wanaku-ai/wanaku/actions)
+[![Release](https://img.shields.io/github/v/release/wanaku-ai/wanaku)](https://github.com/wanaku-ai/wanaku/releases)
 
-## What It Does
+The Wanaku MCP Router is a router for AI-enabled applications powered by the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+It sits between AI clients and your backend services, routing requests through a filter pipeline to provide namespace isolation, tool management, and both local (gRPC) and remote (MCP forwarding) tool execution.
 
-Wanaku Praxis sits between AI clients and your backend capability services. When Claude (or any MCP client) calls a tool, it routes that request to the appropriate gRPC service, gets the result, and hands it back. It also does something more interesting: it can forward tools to remote MCP servers, auto-discover their capabilities, and serve them through a unified catalog. Your client sees one MCP endpoint; behind it, you've got a mix of local gRPC services and forwarded remote tools.
+The project name comes from the origins of the word [Guanaco](https://en.wikipedia.org/wiki/Guanaco), a camelid native to
+South America.
 
-It handles namespaces, too. Register tools under `/finance/mcp` and they're isolated from `/legal/mcp`. Same server, different catalogs.
+## Key Features
 
-## Why This Exists
+- **Unified MCP Routing** - Centralized routing and resource management for AI agents
+- **MCP-to-MCP Bridge** - Act as a gateway or proxy for other MCP servers, with auto-discovery of remote tools
+- **Multi-Namespace Support** - Organize tools and resources across isolated namespaces
+- **Secure by Default** - Authentication and authorization via oauth2-proxy and Keycloak (optional — can run without auth)
+- **Extensible Architecture** - Plugin system via feature crates and a composable filter pipeline
+- **Admin Dashboard** - Web UI for managing tools, resources, prompts, and forwards
+- **Container-Ready** - Multi-arch images (x86_64, aarch64) published automatically
 
-The original Wanaku runs on Quarkus and does this job well—and will continue to. The JVM ecosystem is a strength, not a problem: Quarkus, Camel integration capabilities, and the rest of the stack aren't going anywhere. But the routing engine sits at the bottom of every request path, and that layer benefits from the kind of low-level control that Rust and Praxis provide. This project moves just the routing engine to a stack better suited for that work. It's wire-compatible with Wanaku's protobuf definitions, so your existing capability services don't need to change.
+## Quick Start
 
-Fair warning: this is a PoC. It proves the architecture holds up in Rust. It doesn't have all the polish, observability hooks, or battle scars of the Java version.
+### Install
 
-## Install
-
-Install the latest early-access build on Linux or macOS:
+Download the latest early-access build on Linux or macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wanaku-ai/wanaku-praxis/main/get-wanaku-praxis.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wanaku-ai/wanaku/main/get-wanaku-praxis.sh | bash
 ```
 
 The installer detects the host platform, verifies the release checksum, and installs `wanaku-praxis` into `$HOME/bin`. Override the destination with `WANAKU_PRAXIS_INSTALL_DIR`.
-
-## Architecture
-
-Three crates, clean separation:
-
-- **`apis/`** — The glue layer. gRPC protobuf types (tonic-built from Wanaku's `.proto` files), a pooled gRPC client, an `rmcp`-based MCP client, and an in-memory registry with traits for tools/resources/prompts/forwards/namespaces/services.
-- **`filters/`** — Praxis `HttpFilter` implementations. Namespace extraction, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, MCP initialization—standard MCP protocol stuff, plumbed into the Praxis filter pipeline.
-- **`server/`** — The binary. Wires up the filters, boots a Pingora-based management REST API on port 8080, loads static config from `wanaku.yaml`, and starts listening for MCP traffic on 8081.
-
-The interesting bit: filters are stateless. All the state lives in `InMemoryRegistry` (a `DashMap`-backed concurrent registry). CRUD operations happen via the management API; filters query the registry when routing requests.
-
-## Running It
 
 ### Container
 
@@ -51,33 +47,35 @@ podman run -p 8080:8080 -p 8081:8081 \
   --wanaku-config /etc/wanaku-praxis/wanaku.yaml
 ```
 
-Multi-arch images (x86_64 and aarch64) are published to `quay.io/wanaku/wanaku-praxis` on every push to `main`.
-
 ### From Source
+
+> [!NOTE]
+> Building from source requires: Rust 1.96+, protobuf, and Yarn (for the admin UI).
 
 ```bash
 cargo build
 cargo run
 ```
 
-The first `cargo build` automatically builds the admin UI via `yarn` if `ui/admin/dist/` is missing (requires Node.js and Yarn installed).
-
-> [!NOTE]
-> You need to have the following software installed to build this project: 
-> * protobuf 
-> * yarn
+The first `cargo build` automatically builds the admin UI via `yarn` if `ui/admin/dist/` is missing.
 
 ### Endpoints
 
-MCP endpoint: `http://localhost:8081/mcp` (or `/{namespace}/mcp` if you've registered namespaces).
+| Endpoint | Address | Description |
+|---|---|---|
+| MCP | `http://localhost:8081/mcp` | MCP protocol endpoint (or `/{namespace}/mcp` for namespaced access) |
+| Management API | `http://localhost:8080/api/v1/...` | CRUD for tools, resources, prompts, forwards, namespaces |
+| Admin UI | `http://localhost:8080/admin/` | Web dashboard |
 
-Management API: `http://localhost:8080/api/v1/...` — CRUD for tools, resources, prompts, forwards, namespaces.
+### Learn Wanaku
 
-Admin UI: `http://localhost:8080/admin/`
+The easiest way to learn Wanaku is by following the **[guided tutorial](https://wanaku.ai/docs/demos/)**.
 
-### Configuration
+The reference documentation, including the complete installation and configuration instructions, is available on the [usage guide](https://wanaku.ai/docs/version/).
 
-Optional: drop a `wanaku.yaml` in the working directory to preload static tool and service definitions. Format:
+## Configuration
+
+Drop a `wanaku.yaml` in the working directory to preload tool and service definitions:
 
 ```yaml
 tools:
@@ -97,6 +95,8 @@ services:
     address: "localhost:9191"
     service_type: "tool-invoker"
 ```
+
+If no config file is provided, the server starts with an empty registry that can be populated via the management API.
 
 ## Management API Examples
 
@@ -134,61 +134,47 @@ Refresh tools from the forward (auto-discover):
 curl -X POST http://localhost:8080/api/v1/forwards/upstream-mcp/refreshes
 ```
 
-Now all tools from `remote.example.com` appear in your local catalog. The client has no idea they're forwarded.
-
-## What's Different From Wanaku Java
-
-- **No Quarkus:** Pingora + Praxis instead of Vert.x HTTP.
-- **No Kubernetes config:** This is a standalone binary. Deploy it however you want.
-- **Simpler observability:** Tracing via `tracing` crate, but no built-in metrics export yet.
-- **Same gRPC contract:** Uses the exact same `.proto` files. Your backend services speak the same language.
-
-## Key Dependencies
-
-- `praxis-proxy-core`, `praxis-proxy-filter` — HTTP filter pipeline
-- `praxis-ai` — MCP protocol filter support
-- `tonic`/`prost` — gRPC client/server
-- `rmcp` — MCP client for forwarding
-- `dashmap` — Concurrent in-memory registry
+All tools from the remote server now appear in your local catalog. The client has no idea they're forwarded.
 
 ## Authentication
 
-Authentication is handled externally by [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) — Praxis itself contains no auth code. Two oauth2-proxy instances sit in front of the MCP and management ports, sharing an SSO cookie:
+Authentication is handled externally by [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy). Two instances sit in front of the MCP and management ports, sharing an SSO cookie:
 
 - **MCP proxy** (`:4180` → `:8081`) — protects MCP endpoints, any authenticated user
-- **Management proxy** (`:4181` → `:8080`) — protects admin UI and REST API, admin role required
+- **Management proxy** (`:4181` → `:8080`) — protects the admin UI and REST API, admin role required
+
+Wanaku also serves [RFC 9728](https://datatracker.ietf.org/doc/rfc9728/) OAuth Protected Resource Metadata at `/.well-known/oauth-protected-resource/{namespace}/mcp`. Set `WANAKU_AUTH_ISSUER` to your Keycloak realm URL to populate the `authorization_servers` field.
 
 See [`deploy/auth/README.md`](deploy/auth/README.md) for setup instructions (Docker Compose and local development).
 
-Praxis serves [RFC 9728](https://datatracker.ietf.org/doc/rfc9728/) OAuth Protected Resource Metadata at `/.well-known/oauth-protected-resource/{namespace}/mcp` via the `mcp-metadata` feature crate. Set `WANAKU_AUTH_ISSUER` to your Keycloak realm URL to populate the `authorization_servers` field.
+## Documentation
 
-## Contributing
+The **[Wanaku Documentation](https://wanaku.ai/docs/)** website contains the full project documentation.
 
-### Prerequisites
+Contributors working on the project may want to refer to the development documentation:
 
-- Rust 1.96+ and Cargo
-- Node.js and Yarn (for admin UI)
-- Keycloak (for auth testing)
-- oauth2-proxy (for auth testing): `brew install oauth2-proxy`
+- [Getting Started](docs/getting-started.md) - Development setup guide
+- [Architecture](docs/architecture.md) - System architecture and components
+- [Configuration](docs/configuration.md) - Environment variables and configuration reference
+- [Management API](docs/management-api.md) - API reference
+- [Admin UI](docs/admin-ui.md) - Admin dashboard development
+- [Features / Plugins](docs/features.md) - Feature crate system
+- [Plugin Development](docs/plugin-development-guide.md) - Guide for writing new feature crates
+- [Evaluator Engine](docs/evaluator-engine.md) - WASM-based evaluator
+- [Contributing](CONTRIBUTING.md) - Contribution guidelines
+- [Security](SECURITY.md) - Security policy
 
-### Development Setup
+## Community
 
-```bash
-cargo build    # builds Rust + admin UI
-cargo test     # runs all tests
-cargo run      # starts Praxis (MCP on :8081, management on :8080)
-```
+- [GitHub Issues](https://github.com/wanaku-ai/wanaku/issues) - Bug reports and feature requests
+- [Discussions](https://github.com/wanaku-ai/wanaku/discussions) - Ask questions and share ideas
+- [Examples](https://github.com/wanaku-ai/wanaku-examples) - Example capabilities and integrations
 
-### Testing with Authentication
+## Related Projects
 
-To test with auth locally, run Keycloak and two oauth2-proxy instances alongside Praxis. See [`deploy/auth/README.md`](deploy/auth/README.md) for the full setup and Keycloak client configuration requirements.
-
-## What's Missing (and Known)
-
-- Persistence. Registry is in-memory by default. Set `WANAKU_PERSIST_BACKEND=file` to enable file-based persistence.
-- Metrics. Logs and traces, yes. Prometheus endpoint, no.
-- Graceful config reload. Edit `wanaku.yaml`, restart the binary.
+- [Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability/) - Apache Camel-based capability services
+- [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/) - SDK for building capability services in Java
 
 ## License
 
-Apache 2.0
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

- Rewrites the README adopting the structure and style from the classic Wanaku (wanaku-barn) README, now that this repository is the main project
- Adds badges (license, build, release), key features list, project etymology, community links, documentation index, and related projects section
- Removes PoC/sibling framing, "What's Different From Wanaku Java", "What's Missing", and architecture internals that belong in `docs/`
- Preserves all important technical content: install script, container instructions, configuration example, management API examples, and authentication section

## Test plan

- [ ] Verify badge links resolve correctly on the rendered README
- [ ] Verify documentation links in the Documentation section point to existing files
- [ ] Verify community links point to the correct GitHub org/repo

## Summary by Sourcery

Rewrite the README to position Wanaku as the primary MCP router project and align its documentation with the main Wanaku ecosystem.

Enhancements:
- Clarify authentication and OAuth metadata behavior, including external oauth2-proxy usage and RFC 9728 endpoint details.

Documentation:
- Revamp README with project overview, key features, quick-start instructions, and configuration guidance tailored to Wanaku MCP Router.
- Add badges, endpoint summary, links to official documentation, and a structured documentation index for developers and contributors.
- Introduce community and related projects sections to surface support channels and ecosystem repositories.