### PR TITLE
chore: add JReleaser changelog template

### DIFF
--- a/jreleaser/changelog.tpl
+++ b/jreleaser/changelog.tpl
@@ -1,0 +1,25 @@
+## Downloads
+
+### Wanaku Praxis
+
+The Wanaku Praxis MCP Router binary.
+
+| Platform | File |
+|---|---|
+| **Linux (x86_64)** | [wanaku-praxis-{{projectVersion}}-linux-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-linux-x86_64.tar.gz) |
+| **Linux (aarch64)** | [wanaku-praxis-{{projectVersion}}-linux-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-linux-aarch64.tar.gz) |
+| **macOS (Apple Silicon)** | [wanaku-praxis-{{projectVersion}}-macos-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-macos-aarch64.tar.gz) |
+| **macOS (x86_64)** | [wanaku-praxis-{{projectVersion}}-macos-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-macos-x86_64.tar.gz) |
+| **Windows (x86_64)** | [wanaku-praxis-{{projectVersion}}-windows-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-windows-x86_64.zip) |
+
+### Container Images
+
+```
+docker pull quay.io/wanaku/wanaku-praxis:{{projectVersion}}
+```
+
+---
+
+## Changelog
+
+{{changelogChanges}}


### PR DESCRIPTION
## Summary

- Adds `jreleaser/changelog.tpl` with download links for all five platform artifacts (linux-x86_64, linux-aarch64, macos-aarch64, macos-x86_64, windows-x86_64) and container image pull command
- Uses the same JReleaser mustache variables as the classic Wanaku project (`{{projectVersion}}`, `{{tagName}}`, `{{changelogChanges}}`)
- Artifact names match the existing `early-access.yml` workflow packaging

## Test plan

- [ ] Verify template renders correctly when JReleaser config is added
- [ ] Confirm download URLs resolve after a release is published

## Summary by Sourcery

Documentation:
- Introduce a JReleaser changelog template with platform-specific binary download links and container image pull instructions.