### PR TITLE
feat: discover and forward prompts from MCP forwards

### DIFF
--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -2,7 +2,10 @@ use std::time::Duration;
 
 use rmcp::{
     ServiceExt as _,
-    model::{CallToolRequestParams, PaginatedRequestParams, ReadResourceRequestParams},
+    model::{
+        CallToolRequestParams, GetPromptRequestParams, PaginatedRequestParams,
+        ReadResourceRequestParams,
+    },
     transport::{
         StreamableHttpClientTransport,
         streamable_http_client::StreamableHttpClientTransportConfig,
@@ -14,6 +17,7 @@ const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_TOOLS: usize = 500;
 const MAX_RESOURCES: usize = 500;
 const MAX_RESOURCE_TEMPLATES: usize = 500;
+const MAX_PROMPTS: usize = 500;
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpClientError {
@@ -43,6 +47,16 @@ pub enum McpClientError {
     ReadResource {
         url: String,
         resource_uri: String,
+        message: String,
+    },
+
+    #[error("prompts/list failed for {url}: {message}")]
+    ListPrompts { url: String, message: String },
+
+    #[error("prompts/get failed for {url}, prompt={prompt_name}: {message}")]
+    GetPrompt {
+        url: String,
+        prompt_name: String,
         message: String,
     },
 }
@@ -308,4 +322,95 @@ pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientE
             message: e.to_string(),
         }))
         .collect()
+}
+
+pub async fn list_prompts(url: &str) -> Result<Vec<Value>, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    tracing::debug!(url = %url, "connected to MCP server for prompts/list");
+
+    let mut all_prompts = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page = tokio::time::timeout(
+            TIMEOUT,
+            Box::pin(client.list_prompts(Some(params))),
+        )
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::ListPrompts {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+        all_prompts.extend(page.prompts);
+
+        if all_prompts.len() >= MAX_PROMPTS {
+            all_prompts.truncate(MAX_PROMPTS);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, prompt_count = all_prompts.len(), "discovered prompts from MCP server");
+
+    all_prompts
+        .into_iter()
+        .map(|p| serde_json::to_value(p).map_err(|e| McpClientError::ListPrompts {
+            url: url.to_owned(),
+            message: e.to_string(),
+        }))
+        .collect()
+}
+
+pub async fn get_prompt(
+    url: &str,
+    prompt_name: &str,
+    arguments: Option<serde_json::Map<String, Value>>,
+) -> Result<Value, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    let mut params = GetPromptRequestParams::new(prompt_name.to_owned());
+    if let Some(args) = arguments {
+        params.arguments = Some(args);
+    }
+
+    let result = tokio::time::timeout(TIMEOUT, Box::pin(client.get_prompt(params)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::GetPrompt {
+            url: url.to_owned(),
+            prompt_name: prompt_name.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    serde_json::to_value(result).map_err(|e| McpClientError::GetPrompt {
+        url: url.to_owned(),
+        prompt_name: prompt_name.to_owned(),
+        message: e.to_string(),
+    })
 }

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -197,6 +197,7 @@ pub trait PromptRegistry: Send + Sync {
     fn get_prompt_in_namespace(&self, namespace: &str, name: &str) -> Option<PromptEntry>;
     fn register_prompt(&self, prompt: PromptEntry);
     fn remove_prompt(&self, name: &str) -> bool;
+    fn remove_prompts_batch(&self, names: &[String]) -> usize;
     fn prompt_count(&self) -> usize;
 }
 
@@ -502,6 +503,19 @@ impl PromptRegistry for InMemoryRegistry {
             self.persist();
         }
         removed
+    }
+
+    fn remove_prompts_batch(&self, names: &[String]) -> usize {
+        let mut count = 0;
+        for name in names {
+            if self.prompts.remove(name.as_str()).is_some() {
+                count += 1;
+            }
+        }
+        if count > 0 {
+            self.persist();
+        }
+        count
     }
 
     fn prompt_count(&self) -> usize {

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -99,6 +99,12 @@ impl PromptGetFilter {
             }
         };
 
+        if prompt.messages.is_empty() {
+            if let Some(ref uri) = prompt.configuration_uri {
+                return self.handle_forwarded_get(uri, &prompt_name, &parsed).await;
+            }
+        }
+
         let messages: Vec<serde_json::Value> = prompt
             .messages
             .iter()
@@ -138,6 +144,42 @@ impl PromptGetFilter {
 
         let response_body = Bytes::from(response.to_string());
         Ok(FilterAction::Reject(crate::response::json_response(response_body)))
+    }
+
+    async fn handle_forwarded_get(
+        &self,
+        forward_address: &str,
+        prompt_name: &str,
+        parsed: &ParsedBody,
+    ) -> Result<FilterAction, FilterError> {
+        trace!(prompt = %prompt_name, forward = %forward_address, "forwarding prompts/get to remote MCP server");
+
+        let arguments = if parsed.arguments.is_empty() {
+            None
+        } else {
+            Some(parsed.arguments.clone())
+        };
+
+        match wanaku_praxis_apis::mcp_client::get_prompt(forward_address, prompt_name, arguments).await {
+            Ok(result) => {
+                let response = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": parsed.id,
+                    "result": result,
+                });
+
+                let response_body = Bytes::from(response.to_string());
+                Ok(FilterAction::Reject(crate::response::json_response(response_body)))
+            }
+            Err(e) => {
+                warn!(prompt = %prompt_name, error = %e, "MCP forward prompt get failed");
+                Ok(crate::response::json_rpc_error(
+                    &parsed.id,
+                    crate::response::JSONRPC_INTERNAL_ERROR,
+                    &format!("forwarded prompt get failed: {e}"),
+                ))
+            }
+        }
     }
 }
 

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -281,11 +281,13 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
 
     let tools_count = discover_tools_from_forward(registry, &forward).await;
     let resources_count = discover_resources_from_forward(registry, &forward).await;
