### PR TITLE
fix: sync Containerfile with current workspace feature crates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,22 +34,24 @@ COPY apis/Cargo.toml apis/Cargo.toml
 COPY filters/Cargo.toml filters/Cargo.toml
 COPY server/Cargo.toml server/Cargo.toml
 COPY features/chat/Cargo.toml features/chat/Cargo.toml
+COPY features/evaluator/Cargo.toml features/evaluator/Cargo.toml
 COPY features/intercept/Cargo.toml features/intercept/Cargo.toml
 COPY features/mcp-metadata/Cargo.toml features/mcp-metadata/Cargo.toml
-COPY features/safety/Cargo.toml features/safety/Cargo.toml
+COPY features/plugins/Cargo.toml features/plugins/Cargo.toml
 
 COPY apis/build.rs apis/build.rs
 COPY apis/src/proto apis/src/proto
 
 RUN mkdir -p apis/src filters/src server/src \
-    features/chat/src features/intercept/src features/mcp-metadata/src features/safety/src \
+    features/chat/src features/evaluator/src features/intercept/src features/mcp-metadata/src features/plugins/src \
     && echo '//! stub' > apis/src/lib.rs \
     && echo '//! stub' > filters/src/lib.rs \
     && echo '//! stub' > server/src/lib.rs \
     && echo '//! stub' > features/chat/src/lib.rs \
+    && echo '//! stub' > features/evaluator/src/lib.rs \
     && echo '//! stub' > features/intercept/src/lib.rs \
     && echo '//! stub' > features/mcp-metadata/src/lib.rs \
-    && echo '//! stub' > features/safety/src/lib.rs \
+    && echo '//! stub' > features/plugins/src/lib.rs \
     && printf '//! stub\nfn main() {}\n' > server/src/main.rs
 
 RUN --mount=type=cache,target=/root/.cargo/registry \


### PR DESCRIPTION
## Summary
- Replace the removed `features/safety` with `features/evaluator` and `features/plugins` in the Containerfile to match the current workspace members
- Fixes the early-access container image build failures on both Linux architectures

## Test plan
- [ ] Re-run the early-access workflow and verify both Linux container builds pass

## Summary by Sourcery

Build:
- Synchronize Containerfile feature crate COPY and stub directory entries, replacing the removed safety feature with evaluator and plugins to fix early-access image builds.