### PR TITLE
feat: capture MCP server identity during forward discovery

### DIFF
--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -13,6 +13,8 @@ use rmcp::{
 };
 use serde_json::Value;
 
+use crate::registry::McpServerInfo;
+
 const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_TOOLS: usize = 500;
 const MAX_RESOURCES: usize = 500;
@@ -413,4 +415,264 @@ pub async fn get_prompt(
         prompt_name: prompt_name.to_owned(),
         message: e.to_string(),
     })
+}
+
+#[derive(Debug)]
+pub struct ForwardDiscovery {
+    pub server_info: Option<McpServerInfo>,
+    pub tools: Vec<Value>,
+    pub resources: Vec<Value>,
+    pub resource_templates: Vec<Value>,
+    pub prompts: Vec<Value>,
+}
+
+pub async fn discover_forward(url: &str) -> Result<ForwardDiscovery, McpClientError> {
+    let url = url.to_owned();
+    let transport = build_transport(&url);
+
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+        .await
+        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|e| McpClientError::Connection {
+            url: url.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    tracing::debug!(url = %url, "connected to MCP server for forward discovery");
+
+    let server_info = client.peer_info().and_then(|info| {
+        let impl_info = info.server_info.as_ref()?;
+
+        let mut capabilities = Vec::new();
+        if info.capabilities.tools.is_some() {
+            capabilities.push("tools".to_owned());
+        }
+        if info.capabilities.resources.is_some() {
+            capabilities.push("resources".to_owned());
+        }
+        if info.capabilities.prompts.is_some() {
+            capabilities.push("prompts".to_owned());
+        }
+        if info.capabilities.logging.is_some() {
+            capabilities.push("logging".to_owned());
+        }
+        if info.capabilities.completions.is_some() {
+            capabilities.push("completions".to_owned());
+        }
+
+        let extensions = info
+            .capabilities
+            .extensions
+            .as_ref()
+            .map(|ext| ext.keys().cloned().collect())
+            .unwrap_or_default();
+
+        Some(McpServerInfo {
+            server_name: impl_info.name.clone(),
+            version: impl_info.version.clone(),
+            description: impl_info.description.clone(),
+            website_url: impl_info.website_url.clone(),
+            capabilities,
+            extensions,
+            instructions: info.instructions.clone(),
+        })
+    });
+
+    if let Some(ref si) = server_info {
+        tracing::info!(
+            url = %url,
+            server_name = %si.server_name,
+            version = %si.version,
+            "captured MCP server identity"
+        );
+    }
+
+    let tools = discover_tools_on_session(&client, &url).await;
+    let resources = discover_resources_on_session(&client, &url).await;
+    let resource_templates = discover_resource_templates_on_session(&client, &url).await;
+    let prompts = discover_prompts_on_session(&client, &url).await;
+
+    Ok(ForwardDiscovery {
+        server_info,
+        tools,
+        resources,
+        resource_templates,
+        prompts,
+    })
+}
+
+async fn discover_tools_on_session(
+    client: &rmcp::service::Peer<rmcp::RoleClient>,
+    url: &str,
+) -> Vec<Value> {
+    let mut all_tools = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page = match tokio::time::timeout(TIMEOUT, Box::pin(client.list_tools(Some(params))))
+            .await
+        {
+            Ok(Ok(page)) => page,
+            Ok(Err(e)) => {
+                tracing::warn!(url = %url, error = %e, "tools/list failed during discovery");
+                break;
+            }
+            Err(_) => {
+                tracing::warn!(url = %url, "tools/list timed out during discovery");
+                break;
+            }
+        };
+
+        all_tools.extend(page.tools);
+        if all_tools.len() >= MAX_TOOLS {
+            all_tools.truncate(MAX_TOOLS);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, tool_count = all_tools.len(), "discovered tools");
+
+    all_tools
+        .into_iter()
+        .filter_map(|t| serde_json::to_value(t).ok())
+        .collect()
+}
+
+async fn discover_resources_on_session(
+    client: &rmcp::service::Peer<rmcp::RoleClient>,
+    url: &str,
+) -> Vec<Value> {
+    let mut all_resources = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page =
+            match tokio::time::timeout(TIMEOUT, Box::pin(client.list_resources(Some(params))))
+                .await
+            {
+                Ok(Ok(page)) => page,
+                Ok(Err(e)) => {
+                    tracing::warn!(url = %url, error = %e, "resources/list failed during discovery");
+                    break;
+                }
+                Err(_) => {
+                    tracing::warn!(url = %url, "resources/list timed out during discovery");
+                    break;
+                }
+            };
+
+        all_resources.extend(page.resources);
+        if all_resources.len() >= MAX_RESOURCES {
+            all_resources.truncate(MAX_RESOURCES);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, resource_count = all_resources.len(), "discovered resources");
+
+    all_resources
+        .into_iter()
+        .filter_map(|r| serde_json::to_value(r).ok())
+        .collect()
+}
+
+async fn discover_resource_templates_on_session(
+    client: &rmcp::service::Peer<rmcp::RoleClient>,
+    url: &str,
+) -> Vec<Value> {
+    let mut all_templates = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page = match tokio::time::timeout(
+            TIMEOUT,
+            Box::pin(client.list_resource_templates(Some(params))),
+        )
+        .await
+        {
+            Ok(Ok(page)) => page,
+            Ok(Err(e)) => {
+                tracing::debug!(url = %url, error = %e, "resource_templates/list not supported");
+                break;
+            }
+            Err(_) => {
+                tracing::warn!(url = %url, "resource_templates/list timed out during discovery");
+                break;
+            }
+        };
+
+        all_templates.extend(page.resource_templates);
+        if all_templates.len() >= MAX_RESOURCE_TEMPLATES {
+            all_templates.truncate(MAX_RESOURCE_TEMPLATES);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, template_count = all_templates.len(), "discovered resource templates");
+
+    all_templates
+        .into_iter()
+        .filter_map(|t| serde_json::to_value(t).ok())
+        .collect()
+}
+
+async fn discover_prompts_on_session(
+    client: &rmcp::service::Peer<rmcp::RoleClient>,
+    url: &str,
+) -> Vec<Value> {
+    let mut all_prompts = Vec::new();
+    let mut cursor = None;
+
+    for _ in 0..100 {
+        let params = PaginatedRequestParams::default().with_cursor(cursor);
+        let page =
+            match tokio::time::timeout(TIMEOUT, Box::pin(client.list_prompts(Some(params)))).await
+            {
+                Ok(Ok(page)) => page,
+                Ok(Err(e)) => {
+                    tracing::warn!(url = %url, error = %e, "prompts/list failed during discovery");
+                    break;
+                }
+                Err(_) => {
+                    tracing::warn!(url = %url, "prompts/list timed out during discovery");
+                    break;
+                }
+            };
+
+        all_prompts.extend(page.prompts);
+        if all_prompts.len() >= MAX_PROMPTS {
+            all_prompts.truncate(MAX_PROMPTS);
+            break;
+        }
+
+        match page.next_cursor {
+            Some(next) if !next.is_empty() => cursor = Some(next),
+            _ => break,
+        }
+    }
+
+    tracing::debug!(url = %url, prompt_count = all_prompts.len(), "discovered prompts");
+
+    all_prompts
+        .into_iter()
+        .filter_map(|p| serde_json::to_value(p).ok())
+        .collect()
 }

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -93,11 +93,32 @@ pub struct PromptEntry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct McpServerInfo {
+    #[serde(rename = "serverName", alias = "server_name")]
+    pub server_name: String,
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "websiteUrl", alias = "website_url")]
+    pub website_url: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ForwardEntry {
     pub name: String,
     pub address: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "serverInfo", alias = "server_info")]
