### PR TITLE
chore: remove capabilities from server backend

### DIFF
--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -737,17 +737,6 @@ mod forward_helpers_tests {
     }
 }
 
-pub(super) fn handle_capability_list(_registry: &InMemoryRegistry) -> Response<Vec<u8>> {
-    let targets: Vec<serde_json::Value> = Vec::new();
-    json_ok(&serde_json::json!(targets))
-}
-
-pub(super) fn handle_capability_state() -> Response<Vec<u8>> {
-    let empty: std::collections::HashMap<String, Vec<serde_json::Value>> =
-        std::collections::HashMap::new();
-    json_ok(&serde_json::json!(empty))
-}
-
 pub(super) fn handle_statistics(registry: &InMemoryRegistry) -> Response<Vec<u8>> {
     let tools_count = registry.tool_count() as i64;
     let resources_count = registry.resource_count() as i64;
@@ -760,20 +749,6 @@ pub(super) fn handle_statistics(registry: &InMemoryRegistry) -> Response<Vec<u8>
         "promptsCount": prompts_count,
         "forwardsCount": forwards_count,
         "dataStoresCount": 0,
-        "toolCapabilities": {
-            "total": 0,
-            "healthy": 0,
-            "unhealthy": 0,
-            "down": 0,
-            "pending": 0
-        },
-        "resourceCapabilities": {
-            "total": 0,
-            "healthy": 0,
-            "unhealthy": 0,
-            "down": 0,
-            "pending": 0
-        }
     }))
 }
 
@@ -786,7 +761,6 @@ mod tests {
     };
 
     use super::{
-        handle_capability_list, handle_capability_state,
         handle_forward_delete, handle_forward_get, handle_forward_list,
         handle_namespace_create, handle_namespace_delete, handle_namespace_get,
         handle_namespace_list, handle_namespace_update,
@@ -1314,26 +1288,6 @@ mod tests {
         assert_eq!(handle_forward_delete(&registry, "nope").status(), 404);
     }
 
-    // ---- Capability handlers ----
-
-    #[test]
-    fn capability_list_returns_empty() {
-        let registry = InMemoryRegistry::new();
-        let resp = handle_capability_list(&registry);
-        assert_eq!(resp.status(), 200);
-        assert_eq!(data_field(&resp).as_array().map(|a| a.len()), Some(0));
-    }
-
-    #[test]
-    fn capability_state_returns_empty_object() {
-        let resp = handle_capability_state();
-        assert_eq!(resp.status(), 200);
-
-        let data = data_field(&resp);
-        assert!(data.is_object());
-        assert_eq!(data.as_object().map(|m| m.len()), Some(0));
-    }
-
     // ---- Statistics handler ----
 
     #[test]
@@ -1391,30 +1345,6 @@ mod tests {
         assert_eq!(
             data.get("forwardsCount").and_then(|v| v.as_i64()),
             Some(1)
-        );
-    }
-
-    #[test]
-    fn statistics_includes_capability_fields() {
-        let registry = InMemoryRegistry::new();
-        let data = data_field(&handle_statistics(&registry));
-
-        let tool_caps = data.get("toolCapabilities");
-        assert!(tool_caps.is_some());
-        assert_eq!(
-            tool_caps
-                .and_then(|c| c.get("total"))
-                .and_then(|v| v.as_i64()),
-            Some(0)
-        );
-
-        let resource_caps = data.get("resourceCapabilities");
-        assert!(resource_caps.is_some());
-        assert_eq!(
-            resource_caps
-                .and_then(|c| c.get("total"))
-                .and_then(|v| v.as_i64()),
-            Some(0)
         );
     }
 

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -17,7 +17,6 @@ use wanaku_praxis_apis::feature::Feature;
 use wanaku_praxis_apis::registry::InMemoryRegistry;
 
 use self::handlers::{
-    handle_capability_list, handle_capability_state,
     handle_forward_create, handle_forward_delete, handle_forward_get, handle_forward_list,
     handle_forward_refresh,
     handle_namespace_create, handle_namespace_delete, handle_namespace_get, handle_namespace_list,
@@ -30,9 +29,9 @@ use self::handlers::{
 };
 use self::response::{json_err, json_ok, raw_json_response, read_body, redirect_response};
 use self::routes::{
-    CapabilityRoute, ForwardRoute, ManagementRoute, NamespaceRoute,
+    ForwardRoute, ManagementRoute, NamespaceRoute,
     PromptRoute, ResourceRoute, ToolRoute,
-    resolve_capability_route, resolve_forward_route,
+    resolve_forward_route,
     resolve_management_route, resolve_namespace_route,
     resolve_prompt_route, resolve_resource_route,
     resolve_tool_route,
@@ -100,17 +99,6 @@ impl ServeHttp for WanakuManagementService {
             return match mgmt_route {
                 ManagementRoute::Statistics => handle_statistics(&self.registry),
                 ManagementRoute::NotFound => json_err(404, "not found"),
-            };
-        }
-
-        let capability_route = resolve_capability_route(&method, &path);
-        if capability_route != CapabilityRoute::NotFound {
-            return match capability_route {
-                CapabilityRoute::List => handle_capability_list(&self.registry),
-                CapabilityRoute::ToolsState => handle_capability_state(),
-                CapabilityRoute::ResourcesState => handle_capability_state(),
-                CapabilityRoute::FleetStatus => json_ok(&serde_json::json!({})),
-                CapabilityRoute::NotFound => json_err(404, "not found"),
             };
         }
 

--- a/server/src/management/routes.rs
+++ b/server/src/management/routes.rs
@@ -105,34 +105,6 @@ pub(super) fn resolve_management_route(method: &str, path: &str) -> ManagementRo
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(super) enum CapabilityRoute {
-    List,
-    ToolsState,
-    ResourcesState,
-    FleetStatus,
-    NotFound,
-}
-
-pub(super) fn resolve_capability_route(method: &str, path: &str) -> CapabilityRoute {
-    let suffix = match path.strip_prefix("/api/v1/capabilities") {
-        Some(s) => s,
-        None => return CapabilityRoute::NotFound,
-    };
-
-    if method != "GET" {
-        return CapabilityRoute::NotFound;
-    }
-
-    match suffix {
-        "" | "/" => CapabilityRoute::List,
-        "/tools/state" => CapabilityRoute::ToolsState,
-        "/resources/state" => CapabilityRoute::ResourcesState,
-        "/fleet/status" => CapabilityRoute::FleetStatus,
-        _ => CapabilityRoute::NotFound,
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
 pub(super) enum ForwardRoute {
     List,
     GetByName(String),

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -204,28 +204,6 @@ fn clear_interactions() {}
 )]
 fn get_statistics() {}
 
-// -- Capabilities -------------------------------------------------------------
-
-#[utoipa::path(get, path = "/api/v1/capabilities", tag = "Capabilities",
-    responses((status = 200, description = "List registered capabilities/targets", body = Vec<serde_json::Value>))
-)]
-fn list_capabilities() {}
-
-#[utoipa::path(get, path = "/api/v1/capabilities/tools/state", tag = "Capabilities",
-    responses((status = 200, description = "Tool capabilities state", body = serde_json::Value))
-)]
-fn capabilities_tools_state() {}
-
-#[utoipa::path(get, path = "/api/v1/capabilities/resources/state", tag = "Capabilities",
-    responses((status = 200, description = "Resource capabilities state", body = serde_json::Value))
-)]
-fn capabilities_resources_state() {}
-
-#[utoipa::path(get, path = "/api/v1/capabilities/fleet/status", tag = "Capabilities",
-    responses((status = 200, description = "Fleet status", body = serde_json::Value))
-)]
-fn capabilities_fleet_status() {}
-
 // -- OpenAPI Aggregation ------------------------------------------------------
 
 #[derive(OpenApi)]