+    let prompts_count = discover_prompts_from_forward(registry, &forward).await;
 
     json_ok(&serde_json::json!({
         "forward": &forward,
         "tools_discovered": tools_count,
         "resources_discovered": resources_count,
+        "prompts_discovered": prompts_count,
     }))
 }
 
@@ -299,6 +301,7 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
     if let Some(fwd) = forward {
         remove_forwarded_tools(registry, &fwd.address);
         remove_forwarded_resources(registry, &fwd.address);
+        remove_forwarded_prompts(registry, &fwd.address);
     }
 
     info!(forward = %name, "removed forward via management API");
@@ -313,11 +316,13 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
 
     remove_forwarded_tools(registry, &forward.address);
     remove_forwarded_resources(registry, &forward.address);
+    remove_forwarded_prompts(registry, &forward.address);
     let tools_count = discover_tools_from_forward(registry, &forward).await;
     let resources_count = discover_resources_from_forward(registry, &forward).await;
+    let prompts_count = discover_prompts_from_forward(registry, &forward).await;
 
-    info!(forward = %name, tools_discovered = tools_count, resources_discovered = resources_count, "refreshed forward");
-    json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": tools_count, "resources_discovered": resources_count}))
+    info!(forward = %name, tools_discovered = tools_count, resources_discovered = resources_count, prompts_discovered = prompts_count, "refreshed forward");
+    json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": tools_count, "resources_discovered": resources_count, "prompts_discovered": prompts_count}))
 }
 
 pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
@@ -515,10 +520,89 @@ fn remove_forwarded_tools(registry: &InMemoryRegistry, address: &str) {
     registry.remove_tools_batch(&forwarded);
 }
 