+    pub server_info: Option<McpServerInfo>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -819,5 +840,78 @@ mod tests {
         let props = stored.input_schema["properties"].as_object().expect("has properties");
         assert_eq!(props.len(), 2, "x-request-id should be injected when flag is enabled");
         assert!(props.contains_key("x-request-id"));
+    }
+
+    #[test]
+    fn mcp_server_info_serde_round_trip() {
+        let info = McpServerInfo {
+            server_name: "apache-camel".to_owned(),
+            version: "4.22.0".to_owned(),
+            description: Some("Apache Camel MCP server".to_owned()),
+            website_url: Some("https://camel.apache.org".to_owned()),
+            capabilities: vec!["tools".to_owned(), "resources".to_owned()],
+            extensions: vec!["io.apache.camel/routes".to_owned()],
+            instructions: Some("A Camel MCP server".to_owned()),
+        };
+
+        let json = serde_json::to_string(&info).expect("serialize");
+        let parsed: McpServerInfo = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(parsed.server_name, "apache-camel");
+        assert_eq!(parsed.version, "4.22.0");
+        assert_eq!(parsed.description.as_deref(), Some("Apache Camel MCP server"));
+        assert_eq!(parsed.website_url.as_deref(), Some("https://camel.apache.org"));
+        assert_eq!(parsed.capabilities.len(), 2);
+        assert_eq!(parsed.extensions.len(), 1);
+        assert_eq!(parsed.instructions.as_deref(), Some("A Camel MCP server"));
+    }
+
+    #[test]
+    fn mcp_server_info_camel_case_keys() {
+        let info = McpServerInfo {
+            server_name: "test".to_owned(),
+            version: "1.0".to_owned(),
+            description: None,
+            website_url: Some("https://example.com".to_owned()),
+            capabilities: Vec::new(),
+            extensions: Vec::new(),
+            instructions: None,
+        };
+
+        let json = serde_json::to_string(&info).expect("serialize");
+        assert!(json.contains("\"serverName\""), "expected camelCase key");
+        assert!(!json.contains("\"server_name\""), "unexpected snake_case key");
+        assert!(json.contains("\"websiteUrl\""), "expected camelCase websiteUrl");
+        assert!(!json.contains("\"website_url\""), "unexpected snake_case website_url");
+    }
+
+    #[test]
+    fn forward_entry_with_server_info_round_trip() {
+        let json = r#"{
+            "name": "camel-prod",
+            "address": "http://localhost:8180/mcp",
+            "serverInfo": {
+                "serverName": "apache-camel",
+                "version": "4.22.0",
+                "capabilities": ["tools"]
+            },
+            "labels": {"type": "camel"}
+        }"#;
+
+        let entry: ForwardEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(entry.name, "camel-prod");
+        assert!(entry.server_info.is_some());
+        let si = entry.server_info.as_ref().unwrap();
+        assert_eq!(si.server_name, "apache-camel");
+        assert_eq!(entry.labels.get("type").map(|s| s.as_str()), Some("camel"));
+    }
+
+    #[test]
+    fn forward_entry_without_server_info_backward_compat() {
+        let json = r#"{"name": "legacy", "address": "http://x:1"}"#;
+        let entry: ForwardEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(entry.name, "legacy");
+        assert!(entry.server_info.is_none());
+        assert!(entry.labels.is_empty());
     }
 }

