### PR TITLE
docs: fix outdated documentation across all developer guides

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,22 +16,21 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
 │              Wanaku Praxis Server (Port 8081)                │
 │  ┌────────────────────────────────────────────────────────┐ │
 │  │              Filter Pipeline (Praxis)                   │ │
-│  │  CORS → MCP Parse → Namespace → Tool List/Call →       │ │
-│  │  Resource Read → Prompt Get → Static Response          │ │
+│  │  CORS → MCP Parse → Namespace → Evaluator →            │ │
+│  │  Tool List/Call → Resource → Prompt → Static Response   │ │
 │  └────────────────────────────────────────────────────────┘ │
 │  ┌────────────────────────────────────────────────────────┐ │
 │  │              In-Memory Registry (DashMap)               │ │
-│  │  Tools │ Resources │ Prompts │ Namespaces │ Services   │ │
+│  │  Tools │ Resources │ Prompts │ Forwards │ Namespaces   │ │
 │  └────────────────────────────────────────────────────────┘ │
-└────────────────┬───────────────────────────────────┬────────┘
-                 │                                   │
-    MCP Forward (HTTP)                          gRPC (Tonic)
-                 │                                   │
-                 ▼                                   ▼
-     ┌───────────────────┐           ┌──────────────────────┐
-     │ Upstream MCP      │           │ gRPC Tool Services   │
-     │ Servers           │           │ (ToolInvoker proto)  │
-     └───────────────────┘           └──────────────────────┘
+└────────────────────────────────┬────────────────────────────┘
+                                 │
+                        MCP Forward (HTTP)
+                                 │
+                                 ▼
+                   ┌───────────────────────┐
+                   │ Upstream MCP Servers   │
+                   └───────────────────────┘
 ```
 
 **Request flow:**
@@ -39,9 +38,7 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
 1. LLM sends MCP request to `/mcp` or `/{namespace}/mcp`
 2. Praxis filter pipeline processes the request
 3. Filters query the in-memory registry for tools/resources/prompts
-4. For tool calls:
-   - If `type == "mcp-forward"`: forward to upstream MCP server via HTTP
-   - Otherwise: invoke gRPC service registered for that tool type
+4. For tool calls: the filter forwards the request to the upstream MCP server registered as the tool's forward address via HTTP
 5. Response flows back through filters, wrapped in JSON-RPC
 
 ## The Filter Pipeline
@@ -56,8 +53,9 @@ filter_chains:
       - filter: mcp                     # Parse JSON-RPC, set metadata
         on_invalid: continue
       - filter: wanaku_namespace        # Extract namespace from path
+      - filter: wanaku_well_known       # RFC 9728 OAuth metadata (feature)
       - filter: wanaku_mcp_init         # Initialize MCP context
-      - filter: wanaku_evaluator        # Evaluator engine (optional)
+      - filter: wanaku_evaluator        # Evaluator engine (feature)
       - filter: wanaku_tool_list        # Handle tools/list
       - filter: wanaku_tool_call        # Handle tools/call
       - filter: wanaku_resource_list    # Handle resources/list
@@ -152,7 +150,7 @@ Wanaku uses the praxis-ai `McpFilter` (the classifier) to parse JSON-RPC and set
 |---|---|---|
 | Tool catalog | Static YAML config | Dynamic `InMemoryRegistry`, populated at runtime via management API |
 | Namespace isolation | None | Per-namespace filtering (`/finance/mcp` sees only `finance` tools) |
-| Tool execution | L7 proxy forwarding to Pingora clusters (stateless profile only; unsupported in current profile) | Direct MCP-to-MCP forwarding via `rmcp` crate |
+| Tool execution | L7 proxy forwarding to Pingora clusters (stateless profile only; unsupported in current profile) | MCP-to-MCP forwarding via `rmcp` crate |
 | Forward discovery | None | Auto-discovers tools from upstream MCP servers on registration |
 | Resources & Prompts | Not supported | Full `resources/*` and `prompts/*` filter support |
 
@@ -172,24 +170,25 @@ Wanaku uses the praxis-ai `McpFilter` (the classifier) to parse JSON-RPC and set
 
 ## The Registry
 
-The registry is the source of truth for tools, resources, prompts, namespaces, and services. It's an in-memory data structure (no database) implemented as `InMemoryRegistry` in `apis/src/registry.rs`.
+The registry is the source of truth for tools, resources, prompts, namespaces, and forwards. It's an in-memory data structure (no database) implemented as `InMemoryRegistry` in `apis/src/registry.rs`.
 
 **Key design:**
 
 - **Clone-safe:** Uses `Arc<DashMap>` internally, so cloning is cheap (bumps refcount)
 - **Shared state:** Injected into filter pipeline and management API via `PipelineExtension`
-- **Trait-based:** Implements `ToolRegistry`, `ResourceRegistry`, `PromptRegistry`, `NamespaceRegistry`, `ForwardRegistry`, `ServiceRegistry`
+- **Trait-based:** Implements `ToolRegistry`, `ResourceRegistry`, `PromptRegistry`, `NamespaceRegistry`, `ForwardRegistry`
 
 **Data structures:**
 
 ```rust
 pub struct InMemoryRegistry {
-    tools: Arc<DashMap<String, ToolEntry>>,          // key: name
+    tools: Arc<DashMap<String, ToolEntry>>,
     resources: Arc<DashMap<String, ResourceEntry>>,
     prompts: Arc<DashMap<String, PromptEntry>>,
-    namespaces: Arc<DashMap<String, NamespaceEntry>>,
     forwards: Arc<DashMap<String, ForwardEntry>>,
-    services: Arc<DashMap<String, ServiceEntry>>,    // key: name
+    namespaces: Arc<DashMap<String, NamespaceEntry>>,
+    persistence: Option<Arc<dyn PersistenceBackend>>,
+    inject_request_id: Arc<AtomicBool>,
 }
 ```
 
@@ -220,65 +219,17 @@ On startup, the server loads `registry.json` from `WANAKU_PERSIST_PATH`. On shut
 
 For production, point `WANAKU_CLASSIC_URL` at a classic Wanaku backend and treat Praxis as a stateless proxy.
 
-## Tool Routing: gRPC vs. MCP Forward
+## Tool Routing
 
-When a tool call arrives (`tools/call`), the tool_call filter routes it one of two ways:
+All tool execution in Praxis happens via MCP forwarding. When a tool call arrives (`tools/call`), the tool_call filter:
 
-### 1. gRPC (Local Execution)
+1. Looks up the tool in the registry by name
+2. Calls `mcp_client::call_tool(tool.uri, name, arguments)` to forward the request to the upstream MCP server
+3. Uses the `rmcp` crate to send an HTTP POST
+4. Upstream returns MCP `CallToolResult`
+5. Filter wraps it in JSON-RPC and returns
 
-For tools with `type != "mcp-forward"` (e.g., `"echo-tool"`, `"camel"`):
-
-1. Filter calls `registry.resolve_service(tool.type_, "tool-invoker")` to get gRPC address
-2. Uses `GrpcPool` to get or create a connection to that address
-3. Invokes `ToolInvoke` gRPC method with tool arguments
-4. Returns result or error
-
-**Service registration:**
-
-Services self-register via `POST /api/v1/services`:
-
-```json
-{
-  "name": "echo-tool",
-  "address": "localhost:9191",
-  "service_type": "tool-invoker"
-}
-```
-
-The registry stores this as a `ServiceEntry`. When a tool of type `"echo-tool"` is called, the filter looks up the service and connects via gRPC.
-
-**gRPC proto:**
-
-```protobuf
-service ToolInvoker {
-  rpc InvokeTool (ToolInvokeRequest) returns (ToolInvokeReply) {}
-}
-
-message ToolInvokeRequest {
-  string uri = 1;
-  string body = 2;
-  map<string, string> arguments = 3;
-  string configuration_uri = 4;
-  string secrets_uri = 5;
-  map<string, string> headers = 6;
-  string request_id = 9;
-}
-
-message ToolInvokeReply {
-  repeated string content = 2;
-}
-```
-
-See `apis/src/proto/toolrequest.proto` and `apis/src/proto/resourcerequest.proto` for the full definitions.
-
-### 2. MCP Forward (Remote MCP Server)
-
-For tools with `type == "mcp-forward"`:
-
-1. Filter calls `mcp_client::call_tool(tool.uri, name, arguments)` directly
-2. Uses the `rmcp` crate to send an HTTP POST to the upstream MCP server
-3. Upstream returns MCP `CallToolResult`
-4. Filter wraps it in JSON-RPC and returns
+Tools have `type: "mcp-forward"` and a `uri` pointing at the upstream MCP server. This is the only execution model — there is no built-in gRPC or local tool execution.
 
 **Forward discovery:**
 
@@ -314,12 +265,16 @@ This removes all tools previously discovered from that forward and re-queries th
 Features are self-contained modules that extend Praxis with new capabilities. They live in `features/<name>/` and implement the `Feature` trait from `apis/src/feature.rs`:
 
 ```rust
+#[async_trait::async_trait]
 pub trait Feature: Send + Sync {
-    fn register_filters(&self, registry: &mut FilterRegistry) -> Result<(), FilterError>;
-    fn pipeline_extensions(&self) -> Vec<Box<dyn Any + Send + Sync>>;
-    fn handle_route(&self, req: &HttpRequest, path: &str, body: &[u8]) -> Option<HttpResponse>;
-    fn load_yaml_config(&mut self, config: &serde_yaml::Value) -> Result<(), Box<dyn std::error::Error>>;
-    fn load_env_config(&mut self) -> Result<(), Box<dyn std::error::Error>>;
+    fn name(&self) -> &'static str;
+    fn register_filters(&self, registry: &mut FilterRegistry);
+    fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>>;
+    async fn handle_route(
+        &self, method: &str, path: &str, query: Option<&str>, body: Option<&str>,
+    ) -> Option<Response<Vec<u8>>>;
+    fn load_yaml_config(&self, root: &serde_yaml::Value);
+    fn load_env_config(&self);
 }
 ```
 
@@ -331,13 +286,13 @@ pub trait Feature: Send + Sync {
 4. Calls `pipeline_extensions` to get shared state (e.g., LLM client)
 5. For each request, calls `handle_route` if the path matches the feature's API
 
-**Examples:**
+**Registered features** (in `main.rs`):
 
-**MCP Metadata feature** (`features/mcp-metadata/`):
-- **Filter:** none
-- **Management API:** `GET /.well-known/oauth-protected-resource/{namespace}/mcp` — RFC 9728 metadata
-- **State:** none (reads `WANAKU_AUTH_ISSUER` env var)
-- **Purpose:** exposes OAuth server metadata for MCP clients
+1. **Intercept** (`features/intercept/`) — records request/response interactions for conversation history
+2. **MCP Metadata** (`features/mcp-metadata/`) — RFC 9728 OAuth Protected Resource Metadata and well-known endpoints
+3. **Evaluator** (`features/evaluator/`) — WASM-based LLM evaluation engine for trigger→evaluate→act pipelines
+4. **Chat** (`features/chat/`) — proxies LLM chat completions to an inference backend
+5. **Plugins** (`features/plugins/`) — loads external UI plugins from a filesystem directory
 
 See [Features](./features.md) for how to create your own.
 
@@ -348,7 +303,7 @@ The management API runs on port 8080 and uses Pingora's `ServeHttp` trait (not a
 **Request flow:**
 
 1. Pingora calls `handle_request` in `server/src/management/mod.rs`
-2. Dispatcher tries core routes (tools, resources, prompts, namespaces, forwards, services)
+2. Dispatcher tries core routes (tools, resources, prompts, namespaces, forwards)
 3. If no match, iterates over registered features and calls `feature.handle_route()`
 4. If still no match, returns 404
 
@@ -415,10 +370,10 @@ See [Admin UI](./admin-ui.md) for development details.
 
 ### Standalone
 
-Run Praxis as the only MCP server. All tools and services are gRPC-based, registered via the management API or `wanaku.yaml`.
+Run Praxis as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, and execute via MCP forwarding to upstream servers.
 
 **Pros:** Simple, no dependencies
-**Cons:** No persistence, no classic Wanaku features (service catalogs, complex Camel routes)
+**Cons:** No persistence beyond file snapshots, no classic Wanaku features (service catalogs, Camel routes)
 
 ### Hybrid (Praxis + Classic Backend)
 
@@ -428,9 +383,9 @@ Run Praxis as a stateless proxy. Point `WANAKU_CLASSIC_URL` at a classic Wanaku 
 export WANAKU_CLASSIC_URL=http://classic-wanaku:8080
 ```
 
-Praxis handles MCP protocol and namespace isolation. Classic handles persistence, service catalogs, and advanced Camel integrations.
+Praxis handles MCP protocol and namespace isolation. Classic handles persistence and service catalogs.
 
-**Pros:** Best of both worlds—Praxis performance, classic features
+**Pros:** Best of both worlds — Praxis performance, classic features
 **Cons:** Two servers to manage
 
 ### Kubernetes
@@ -457,7 +412,6 @@ Praxis uses Pingora's async worker pool. Each worker handles requests concurrent
 | Component | Typical Latency | Notes |
 |---|---|---|
 | Filter pipeline | ~1ms | CORS + MCP parse + namespace + tool lookup |
-| gRPC call | ~5ms | Local network, depends on service |
 | MCP forward | ~20ms | HTTP roundtrip to upstream MCP server |
 
 **Memory:**
@@ -499,9 +453,7 @@ CORS is enabled by default via the `cors` filter (allows all origins). Restrict 
 
 ## What's Not Here (Yet)
 
-This architecture is a proof-of-concept. Missing pieces:
-
-- **Persistence beyond file dumps** — no PostgreSQL/Redis integration
+- **Persistence beyond file snapshots** — no PostgreSQL/Redis integration
 - **Multi-tenancy** — namespaces provide isolation, but no user/tenant association
 - **Rate limiting** — no throttling on MCP or management API
 - **Metrics/observability** — no Prometheus, no tracing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ These are defined in `apis/src/config.rs` and accessed via `wanaku_praxis_apis::
 | `WANAKU_PERSIST_PATH` | `/data/registry` | Directory where `registry.json` is read/written |
 | `WANAKU_CLASSIC_URL` | _(unset = disabled)_ | Classic Wanaku backend base URL (e.g., `http://classic:8080`) |
 | `WANAKU_UI_PATH` | _(unset = embedded)_ | Filesystem path to admin UI override (use for local dev) |
+| `WANAKU_CORS_ORIGIN` | `*` | Value for `Access-Control-Allow-Origin` on management API responses |
 | `WANAKU_AUTH_ISSUER` | _(unset = disabled)_ | OIDC issuer URL for RFC 9728 metadata endpoint |
 | `WANAKU_INFERENCE_API_KEY` | _(unset = no auth)_ | Bearer token API key for the inference upstream. Empty means no auth. |
 
@@ -76,8 +77,7 @@ On startup, the server loads `registry.json` from `WANAKU_PERSIST_PATH`. On shut
   "resources": [...],
   "prompts": [...],
   "namespaces": [...],
-  "forwards": [...],
-  "services": [...]
+  "forwards": [...]
 }
 ```
 
@@ -95,9 +95,9 @@ When set, Praxis proxies certain management API calls (e.g., service catalog ope
 
 **Hybrid mode workflow:**
 
-1. Register tools/services in classic Wanaku via its REST API
+1. Register tools in classic Wanaku via its REST API
 2. Praxis queries classic backend on startup to populate its registry
-3. MCP requests hit Praxis (port 8081), tool calls are routed to gRPC services
+3. MCP requests hit Praxis (port 8081), tool calls are forwarded to upstream MCP servers
 4. Management API writes go to Praxis AND classic (eventual consistency)
 
 This is experimental. Not all classic features are supported.
@@ -163,6 +163,14 @@ Access:
 - MCP endpoint: `http://localhost:4180/mcp`
 - Public MCP (no auth): `http://localhost:4180/public/mcp`
 
+### Intercept Feature
+
+The intercept feature records request/response interactions for conversation tracking. Evaluators use this history to provide context to LLM operations.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WANAKU_INTERACTION_CAPACITY` | `1000` | Maximum number of interactions kept in the in-memory store |
+
 ### Chat Feature
 
 The chat feature proxies LLM chat completions to an inference backend (any OpenAI-compatible endpoint).
@@ -207,6 +215,7 @@ filter_chains:
       - filter: mcp
         on_invalid: continue
       - filter: wanaku_namespace
+      - filter: wanaku_well_known
       - filter: wanaku_mcp_init
       - filter: wanaku_evaluator
       - filter: wanaku_tool_list
@@ -290,7 +299,7 @@ If you reorder filters and requests start failing, check the logs. The filter th
 
 ## Wanaku Config File (wanaku.yaml)
 
-The Wanaku config bootstraps tools, resources, prompts, namespaces, and services on startup. It's optional—if omitted, the registry starts empty.
+The Wanaku config bootstraps tools and forwards on startup. It's optional — if omitted, the registry starts empty. Resources, prompts, and namespaces must be registered via the management API.
 
 **Location:** Pass with `--wanaku-config`:
 
@@ -303,8 +312,8 @@ cargo run -- --praxis-config /path/to/praxis.yaml --wanaku-config /path/to/wanak
 ```yaml
 tools:
   - name: "echo"
-    type: "echo-tool"
-    uri: "echo-tool://echo"
+    type: "mcp-forward"
+    uri: "http://echo-mcp:8080/mcp"
     description: "Echoes a message"
     namespace: "default"
     input_schema:
@@ -314,46 +323,24 @@ tools:
           type: string
       required: [message]
 
-resources:
-  - name: "readme"
-    type: "file"
-    uri: "file:///README.md"
-    description: "Project README"
-    namespace: "default"
-
-prompts:
-  - name: "code-review"
-    description: "Review code for issues"
-    namespace: "default"
-    messages:
-      - role: "user"
-        content:
-          type: "text"
-          text: "Review this code: {{code}}"
-
-namespaces:
-  - name: "finance"
-    description: "Financial tools and resources"
-
 forwards:
   - name: "upstream-mcp"
     address: "http://upstream:8080/mcp"
-
-services:
-  - name: "echo-tool"
-    address: "localhost:9191"
-    service_type: "tool-invoker"
 ```
 
+**Note:** Only `tools` and `forwards` are loaded from wanaku.yaml at startup. Resources, prompts, and namespaces must be registered via the management API (POST `/api/v1/resources`, `/api/v1/prompts`, `/api/v1/namespaces`).
+
 ### Tool Definitions
+
+**All tools must have `type: "mcp-forward"`** — other tool types are not supported. The `uri` field points to the upstream MCP server that will execute the tool.
 
 **Minimal:**
 
 ```yaml
 tools:
   - name: "my-tool"
-    type: "my-service"
-    uri: "my-service://operation"
+    type: "mcp-forward"
+    uri: "http://my-mcp-server:8080/mcp"
     description: "Does a thing"
 ```
 
@@ -362,16 +349,16 @@ tools:
 ```yaml
 tools:
   - name: "http-get"
-    type: "http"
-    uri: "http://example.com/api/{path}"
+    type: "mcp-forward"
+    uri: "http://http-mcp-server:8080/mcp"
     description: "HTTP GET request"
     input_schema:
       type: object
       properties:
-        path:
+        url:
           type: string
-          description: "API endpoint path"
-      required: [path]
+          description: "Target URL"
+      required: [url]
 ```
 
 **Namespace isolation:**
@@ -379,8 +366,8 @@ tools:
 ```yaml
 tools:
   - name: "get-stock-price"
-    type: "market-data"
-    uri: "market://stocks"
+    type: "mcp-forward"
+    uri: "http://market-mcp:8080/mcp"
     namespace: "finance"
     input_schema:
       type: object
@@ -391,51 +378,7 @@ tools:
 
 This tool only appears in `/finance/mcp`, not `/mcp`.
 
-**MCP forward:**
-
-```yaml
-tools:
-  - name: "upstream-tool"
-    type: "mcp-forward"
-    uri: "http://upstream:8080/mcp"
-    description: "Tool from upstream MCP server"
-```
-
-When called, Praxis forwards the request to `http://upstream:8080/mcp` via HTTP POST.
-
-### Service Definitions
-
-Services are gRPC endpoints that implement the `ToolInvoker` or `ResourceProvider` protocol.
-
-**Format:**
-
-```yaml
-services:
-  - name: "echo-tool"
-    address: "localhost:9191"
-    service_type: "tool-invoker"
-```
-
-**Fields:**
-
-- `name` — must match the `type` field in tool definitions
-- `address` — `host:port` of the gRPC server
-- `service_type` — one of: `"tool-invoker"`, `"resource-provider"`, `"multi-capability"`
-
-**Example with multiple services:**
-
-```yaml
-services:
-  - name: "http"
-    address: "http-service:9000"
-    service_type: "tool-invoker"
-  - name: "camel"
-    address: "camel-service:9001"
-    service_type: "tool-invoker"
-  - name: "file"
-    address: "file-provider:9002"
-    service_type: "resource-provider"
-```
+**Note:** When called, Praxis forwards the request to the upstream MCP server via HTTP POST and returns the result.
 
 ## Common Configuration Patterns
 
@@ -504,8 +447,8 @@ data:
   wanaku.yaml: |
     tools:
       - name: "echo"
-        type: "echo-tool"
-        uri: "echo-tool://echo"
+        type: "mcp-forward"
+        uri: "http://echo-mcp:8080/mcp"
         description: "Echoes a message"
 ```
 

--- a/docs/evaluator-engine.md
+++ b/docs/evaluator-engine.md
@@ -8,7 +8,7 @@ You write the logic in JavaScript or Rust. The engine compiles it to WASM and ru
 
 ## YAML Configuration
 
-Evaluators live in `wanaku.yaml` or get pushed via the management API. Each evaluator has five parts:
+Evaluators live in `wanaku.yaml` or get pushed via the management API. Each evaluator has four parts:
 
 ```yaml
 evaluators:
@@ -16,20 +16,14 @@ evaluators:
     trigger:                          # When to run
       method: "tools/call"            # MCP method (tools/call, tools/list, etc.)
       namespace: "production"         # Optional: only this namespace
-      binding: "conv-12345"           # Optional: only this conversation ID
     llm:                              # LLM operation
       operation: classify             # classify | filter | augment
-      labels: ["green", "yellow", "red"]  # For classify: possible outputs
       prompt: "You are a safety classifier..."
       model: "llama3.2"
       url: "http://localhost:11434/v1"
       api_key: ""                     # Optional bearer token
-    rules:                            # For classify: label → action map
-      green: "pass"
-      yellow: "pass"
-      red: {path: "/wasm/safety-block.wasm"}
-    action:                           # For filter/augment: single action
-      path: "/wasm/assembly-filter.wasm"
+    processor:                        # WASM action script
+      path: "/wasm/safety-gate.wasm"
     on_error: continue                # continue | block (default: continue)
 ```
 
@@ -39,16 +33,12 @@ evaluators:
 |-------|------|---------|
 | `method` | string | MCP method to match (e.g., `tools/call`, `tools/list`, `resources/read`) |
 | `namespace` | string | Optional. Only trigger for this namespace (extracted from URL path `/finance/mcp` → `finance`) |
-| `binding` | string | Optional. Only trigger for requests with this conversation ID |
-
-**Namespace binding pattern:** Use `PUT /api/v1/evaluators/namespaces/{namespace}` to bind a namespace to a conversation ID. Then set `binding` to that conversation ID. This lets you create per-conversation tool catalogs.
 
 ### LLM Fields
 
 | Field | Type | Purpose |
 |-------|------|---------|
 | `operation` | string | `classify` (pick a label), `filter` (return structured data), or `augment` (enrich prompt) |
-| `labels` | array | For classify only: the allowed labels (e.g., `["safe", "dangerous"]`) |
 | `prompt` | string | System prompt for the LLM. The engine builds a user prompt with request context. |
 | `model` | string | Model name (passed to `/v1/chat/completions`) |
 | `url` | string | OpenAI-compatible endpoint URL |
@@ -62,31 +52,16 @@ evaluators:
 
 Your system prompt tells the LLM what to do with that context.
 
-### Rules (classify only)
+### Processor
 
-Map each label to an action. Actions are either `"pass"` (continue) or a WASM file path:
-
-```yaml
-rules:
-  safe: "pass"
-  dangerous: {path: "/wasm/block-dangerous.wasm"}
-```
-
-**The WASM script receives the raw LLM output** in `ctx.llmResult` — useful if the LLM returns JSON with extra metadata beyond just the label.
-
-### Action (filter/augment only)
-
-Single WASM action that processes the LLM output:
+A single WASM action script that processes the LLM output. The script receives the raw LLM result in `ctx.llmResult` and decides what to do:
 
 ```yaml
-action: {path: "/wasm/assembly-filter.wasm"}
+processor:
+  path: "/wasm/safety-gate.wasm"
 ```
 
-Or string shorthand:
-
-```yaml
-action: "/wasm/assembly-filter.wasm"
-```
+The WASM script can call `block()`, `pass()`, `warn()`, `filterTools()`, or `setMetadata()` based on its analysis of the LLM output.
 
 ### Error Policy
 
@@ -106,7 +81,6 @@ evaluators:
       method: "tools/call"
     llm:
       operation: classify
-      labels: ["green", "yellow", "red"]
       prompt: |
         You are a strict safety classifier. Classify this tool call as:
         - green: safe operations (read-only, low impact)
@@ -116,10 +90,8 @@ evaluators:
         Respond with ONLY a JSON object: {"level": "green|yellow|red", "reason": "brief explanation"}
       model: "llama3.2"
       url: "http://localhost:11434/v1"
-    rules:
-      green: "pass"
-      yellow: "pass"
-      red: {path: "/wasm/safety-block.wasm"}
+    processor:
+      path: "/wasm/safety-block.wasm"
     on_error: continue
 ```
 
@@ -127,20 +99,20 @@ evaluators:
 1. User calls `restart-database` tool
 2. Engine sends tool name + args to LLM with your prompt
 3. LLM returns `{"level": "red", "reason": "database restart is dangerous"}`
-4. Engine extracts `"red"` label, runs `safety-block.wasm`
-5. WASM script calls `block("Tool call blocked by safety classification: red")`
+4. Engine runs `safety-block.wasm` with the raw LLM output in `ctx.llmResult`
+5. WASM script parses the JSON, sees `"red"`, calls `block("Tool call blocked: red")`
 6. User gets JSON-RPC error instead of executing the tool
 
 ### Example 2: Tool Assembly
 
-Dynamically populate a namespace with only the tools the LLM approves for this conversation.
+Dynamically populate a namespace with only the tools the LLM approves.
 
 ```yaml
 evaluators:
   - name: "assembly-gate"
     trigger:
       method: "tools/list"
-      binding: "conv-finance-2024"  # Only for this conversation
+      namespace: "curated"
     llm:
       operation: filter
       prompt: |
@@ -150,26 +122,18 @@ evaluators:
         Respond with ONLY a JSON array: ["tool-name-1", "tool-name-2"]
       model: "llama3.2"
       url: "http://localhost:11434/v1"
-    action: {path: "/wasm/assembly-filter.wasm"}
+    processor:
+      path: "/wasm/assembly-filter.wasm"
 ```
 
 **What happens:**
-1. User sends `tools/list` with conversation ID `conv-finance-2024`
+1. User sends `tools/list` to the `curated` namespace (`/curated/mcp`)
 2. Engine sends conversation history + available tools to LLM
 3. LLM returns `["read-balance", "transfer-funds", "generate-report"]`
 4. Engine runs `assembly-filter.wasm` with that JSON in `ctx.llmResult`
 5. WASM script parses JSON, calls `copyToolToNamespace(name, ctx.namespace)` for each
 6. WASM calls `filterTools(approved)` to return only the assembled tools
 7. User sees a curated tool list
-
-**Namespace binding setup:**
-
-```bash
-# Bind the 'finance-team' namespace to conversation ID 'conv-finance-2024'
-curl -X PUT http://localhost:8080/api/v1/evaluators/namespaces/finance-team \
-  -H "Content-Type: application/json" \
-  -d '{"conversationId": "conv-finance-2024"}'
-```
 
 ## Writing Action Scripts in JavaScript
 
@@ -316,11 +280,11 @@ The first time you compile, expect cryptic errors if your imports don't match th
 
 ### Step 6: Deploy
 
-Place the `.wasm` file somewhere the server can read it (e.g., `/wasm/` directory), then reference it in your YAML:
+Place the `.wasm` file somewhere the server can read it (e.g., `/wasm/` directory), then reference it in your evaluator config:
 
 ```yaml
-rules:
-  red: {path: "/wasm/safety-block.wasm"}
+processor:
+  path: "/wasm/safety-block.wasm"
 ```
 
 Or update via the management API:
@@ -333,16 +297,28 @@ curl -X PUT http://localhost:8080/api/v1/evaluators \
 
 ### Complete JavaScript Examples
 
-#### Safety Block (classify → block)
+#### Safety Gate (classify → block or pass)
 
 ```javascript
-import { block } from 'wanaku:evaluator/response';
+import { block, pass } from 'wanaku:evaluator/response';
 import { warn } from 'wanaku:evaluator/log';
 
 export function evaluate(ctx) {
-  const reason = `Tool call blocked by safety classification: ${ctx.llmResult}`;
-  warn(reason);
-  block(reason);
+  let level = "red";
+  try {
+    const result = JSON.parse(ctx.llmResult);
+    level = result.level || "red";
+  } catch (e) {
+    warn("Failed to parse LLM result, defaulting to red");
+  }
+
+  if (level === "red") {
+    const reason = `Tool call blocked by safety classification: ${ctx.llmResult}`;
+    warn(reason);
+    block(reason);
+  } else {
+    pass();
+  }
 }
 ```
 
@@ -523,8 +499,8 @@ The filename comes from your `[package] name` with `_` replacing `-`.
 Same as JavaScript — reference the WASM file in your evaluator config:
 
 ```yaml
-rules:
-  red: {path: "/wasm/safety_block_action.wasm"}
+processor:
+  path: "/wasm/safety_block_action.wasm"
 ```
 
 ### Complete Rust Example
@@ -576,16 +552,12 @@ curl http://localhost:8080/api/v1/evaluators
       "trigger": {"method": "tools/call"},
       "llm": {
         "operation": "classify",
-        "labels": ["green", "yellow", "red"],
         "prompt": "...",
         "model": "llama3.2",
         "url": "http://localhost:11434/v1",
         "api_key": ""
       },
-      "rules": {
-        "green": "pass",
-        "red": {"path": "/wasm/safety-block.wasm"}
-      },
+      "processor": {"path": "/wasm/safety-gate.wasm"},
       "on_error": "continue"
     }
   ],
@@ -605,15 +577,11 @@ curl -X PUT http://localhost:8080/api/v1/evaluators \
         "trigger": {"method": "tools/call"},
         "llm": {
           "operation": "classify",
-          "labels": ["green", "yellow", "red"],
           "prompt": "You are a safety classifier...",
           "model": "llama3.2",
           "url": "http://localhost:11434/v1"
         },
-        "rules": {
-          "green": "pass",
-          "red": {"path": "/wasm/safety-block.wasm"}
-        }
+        "processor": {"path": "/wasm/safety-gate.wasm"}
       }
     ]
   }'
@@ -653,7 +621,7 @@ curl -X PUT http://localhost:8080/api/v1/evaluators/namespaces/finance-team \
   -d '{"conversationId": "conv-finance-2024"}'
 ```
 
-**Use case:** You want the `assembly-gate` evaluator to only fire for namespace `finance-team` when the conversation ID is `conv-finance-2024`. This binding makes that work.
+**Use case:** You want the evaluator to retrieve conversation history for a specific namespace. When a request arrives for the `finance-team` namespace, the evaluator looks up the binding, resolves the conversation ID, and fetches the matching interaction history to include in the LLM prompt.
 
 ### Unbind Namespace
 
@@ -687,16 +655,11 @@ curl -sf -X PUT $MGMT/api/v1/evaluators -H "Content-Type: application/json" \
       "trigger": {"method": "tools/call"},
       "llm": {
         "operation": "classify",
-        "labels": ["green", "yellow", "red"],
         "prompt": "You are a safety classifier. You MUST classify every tool call as exactly one of: green, yellow, or red. Restarting any database is ALWAYS red. Respond with ONLY a JSON object, no other text: {\"level\": \"green|yellow|red\", \"reason\": \"brief\"}",
         "model": "llama3.2",
         "url": "http://localhost:11434/v1"
       },
-      "rules": {
-        "green": "pass",
-        "yellow": "pass",
-        "red": {"path": "'"$WASM"'"}
-      }
+      "processor": {"path": "'"$WASM"'"}
     }]
   }' > /dev/null
 
@@ -755,8 +718,8 @@ You don't need to understand this to use the engine, but it helps when things go
    - For each match:
      - Builds context prompt (conversation history + request details)
      - Calls LLM with your system prompt + context
-     - Extracts result (classify → label, filter/augment → raw output)
-     - Loads pre-compiled WASM module
+     - Extracts the raw LLM output
+     - Loads pre-compiled WASM processor module
      - Instantiates WASM with fresh host state (registry, interactions, result accumulator)
      - Calls `evaluate(ctx)` export
      - WASM calls host imports (e.g., `block()`, `copyToolToNamespace()`)
@@ -799,43 +762,45 @@ Your system prompt tells the LLM what to extract from that context. The engine s
 
 ```yaml
 on_error: continue  # LLM/WASM failures don't block production
-rules:
-  dangerous: {path: "/wasm/block.wasm"}
-  safe: "pass"
+processor:
+  path: "/wasm/safety-gate.wasm"
 ```
 
-If the LLM is down, requests proceed. Only active blocking happens when the LLM explicitly returns `dangerous`.
+If the LLM is down, requests proceed. The WASM script decides whether to block based on the LLM output — if it never runs, the request continues.
 
 ### Fail-Closed Safety Gate
 
 ```yaml
 on_error: block  # Any failure blocks the request
-rules:
-  safe: "pass"
-  dangerous: {path: "/wasm/block.wasm"}
+processor:
+  path: "/wasm/safety-gate.wasm"
 ```
 
 If the LLM is down or WASM crashes, the request is blocked. Use this for high-security environments where availability is secondary to safety.
 
-### Per-Conversation Tool Assembly
+### Namespace-Scoped Evaluation
 
-1. Bind namespace to conversation:
-   ```bash
-   curl -X PUT http://localhost:8080/api/v1/evaluators/namespaces/user-123 \
-     -H "Content-Type: application/json" \
-     -d '{"conversationId": "conv-abc-xyz"}'
-   ```
+Restrict evaluators to specific namespaces:
 
-2. Configure evaluator with binding:
-   ```yaml
-   trigger:
-     method: "tools/list"
-     binding: "conv-abc-xyz"
-   ```
+```yaml
+trigger:
+  method: "tools/list"
+  namespace: "production"
+```
 
-3. WASM action copies approved tools into `ctx.namespace` and calls `filterTools(approved)`
+This evaluator only fires for requests to `/production/mcp`. The WASM action can use `filterTools()` to curate the tool catalog for that namespace.
 
-Result: Each conversation gets its own curated tool catalog, and the LLM only sees tools it approved for that user.
+### Namespace-Conversation Binding
+
+Bind a namespace to a conversation ID so the evaluator can retrieve relevant interaction history:
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/evaluators/namespaces/finance-team \
+  -H "Content-Type: application/json" \
+  -d '{"conversationId": "conv-finance-2024"}'
+```
+
+When a request arrives for the `finance-team` namespace, the evaluator resolves the conversation ID from the binding and includes the matching interaction history in the LLM prompt. This gives the LLM context about what the user has been doing in this session.
 
 ### Metadata Propagation
 
@@ -873,7 +838,6 @@ Downstream filters can read this metadata and make decisions (e.g., extra loggin
 1. Check server logs for `evaluator filter` trace messages — they show what the filter sees
 2. Verify `trigger.method` matches `mcp.method` metadata (e.g., `tools/call` not `tool/call`)
 3. If using `trigger.namespace`, verify the request URL is `/namespace/mcp`, not `/mcp`
-4. If using `trigger.binding`, verify the conversation ID is set and matches the binding
 
 Enable trace logs: `RUST_LOG=wanaku_praxis_evaluator=trace`
 
@@ -892,7 +856,7 @@ Enable trace logs: `RUST_LOG=wanaku_praxis_evaluator=trace`
      return;  // Default: pass
    }
    ```
-3. Use `llm.labels` to constrain classify operations — the engine will fuzzy-match even if JSON parsing fails
+3. Use a smaller, faster model for classification tasks — they need less context
 
 ### "WASM action did nothing"
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,24 @@ Think of features as plugins. The core server provides the infrastructure (filte
 
 ## Built-in Features
 
-Wanaku Praxis ships with two features out of the box:
+Wanaku Praxis ships with five features:
+
+### Intercept Feature (`features/intercept/`)
+
+Records MCP request/response interactions in an in-memory store. Other features — especially the evaluator engine — use this history to provide conversation context to LLM operations.
+
+**Filter:** `wanaku_intercept` (runs in the inference proxy pipeline)
+
+**Management API routes:**
+
+- `GET /api/v1/interactions` — list recorded interactions
+- `DELETE /api/v1/interactions` — clear the interaction store
+
+**Configuration:**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WANAKU_INTERACTION_CAPACITY` | `1000` | Maximum interactions kept in memory |
 
 ### MCP Metadata Feature (`features/mcp-metadata/`)
 
@@ -81,6 +98,36 @@ curl -X POST http://localhost:8080/api/v1/chat/completions \
 
 The request is proxied to `WANAKU_INFERENCE_UPSTREAM/v1/chat/completions`.
 
+### Evaluator Feature (`features/evaluator/`)
+
+A WASM-based evaluation engine that lets you build trigger→evaluate→act pipelines. When an MCP request matches a trigger, the engine calls an LLM to classify or filter, then runs a WebAssembly action script that can block requests, filter tool lists, or set metadata.
+
+**Filter:** `wanaku_evaluator`
+
+**Management API routes:**
+
+- `GET /api/v1/evaluators` — list configured evaluators
+- `PUT /api/v1/evaluators` — hot-reload evaluator configuration
+- `GET /api/v1/evaluators/namespaces` — list namespace-to-conversation bindings
+- `PUT /api/v1/evaluators/namespaces/{namespace}` — bind a namespace to a conversation ID
+- `DELETE /api/v1/evaluators/namespaces/{namespace}` — unbind
+
+See the [Evaluator Engine](./evaluator-engine.md) guide for configuration details and WASM action script development.
+
+### Plugins Feature (`features/plugins/`)
+
+Loads external UI plugins from a filesystem directory. Plugins are ES modules that can add navigation entries, pages, and backend service integrations to the admin UI at runtime.
+
+**Configuration:**
+
+Start the server with `--plugins-path`:
+
+```bash
+cargo run -- --plugins-path /path/to/plugins
+```
+
+See the [Plugin Development Guide](./plugin-development-guide.md) for details.
+
 ## Creating a Custom Feature
 
 Let's build a simple feature that counts tool calls and exposes stats via the management API.
@@ -105,6 +152,8 @@ edition = "2024"
 wanaku-praxis-apis = { path = "../../apis" }
 wanaku-praxis-filters = { path = "../../filters" }
 praxis-filter = "0.4.1"
+async-trait = "0.1"
+http = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
@@ -115,11 +164,11 @@ tracing = "0.1"
 Create `src/lib.rs`:
 
 ```rust
-use wanaku_praxis_apis::Feature;
-use praxis_filter::{FilterRegistry, FilterError};
+use wanaku_praxis_apis::feature::Feature;
+use praxis_filter::{FilterRegistry, PipelineExtension};
+use http::Response;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::any::Any;
 
 pub struct ToolStatsFeature {
     counter: Arc<AtomicU64>,
@@ -133,40 +182,43 @@ impl ToolStatsFeature {
     }
 }
 
+#[async_trait::async_trait]
 impl Feature for ToolStatsFeature {
-    fn register_filters(&self, registry: &mut FilterRegistry) -> Result<(), FilterError> {
-        // Register a filter that increments the counter on every tool call
-        let counter = self.counter.clone();
-        registry.register("wanaku_tool_stats", move || {
-            Box::new(ToolStatsFilter { counter: counter.clone() })
-        })
+    fn name(&self) -> &'static str {
+        "tool-stats"
     }
 
-    fn pipeline_extensions(&self) -> Vec<Box<dyn Any + Send + Sync>> {
-        // No shared state needed
+    fn register_filters(&self, registry: &mut FilterRegistry) {
+        // Register a filter that increments the counter on every tool call
+        let counter = self.counter.clone();
+        praxis_filter::register_filters!(
+            @register registry,
+            http "wanaku_tool_stats" => move |_| ToolStatsFilter { counter: counter.clone() }
+        );
+    }
+
+    fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>> {
         vec![]
     }
 
-    fn handle_route(&self, req: &HttpRequest, path: &str, _body: &[u8]) -> Option<HttpResponse> {
-        if req.method() == "GET" && path == "/api/v1/stats/tools" {
+    async fn handle_route(
+        &self, method: &str, path: &str, _query: Option<&str>, _body: Option<&str>,
+    ) -> Option<Response<Vec<u8>>> {
+        if method == "GET" && path == "/api/v1/stats/tools" {
             let count = self.counter.load(Ordering::Relaxed);
-            let response = serde_json::json!({
+            let body = serde_json::json!({
                 "data": {"tool_calls": count},
                 "error": null
             });
-            Some(HttpResponse::ok(response.to_string()))
+            Some(wanaku_praxis_apis::http_response::json_ok(&body))
         } else {
-            None  // Not our route
+            None
         }
     }
 
-    fn load_yaml_config(&mut self, _config: &serde_yaml::Value) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())  // No YAML config needed
-    }
+    fn load_yaml_config(&self, _root: &serde_yaml::Value) {}
 
-    fn load_env_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())  // No env vars needed
-    }
+    fn load_env_config(&self) {}
 }
 ```
 
@@ -176,7 +228,7 @@ Add to `src/lib.rs`:
 
 ```rust
 use wanaku_praxis_filters::body_filter_boilerplate;
-use praxis_filter::{HttpFilter, HttpFilterContext, FilterAction};
+use praxis_filter::{HttpFilterContext, FilterAction, FilterError};
 use bytes::Bytes;
 
 struct ToolStatsFilter {
@@ -191,10 +243,11 @@ impl ToolStatsFilter {
         ctx: &mut HttpFilterContext<'_>,
         _body: &Bytes,
     ) -> Result<FilterAction, FilterError> {
-        let method = ctx.get_metadata("mcp.method")?;
-        if method == "tools/call" {
-            self.counter.fetch_add(1, Ordering::Relaxed);
-            tracing::info!("Tool call count: {}", self.counter.load(Ordering::Relaxed));
+        if let Some(method) = ctx.get_metadata("mcp.method") {
+            if method == "tools/call" {
+                self.counter.fetch_add(1, Ordering::Relaxed);
+                tracing::info!("Tool call count: {}", self.counter.load(Ordering::Relaxed));
+            }
         }
         Ok(FilterAction::Continue)
     }
@@ -263,18 +316,28 @@ Expected response:
 
 ### State Management
 
-Features can share state between filters and management API handlers via `pipeline_extensions`:
+Features can share state between filters and management API handlers via `pipeline_extensions`. Implement `PipelineExtension` on a wrapper type:
 
 ```rust
-fn pipeline_extensions(&self) -> Vec<Box<dyn Any + Send + Sync>> {
-    vec![Box::new(self.counter.clone())]
+struct CounterExtension {
+    counter: Arc<AtomicU64>,
+}
+
+impl PipelineExtension for CounterExtension {
+    fn prepare(&self, extensions: &mut RequestExtensions) {
+        extensions.insert(self.counter.clone());
+    }
+}
+
+fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>> {
+    vec![Box::new(CounterExtension { counter: self.counter.clone() })]
 }
 ```
 
 Filters retrieve the state via:
 
 ```rust
-let counter = ctx.extensions.get::<Arc<AtomicU64>>().unwrap();
+let counter = ctx.extensions.get::<Arc<AtomicU64>>();
 ```
 
 ### Hot-Reloadable Config

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,15 +55,15 @@ That empty array means the server is running, but you haven't registered any too
 
 ### 4. Register Your First Tool
 
-Create a simple echo tool:
+Create a simple echo tool (note: this registers the tool metadata, but it won't actually execute without an upstream MCP server):
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/tools \
   -H "Content-Type: application/json" \
   -d '{
     "name": "echo",
-    "type": "echo-tool",
-    "uri": "echo-tool://echo",
+    "type": "mcp-forward",
+    "uri": "http://echo-mcp:8080/mcp",
     "description": "Echoes back whatever you send it",
     "input_schema": {
       "type": "object",
@@ -109,15 +109,20 @@ No downstream services were called. The tool list is served directly from the in
 
 ## Next Steps
 
-### Add a gRPC Tool Service
+### Forward to an Upstream MCP Server
 
-The echo tool above is a stub—it doesn't actually execute. To call a real service, you need to:
+The echo tool above is registered locally but doesn't actually execute — there's no upstream server behind it. To connect to a real MCP server, register it as a forward:
 
-1. Run a gRPC service that implements the tool invoker protocol (see `apis/src/proto/toolrequest.proto`)
-2. Register the service in the registry
-3. Create a tool with `type` matching the service name
+```bash
+curl -X POST http://localhost:8080/api/v1/forwards \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-mcp-server",
+    "address": "http://localhost:8180/mcp"
+  }'
+```
 
-See [Architecture](./architecture.md) for how gRPC tool routing works.
+Praxis auto-discovers all tools from that server and registers them with `type: "mcp-forward"`. Now when an LLM calls one of those tools, Praxis forwards the request transparently.
 
 ### Explore Namespaces
 
@@ -133,8 +138,8 @@ curl -X POST http://localhost:8080/api/v1/tools \
   -d '{
     "name": "get-stock-price",
     "namespace": "finance",
-    "type": "market-data",
-    "uri": "market://stocks",
+    "type": "mcp-forward",
+    "uri": "http://market-data-mcp:8080/mcp",
     "description": "Retrieves current stock prices",
     "input_schema": {"type": "object", "properties": {"symbol": {"type": "string"}}}
   }'
@@ -154,7 +159,7 @@ Only the `get-stock-price` tool appears. The default namespace tools are invisib
 
 Open `http://localhost:8080` in your browser. You'll see the React-based admin UI embedded in the server binary. It talks to the same management API you just used via curl.
 
-From here you can view and manage tools, namespaces, resources, and services.
+From here you can view and manage tools, namespaces, resources, prompts, and forwards.
 
 ### Enable Authentication
 
@@ -228,7 +233,7 @@ The server embeds `server/src/default.yaml` at compile time. To override:
 ```
 
 - **`--praxis-config`:** Praxis filter pipeline config (listeners, filter chains)
-- **`--wanaku-config`:** Wanaku bootstrap config (tools, services, namespaces)
+- **`--wanaku-config`:** Wanaku bootstrap config (tools, forwards, namespaces)
 
 Both are optional. If omitted, embedded defaults are used.
 
@@ -294,7 +299,7 @@ Praxis denies `unsafe_code`, `unwrap_used`, `expect_used`, and `panic` at the cr
 
 **Tool calls time out:**
 
-gRPC calls have a default deadline. If your service takes too long, check the gRPC pool configuration or optimize the service.
+MCP forward calls have a connection timeout. If your upstream MCP server takes too long, verify it's reachable and responding.
 
 **Tools don't appear in `/mcp` but show up in `/api/v1/tools`:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Wanaku Praxis Documentation
 
-Wanaku Praxis is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. It routes AI agent requests through a sophisticated filter pipeline to provide namespace isolation, tool/resource/prompt management, and both local (gRPC) and remote (MCP forwarding) tool execution.
+Wanaku Praxis is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. It routes AI agent requests through a filter pipeline to provide namespace isolation, tool/resource/prompt management, and MCP-to-MCP tool forwarding.
 
 ## Why Praxis?
 
@@ -14,8 +14,8 @@ Praxis shares the same MCP protocol and management API as classic Wanaku. It can
 - **Management API** (port 8080) — REST API for tools, resources, prompts, namespaces
 - **Admin UI** — React-based web interface embedded in the binary
 - **Namespace isolation** — different tools visible to different namespaces
-- **Tool routing** — local gRPC services or remote MCP server forwarding
-- **Feature system** — pluggable filters for LLM chat, custom logic
+- **Tool routing** — MCP-to-MCP forwarding to upstream servers with auto-discovery
+- **Feature system** — pluggable filters for evaluation, LLM chat, interaction tracking
 - **File persistence** — optional registry snapshots to survive restarts
 
 All in a single binary with no runtime dependencies (except libc).
@@ -47,8 +47,7 @@ All in a single binary with no runtime dependencies (except libc).
 ## Who This Isn't For (Yet)
 
 - **You need service catalogs** — use classic Wanaku or build a custom feature
-- **You need complex Camel routes** — delegate to classic backend or a gRPC service
-- **You need OIDC/OAuth** — authentication isn't implemented (yet)
+- **You need complex Camel routes** — delegate to classic backend via an MCP forward
 - **You need clustering** — Praxis is single-node only
 - **You need metrics/tracing** — no Prometheus or OpenTelemetry integration
 
@@ -65,22 +64,19 @@ These are solvable, but they're not in scope for the initial release.
 ┌────────────────────────────────────────────┐
 │       Praxis Filter Pipeline                │
 │  CORS → MCP Parse → Namespace →             │
-│  Tool List/Call → Resource → Prompt        │
+│  Evaluator → Tool/Resource/Prompt          │
 └──────────────┬─────────────────────────────┘
                │
-       ┌───────┴────────┐
-       │                │
-    gRPC            HTTP MCP
-  (Local)          (Forward)
-       │                │
-       ▼                ▼
- ┌──────────┐    ┌──────────┐
- │  Tool    │    │ Upstream │
- │ Services │    │   MCP    │
- └──────────┘    └──────────┘
+          MCP Forward
+               │
+               ▼
+        ┌──────────┐
+        │ Upstream │
+        │   MCP    │
+        └──────────┘
 ```
 
-Requests flow through a chain of filters. Each filter reads metadata (method, namespace, tool name) and decides whether to continue, reject, or synthesize a response. The in-memory registry tracks tools, resources, prompts, and services. Tool calls are routed to gRPC services or forwarded to upstream MCP servers.
+Requests flow through a chain of filters. Each filter reads metadata (method, namespace, tool name) and decides whether to continue, reject, or synthesize a response. The in-memory registry tracks tools, resources, prompts, forwards, and namespaces. Tool calls are forwarded to upstream MCP servers.
 
 See [Architecture](./architecture.md) for the full story.
 
@@ -100,7 +96,7 @@ Filters are middleware that processes requests. Each filter hooks into the Praxi
 
 ### Registry
 
-The registry is the source of truth for tools, resources, prompts, namespaces, forwards, and services. It's an in-memory `DashMap` (concurrent hash map) shared between the filter pipeline and management API.
+The registry is the source of truth for tools, resources, prompts, namespaces, and forwards. It's an in-memory `DashMap` (concurrent hash map) shared between the filter pipeline and management API.
 
 **Persistence:** By default, the registry is ephemeral. Enable file persistence with `WANAKU_PERSIST_BACKEND=file` to snapshot to `registry.json` on shutdown.
 
@@ -110,10 +106,7 @@ Namespaces isolate tools. A tool registered with `namespace: "finance"` only app
 
 ### Tool Routing
 
-Tools can execute in two ways:
-
-1. **gRPC (local):** Tool has `type != "mcp-forward"`. The filter looks up a gRPC service registered for that type and calls it.
-2. **MCP forward (remote):** Tool has `type == "mcp-forward"`. The filter forwards the request to an upstream MCP server via HTTP.
+Tools execute via MCP forwarding. When an LLM calls a tool, Praxis forwards the request to the upstream MCP server specified in the tool's `uri` field. The upstream server handles actual execution and returns the result, which Praxis wraps in a JSON-RPC response.
 
 ### Features
 
@@ -145,8 +138,8 @@ curl -X POST http://localhost:8080/api/v1/tools \
   -H "Content-Type: application/json" \
   -d '{
     "name": "echo",
-    "type": "echo-tool",
-    "uri": "echo-tool://echo",
+    "type": "mcp-forward",
+    "uri": "http://echo-mcp:8080/mcp",
     "description": "Echoes a message",
     "input_schema": {
       "type": "object",
@@ -189,10 +182,10 @@ See [Configuration](./configuration.md) for details.
 
 ### Standalone
 
-Run Praxis as the only MCP server. All tools are gRPC-based, registered via the management API or `wanaku.yaml`.
+Run Praxis as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, executing via MCP forwarding to upstream servers.
 
 **Pros:** Simple, no dependencies
-**Cons:** No persistence beyond file snapshots, no advanced features
+**Cons:** No persistence beyond file snapshots
 
 ### Hybrid (Praxis + Classic Backend)
 
@@ -214,19 +207,19 @@ Deploy Praxis as a `Deployment` with a `PersistentVolume` for the registry. Use 
 |---|---|---|
 | **MCP protocol** | ✅ Full support | ✅ Full support |
 | **Namespace isolation** | ✅ Yes | ✅ Yes |
-| **Tool routing (gRPC)** | ✅ Yes | ✅ Yes |
-| **MCP forwarding** | ✅ Yes | ✅ Yes |
+| **MCP forwarding** | ✅ Yes | ✅ Yes (with auto-discovery) |
 | **Filter pipeline** | — | ✅ Composable filter chain |
 | **Feature crates** | — | ✅ Pluggable Rust crates |
+| **WASM evaluators** | — | ✅ LLM + WASM action scripts |
 | **Service catalogs** | ✅ Yes | ❌ Not yet |
-| **Camel routes** | ✅ Yes | ⚠️ Delegate to gRPC service |
-| **OIDC/OAuth** | ✅ Keycloak | ❌ Not yet |
+| **Camel routes** | ✅ Yes | ⚠️ Delegate via MCP forward |
+| **OIDC/OAuth** | ✅ Keycloak | ✅ oauth2-proxy + Keycloak |
 | **Persistence** | ✅ Infinispan | ⚠️ File snapshots only |
 | **Admin UI** | ✅ React + Orval | ✅ React + Orval |
 
 ## Performance Characteristics
 
-Praxis is built on Pingora (Cloudflare's proxy framework) and uses async I/O throughout. The filter pipeline adds minimal overhead to each request. Actual throughput and latency depend on your downstream services (gRPC, upstream MCP servers, LLM endpoints).
+Praxis is built on Pingora (Cloudflare's proxy framework) and uses async I/O throughout. The filter pipeline adds minimal overhead to each request. Actual throughput and latency depend on your downstream services (upstream MCP servers, LLM endpoints).
 
 The binary is a single statically-linked executable with low memory footprint.
 

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -1,6 +1,6 @@
 # Management API
 
-The management API runs on port 8080 (configurable via `WANAKU_MGMT_LISTEN`) and provides REST endpoints for managing tools, resources, prompts, namespaces, forwards, and services.
+The management API runs on port 8080 (configurable via `WANAKU_MGMT_LISTEN`) and provides REST endpoints for managing tools, resources, prompts, namespaces, and forwards.
 
 This isn't axum or actix-web. It's Pingora's native `ServeHttp` trait. Requests are dispatched via a guard pattern defined in `server/src/management/routes.rs`, and responses are wrapped in a standard envelope.
 
@@ -20,7 +20,7 @@ This matches the classic Wanaku API format for CLI compatibility. The `data` fie
 ```json
 {
   "data": [
-    {"name": "echo", "type": "echo-tool", "uri": "echo-tool://echo", "namespace": "default"}
+    {"name": "echo", "type": "mcp-forward", "uri": "http://echo-mcp:8080/mcp", "namespace": "default"}
   ],
   "error": null
 }
@@ -63,8 +63,8 @@ Content-Type: application/json
 
 {
   "name": "echo",
-  "type": "echo-tool",
-  "uri": "echo-tool://echo",
+  "type": "mcp-forward",
+  "uri": "http://echo-mcp:8080/mcp",
   "description": "Echoes a message",
   "namespace": "default",
   "input_schema": {
@@ -79,8 +79,8 @@ Content-Type: application/json
 
 Fields:
 - `name` (required) — unique tool identifier
-- `type` (required) — service type or `"mcp-forward"`
-- `uri` (required) — tool-specific URI
+- `type` (required) — must be `"mcp-forward"` (only MCP-forwarded tools are supported)
+- `uri` (required) — upstream MCP server address (e.g., `http://server:8080/mcp`)
 - `description` (optional) — human-readable description
 - `namespace` (optional, defaults to `"default"`)
 - `input_schema` (optional) — JSON Schema for tool arguments
@@ -263,38 +263,6 @@ POST /api/v1/forwards/{name}/refreshes
 
 Re-queries the upstream server and updates the tool list.
 
-### Services
-
-**List all services:**
-
-```bash
-GET /api/v1/services
-```
-
-**Create a service:**
-
-```bash
-POST /api/v1/services
-Content-Type: application/json
-
-{
-  "name": "echo-tool",
-  "address": "localhost:9191",
-  "service_type": "tool-invoker"
-}
-```
-
-Fields:
-- `name` (required) — must match tool `type` field
-- `address` (required) — `host:port` of gRPC server
-- `service_type` (required) — `"tool-invoker"`, `"resource-provider"`, or `"multi-capability"`
-
-**Delete a service:**
-
-```bash
-DELETE /api/v1/services/{name}
-```
-
 ## Feature Routes
 
 Features can expose their own management API routes via the `handle_route` method. These routes are dispatched after core routes.
@@ -402,14 +370,31 @@ Errors are returned in the standard envelope:
 
 The HTTP status code indicates the error class (400, 404, 500), and the `error` field provides details.
 
+### Intercept Feature
+
+**List interactions:**
+
+```bash
+GET /api/v1/interactions
+```
+
+Returns the recorded request/response interactions. These are used by the evaluator engine for conversation history context.
+
+**Clear interactions:**
+
+```bash
+DELETE /api/v1/interactions
+```
+
+Clears all stored interactions from the in-memory store.
+
 ## CORS
 
-The management API does NOT set CORS headers by default. If you're calling it from a browser, you'll get CORS errors.
+The management API sets `Access-Control-Allow-Origin` via the `WANAKU_CORS_ORIGIN` environment variable (defaults to `*`). Set this to a specific origin in production:
 
-Workarounds:
-1. Run the API behind a reverse proxy (nginx, Envoy) that adds CORS headers
-2. Add a CORS filter to the management API pipeline (not implemented yet)
-3. Use a browser extension to disable CORS (dev only)
+```bash
+export WANAKU_CORS_ORIGIN=https://app.example.com
+```
 
 The MCP endpoint (port 8081) has CORS enabled via the `cors` filter in the pipeline.
 
@@ -457,21 +442,16 @@ See [Configuration](./configuration.md) for details.
 
 ## Example Workflows
 
-### Register a Tool and Service
+### Register a Tool
 
 ```bash
-# 1. Register the service
-curl -X POST http://localhost:8080/api/v1/services \
-  -H "Content-Type: application/json" \
-  -d '{"name": "echo-tool", "address": "localhost:9191", "service_type": "tool-invoker"}'
-
-# 2. Register the tool
+# 1. Register the tool
 curl -X POST http://localhost:8080/api/v1/tools \
   -H "Content-Type: application/json" \
   -d '{
     "name": "echo",
-    "type": "echo-tool",
-    "uri": "echo-tool://echo",
+    "type": "mcp-forward",
+    "uri": "http://localhost:8180/mcp",
     "description": "Echoes a message",
     "input_schema": {
       "type": "object",
@@ -480,7 +460,7 @@ curl -X POST http://localhost:8080/api/v1/tools \
     }
   }'
 
-# 3. Verify
+# 2. Verify
 curl http://localhost:8080/api/v1/tools
 ```
 
@@ -512,8 +492,8 @@ curl -X POST http://localhost:8080/api/v1/tools \
   -H "Content-Type: application/json" \
   -d '{
     "name": "get-stock-price",
-    "type": "market-data",
-    "uri": "market://stocks",
+    "type": "mcp-forward",
+    "uri": "http://market-data-mcp:8080/mcp",
     "namespace": "finance"
   }'
 


### PR DESCRIPTION
## Summary

Deep review and correction of all developer documentation against the current codebase. The docs had significant factual errors from features that were removed or redesigned.

### What changed

- **Removed all gRPC/services references** — gRPC support (tonic, proto files, ServiceEntry, ServiceRegistry, /api/v1/services routes) was removed from the codebase but still documented extensively across 6 files
- **Fixed evaluator engine config format** — docs showed `rules`/`action`/`labels`/`binding` fields but actual code uses `processor` with a `path` field
- **Fixed Feature trait signature** — updated to match actual `#[async_trait]` API with correct method signatures (`name()`, `handle_route(method, path, query, body)`, etc.)
- **Fixed InMemoryRegistry struct** — removed non-existent `services` field, added actual `persistence` and `inject_request_id` fields
- **Fixed filter pipeline** — added missing `wanaku_well_known` filter between namespace and mcp_init
- **Added missing features** — documented intercept, evaluator, and plugins features in the features guide
- **Fixed tool examples** — all tool type references now use `"mcp-forward"` (the only supported type)
- **Added missing env vars** — `WANAKU_CORS_ORIGIN`, `WANAKU_INTERACTION_CAPACITY`
- **Fixed wanaku.yaml scope** — correctly states it only bootstraps tools and forwards (not resources/prompts/namespaces)
- **Fixed comparison table** — added WASM evaluators row, updated auth to show oauth2-proxy support

### Files modified

- `docs/architecture.md` — diagram, registry, tool routing, Feature trait, feature list
- `docs/configuration.md` — env vars, wanaku.yaml format, filter pipeline
- `docs/evaluator-engine.md` — config format, examples, patterns, management API
- `docs/features.md` — Feature trait code, added intercept/evaluator/plugins docs
- `docs/getting-started.md` — tool examples, next steps, troubleshooting
- `docs/index.md` — diagram, comparison table, tool routing description
- `docs/management-api.md` — removed services routes, added interactions, fixed CORS

## Test plan

- [ ] Read each doc file and verify factual claims against source code
- [ ] Verify all curl examples use valid API endpoints and request formats
- [ ] Verify YAML config examples match actual serde deserialization types

## Summary by Sourcery

Align developer documentation with the current MCP-forward–only architecture, evaluator engine API, and feature set.

Documentation:
- Update evaluator engine docs to describe the simplified processor-based config model and namespace-scoped evaluation without label rules or bindings.
- Revise architecture and index docs to remove gRPC/service-based execution, document MCP forwarding as the sole tool routing model, and reflect the current registry structure and filter pipeline (including the well-known/OAuth and evaluator filters).
- Clarify configuration docs to show that wanaku.yaml only bootstraps tools and forwards, that all tools use type "mcp-forward", and to add new env vars such as WANAKU_CORS_ORIGIN and WANAKU_INTERACTION_CAPACITY.
- Expand features documentation to cover the intercept, evaluator, chat, and plugins features, and update the Feature trait example and dependencies to match the async trait-based API and PipelineExtension usage.
- Update management API docs to drop service endpoints, document intercept feature routes, and describe the new CORS behavior controlled via WANAKU_CORS_ORIGIN.
- Refresh getting-started examples to use MCP-forwarded tools and forwards instead of gRPC services, and to clarify the role of upstream MCP servers and the admin UI.