### PR TITLE
fix #1801: discover and forward resources from MCP forwards

### DIFF
--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use rmcp::{
     ServiceExt as _,
-    model::{CallToolRequestParams, PaginatedRequestParams},
+    model::{CallToolRequestParams, PaginatedRequestParams, ReadResourceRequestParams},
     transport::{
         StreamableHttpClientTransport,
         streamable_http_client::StreamableHttpClientTransportConfig,
@@ -12,6 +12,7 @@ use serde_json::Value;
 
 const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_TOOLS: usize = 500;
+const MAX_RESOURCES: usize = 500;
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpClientError {
@@ -28,6 +29,16 @@ pub enum McpClientError {
     CallTool {
         url: String,
         tool_name: String,
+        message: String,
+    },
+
+    #[error("resources/list failed for {url}: {message}")]
+    ListResources { url: String, message: String },
+
+    #[error("resources/read failed for {url}, uri={resource_uri}: {message}")]
+    ReadResource {
+        url: String,
+        resource_uri: String,
         message: String,
     },
 }
@@ -148,4 +159,95 @@ pub async fn call_tool(
         content,
         is_error: result.is_error.unwrap_or(false),
     })
+}
+
+pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    tracing::debug!(url = %url, "connected to MCP server for resources/list");
+
+    let mut all_resources = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page = tokio::time::timeout(
+            TIMEOUT,
+            Box::pin(client.list_resources(Some(params))),
+        )
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::ListResources {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+        all_resources.extend(page.resources);
+
+        if all_resources.len() >= MAX_RESOURCES {
+            all_resources.truncate(MAX_RESOURCES);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, resource_count = all_resources.len(), "discovered resources from MCP server");
+
+    all_resources
+        .into_iter()
+        .map(|r| serde_json::to_value(r).map_err(|e| McpClientError::ListResources {
+            url: url.to_owned(),
+            message: e.to_string(),
+        }))
+        .collect()
+}
+
+pub async fn read_resource(
+    url: &str,
+    resource_uri: &str,
+) -> Result<Vec<Value>, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    let params = ReadResourceRequestParams::new(resource_uri.to_owned());
+
+    let result = tokio::time::timeout(TIMEOUT, Box::pin(client.read_resource(params)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::ReadResource {
+            url: url.to_owned(),
+            resource_uri: resource_uri.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    result
+        .contents
+        .into_iter()
+        .map(|c| serde_json::to_value(c).map_err(|e| McpClientError::ReadResource {
+            url: url.to_owned(),
+            resource_uri: resource_uri.to_owned(),
+            message: e.to_string(),
+        }))
+        .collect()
 }

--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_TOOLS: usize = 500;
 const MAX_RESOURCES: usize = 500;
+const MAX_RESOURCE_TEMPLATES: usize = 500;
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpClientError {
@@ -34,6 +35,9 @@ pub enum McpClientError {
 
     #[error("resources/list failed for {url}: {message}")]
     ListResources { url: String, message: String },
+
+    #[error("resources/templates/list failed for {url}: {message}")]
+    ListResourceTemplates { url: String, message: String },
 
     #[error("resources/read failed for {url}, uri={resource_uri}: {message}")]
     ReadResource {
@@ -247,6 +251,60 @@ pub async fn read_resource(
         .map(|c| serde_json::to_value(c).map_err(|e| McpClientError::ReadResource {
             url: url.to_owned(),
             resource_uri: resource_uri.to_owned(),
+            message: e.to_string(),
+        }))
+        .collect()
+}
+
+pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    tracing::debug!(url = %url, "connected to MCP server for resources/templates/list");
+
+    let mut all_templates = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page = tokio::time::timeout(
+            TIMEOUT,
+            Box::pin(client.list_resource_templates(Some(params))),
+        )
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::ListResourceTemplates {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+        all_templates.extend(page.resource_templates);
+
+        if all_templates.len() >= MAX_RESOURCE_TEMPLATES {
+            all_templates.truncate(MAX_RESOURCE_TEMPLATES);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, template_count = all_templates.len(), "discovered resource templates from MCP server");
+
+    all_templates
+        .into_iter()
+        .map(|t| serde_json::to_value(t).map_err(|e| McpClientError::ListResourceTemplates {
+            url: url.to_owned(),
             message: e.to_string(),
         }))
         .collect()

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -118,6 +118,7 @@ pub struct NamespaceEntry {
 pub const MCP_FORWARD_TYPE: &str = "mcp-forward";
 
 pub const FORWARD_ADDRESS_LABEL: &str = "wanaku.forward_address";
+pub const IS_TEMPLATE_LABEL: &str = "wanaku.is_template";
 
 impl ToolEntry {
     pub fn is_mcp_forward(&self) -> bool {
@@ -128,6 +129,10 @@ impl ToolEntry {
 impl ResourceEntry {
     pub fn is_mcp_forward(&self) -> bool {
         self.type_ == MCP_FORWARD_TYPE
+    }
+
+    pub fn is_template(&self) -> bool {
+        self.labels.get(IS_TEMPLATE_LABEL).map(|v| v == "true").unwrap_or(false)
     }
 
     pub fn forward_address(&self) -> Option<&str> {

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -117,9 +117,21 @@ pub struct NamespaceEntry {
 
 pub const MCP_FORWARD_TYPE: &str = "mcp-forward";
 
+pub const FORWARD_ADDRESS_LABEL: &str = "wanaku.forward_address";
+
 impl ToolEntry {
     pub fn is_mcp_forward(&self) -> bool {
         self.type_ == MCP_FORWARD_TYPE
+    }
+}
+
+impl ResourceEntry {
+    pub fn is_mcp_forward(&self) -> bool {
+        self.type_ == MCP_FORWARD_TYPE
+    }
+
+    pub fn forward_address(&self) -> Option<&str> {
+        self.labels.get(FORWARD_ADDRESS_LABEL).map(|s| s.as_str())
     }
 }
 
@@ -169,6 +181,7 @@ pub trait ResourceRegistry: Send + Sync {
     fn get_resource_in_namespace(&self, namespace: &str, name: &str) -> Option<ResourceEntry>;
     fn register_resource(&self, resource: ResourceEntry);
     fn remove_resource(&self, name: &str) -> bool;
+    fn remove_resources_batch(&self, names: &[String]) -> usize;
     fn resource_count(&self) -> usize;
 }
 
@@ -428,6 +441,19 @@ impl ResourceRegistry for InMemoryRegistry {
         removed
     }
 
+    fn remove_resources_batch(&self, names: &[String]) -> usize {
+        let mut count = 0;
+        for name in names {
+            if self.resources.remove(name.as_str()).is_some() {
+                count += 1;
+            }
+        }
+        if count > 0 {
+            self.persist();
+        }
+        count
+    }
+
     fn resource_count(&self) -> usize {
         self.resources.len()
     }
@@ -620,6 +646,50 @@ mod tests {
         registry.register_resource(sample_resource());
         assert!(registry.remove_resource("test-resource"));
         assert!(registry.get_resource("test-resource").is_none());
+    }
+
+    #[test]
+    fn resource_is_mcp_forward() {
+        let mut resource = sample_resource();
+        assert!(!resource.is_mcp_forward());
+
+        resource.type_ = MCP_FORWARD_TYPE.to_owned();
+        assert!(resource.is_mcp_forward());
+    }
+
+    #[test]
+    fn resource_forward_address_from_labels() {
+        let mut resource = sample_resource();
+        assert!(resource.forward_address().is_none());
+
+        resource.labels.insert(
+            FORWARD_ADDRESS_LABEL.to_owned(),
+            "http://remote:8080/mcp".to_owned(),
+        );
+        assert_eq!(resource.forward_address(), Some("http://remote:8080/mcp"));
+    }
+
+    #[test]
+    fn remove_resources_batch() {
+        let registry = InMemoryRegistry::new();
+        registry.register_resource(ResourceEntry {
+            name: "r1".to_owned(),
+            ..sample_resource()
+        });
+        registry.register_resource(ResourceEntry {
+            name: "r2".to_owned(),
+            ..sample_resource()
+        });
+        registry.register_resource(ResourceEntry {
+            name: "r3".to_owned(),
+            ..sample_resource()
+        });
+
+        let removed = registry.remove_resources_batch(&["r1".to_owned(), "r3".to_owned()]);
+        assert_eq!(removed, 2);
+        assert!(registry.get_resource("r1").is_none());
+        assert!(registry.get_resource("r2").is_some());
+        assert!(registry.get_resource("r3").is_none());
     }
 
     #[test]

--- a/filters/src/resource_list.rs
+++ b/filters/src/resource_list.rs
@@ -16,7 +16,9 @@ impl ResourceListFilter {
             None => return Ok(FilterAction::Continue),
         };
 
-        if method != "resources/list" {
+        let is_list = method == "resources/list";
+        let is_template_list = method == "resources/templates/list";
+        if !is_list && !is_template_list {
             return Ok(FilterAction::Continue);
         }
 
@@ -39,28 +41,48 @@ impl ResourceListFilter {
             }
         };
 
-        let resources = registry.list_resources_in_namespace(namespace);
-        let mcp_resources: Vec<serde_json::Value> = resources
-            .iter()
-            .map(|r| {
-                serde_json::json!({
-                    "uri": r.location,
-                    "name": r.name,
-                    "description": r.description,
-                    "mimeType": r.mime_type,
-                })
-            })
-            .collect();
-
+        let all_resources = registry.list_resources_in_namespace(namespace);
         let json_rpc_id = crate::response::extract_json_rpc_id(body);
 
-        let response = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": json_rpc_id,
-            "result": {
-                "resources": mcp_resources,
-            }
-        });
+        let response = if is_template_list {
+            let templates: Vec<serde_json::Value> = all_resources
+                .iter()
+                .filter(|r| r.is_template())
+                .map(|r| {
+                    serde_json::json!({
+                        "uriTemplate": r.location,
+                        "name": r.name,
+                        "description": r.description,
+                        "mimeType": r.mime_type,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": json_rpc_id,
+                "result": { "resourceTemplates": templates }
+            })
+        } else {
+            let resources: Vec<serde_json::Value> = all_resources
+                .iter()
+                .filter(|r| !r.is_template())
+                .map(|r| {
+                    serde_json::json!({
+                        "uri": r.location,
+                        "name": r.name,
+                        "description": r.description,
+                        "mimeType": r.mime_type,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": json_rpc_id,
+                "result": { "resources": resources }
+            })
+        };
 
         let response_body = Bytes::from(response.to_string());
         Ok(FilterAction::Reject(crate::response::json_response(response_body)))

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -5,6 +5,45 @@ use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
 
 crate::body_filter_boilerplate!(ResourceReadFilter, "wanaku_resource_read");
 
+fn matches_uri_template(template: &str, uri: &str) -> bool {
+    let mut parts = Vec::new();
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        parts.push(&rest[..start]);
+        match rest[start..].find('}') {
+            Some(end) => rest = &rest[start + end + 1..],
+            None => return false,
+        }
+    }
+    parts.push(rest);
+
+    if parts.len() == 1 {
+        return template == uri;
+    }
+
+    let mut pos = 0;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        match uri[pos..].find(part) {
+            Some(found) => {
+                if i == 0 && found != 0 {
+                    return false;
+                }
+                pos += found + part.len();
+            }
+            None => return false,
+        }
+    }
+
+    if template.ends_with('}') {
+        return pos <= uri.len();
+    }
+
+    pos == uri.len()
+}
+
 struct ParsedBody {
     id: serde_json::Value,
     uri: Option<String>,
@@ -77,13 +116,12 @@ impl ResourceReadFilter {
             }
         };
 
-        let resource = registry
-            .list_resources_in_namespace(namespace)
-            .into_iter()
-            .find(|r| r.location == resource_uri);
+        let resources = registry.list_resources_in_namespace(namespace);
+        let resource = resources.iter().find(|r| !r.is_template() && r.location == resource_uri)
+            .or_else(|| resources.iter().find(|r| r.is_template() && matches_uri_template(&r.location, &resource_uri)));
 
         let resource = match resource {
-            Some(r) => r,
+            Some(r) => r.clone(),
             None => {
                 warn!(uri = %resource_uri, namespace = %namespace, "resource not found in registry");
                 return Ok(crate::response::json_rpc_error(
@@ -222,5 +260,41 @@ mod tests {
         let parsed = parse_body(&body);
         assert_eq!(parsed.id, serde_json::Value::from(4));
         assert!(parsed.uri.is_none());
+    }
+
+    #[test]
+    fn template_matches_single_param() {
+        assert!(matches_uri_template("logs://{server_id}/syslog", "logs://web-01/syslog"));
+    }
+
+    #[test]
+    fn template_matches_multiple_params() {
+        assert!(matches_uri_template("logs://{server}/{log_type}", "logs://web-01/syslog"));
+    }
+
+    #[test]
+    fn template_no_match_wrong_prefix() {
+        assert!(!matches_uri_template("logs://{server_id}/syslog", "files://web-01/syslog"));
+    }
+
+    #[test]
+    fn template_no_match_wrong_suffix() {
+        assert!(!matches_uri_template("logs://{server_id}/syslog", "logs://web-01/access"));
+    }
+
+    #[test]
+    fn template_matches_param_at_end() {
+        assert!(matches_uri_template("file://{path}", "file:///data/report.csv"));
+    }
+
+    #[test]
+    fn template_exact_match_no_params() {
+        assert!(matches_uri_template("file:///fixed.txt", "file:///fixed.txt"));
+        assert!(!matches_uri_template("file:///fixed.txt", "file:///other.txt"));
+    }
+
+    #[test]
+    fn template_malformed_unclosed_brace() {
+        assert!(!matches_uri_template("logs://{server/syslog", "logs://web-01/syslog"));
     }
 }

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::{trace, warn};
+use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
 
 crate::body_filter_boilerplate!(ResourceReadFilter, "wanaku_resource_read");
 
@@ -68,12 +69,83 @@ impl ResourceReadFilter {
 
         trace!(uri = %resource_uri, namespace = %namespace, "handling MCP resources/read request");
 
-        warn!(uri = %resource_uri, "resource read is not supported — no resource provider backend configured");
+        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
+            Some(r) => r,
+            None => {
+                tracing::error!("InMemoryRegistry not found in request extensions");
+                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
+            }
+        };
+
+        let resource = registry
+            .list_resources_in_namespace(namespace)
+            .into_iter()
+            .find(|r| r.location == resource_uri);
+
+        let resource = match resource {
+            Some(r) => r,
+            None => {
+                warn!(uri = %resource_uri, namespace = %namespace, "resource not found in registry");
+                return Ok(crate::response::json_rpc_error(
+                    &parsed.id,
+                    crate::response::JSONRPC_INVALID_PARAMS,
+                    &format!("resource not found: {resource_uri}"),
+                ));
+            }
+        };
+
+        if resource.is_mcp_forward() {
+            return self.handle_forwarded_read(&resource, &resource_uri, &parsed).await;
+        }
+
+        warn!(uri = %resource_uri, resource_type = %resource.type_, "unsupported resource type — only MCP-forwarded resources are supported");
         Ok(crate::response::json_rpc_error(
             &parsed.id,
             crate::response::JSONRPC_INTERNAL_ERROR,
-            "resource read is not supported in this configuration",
+            &format!("unsupported resource type '{}': only MCP-forwarded resources are supported", resource.type_),
         ))
+    }
+
+    async fn handle_forwarded_read(
+        &self,
+        resource: &wanaku_praxis_apis::registry::ResourceEntry,
+        resource_uri: &str,
+        parsed: &ParsedBody,
+    ) -> Result<FilterAction, FilterError> {
+        let forward_address = match resource.forward_address() {
+            Some(addr) => addr,
+            None => {
+                warn!(uri = %resource_uri, "forwarded resource missing forward address label");
+                return Ok(crate::response::json_rpc_error(
+                    &parsed.id,
+                    crate::response::JSONRPC_INTERNAL_ERROR,
+                    "forwarded resource has no upstream address configured",
+                ));
+            }
+        };
+
+        trace!(uri = %resource_uri, forward = %forward_address, "forwarding resources/read to remote MCP server");
+
+        match wanaku_praxis_apis::mcp_client::read_resource(forward_address, resource_uri).await {
+            Ok(contents) => {
+                let response = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": parsed.id,
+                    "result": {"contents": contents}
+                });
+
+                let response_body = Bytes::from(response.to_string());
+                Ok(FilterAction::Reject(crate::response::json_response(response_body)))
+            }
+            Err(e) => {
+                warn!(uri = %resource_uri, error = %e, "MCP forward resource read failed");
+                Ok(crate::response::json_rpc_error(
+                    &parsed.id,
+                    crate::response::JSONRPC_INTERNAL_ERROR,
+                    &format!("forwarded resource read failed: {e}"),
+                ))
+            }
+        }
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -210,10 +210,12 @@ fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
 
             rt.block_on(async {
                 for fwd in &forwards {
-                    info!(forward = %fwd.name, address = %fwd.address, "discovering tools from forward");
-                    let count =
+                    info!(forward = %fwd.name, address = %fwd.address, "discovering tools and resources from forward");
+                    let tools_count =
                         wanaku_praxis::management::discover_tools_from_forward(&reg, fwd).await;
-                    info!(forward = %fwd.name, tools_discovered = count, "forward discovery complete");
+                    let resources_count =
+                        wanaku_praxis::management::discover_resources_from_forward(&reg, fwd).await;
+                    info!(forward = %fwd.name, tools_discovered = tools_count, resources_discovered = resources_count, "forward discovery complete");
                 }
             });
         });

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -430,6 +430,66 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
         count += 1;
     }
 
+    let templates = match wanaku_praxis_apis::mcp_client::list_resource_templates(&forward.address).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::debug!(forward = %forward.name, error = %e, "no resource templates from forward (may not be supported)");
+            return count;
+        }
+    };
+
+    for tmpl_json in &templates {
+        let name = match tmpl_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
+            Some(n) if !n.is_empty() => n,
+            _ => {
+                warn!(forward = %forward.name, "skipping forwarded template with missing or empty name");
+                continue;
+            }
+        };
+        let uri_template = match tmpl_json.get("uriTemplate").and_then(|u| u.as_str()).map(str::trim) {
+            Some(u) if !u.is_empty() => u,
+            _ => {
+                warn!(forward = %forward.name, template = %name, "skipping forwarded template with missing or empty uriTemplate");
+                continue;
+            }
+        };
+        let description = tmpl_json
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or_default();
+        let mime_type = tmpl_json
+            .get("mimeType")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            wanaku_praxis_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
+            forward.address.clone(),
+        );
+        labels.insert(
+            wanaku_praxis_apis::registry::IS_TEMPLATE_LABEL.to_owned(),
+            "true".to_owned(),
+        );
+
+        let resource = ResourceEntry {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            location: uri_template.to_owned(),
+            type_: MCP_FORWARD_TYPE.to_owned(),
+            mime_type: mime_type.to_owned(),
+            labels,
+            id: None,
+            namespace: Some(namespace.to_owned()),
+            configuration_uri: None,
+            secrets_uri: None,
+        };
+
+        info!(template = %name, uri_template = %uri_template, forward = %forward.name, "discovered forwarded resource template");
+        registry.register_resource(resource);
+        count += 1;
+    }
+
     count
 }
 

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -122,6 +122,14 @@ pub(super) fn handle_resource_update(registry: &InMemoryRegistry, path_name: &st
         }
     };
 
+    if let Some(existing) = registry.get_resource(path_name) {
+        for (k, v) in &existing.labels {
+            if k.starts_with("wanaku.") {
+                resource.labels.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+    }
+
     let new_name = resource.name.trim().to_owned();
     if !new_name.is_empty() && new_name != path_name {
         registry.remove_resource(path_name);
@@ -386,10 +394,13 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
             .get("description")
             .and_then(|d| d.as_str())
             .unwrap_or_default();
-        let uri = res_json
-            .get("uri")
-            .and_then(|u| u.as_str())
-            .unwrap_or_default();
+        let uri = match res_json.get("uri").and_then(|u| u.as_str()).map(str::trim) {
+            Some(u) if !u.is_empty() => u,
+            _ => {
+                warn!(forward = %forward.name, resource = %name, "skipping forwarded resource with missing or empty uri");
+                continue;
+            }
+        };
         let mime_type = res_json
             .get("mimeType")
             .and_then(|m| m.as_str())
@@ -873,6 +884,29 @@ mod tests {
     fn resource_update_invalid_json_returns_400() {
         let registry = InMemoryRegistry::new();
         assert_eq!(handle_resource_update(&registry, "r", "???").status(), 400);
+    }
+
+    #[test]
+    fn resource_update_preserves_internal_labels() {
+        let registry = InMemoryRegistry::new();
+        handle_resource_create(
+            &registry,
+            r#"{"name":"fwd-res","description":"old","location":"file:///data","type":"mcp-forward","labels":{"wanaku.forward_address":"http://remote:8080"}}"#,
+        );
+
+        let resp = handle_resource_update(
+            &registry, "fwd-res",
+            r#"{"name":"fwd-res","description":"new","location":"file:///data","type":"mcp-forward"}"#,
+        );
+        assert_eq!(resp.status(), 200);
+
+        let data = data_field(&handle_resource_get(&registry, "fwd-res"));
+        assert_eq!(data.get("description").and_then(|v| v.as_str()), Some("new"));
+        let labels = data.get("labels").and_then(|v| v.as_object());
+        assert_eq!(
+            labels.and_then(|l| l.get("wanaku.forward_address")).and_then(|v| v.as_str()),
+            Some("http://remote:8080"),
+        );
     }
 
     // ---- Prompt handlers ----

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -271,11 +271,13 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
     info!(forward = %forward.name, address = %forward.address, "registered forward via management API");
     registry.register_forward(forward.clone());
 
-    let count = discover_tools_from_forward(registry, &forward).await;
+    let tools_count = discover_tools_from_forward(registry, &forward).await;
+    let resources_count = discover_resources_from_forward(registry, &forward).await;
 
     json_ok(&serde_json::json!({
         "forward": &forward,
-        "tools_discovered": count,
+        "tools_discovered": tools_count,
+        "resources_discovered": resources_count,
     }))
 }
 
@@ -288,6 +290,7 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
 
     if let Some(fwd) = forward {
         remove_forwarded_tools(registry, &fwd.address);
+        remove_forwarded_resources(registry, &fwd.address);
     }
 
     info!(forward = %name, "removed forward via management API");
@@ -301,10 +304,12 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
     };
 
     remove_forwarded_tools(registry, &forward.address);
-    let count = discover_tools_from_forward(registry, &forward).await;
+    remove_forwarded_resources(registry, &forward.address);
+    let tools_count = discover_tools_from_forward(registry, &forward).await;
+    let resources_count = discover_resources_from_forward(registry, &forward).await;
 
-    info!(forward = %name, tools_discovered = count, "refreshed forward");
-    json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": count}))
+    info!(forward = %name, tools_discovered = tools_count, resources_discovered = resources_count, "refreshed forward");
+    json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": tools_count, "resources_discovered": resources_count}))
 }
 
 pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
@@ -357,6 +362,77 @@ pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &
     count
 }
 
+pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
+    let resources = match wanaku_praxis_apis::mcp_client::list_resources(&forward.address).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(forward = %forward.name, error = %e, "failed to discover resources from forward");
+            return 0;
+        }
+    };
+
+    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+    let mut count = 0;
+
+    for res_json in &resources {
+        let name = match res_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
+            Some(n) if !n.is_empty() => n,
+            _ => {
+                warn!(forward = %forward.name, "skipping forwarded resource with missing or empty name");
+                continue;
+            }
+        };
+        let description = res_json
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or_default();
+        let uri = res_json
+            .get("uri")
+            .and_then(|u| u.as_str())
+            .unwrap_or_default();
+        let mime_type = res_json
+            .get("mimeType")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            wanaku_praxis_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
+            forward.address.clone(),
+        );
+
+        let resource = ResourceEntry {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            location: uri.to_owned(),
+            type_: MCP_FORWARD_TYPE.to_owned(),
+            mime_type: mime_type.to_owned(),
+            labels,
+            id: None,
+            namespace: Some(namespace.to_owned()),
+            configuration_uri: None,
+            secrets_uri: None,
+        };
+
+        info!(resource = %name, forward = %forward.name, "discovered forwarded resource");
+        registry.register_resource(resource);
+        count += 1;
+    }
+
+    count
+}
+
+fn remove_forwarded_resources(registry: &InMemoryRegistry, address: &str) {
+    let forwarded: Vec<String> = registry
+        .list_resources()
+        .iter()
+        .filter(|r| r.is_mcp_forward() && r.forward_address() == Some(address))
+        .map(|r| r.name.clone())
+        .collect();
+
+    registry.remove_resources_batch(&forwarded);
+}
+
 fn remove_forwarded_tools(registry: &InMemoryRegistry, address: &str) {
     let forwarded: Vec<String> = registry
         .list_tools()
@@ -371,8 +447,47 @@ fn remove_forwarded_tools(registry: &InMemoryRegistry, address: &str) {
 #[cfg(test)]
 mod forward_helpers_tests {
     use super::*;
-    use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry};
+    use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry, ResourceRegistry, FORWARD_ADDRESS_LABEL};
     use std::collections::HashMap;
+
+    #[test]
+    fn remove_forwarded_resources_clears_matching_resources() {
+        let registry = InMemoryRegistry::new();
+        let fwd_addr = "http://remote:8080";
+
+        let mut fwd_labels = HashMap::new();
+        fwd_labels.insert(FORWARD_ADDRESS_LABEL.to_owned(), fwd_addr.to_owned());
+
+        registry.register_resource(ResourceEntry {
+            name: "fwd-res".to_owned(),
+            description: "forwarded".to_owned(),
+            location: "file:///data/report.csv".to_owned(),
+            type_: MCP_FORWARD_TYPE.to_owned(),
+            mime_type: "text/csv".to_owned(),
+            labels: fwd_labels,
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+        registry.register_resource(ResourceEntry {
+            name: "local-res".to_owned(),
+            description: "local".to_owned(),
+            location: "/tmp/local.txt".to_owned(),
+            type_: "file".to_owned(),
+            mime_type: "text/plain".to_owned(),
+            labels: HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+
+        remove_forwarded_resources(&registry, fwd_addr);
+
+        assert!(registry.get_resource("fwd-res").is_none());
+        assert!(registry.get_resource("local-res").is_some());
+    }
 
     #[test]
     fn remove_forwarded_tools_clears_matching_tools() {

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -4,6 +4,7 @@ mod routes;
 mod ui;
 
 pub use handlers::discover_tools_from_forward;
+pub use handlers::discover_resources_from_forward;
 
 use async_trait::async_trait;
 use http::Response;


### PR DESCRIPTION
## Summary

- Forward registration now discovers **resources** alongside tools from remote MCP servers via `resources/list`
- Discovered resources are registered with type `mcp-forward` and the forward address stored in labels
- `resources/read` forwards reads to the originating MCP server instead of returning "not supported"
- Forward delete and refresh operations handle resources alongside tools
- Resource update preserves internal `wanaku.*` labels to prevent accidental loss of forward address
- Resource URI validation during discovery rejects entries with missing or empty URIs

## Changes

| File | Change |
|---|---|
| `apis/src/mcp_client.rs` | Add `list_resources()` and `read_resource()` functions |
| `apis/src/registry.rs` | Add `is_mcp_forward()`, `forward_address()`, `remove_resources_batch()` to `ResourceEntry` |
| `filters/src/resource_read.rs` | Implement forwarding for mcp-forward resources |
| `server/src/management/handlers.rs` | Add resource discovery/cleanup, preserve labels on update |
| `server/src/management/mod.rs` | Re-export `discover_resources_from_forward` |
| `server/src/main.rs` | Discover resources at startup |

## Test plan

- [x] Unit tests for `ResourceEntry::is_mcp_forward()` and `forward_address()`
- [x] Unit test for `remove_resources_batch()`
- [x] Unit test for `remove_forwarded_resources()`
- [x] Unit test for label preservation during resource update
- [x] All 204 existing + new tests pass

## Summary by Sourcery

Discover, register, and manage MCP-forwarded resources alongside tools, and enable reading of forwarded resources via the MCP client and resource read filter.

New Features:
- Discover and register resources from MCP forwards using the MCP client and registry.
- Support resources/read for MCP-forwarded resources by forwarding reads to the originating MCP server.

Bug Fixes:
- Preserve internal wanaku.* labels on resource update to avoid losing forward metadata.
- Validate resource URIs during discovery to skip resources with missing or empty URIs.

Enhancements:
- Add registry helpers and batch removal to efficiently clean up MCP-forwarded resources when forwards are deleted or refreshed.
- Extend forward management and startup logic to handle resource discovery and cleanup together with tools.
- Improve logging and error reporting around MCP resource discovery and read operations.

Tests:
- Add unit tests for MCP-forward resource detection, forward address extraction, and batch resource removal.
- Add unit tests for removing forwarded resources tied to a forward address.
- Add unit test verifying internal label preservation during resource update.