### PR TITLE
fix: forward Accept header from plugin proxy to upstream services

### DIFF
--- a/apis/src/feature.rs
+++ b/apis/src/feature.rs
@@ -15,6 +15,7 @@ pub trait Feature: Send + Sync {
         path: &str,
         query: Option<&str>,
         body: Option<&str>,
+        headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>>;
 
     fn load_yaml_config(&self, root: &serde_yaml::Value);

--- a/features/chat/src/lib.rs
+++ b/features/chat/src/lib.rs
@@ -53,6 +53,7 @@ impl Feature for ChatFeature {
         path: &str,
         _query: Option<&str>,
         body: Option<&str>,
+        _headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>> {
         let route = resolve_chat_route(method, path);
         if route == ChatRoute::NotFound {

--- a/features/evaluator/src/lib.rs
+++ b/features/evaluator/src/lib.rs
@@ -69,6 +69,7 @@ impl Feature for EvaluatorFeature {
         path: &str,
         _query: Option<&str>,
         body: Option<&str>,
+        _headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>> {
         let route = resolve_evaluator_route(method, path);
         if route == EvaluatorRoute::NotFound {

--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -68,6 +68,7 @@ impl Feature for InterceptFeature {
         path: &str,
         _query: Option<&str>,
         _body: Option<&str>,
+        _headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>> {
         let route = resolve_interaction_route(method, path);
         if route == InteractionRoute::NotFound {

--- a/features/mcp-metadata/src/lib.rs
+++ b/features/mcp-metadata/src/lib.rs
@@ -59,6 +59,7 @@ impl Feature for McpMetadataFeature {
         _path: &str,
         _query: Option<&str>,
         _body: Option<&str>,
+        _headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>> {
         None
     }

--- a/features/plugins/src/handlers.rs
+++ b/features/plugins/src/handlers.rs
@@ -61,6 +61,7 @@ pub(crate) async fn handle_proxy_service(
     query: Option<&str>,
     method: &str,
     body: Option<&str>,
+    headers: &http::HeaderMap,
 ) -> Response<Vec<u8>> {
     let url = match query {
         Some(q) => format!("{target_url}{path}?{q}"),
@@ -73,6 +74,12 @@ pub(crate) async fn handle_proxy_service(
     };
 
     let mut request = client.request(req_method, &url);
+
+    let accept = headers
+        .get(http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json");
+    request = request.header(http::header::ACCEPT, accept);
 
     if let Some(b) = body {
         request = request

--- a/features/plugins/src/lib.rs
+++ b/features/plugins/src/lib.rs
@@ -121,6 +121,7 @@ impl Feature for PluginsFeature {
         path: &str,
         query: Option<&str>,
         body: Option<&str>,
+        headers: &http::HeaderMap,
     ) -> Option<Response<Vec<u8>>> {
         let route = resolve_plugin_route(method, path);
         if route == PluginRoute::NotFound {
@@ -151,6 +152,7 @@ impl Feature for PluginsFeature {
                             query,
                             method,
                             body,
+                            headers,
                         )
                         .await
                     }

--- a/features/plugins/src/routes.rs
+++ b/features/plugins/src/routes.rs
@@ -76,8 +76,9 @@ pub(crate) async fn handle_proxy(
     query: Option<&str>,
     method: &str,
     body: Option<&str>,
+    headers: &http::HeaderMap,
 ) -> Response<Vec<u8>> {
-    handlers::handle_proxy_service(client, target_url, path, query, method, body).await
+    handlers::handle_proxy_service(client, target_url, path, query, method, body, headers).await
 }
 
 #[cfg(test)]

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -72,10 +72,12 @@ impl WanakuManagementService {
 #[async_trait]
 impl ServeHttp for WanakuManagementService {
     async fn response(&self, http_session: &mut ServerSession) -> Response<Vec<u8>> {
-        let uri = &http_session.req_header().uri;
+        let req = http_session.req_header();
+        let uri = &req.uri;
         let path = uri.path().to_owned();
         let query = uri.query().map(|q| q.to_owned());
-        let method = http_session.req_header().method.as_str().to_owned();
+        let method = req.method.as_str().to_owned();
+        let headers = req.headers.clone();
 
         if path == "/healthz" || path == "/health" {
             return json_ok(&serde_json::json!({"status": "ok"}));
@@ -198,7 +200,7 @@ impl ServeHttp for WanakuManagementService {
 
         for feature in &self.features {
             if let Some(response) = feature
-                .handle_route(&method, &path, query.as_deref(), feature_body.as_deref())
+                .handle_route(&method, &path, query.as_deref(), feature_body.as_deref(), &headers)
                 .await
             {
                 return response;

--- a/ui/admin/src/plugins/plugin-host.ts
+++ b/ui/admin/src/plugins/plugin-host.ts
@@ -30,13 +30,16 @@ export function createPluginHost(
     },
     http: {
       async get<T>(service: string, path: string): Promise<T> {
-        const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, { method: "GET" });
+        const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, {
+          method: "GET",
+          headers: { "Accept": "application/json" },
+        });
         return res.data as T;
       },
       async post<T>(service: string, path: string, body?: unknown): Promise<T> {
         const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", "Accept": "application/json" },
           body: body ? JSON.stringify(body) : undefined,
         });
         return res.data as T;
@@ -44,13 +47,16 @@ export function createPluginHost(
       async put<T>(service: string, path: string, body?: unknown): Promise<T> {
         const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", "Accept": "application/json" },
           body: body ? JSON.stringify(body) : undefined,
         });
         return res.data as T;
       },
       async delete<T>(service: string, path: string): Promise<T> {
-        const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, { method: "DELETE" });
+        const res: Record<string, unknown> = await customFetch(`/api/plugins/${pluginId}/${service}${path}`, {
+          method: "DELETE",
+          headers: { "Accept": "application/json" },
+        });
         return res.data as T;
       },
     },


### PR DESCRIPTION
## Summary

- The plugin proxy (`features/plugins/src/handlers.rs`) was not forwarding request headers to the upstream service. Backends using content negotiation (e.g., Camel's dev console) returned `text/plain` instead of `application/json` because they never saw `Accept: application/json`.
- Added `headers: &http::HeaderMap` to the `Feature::handle_route` trait so features can access incoming request headers.
- The plugin proxy now extracts and forwards the `Accept` header, defaulting to `application/json` when absent.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 209 tests pass
- [ ] Manual: start server, register a plugin service, send a request with `Accept: application/json` and verify the upstream receives it
- [ ] Manual: send a request without an `Accept` header and verify the upstream receives `application/json` as default

## Summary by Sourcery

Forward HTTP request headers, including Accept, from the management service to features so the plugin proxy can propagate content negotiation to upstream services.

Bug Fixes:
- Ensure plugin proxy forwards the incoming Accept header to upstream services, defaulting to application/json when absent.

Enhancements:
- Extend the Feature::handle_route interface to expose incoming HTTP headers to feature implementations.