--- a/forward-supported-plugins.md
+++ b/forward-supported-plugins.md
@@ -1,0 +1,106 @@
+# Forward-Supported Plugins
+
+Design notes for linking forwarded MCP server identity to UI plugins.
+
+## Context
+
+Wanaku now captures `McpServerInfo` (server name, version, capabilities, extensions) during forward discovery via `peer_info()`. The admin UI shows this in the forwards table. This document describes the next step: letting plugins discover which forwards they support and interact with them.
+
+## Problem
+
+The existing plugin system is UI-only — plugins add pages and navigation, and can proxy HTTP calls to backend services. But plugins have no awareness of forwarded MCP servers. A Camel plugin can't discover that a "camel-prod" forward exists, what type of server it is, or call its tools.
+
+## Research Findings: MCP Server Identity
+
+Investigation of the three MCP server stacks in the ecosystem:
+
+| Field | Camel MCP (4.22.0) | Quarkiverse MCP (1.13.1) | Wanaku Praxis (Rust) |
+|---|---|---|---|
+| `serverInfo.name` | `camelContext.getName()` (auto-generated, e.g. `"camel-1"`) | `quarkus.application.name` or `"N/A"` | `"wanaku-praxis"` |
+| `serverInfo.version` | `camelContext.getVersion()` (e.g. `"4.22.0"`) | `quarkus.application.version` or `"N/A"` | `"0.3.0"` |
+| `experimental`/`extensions` | none | none | none |
+
+**Key finding:** Camel MCP servers default to auto-generated names — not useful for type identification. The config option `camel.server.mcp-server-name` exists but the Wanaku Camel integration doesn't set it. No server in the ecosystem uses `experimental` or `extensions` fields.
+
+## Proposed Design
+
+### Plugin Manifest Extension
+
+Add optional `mcpServers` field to `plugin.json`:
+
+```json
+{
+  "id": "camel-plugin",
+  "name": "Apache Camel",
+  "mcpServers": {
+    "matchNames": ["apache-camel*"],
+    "matchTools": ["camel_*"],
+    "matchLabels": {"type": "camel"}
+  }
+}
+```
+
+Three matching strategies (any match activates):
+- `matchNames` — glob patterns against `serverInfo.serverName`
+- `matchTools` — glob patterns against discovered tool names for that forward
+- `matchLabels` — key-value pairs that must all match forward labels
+
+### Server-Side Matching Endpoint
+
+`GET /api/v1/plugins/{id}/forwards` — returns forwards matching this plugin's `mcpServers` declaration.
+
+### PluginHost API Extension
+
+```typescript
+export interface ForwardsAPI {
+  list(): Promise<ForwardEntry[]>;
+  listMatching(): Promise<ForwardEntry[]>;
+}
+
+export interface McpAPI {
+  callTool(forwardName: string, toolName: string, args: object): Promise<unknown>;
+}
+```
+
+Plugins call `host.forwards.listMatching()` at activation to find their forwards, and `host.mcp.callTool()` to interact with them.
+
+### Communication Channels
+
+1. **MCP tool calls via PluginHost** — proxied through management API to `mcp_client::call_tool()`. A Camel server exposes tools like `camel_get_routes` — the plugin calls them directly.
+2. **HTTP proxy (already exists)** — if the MCP server also exposes REST endpoints, the plugin's `host.http` proxy reaches them via service mapping in `wanaku.yaml`.
+
+### End-to-End Flow
+
+```
+1. Admin registers forward with labels: {"type": "camel"}
+2. Server captures McpServerInfo {serverName: "apache-camel", ...}
+3. Plugin "camel-plugin" activates, calls host.forwards.listMatching()
+4. Server matches: matchNames ✓ OR matchTools "camel_*" ✓ OR matchLabels ✓
+5. Plugin gets [{name: "camel-prod", serverInfo: {...}, labels: {...}}]
+6. Plugin registers "Camel: camel-prod" nav entry and page
+7. Page calls host.mcp.callTool("camel-prod", "camel_get_routes", {})
+8. Plugin renders route topology
+```
+
+## Open Questions
+
+1. **Camel server naming convention** — need upstream change in wanaku-barn to set `camel.server.mcp-server-name` to a well-known value (e.g., `"apache-camel"`).
+
+2. **Live discovery notifications** — should plugins be notified when a new matching forward appears? Polling is simpler to start.
+
+3. **MCP session persistence** — ephemeral connections are fine initially; optimize with a connection pool if latency becomes an issue.
+
+4. **Namespace scoping** — should plugins be restricted to forwards in specific namespaces? The existing `permissions` field in plugin manifests is reserved but not enforced.
+
+5. **Camel-specific tools** — does the Camel MCP server expose introspection tools (get routes, get context, etc.) today? If not, that's upstream work.
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `features/plugins/src/manifest.rs` | Add `mcpServers` field to `PluginManifest` |
+| `features/plugins/src/lib.rs` | Server-side matching logic |
+| `ui/admin/src/plugins/types.ts` | Add `ForwardsAPI` and `McpAPI` to `PluginHost` |
+| `ui/admin/src/plugins/plugin-host.ts` | Implement the new APIs |
+| `apis/src/registry.rs` | `ForwardEntry` already has `server_info` and `labels` |
+| `apis/src/mcp_client.rs` | `call_tool()` already exists for MCP proxying |

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -210,12 +210,8 @@ fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
 
             rt.block_on(async {
                 for fwd in &forwards {
-                    info!(forward = %fwd.name, address = %fwd.address, "discovering tools and resources from forward");
-                    let tools_count =
-                        wanaku_praxis::management::discover_tools_from_forward(&reg, fwd).await;
-                    let resources_count =
-                        wanaku_praxis::management::discover_resources_from_forward(&reg, fwd).await;
-                    info!(forward = %fwd.name, tools_discovered = tools_count, resources_discovered = resources_count, "forward discovery complete");
+                    info!(forward = %fwd.name, address = %fwd.address, "discovering from forward");
+                    wanaku_praxis::management::discover_and_update_forward(&reg, fwd).await;
                 }
             });
         });

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -268,7 +268,7 @@ pub(super) fn handle_forward_get(registry: &InMemoryRegistry, name: &str) -> Res
 
 pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &str) -> Response<Vec<u8>> {
     tracing::debug!(body = %body, "forward create request body");
-    let forward: ForwardEntry = match serde_json::from_str(body) {
+    let mut forward: ForwardEntry = match serde_json::from_str(body) {
         Ok(f) => f,
         Err(e) => {
             warn!(error = %e, "invalid forward JSON");
@@ -276,12 +276,27 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
         }
     };
 
+    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(forward = %forward.name, error = %e, "forward discovery failed");
+            registry.register_forward(forward.clone());
+            return json_ok(&serde_json::json!({
+                "forward": &forward,
+                "tools_discovered": 0,
+                "resources_discovered": 0,
+                "prompts_discovered": 0,
+            }));
+        }
+    };
+
+    forward.server_info = discovery.server_info;
     info!(forward = %forward.name, address = %forward.address, "registered forward via management API");
     registry.register_forward(forward.clone());
 