+pub async fn discover_prompts_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
+    let prompts = match wanaku_praxis_apis::mcp_client::list_prompts(&forward.address).await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(forward = %forward.name, error = %e, "failed to discover prompts from forward");
+            return 0;
+        }
+    };
+
+    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+    let mut count = 0;
+
+    for prompt_json in &prompts {
+        let name = match prompt_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
+            Some(n) if !n.is_empty() => n,
+            _ => {
+                warn!(forward = %forward.name, "skipping forwarded prompt with missing or empty name");
+                continue;
+            }
+        };
+        let description = prompt_json
+            .get("description")
+            .and_then(|d| d.as_str())
+            .unwrap_or_default();
+
+        let arguments: Vec<wanaku_praxis_apis::registry::PromptArgument> = prompt_json
+            .get("arguments")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|arg| {
+                        let arg_name = arg.get("name")?.as_str()?;
+                        Some(wanaku_praxis_apis::registry::PromptArgument {
+                            name: arg_name.to_owned(),
+                            description: arg
+                                .get("description")
+                                .and_then(|d| d.as_str())
+                                .unwrap_or_default()
+                                .to_owned(),
+                            required: arg
+                                .get("required")
+                                .and_then(|r| r.as_bool())
+                                .unwrap_or(false),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let prompt = PromptEntry {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            arguments,
+            messages: Vec::new(),
+            id: None,
+            namespace: Some(namespace.to_owned()),
+            configuration_uri: Some(forward.address.clone()),
+        };
+
+        info!(prompt = %name, forward = %forward.name, "discovered forwarded prompt");
+        registry.register_prompt(prompt);
+        count += 1;
+    }
+
+    count
+}
+
+fn remove_forwarded_prompts(registry: &InMemoryRegistry, address: &str) {
+    let forwarded: Vec<String> = registry
+        .list_prompts()
+        .iter()
+        .filter(|p| p.messages.is_empty() && p.configuration_uri.as_deref() == Some(address))
+        .map(|p| p.name.clone())
+        .collect();
+
+    registry.remove_prompts_batch(&forwarded);
+}
+
 #[cfg(test)]
 mod forward_helpers_tests {
     use super::*;
-    use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry, ResourceRegistry, FORWARD_ADDRESS_LABEL};
+    use wanaku_praxis_apis::registry::{InMemoryRegistry, PromptEntry, PromptRegistry, ToolEntry, ToolRegistry, ResourceRegistry, FORWARD_ADDRESS_LABEL};
+    use wanaku_praxis_apis::registry::{PromptMessage, PromptRole};
     use std::collections::HashMap;
 
     #[test]
@@ -594,6 +678,62 @@ mod forward_helpers_tests {
 
         assert!(registry.get_tool("fwd-tool").is_none());
         assert!(registry.get_tool("local-tool").is_some());
+    }
+
+    #[test]
+    fn remove_forwarded_prompts_clears_matching_prompts() {
+        let registry = InMemoryRegistry::new();
+        let fwd_addr = "http://remote:8080";
+
+        registry.register_prompt(PromptEntry {
+            name: "fwd-prompt".to_owned(),
+            description: "forwarded".to_owned(),
+            arguments: Vec::new(),
+            messages: Vec::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: Some(fwd_addr.to_owned()),
+        });
+        registry.register_prompt(PromptEntry {
+            name: "local-prompt".to_owned(),
+            description: "local".to_owned(),
+            arguments: Vec::new(),
+            messages: Vec::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+        });
+
+        remove_forwarded_prompts(&registry, fwd_addr);
+
+        assert!(registry.get_prompt("fwd-prompt").is_none());
+        assert!(registry.get_prompt("local-prompt").is_some());
+    }
+
+    #[test]
+    fn remove_forwarded_prompts_preserves_user_prompts_with_same_uri() {
+        let registry = InMemoryRegistry::new();
+        let fwd_addr = "http://remote:8080";
+
+        registry.register_prompt(PromptEntry {
+            name: "user-prompt".to_owned(),
+            description: "user-created with configurationURI".to_owned(),
+            arguments: Vec::new(),
+            messages: vec![PromptMessage {
+                role: PromptRole::User,
+                content: serde_json::json!("Hello {name}"),
+            }],
+            id: None,
+            namespace: None,
+            configuration_uri: Some(fwd_addr.to_owned()),
+        });
+
+        remove_forwarded_prompts(&registry, fwd_addr);
+
+        assert!(
+            registry.get_prompt("user-prompt").is_some(),
+            "user-created prompt with messages must not be removed"
+        );
     }
 }
 

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -5,6 +5,7 @@ mod ui;
 
 pub use handlers::discover_tools_from_forward;
 pub use handlers::discover_resources_from_forward;
+pub use handlers::discover_prompts_from_forward;
 
 use async_trait::async_trait;
 use http::Response;


### PR DESCRIPTION
## Summary

- Add `list_prompts()` and `get_prompt()` to `mcp_client.rs` with pagination, timeouts, and error handling
- Add `remove_prompts_batch()` to `PromptRegistry` trait and `InMemoryRegistry` implementation
- Add `discover_prompts_from_forward()` and `remove_forwarded_prompts()` to the forward lifecycle (create/delete/refresh)
- Add upstream forwarding in `prompt_get.rs` — when a prompt has no messages but has a `configuration_uri`, the filter forwards `prompts/get` to the remote MCP server
- Export `discover_prompts_from_forward` from the management module

Forwarded prompts store the upstream address in `configuration_uri` and leave `messages` empty. The `remove_forwarded_prompts` guard checks both `messages.is_empty()` and `configuration_uri` match, so user-created prompts with a `configurationURI` and non-empty messages are never accidentally deleted.

## Test plan

- [x] All 212 existing + new unit tests pass (`cargo test`)
- [x] New tests for `remove_forwarded_prompts` verify correct removal and user-prompt preservation
- [ ] Integration test: register a forward pointing to an MCP server that exposes prompts, verify `prompts/list` returns them
- [ ] Integration test: invoke `prompts/get` with arguments on a forwarded prompt, verify upstream response is returned

## Summary by Sourcery

Integrate MCP-backed prompt discovery and forwarding into forwards management and prompt retrieval.

New Features:
- Discover prompts from MCP forwards and register them in the in-memory registry alongside tools and resources.
- Forward prompts/get requests to upstream MCP servers when a prompt is marked as forwarded via configuration_uri and has no local messages.

Enhancements:
- Extend the MCP client with paginated prompts/list and prompts/get helpers using consistent timeouts and error handling.
- Expose a batch prompt removal API on the PromptRegistry and use it to clean up prompts originating from a specific forward during delete/refresh operations.
- Include discovered prompt counts in forward create/refresh management responses and re-export the new prompt discovery helper from the management module.

Tests:
- Add unit tests to verify forwarded prompts are selectively removed while local and user-created prompts with messages are preserved.