@@ -244,7 +222,6 @@ fn capabilities_fleet_status() {}
         list_forwards, get_forward, create_forward, delete_forward, refresh_forward,
         list_interactions, clear_interactions,
         get_statistics,
-        list_capabilities, capabilities_tools_state, capabilities_resources_state, capabilities_fleet_status,
     ),
     components(schemas(
         ToolEntry, ResourceEntry, PromptEntry, PromptArgument, PromptMessage,


### PR DESCRIPTION
## Summary
- Remove `/api/v1/capabilities` endpoints (list, tools/state, resources/state, fleet/status) from the management API
- Remove `CapabilityRoute` enum, resolver, and dispatch logic
- Remove `handle_capability_list` and `handle_capability_state` handlers
- Remove capability OpenAPI stubs from the spec
- Drop zeroed-out `toolCapabilities`/`resourceCapabilities` from the statistics response
- Remove associated tests (`capability_list_returns_empty`, `capability_state_returns_empty_object`, `statistics_includes_capability_fields`)

Follow-up to #1804 which removed the UI side.

## Test plan
- [x] All 82 server crate tests pass
- [x] TypeScript UI compiles cleanly
- [ ] Verify `GET /api/v1/capabilities` returns 404
- [ ] Verify `GET /api/v1/management/statistics` no longer includes capability fields
- [ ] Verify `/openapi.json` no longer lists capability endpoints

## Summary by Sourcery

Remove legacy capabilities endpoints and related routing from the management API, and stop exposing capability fields in statistics and OpenAPI.

Enhancements:
- Simplify management service routing by dropping capability-specific route resolution and handlers.
- Streamline statistics responses by omitting unused tool/resource capability fields.

Documentation:
- Update OpenAPI specification to no longer describe capabilities endpoints.

Tests:
- Remove tests that exercised capabilities handlers and capability-related statistics fields.