-    let tools_count = discover_tools_from_forward(registry, &forward).await;
-    let resources_count = discover_resources_from_forward(registry, &forward).await;
-    let prompts_count = discover_prompts_from_forward(registry, &forward).await;
+    let tools_count = register_discovered_tools(registry, &forward, &discovery.tools);
+    let resources_count = register_discovered_resources(registry, &forward, &discovery.resources, &discovery.resource_templates);
+    let prompts_count = register_discovered_prompts(registry, &forward, &discovery.prompts);
 
     json_ok(&serde_json::json!({
         "forward": &forward,
@@ -309,7 +324,7 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
 }
 
 pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
-    let forward = match registry.get_forward(name) {
+    let mut forward = match registry.get_forward(name) {
         Some(f) => f,
         None => return json_err(404, &format!("forward not found: {name}")),
     };
@@ -317,12 +332,50 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
     remove_forwarded_tools(registry, &forward.address);
     remove_forwarded_resources(registry, &forward.address);
     remove_forwarded_prompts(registry, &forward.address);
-    let tools_count = discover_tools_from_forward(registry, &forward).await;
-    let resources_count = discover_resources_from_forward(registry, &forward).await;
-    let prompts_count = discover_prompts_from_forward(registry, &forward).await;
+
+    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(forward = %name, error = %e, "forward refresh discovery failed");
+            return json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": 0, "resources_discovered": 0, "prompts_discovered": 0}));
+        }
+    };
+
+    forward.server_info = discovery.server_info;
+    registry.register_forward(forward.clone());
+
+    let tools_count = register_discovered_tools(registry, &forward, &discovery.tools);
+    let resources_count = register_discovered_resources(registry, &forward, &discovery.resources, &discovery.resource_templates);
+    let prompts_count = register_discovered_prompts(registry, &forward, &discovery.prompts);
 
     info!(forward = %name, tools_discovered = tools_count, resources_discovered = resources_count, prompts_discovered = prompts_count, "refreshed forward");
     json_ok(&serde_json::json!({"refreshed": name, "tools_discovered": tools_count, "resources_discovered": resources_count, "prompts_discovered": prompts_count}))
+}
+
+pub async fn discover_and_update_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) {
+    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(forward = %forward.name, error = %e, "forward discovery failed at startup");
+            return;
+        }
+    };
+
+    let mut updated = forward.clone();
+    updated.server_info = discovery.server_info;
+    registry.register_forward(updated.clone());
+
+    let tools_count = register_discovered_tools(registry, &updated, &discovery.tools);
+    let resources_count = register_discovered_resources(registry, &updated, &discovery.resources, &discovery.resource_templates);
+    let prompts_count = register_discovered_prompts(registry, &updated, &discovery.prompts);
+
+    info!(
+        forward = %forward.name,
+        tools_discovered = tools_count,
+        resources_discovered = resources_count,
+        prompts_discovered = prompts_count,
+        "forward discovery complete"
+    );
 }
 
 pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
@@ -334,10 +387,14 @@ pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &
         }
     };
 
+    register_discovered_tools(registry, forward, &tools)
+}
+
+fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry, tools: &[serde_json::Value]) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
-    for tool_json in &tools {
+    for tool_json in tools {
         let name = match tool_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
             Some(n) if !n.is_empty() => n,
             _ => {
@@ -384,10 +441,27 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
         }
     };
 
+    let templates = match wanaku_praxis_apis::mcp_client::list_resource_templates(&forward.address).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::debug!(forward = %forward.name, error = %e, "no resource templates from forward (may not be supported)");
+            Vec::new()
+        }
+    };
+
+    register_discovered_resources(registry, forward, &resources, &templates)
+}
+
+fn register_discovered_resources(
+    registry: &InMemoryRegistry,
+    forward: &ForwardEntry,
+    resources: &[serde_json::Value],
+    templates: &[serde_json::Value],
+) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
-    for res_json in &resources {
+    for res_json in resources {
         let name = match res_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
             Some(n) if !n.is_empty() => n,
             _ => {
@@ -435,15 +509,7 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
         count += 1;
     }
 
-    let templates = match wanaku_praxis_apis::mcp_client::list_resource_templates(&forward.address).await {
-        Ok(t) => t,
-        Err(e) => {
-            tracing::debug!(forward = %forward.name, error = %e, "no resource templates from forward (may not be supported)");
-            return count;
-        }
-    };
-
-    for tmpl_json in &templates {
+    for tmpl_json in templates {
         let name = match tmpl_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
             Some(n) if !n.is_empty() => n,
             _ => {
@@ -529,10 +595,18 @@ pub async fn discover_prompts_from_forward(registry: &InMemoryRegistry, forward:
         }
     };
 
+    register_discovered_prompts(registry, forward, &prompts)
+}
+
+fn register_discovered_prompts(
+    registry: &InMemoryRegistry,
+    forward: &ForwardEntry,
+    prompts: &[serde_json::Value],
+) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
-    for prompt_json in &prompts {
+    for prompt_json in prompts {
         let name = match prompt_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
             Some(n) if !n.is_empty() => n,
             _ => {
@@ -754,6 +828,8 @@ pub(super) fn handle_statistics(registry: &InMemoryRegistry) -> Response<Vec<u8>
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use http::Response;
     use wanaku_praxis_apis::registry::{
         ForwardEntry, ForwardRegistry, InMemoryRegistry,
@@ -1245,6 +1321,8 @@ mod tests {
             name: "upstream".to_owned(),
             address: "http://remote:8080".to_owned(),
             namespace: None,
+            server_info: None,
+            labels: HashMap::new(),
         });
 
         let list_resp = handle_forward_list(&registry);
@@ -1277,6 +1355,8 @@ mod tests {
             name: "del-fwd".to_owned(),
             address: "http://x:1".to_owned(),
             namespace: None,
+            server_info: None,
+            labels: HashMap::new(),
         });
         assert_eq!(handle_forward_delete(&registry, "del-fwd").status(), 200);
         assert_eq!(handle_forward_get(&registry, "del-fwd").status(), 404);
@@ -1330,6 +1410,8 @@ mod tests {
             name: "f1".to_owned(),
             address: "http://x:1".to_owned(),
             namespace: None,
+            server_info: None,
+            labels: HashMap::new(),
         });
 
         let data = data_field(&handle_statistics(&registry));

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -3,6 +3,7 @@ mod response;
 mod routes;
 mod ui;
 
+pub use handlers::discover_and_update_forward;
 pub use handlers::discover_tools_from_forward;
 pub use handlers::discover_resources_from_forward;
 pub use handlers::discover_prompts_from_forward;

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -4,8 +4,8 @@ use utoipa::OpenApi;
 
 use wanaku_praxis_apis::interactions::Interaction;
 use wanaku_praxis_apis::registry::{
-    ForwardEntry, NamespaceEntry, PromptArgument, PromptEntry, PromptMessage, ResourceEntry,
-    ToolEntry,
+    ForwardEntry, McpServerInfo, NamespaceEntry, PromptArgument, PromptEntry, PromptMessage,
+    ResourceEntry, ToolEntry,
 };
 
 #[derive(serde::Serialize, utoipa::ToSchema)]
@@ -225,7 +225,7 @@ fn get_statistics() {}
     ),
     components(schemas(
         ToolEntry, ResourceEntry, PromptEntry, PromptArgument, PromptMessage,
-        ForwardEntry, NamespaceEntry, Interaction,
+        ForwardEntry, McpServerInfo, NamespaceEntry, Interaction,
     ))
 )]
 pub struct ApiDoc;

--- a/tests/e2e/ui/helpers/api-helpers.ts
+++ b/tests/e2e/ui/helpers/api-helpers.ts
@@ -74,4 +74,24 @@ export class ApiHelper {
   async deletePrompt(name: string) {
     return this.request.delete(`${this.baseUrl}/api/v1/prompts/${name}`);
   }
+
+  async addForward(forward: { name: string; address: string; namespace?: string }) {
+    const resp = await this.request.post(`${this.baseUrl}/api/v1/forwards`, {
+      data: {
+        name: forward.name,
+        address: forward.address,
+        namespace: forward.namespace,
+      },
+    });
+    return this.assertOk(resp, `addForward(${forward.name})`);
+  }
+
+  async getForward(name: string) {
+    const resp = await this.request.get(`${this.baseUrl}/api/v1/forwards/${name}`);
+    return this.assertOk(resp, `getForward(${name})`);
+  }
+
+  async deleteForward(name: string) {
+    return this.request.delete(`${this.baseUrl}/api/v1/forwards/${name}`);
+  }
 }

--- a/tests/e2e/ui/helpers/test-data.ts
+++ b/tests/e2e/ui/helpers/test-data.ts
@@ -26,3 +26,10 @@ export function promptData(overrides?: Partial<{ name: string; description: stri
     description: overrides?.description ?? 'E2E test prompt',
   };
 }
+
+export function forwardData(overrides?: Partial<{ name: string; address: string }>) {
+  return {
+    name: overrides?.name ?? `e2e-forward-${suffix()}`,
+    address: overrides?.address ?? 'http://localhost:19999/mcp',
+  };
+}

--- a/tests/e2e/ui/pages/forwards.page.ts
+++ b/tests/e2e/ui/pages/forwards.page.ts
@@ -1,0 +1,70 @@
+import { type Page, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+import { Carbon } from '../helpers/carbon';
+
+export class ForwardsPage extends BasePage {
+  constructor(page: Page, baseUrl: string) {
+    super(page, baseUrl);
+  }
+
+  async goto() {
+    await this.navigateTo('/forwards');
+  }
+
+  async clickAddForward() {
+    await this.page.locator(Carbon.buttonWithText('Add Forward')).click();
+    await this.modal().waitFor({ state: 'visible' });
+  }
+
+  async fillForwardForm(forward: { name: string; address: string }) {
+    await this.page.locator(Carbon.textInput('forward-name')).fill(forward.name);
+    await this.page.locator(Carbon.textInput('forward-address')).fill(forward.address);
+  }
+
+  async clickDetailForward(name: string) {
+    await this.rowWithText(name).getByRole('button', { name: 'Details' }).click();
+    await this.detailModal().waitFor({ state: 'visible' });
+  }
+
+  async clickEditForward(name: string) {
+    await this.rowWithText(name).getByRole('button', { name: 'Edit' }).click();
+    await this.modal().waitFor({ state: 'visible' });
+  }
+
+  async clickDeleteForward(name: string) {
+    await this.rowWithText(name).getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async waitForForwardInTable(name: string) {
+    await expect(this.rowWithText(name)).toBeVisible({ timeout: 10_000 });
+  }
+
+  async waitForForwardRemoved(name: string) {
+    await expect(this.rowWithText(name)).toBeHidden({ timeout: 5_000 });
+  }
+
+  detailModal() {
+    return this.page.locator('.cds--modal.is-visible');
+  }
+
+  async getDetailModalHeading(): Promise<string> {
+    return this.detailModal().locator(Carbon.modalHeading).innerText();
+  }
+
+  async getDetailField(label: string): Promise<string> {
+    return this.detailModal()
+      .locator(`strong:has-text("${label}")`)
+      .locator('..')
+      .innerText();
+  }
+
+  async detailModalHasText(text: string): Promise<boolean> {
+    const content = await this.detailModal().innerText();
+    return content.includes(text);
+  }
+
+  async closeDetailModal() {
+    await this.detailModal().locator('button[aria-label="Close"]').click();
+    await this.detailModal().waitFor({ state: 'hidden', timeout: 5_000 });
+  }
+}

--- a/tests/e2e/ui/tests/forwards.spec.ts
+++ b/tests/e2e/ui/tests/forwards.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { ForwardsPage } from '../pages/forwards.page';
+import { ApiHelper } from '../helpers/api-helpers';
+import { forwardData } from '../helpers/test-data';
+
+const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
+
+test.describe('Forwards', () => {
+  let forwards: ForwardsPage;
+  let api: ApiHelper;
+  const createdForwards: string[] = [];
+
+  test.beforeEach(async ({ page, request }) => {
+    forwards = new ForwardsPage(page, `${routerUrl}/admin/`);
+    api = new ApiHelper(request, routerUrl);
+  });
+
+  test.afterEach(async () => {
+    for (const name of createdForwards) {
+      await api.deleteForward(name).catch(() => {});
+    }
+    createdForwards.length = 0;
+  });
+
+  test('displays page title', async () => {
+    await forwards.goto();
+    const title = await forwards.getPageTitle();
+    expect(title).toBe('Forwards');
+  });
+
+  test('add a forward via modal', async () => {
+    const data = forwardData();
+    createdForwards.push(data.name);
+
+    await forwards.goto();
+    await forwards.clickAddForward();
+
+    const heading = await forwards.getModalHeading();
+    expect(heading).toBe('Add a Forward');
+
+    await forwards.fillForwardForm(data);
+    await forwards.submitModal();
+
+    await forwards.waitForForwardInTable(data.name);
+  });
+
+  test('delete a forward', async () => {
+    const data = forwardData();
+    await api.addForward(data);
+
+    await forwards.goto();
+    await forwards.waitForForwardInTable(data.name);
+    await forwards.clickDeleteForward(data.name);
+
+    await forwards.waitForForwardRemoved(data.name);
+  });
+
+  test('detail modal shows forward info', async () => {
+    const data = forwardData();
+    createdForwards.push(data.name);
+    await api.addForward(data);
+
+    await forwards.goto();
+    await forwards.waitForForwardInTable(data.name);
+    await forwards.clickDetailForward(data.name);
+
+    const heading = await forwards.getDetailModalHeading();
+    expect(heading).toBe(data.name);
+
+    const hasAddress = await forwards.detailModalHasText(data.address);
+    expect(hasAddress).toBeTruthy();
+
+    await forwards.closeDetailModal();
+  });
+
+  test('detail modal shows server info section', async () => {
+    const data = forwardData();
+    createdForwards.push(data.name);
+    await api.addForward(data);
+
+    await forwards.goto();
+    await forwards.waitForForwardInTable(data.name);
+    await forwards.clickDetailForward(data.name);
+
+    const hasServerInfoHeading = await forwards.detailModalHasText('Server Info');
+    expect(hasServerInfoHeading).toBeTruthy();
+
+    await forwards.closeDetailModal();
+  });
+
+  test('server column appears in table', async () => {
+    await forwards.goto();
+    const headerText = await forwards.page.locator('th').allInnerTexts();
+    expect(headerText.some(h => h.includes('Server'))).toBeTruthy();
+  });
+});

--- a/ui/admin/src/Pages/Forwards/ForwardDetailModal.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardDetailModal.tsx
@@ -1,0 +1,116 @@
+import { ComposedModal, ModalHeader, ModalBody, Tag } from "@carbon/react";
+import React from "react";
+import { ForwardReference } from "../../models";
+
+interface ServerInfo {
+  serverName?: string;
+  version?: string;
+  description?: string;
+  websiteUrl?: string;
+  capabilities?: string[];
+  extensions?: string[];
+  instructions?: string;
+}
+
+interface ForwardDetailModalProps {
+  forward: ForwardReference;
+  onRequestClose: () => void;
+}
+
+export const ForwardDetailModal: React.FC<ForwardDetailModalProps> = ({
+  forward,
+  onRequestClose,
+}) => {
+  const si = (forward as Record<string, unknown>).serverInfo as
+    | ServerInfo
+    | undefined;
+  const labels = (forward as Record<string, unknown>).labels as
+    | Record<string, string>
+    | undefined;
+
+  return (
+    <ComposedModal open onClose={onRequestClose}>
+      <ModalHeader title={forward.name ?? "Forward Details"} />
+      <ModalBody>
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div>
+            <strong>Address:</strong> {forward.address}
+          </div>
+          <div>
+            <strong>Namespace:</strong> {forward.namespace ?? "default"}
+          </div>
+
+          <h4 style={{ marginBottom: 0 }}>Server Info</h4>
+          {si?.serverName ? (
+            <>
+              <div>
+                <strong>Name:</strong> {si.serverName}
+              </div>
+              <div>
+                <strong>Version:</strong> {si.version ?? "Unknown"}
+              </div>
+              {si.description && (
+                <div>
+                  <strong>Description:</strong> {si.description}
+                </div>
+              )}
+              {si.websiteUrl && (
+                <div>
+                  <strong>Website:</strong>{" "}
+                  <a href={si.websiteUrl} target="_blank" rel="noopener noreferrer">
+                    {si.websiteUrl}
+                  </a>
+                </div>
+              )}
+              <div>
+                <strong>Capabilities:</strong>{" "}
+                {si.capabilities && si.capabilities.length > 0
+                  ? si.capabilities.map((cap) => (
+                      <Tag key={cap} type="blue" size="sm" style={{ marginLeft: "0.25rem" }}>
+                        {cap}
+                      </Tag>
+                    ))
+                  : "None"}
+              </div>
+              <div>
+                <strong>Extensions:</strong>{" "}
+                {si.extensions && si.extensions.length > 0
+                  ? si.extensions.map((ext) => (
+                      <Tag key={ext} type="purple" size="sm" style={{ marginLeft: "0.25rem" }}>
+                        {ext}
+                      </Tag>
+                    ))
+                  : "None"}
+              </div>
+              {si.instructions && (
+                <div>
+                  <strong>Instructions:</strong>
+                  <p style={{ marginTop: "0.25rem", whiteSpace: "pre-wrap" }}>
+                    {si.instructions}
+                  </p>
+                </div>
+              )}
+            </>
+          ) : (
+            <div style={{ color: "var(--cds-text-secondary, #525252)" }}>
+              No server info available. The upstream MCP server may not report identity during initialization.
+            </div>
+          )}
+
+          {labels && Object.keys(labels).length > 0 && (
+            <>
+              <h4 style={{ marginBottom: 0 }}>Labels</h4>
+              <div>
+                {Object.entries(labels).map(([key, value]) => (
+                  <Tag key={key} type="gray" size="sm" style={{ marginRight: "0.25rem" }}>
+                    {key}={value}
+                  </Tag>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </ModalBody>
+    </ComposedModal>
+  );
+};

--- a/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
@@ -4,6 +4,7 @@ import {
 import {useEffect, useState} from "react"
 import {addForward, updateForward, listForwards, refreshForward, removeForward} from "../../hooks/api/use-forwards"
 import {ForwardReference} from "../../models"
+import {ForwardDetailModal} from "./ForwardDetailModal.tsx"
 import {ForwardModal} from "./ForwardModal.tsx"
 import {ForwardsTable} from "./ForwardsTable.tsx"
 
@@ -12,6 +13,7 @@ const ForwardsPage = () => {
   const [forwards, setForwards] = useState<ForwardReference[]>([])
   const [isModalOpen, setModalOpen] = useState(false)
   const [openedForward, setOpenedForward] = useState<ForwardReference>()
+  const [detailForward, setDetailForward] = useState<ForwardReference>()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   function fetchForwards() {
@@ -34,6 +36,10 @@ const ForwardsPage = () => {
   function closeModal() {
     setOpenedForward(undefined)
     setModalOpen(false)
+  }
+
+  function handleDetailButton(forward: ForwardReference) {
+    setDetailForward(forward)
   }
 
   function handleAddButton() {
@@ -128,12 +134,19 @@ const ForwardsPage = () => {
           <ForwardsTable
             forwards={forwards}
             onAdd={handleAddButton}
+            onDetail={handleDetailButton}
             onEdit={handleEditButton}
             onDelete={handleDeleteForward}
             onRefresh={handleRefreshForward}
           />
         )}
       </div>
+      {detailForward && (
+        <ForwardDetailModal
+          forward={detailForward}
+          onRequestClose={() => setDetailForward(undefined)}
+        />
+      )}
       {isModalOpen && (
         <ForwardModal
           forward={openedForward}

--- a/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
@@ -11,7 +11,7 @@ import {
   TableToolbar,
   TableToolbarContent
 } from "@carbon/react"
-import {Add, Edit, Renew, TrashCan} from "@carbon/icons-react"
+import {Add, Edit, Information, Renew, TrashCan} from "@carbon/icons-react"
 import {ForwardReference} from "../../models"
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import React from "react"
@@ -20,6 +20,7 @@ import {TableEmptyState} from "../EmptyTableState"
 interface ForwardsTableProps {
   forwards: ForwardReference[]
   onAdd: () => void
+  onDetail: (forward: ForwardReference) => void
   onEdit: (forward: ForwardReference) => void
   onDelete: (forward: ForwardReference) => void
   onRefresh: (forward: ForwardReference) => void
@@ -28,6 +29,7 @@ interface ForwardsTableProps {
 export const ForwardsTable: React.FC<ForwardsTableProps> = ({
   forwards,
   onAdd,
+  onDetail,
   onEdit,
   onDelete,
   onRefresh
@@ -36,18 +38,28 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
   const headers = [
     {key: "name", header: "Name"},
     {key: "address", header: "Address"},
-    {key: "namespace", header: "Namespace"}
+    {key: "namespace", header: "Namespace"},
+    {key: "server", header: "Server"}
   ]
 
   function forwardsToRows() {
     return forwards
       //.filter((forward: ForwardReference) => forward.id)
-      .map((forward: ForwardReference) => ({
-        id: forward.id!,
-        name: forward.name,
-        address: forward.address,
-        namespace: getNamespacePathById(forward.namespace)
-      }))
+      .map((forward: ForwardReference) => {
+        const si = (forward as Record<string, unknown>).serverInfo as
+          | {serverName?: string; version?: string}
+          | undefined
+        const server = si?.serverName
+          ? `${si.serverName} ${si.version ?? ""}`.trim()
+          : ""
+        return {
+          id: forward.name ?? forward.id!,
+          name: forward.name,
+          address: forward.address,
+          namespace: getNamespacePathById(forward.namespace),
+          server
+        }
+      })
   }
 
   return (
@@ -81,7 +93,7 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
           </TableHead>
           <TableBody>
             {rows.map((row) => {
-              const forward = forwards.find(forward => forward.id === row.id)
+              const forward = forwards.find(f => (f.name ?? f.id) === row.id)
               if (forward) {
                 return (
                   <TableRow {...getRowProps({row})}>
@@ -89,6 +101,13 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
                       <TableCell key={cell.id}>{cell.value}</TableCell>
                     ))}
                     <TableCell>
+                      <Button
+                        kind="ghost"
+                        renderIcon={Information}
+                        iconDescription="Details"
+                        hasIconOnly
+                        onClick={() => {onDetail(forward)}}
+                      />
                       <Button
                         kind="ghost"
                         renderIcon={Renew}


### PR DESCRIPTION
## Summary

- Capture `serverInfo` (name, version, capabilities, extensions) from the MCP `initialize` handshake when a forward is registered or refreshed
- Store server identity in `ForwardEntry` alongside user-assignable `labels` for explicit tagging
- Show server name and version in the admin UI forwards table
- Refactor forward discovery to use a single MCP session instead of 4+ ephemeral connections per cycle
- Add design document (`forward-supported-plugins.md`) for the follow-up work: binding plugin discovery to forward server identity

## Test plan

- [ ] Register a forward to a real MCP server, confirm `GET /api/v1/forwards` returns `serverInfo`
- [ ] Verify admin UI forwards table shows "Server" column with name + version
- [ ] Test with MCP server that does not populate `serverInfo` (graceful fallback to empty)
- [ ] Verify tool/resource/prompt discovery still works (regression)
- [ ] Confirm old persisted `ForwardEntry` JSON (without `serverInfo`/`labels`) loads correctly

## Summary by Sourcery

Capture MCP server identity during forward discovery and surface it throughout the API and administration UI.

New Features:
- Capture MCP server identity and capabilities during forward registration, refresh, and startup discovery.
- Expose forward server information and user-defined labels through the API and OpenAPI schema.
- Display forward server identity and detailed metadata in the admin UI.
- Add end-to-end coverage for forward management and server-information views.

Enhancements:
- Reuse a single MCP session to discover tools, resources, templates, and prompts during each forward discovery cycle.
- Maintain backward compatibility when loading persisted forwards without server information or labels.

Documentation:
- Add design documentation for associating plugin discovery with forwarded MCP server identity.

Tests:
- Add registry serialization tests and Playwright coverage for forward creation, deletion, details, and server columns.