### PR TITLE
refactor: replace hard-coded HTTP status numbers with StatusCode constants

### DIFF
--- a/apis/src/http_response.rs
+++ b/apis/src/http_response.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 
 use crate::config::ENV;
 
@@ -7,7 +7,7 @@ pub fn json_ok(data: &serde_json::Value) -> Response<Vec<u8>> {
     let wrapper = serde_json::json!({"data": data, "error": null});
     let body = serde_json::to_vec(&wrapper).unwrap_or_default();
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", "application/json")
         .header("Content-Length", body.len())
         .header("Access-Control-Allow-Origin", ENV.cors_origin.as_str())
@@ -16,7 +16,7 @@ pub fn json_ok(data: &serde_json::Value) -> Response<Vec<u8>> {
 }
 
 #[expect(clippy::expect_used, reason = "valid static response")]
-pub fn json_err(status: u16, message: &str) -> Response<Vec<u8>> {
+pub fn json_err(status: StatusCode, message: &str) -> Response<Vec<u8>> {
     let wrapper = serde_json::json!({"data": null, "error": message});
     let body = serde_json::to_vec(&wrapper).unwrap_or_default();
     Response::builder()

--- a/features/chat/src/routes.rs
+++ b/features/chat/src/routes.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 use tracing::warn;
 use wanaku_praxis_apis::http_response::json_err;
 
@@ -33,7 +33,7 @@ pub(crate) fn resolve_chat_route(method: &str, path: &str) -> ChatRoute {
 #[expect(clippy::expect_used, reason = "valid static json response")]
 fn raw_json_response(body: Vec<u8>) -> Response<Vec<u8>> {
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", "application/json")
         .header("Content-Length", body.len())
         .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())
@@ -65,7 +65,7 @@ pub(crate) async fn handle_chat_list_models(
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "failed to fetch models from inference backend");
-            return json_err(502, &format!("failed to reach inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to reach inference backend: {e}"));
         }
     };
 
@@ -74,20 +74,20 @@ pub(crate) async fn handle_chat_list_models(
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, status = %status, "failed to read inference backend models response");
-            return json_err(502, &format!("failed to read inference backend response: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to read inference backend response: {e}"));
         }
     };
 
     if !status.is_success() {
         warn!(status = %status, body = %raw, "inference backend returned error for models");
-        return json_err(status.as_u16(), &format!("inference backend error: {raw}"));
+        return json_err(status, &format!("inference backend error: {raw}"));
     }
 
     let body: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(b) => b,
         Err(e) => {
             warn!(error = %e, status = %status, body = %raw, "failed to parse inference backend models response");
-            return json_err(502, &format!("invalid response from inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("invalid response from inference backend: {e}"));
         }
     };
 
@@ -114,7 +114,7 @@ pub(crate) async fn handle_chat_completions(
 ) -> Response<Vec<u8>> {
     let request: serde_json::Value = match serde_json::from_str(body) {
         Ok(r) => r,
-        Err(e) => return json_err(400, &format!("invalid request: {e}")),
+        Err(e) => return json_err(StatusCode::BAD_REQUEST, &format!("invalid request: {e}")),
     };
 
     let request_api_key = request
@@ -173,7 +173,7 @@ pub(crate) async fn handle_chat_completions(
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "chat completions request to inference backend failed");
-            return json_err(502, &format!("failed to reach inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to reach inference backend: {e}"));
         }
     };
 
@@ -182,20 +182,20 @@ pub(crate) async fn handle_chat_completions(
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, status = %status, "failed to read inference backend completions response");
-            return json_err(502, &format!("failed to read inference backend response: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to read inference backend response: {e}"));
         }
     };
 
     if !status.is_success() {
         warn!(status = %status, body = %raw, "inference backend returned error for completions");
-        return json_err(status.as_u16(), &format!("inference backend error: {raw}"));
+        return json_err(status, &format!("inference backend error: {raw}"));
     }
 
     let resp_body: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(b) => b,
         Err(e) => {
             warn!(error = %e, status = %status, body = %raw, "failed to parse inference backend completions response");
-            return json_err(502, &format!("invalid response from inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, &format!("invalid response from inference backend: {e}"));
         }
     };
 
@@ -209,7 +209,7 @@ pub(crate) async fn handle_chat_completions(
 
     let response_body = content.as_bytes().to_vec();
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", "text/plain")
         .header("Content-Length", response_body.len())
         .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())

--- a/features/evaluator/src/routes.rs
+++ b/features/evaluator/src/routes.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 use tracing::info;
 use wanaku_praxis_apis::http_response::{json_err, json_ok};
 
@@ -62,7 +62,7 @@ pub(crate) fn handle_update_evaluators(
 ) -> Response<Vec<u8>> {
     let config: EvaluatorsConfig = match serde_json::from_str(body) {
         Ok(c) => c,
-        Err(e) => return json_err(400, &format!("invalid evaluators config: {e}")),
+        Err(e) => return json_err(StatusCode::BAD_REQUEST, &format!("invalid evaluators config: {e}")),
     };
 
     let count = config.evaluators.len();
@@ -88,7 +88,7 @@ pub(crate) fn handle_bind_namespace(
 
     let req: BindRequest = match serde_json::from_str(body) {
         Ok(r) => r,
-        Err(e) => return json_err(400, &format!("invalid bind request: {e}")),
+        Err(e) => return json_err(StatusCode::BAD_REQUEST, &format!("invalid bind request: {e}")),
     };
 
     info!(

--- a/features/mcp-metadata/src/filter.rs
+++ b/features/mcp-metadata/src/filter.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use http::StatusCode;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext, Rejection};
 
 use crate::IssuerConfig;
@@ -73,7 +74,7 @@ impl WellKnownFilter {
         });
 
         tracing::debug!("served openid-configuration");
-        json_response(200, &doc)
+        json_response(StatusCode::OK, &doc)
     }
 
     fn handle_protected_resource_metadata(
@@ -119,7 +120,7 @@ impl WellKnownFilter {
         });
 
         tracing::debug!(namespace = %namespace, "served protected resource metadata");
-        Ok(FilterAction::Reject(json_response(200, &metadata)))
+        Ok(FilterAction::Reject(json_response(StatusCode::OK, &metadata)))
     }
 }
 
@@ -138,7 +139,7 @@ async fn proxy_token_endpoint(issuer: &str, body: &Option<Bytes>) -> Rejection {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!(error = %e, "failed to create HTTP client for token proxy");
-            return json_response(503, &serde_json::json!({"error": "token_proxy_error"}));
+            return json_response(StatusCode::SERVICE_UNAVAILABLE, &serde_json::json!({"error": "token_proxy_error"}));
         }
     };
 
@@ -160,13 +161,13 @@ async fn proxy_token_endpoint(issuer: &str, body: &Option<Bytes>) -> Rejection {
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "failed to read token response");
-                    json_response(503, &serde_json::json!({"error": "token_proxy_read_error"}))
+                    json_response(StatusCode::SERVICE_UNAVAILABLE, &serde_json::json!({"error": "token_proxy_read_error"}))
                 }
             }
         }
         Err(e) => {
             tracing::warn!(error = %e, url = %url, "token proxy request failed");
-            json_response(503, &serde_json::json!({"error": "token_proxy_unreachable"}))
+            json_response(StatusCode::SERVICE_UNAVAILABLE, &serde_json::json!({"error": "token_proxy_unreachable"}))
         }
     }
 }
@@ -177,14 +178,14 @@ fn redirect_to(url: &str, query: Option<&str>) -> Rejection {
         _ => url.to_owned(),
     };
     tracing::debug!(target = %target, "redirecting to issuer");
-    Rejection::status(302)
+    Rejection::status(StatusCode::FOUND.as_u16())
         .with_header("location", &target)
         .with_header("access-control-allow-origin", "*")
 }
 
-fn json_response(status: u16, value: &serde_json::Value) -> Rejection {
+fn json_response(status: StatusCode, value: &serde_json::Value) -> Rejection {
     let body = Bytes::from(value.to_string());
-    Rejection::status(status)
+    Rejection::status(status.as_u16())
         .with_header("content-type", "application/json")
         .with_header("access-control-allow-origin", "*")
         .with_body(body)

--- a/features/plugins/src/handlers.rs
+++ b/features/plugins/src/handlers.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use http::Response;
+use http::{Response, StatusCode};
 use tracing::warn;
 use wanaku_praxis_apis::http_response::{json_err, json_ok};
 
@@ -27,27 +27,27 @@ pub(crate) fn handle_serve_file(
 
     let canonical = match target.canonicalize() {
         Ok(p) => p,
-        Err(_) => return json_err(404, "file not found"),
+        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
     };
 
     let canonical_root = match plugin_root.canonicalize() {
         Ok(r) => r,
-        Err(_) => return json_err(404, "plugin not found"),
+        Err(_) => return json_err(StatusCode::NOT_FOUND, "plugin not found"),
     };
 
     if !canonical.starts_with(&canonical_root) {
-        return json_err(403, "forbidden");
+        return json_err(StatusCode::FORBIDDEN, "forbidden");
     }
 
     let body = match std::fs::read(&canonical) {
         Ok(b) => b,
-        Err(_) => return json_err(404, "file not found"),
+        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
     };
 
     let content_type = mime_for_path(canonical.to_str().unwrap_or(""));
 
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", content_type)
         .header("Content-Length", body.len())
         .body(body)
@@ -70,7 +70,7 @@ pub(crate) async fn handle_proxy_service(
 
     let req_method = match method.parse::<reqwest::Method>() {
         Ok(m) => m,
-        Err(_) => return json_err(400, &format!("unsupported method: {method}")),
+        Err(_) => return json_err(StatusCode::BAD_REQUEST, &format!("unsupported method: {method}")),
     };
 
     let mut request = client.request(req_method, &url);
@@ -91,7 +91,7 @@ pub(crate) async fn handle_proxy_service(
         Ok(r) => r,
         Err(e) => {
             warn!(url = %url, error = %e, "plugin proxy request failed");
-            return json_err(502, "upstream request failed");
+            return json_err(StatusCode::BAD_GATEWAY, "upstream request failed");
         }
     };
 
@@ -106,7 +106,7 @@ pub(crate) async fn handle_proxy_service(
         Ok(b) => b.to_vec(),
         Err(e) => {
             warn!(error = %e, "failed to read plugin proxy response body");
-            return json_err(502, "upstream response read failed");
+            return json_err(StatusCode::BAD_GATEWAY, "upstream response read failed");
         }
     };
 

--- a/features/plugins/src/lib.rs
+++ b/features/plugins/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::RwLock;
 
-use http::Response;
+use http::{Response, StatusCode};
 use praxis_filter::{FilterRegistry, PipelineExtension};
 use wanaku_praxis_apis::feature::Feature;
 use wanaku_praxis_apis::http_response::json_err;
@@ -134,7 +134,7 @@ impl Feature for PluginsFeature {
             PluginRoute::ServeFile(plugin_id, file_path) => {
                 match &self.plugins_path {
                     Some(p) => routes::handle_file(p, &plugin_id, &file_path),
-                    None => json_err(404, "plugins directory not configured"),
+                    None => json_err(StatusCode::NOT_FOUND, "plugins directory not configured"),
                 }
             }
             PluginRoute::ProxyService(plugin_id, service_id, proxy_path) => {
@@ -157,7 +157,7 @@ impl Feature for PluginsFeature {
                         .await
                     }
                     None => json_err(
-                        404,
+                        StatusCode::NOT_FOUND,
                         &format!("service {service_id} not found for plugin {plugin_id}"),
                     ),
                 }

--- a/filters/src/response.rs
+++ b/filters/src/response.rs
@@ -1,18 +1,19 @@
 use bytes::Bytes;
+use http::StatusCode;
 use praxis_filter::Rejection;
 
 pub const JSONRPC_INVALID_PARAMS: i32 = -32602;
 pub const JSONRPC_INTERNAL_ERROR: i32 = -32603;
 
 pub fn json_response(body: Bytes) -> Rejection {
-    Rejection::status(200)
+    Rejection::status(StatusCode::OK.as_u16())
         .with_header("content-type", "application/json")
         .with_header("access-control-allow-origin", "*")
         .with_body(body)
 }
 
 pub fn empty_accepted() -> Rejection {
-    Rejection::status(202)
+    Rejection::status(StatusCode::ACCEPTED.as_u16())
         .with_header("access-control-allow-origin", "*")
 }
 

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 use tracing::{info, warn};
 
 use wanaku_praxis_apis::registry::{
@@ -16,7 +16,7 @@ pub(super) fn handle_tool_list(registry: &InMemoryRegistry) -> Response<Vec<u8>>
 pub(super) fn handle_tool_get(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     match registry.get_tool(name) {
         Some(tool) => json_ok(&serde_json::json!(tool)),
-        None => json_err(404, &format!("tool not found: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("tool not found: {name}")),
     }
 }
 
@@ -26,14 +26,14 @@ pub(super) fn handle_tool_create(registry: &InMemoryRegistry, body: &str) -> Res
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, "invalid tool JSON");
-            return json_err(400, &format!("invalid tool JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid tool JSON: {e}"));
         }
     };
 
     tool.name = tool.name.trim().to_owned();
     if tool.name.is_empty() {
         warn!("rejected tool with empty name");
-        return json_err(400, "tool name must not be empty");
+        return json_err(StatusCode::BAD_REQUEST, "tool name must not be empty");
     }
 
     let name = tool.name.clone();
@@ -41,7 +41,7 @@ pub(super) fn handle_tool_create(registry: &InMemoryRegistry, body: &str) -> Res
     info!(tool = %name, "registered tool via management API");
     match registry.get_tool(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("tool not found after registration: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("tool not found after registration: {name}")),
     }
 }
 
@@ -51,7 +51,7 @@ pub(super) fn handle_tool_update(registry: &InMemoryRegistry, path_name: &str, b
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, "invalid tool JSON");
-            return json_err(400, &format!("invalid tool JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid tool JSON: {e}"));
         }
     };
 
@@ -68,7 +68,7 @@ pub(super) fn handle_tool_update(registry: &InMemoryRegistry, path_name: &str, b
     info!(tool = %name, "updated tool via management API");
     match registry.get_tool(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("tool not found after update: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("tool not found after update: {name}")),
     }
 }
 
@@ -77,7 +77,7 @@ pub(super) fn handle_tool_delete(registry: &InMemoryRegistry, name: &str) -> Res
         info!(tool = %name, "removed tool via management API");
         json_ok(&serde_json::json!({"removed": name}))
     } else {
-        json_err(404, &format!("tool not found: {name}"))
+        json_err(StatusCode::NOT_FOUND, &format!("tool not found: {name}"))
     }
 }
 
@@ -89,7 +89,7 @@ pub(super) fn handle_resource_list(registry: &InMemoryRegistry) -> Response<Vec<
 pub(super) fn handle_resource_get(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     match registry.get_resource(name) {
         Some(resource) => json_ok(&serde_json::json!(resource)),
-        None => json_err(404, &format!("resource not found: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("resource not found: {name}")),
     }
 }
 
@@ -99,7 +99,7 @@ pub(super) fn handle_resource_create(registry: &InMemoryRegistry, body: &str) ->
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "invalid resource JSON");
-            return json_err(400, &format!("invalid resource JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid resource JSON: {e}"));
         }
     };
 
@@ -108,7 +108,7 @@ pub(super) fn handle_resource_create(registry: &InMemoryRegistry, body: &str) ->
     info!(resource = %name, "registered resource via management API");
     match registry.get_resource(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("resource not found after registration: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("resource not found after registration: {name}")),
     }
 }
 
@@ -118,7 +118,7 @@ pub(super) fn handle_resource_update(registry: &InMemoryRegistry, path_name: &st
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "invalid resource JSON");
-            return json_err(400, &format!("invalid resource JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid resource JSON: {e}"));
         }
     };
 
@@ -143,7 +143,7 @@ pub(super) fn handle_resource_update(registry: &InMemoryRegistry, path_name: &st
     info!(resource = %name, "updated resource via management API");
     match registry.get_resource(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("resource not found after update: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("resource not found after update: {name}")),
     }
 }
 
@@ -152,7 +152,7 @@ pub(super) fn handle_resource_delete(registry: &InMemoryRegistry, name: &str) ->
         info!(resource = %name, "removed resource via management API");
         json_ok(&serde_json::json!({"removed": name}))
     } else {
-        json_err(404, &format!("resource not found: {name}"))
+        json_err(StatusCode::NOT_FOUND, &format!("resource not found: {name}"))
     }
 }
 
@@ -164,7 +164,7 @@ pub(super) fn handle_prompt_list(registry: &InMemoryRegistry) -> Response<Vec<u8
 pub(super) fn handle_prompt_get(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     match registry.get_prompt(name) {
         Some(prompt) => json_ok(&serde_json::json!(prompt)),
-        None => json_err(404, &format!("prompt not found: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("prompt not found: {name}")),
     }
 }
 
@@ -174,7 +174,7 @@ pub(super) fn handle_prompt_create(registry: &InMemoryRegistry, body: &str) -> R
         Ok(p) => p,
         Err(e) => {
             warn!(error = %e, "invalid prompt JSON");
-            return json_err(400, &format!("invalid prompt JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid prompt JSON: {e}"));
         }
     };
 
@@ -183,7 +183,7 @@ pub(super) fn handle_prompt_create(registry: &InMemoryRegistry, body: &str) -> R
     info!(prompt = %name, "registered prompt via management API");
     match registry.get_prompt(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("prompt not found after registration: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("prompt not found after registration: {name}")),
     }
 }
 
@@ -192,7 +192,7 @@ pub(super) fn handle_prompt_delete(registry: &InMemoryRegistry, name: &str) -> R
         info!(prompt = %name, "removed prompt via management API");
         json_ok(&serde_json::json!({"removed": name}))
     } else {
-        json_err(404, &format!("prompt not found: {name}"))
+        json_err(StatusCode::NOT_FOUND, &format!("prompt not found: {name}"))
     }
 }
 
@@ -204,7 +204,7 @@ pub(super) fn handle_namespace_list(registry: &InMemoryRegistry) -> Response<Vec
 pub(super) fn handle_namespace_get(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     match registry.get_namespace(name) {
         Some(ns) => json_ok(&serde_json::json!(ns)),
-        None => json_err(404, &format!("namespace not found: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("namespace not found: {name}")),
     }
 }
 
@@ -213,7 +213,7 @@ pub(super) fn handle_namespace_create(registry: &InMemoryRegistry, body: &str) -
         Ok(n) => n,
         Err(e) => {
             warn!(error = %e, "invalid namespace JSON");
-            return json_err(400, &format!("invalid namespace JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid namespace JSON: {e}"));
         }
     };
 
@@ -222,7 +222,7 @@ pub(super) fn handle_namespace_create(registry: &InMemoryRegistry, body: &str) -
     info!(namespace = %name, "registered namespace via management API");
     match registry.get_namespace(&name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("namespace not found after registration: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("namespace not found after registration: {name}")),
     }
 }
 
@@ -231,7 +231,7 @@ pub(super) fn handle_namespace_update(registry: &InMemoryRegistry, path_name: &s
         Ok(n) => n,
         Err(e) => {
             warn!(error = %e, "invalid namespace JSON");
-            return json_err(400, &format!("invalid namespace JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid namespace JSON: {e}"));
         }
     };
 
@@ -241,7 +241,7 @@ pub(super) fn handle_namespace_update(registry: &InMemoryRegistry, path_name: &s
     info!(namespace = %path_name, "updated namespace via management API");
     match registry.get_namespace(path_name) {
         Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(404, &format!("namespace not found after update: {path_name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("namespace not found after update: {path_name}")),
     }
 }
 
@@ -250,7 +250,7 @@ pub(super) fn handle_namespace_delete(registry: &InMemoryRegistry, name: &str) -
         info!(namespace = %name, "removed namespace via management API");
         json_ok(&serde_json::json!({"removed": name}))
     } else {
-        json_err(404, &format!("namespace not found: {name}"))
+        json_err(StatusCode::NOT_FOUND, &format!("namespace not found: {name}"))
     }
 }
 
@@ -262,7 +262,7 @@ pub(super) fn handle_forward_list(registry: &InMemoryRegistry) -> Response<Vec<u
 pub(super) fn handle_forward_get(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     match registry.get_forward(name) {
         Some(forward) => json_ok(&serde_json::json!(forward)),
-        None => json_err(404, &format!("forward not found: {name}")),
+        None => json_err(StatusCode::NOT_FOUND, &format!("forward not found: {name}")),
     }
 }
 
@@ -272,7 +272,7 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
         Ok(f) => f,
         Err(e) => {
             warn!(error = %e, "invalid forward JSON");
-            return json_err(400, &format!("invalid forward JSON: {e}"));
+            return json_err(StatusCode::BAD_REQUEST, &format!("invalid forward JSON: {e}"));
         }
     };
 
@@ -310,7 +310,7 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
     let forward = registry.get_forward(name);
 
     if !registry.remove_forward(name) {
-        return json_err(404, &format!("forward not found: {name}"));
+        return json_err(StatusCode::NOT_FOUND, &format!("forward not found: {name}"));
     }
 
     if let Some(fwd) = forward {
@@ -326,7 +326,7 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
 pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
     let mut forward = match registry.get_forward(name) {
         Some(f) => f,
-        None => return json_err(404, &format!("forward not found: {name}")),
+        None => return json_err(StatusCode::NOT_FOUND, &format!("forward not found: {name}")),
     };
 
     remove_forwarded_tools(registry, &forward.address);

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -9,7 +9,7 @@ pub use handlers::discover_resources_from_forward;
 pub use handlers::discover_prompts_from_forward;
 
 use async_trait::async_trait;
-use http::Response;
+use http::{Response, StatusCode};
 use pingora_core::apps::http_app::ServeHttp;
 use pingora_core::protocols::http::ServerSession;
 use tracing::info;
@@ -101,7 +101,7 @@ impl ServeHttp for WanakuManagementService {
         if mgmt_route != ManagementRoute::NotFound {
             return match mgmt_route {
                 ManagementRoute::Statistics => handle_statistics(&self.registry),
-                ManagementRoute::NotFound => json_err(404, "not found"),
+                ManagementRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -121,7 +121,7 @@ impl ServeHttp for WanakuManagementService {
                     Err(resp) => resp,
                 },
                 ToolRoute::Delete(name) => handle_tool_delete(&self.registry, &name),
-                ToolRoute::NotFound => json_err(404, "not found"),
+                ToolRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -139,7 +139,7 @@ impl ServeHttp for WanakuManagementService {
                     Err(resp) => resp,
                 },
                 ResourceRoute::Delete(name) => handle_resource_delete(&self.registry, &name),
-                ResourceRoute::NotFound => json_err(404, "not found"),
+                ResourceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -153,7 +153,7 @@ impl ServeHttp for WanakuManagementService {
                     Err(resp) => resp,
                 },
                 PromptRoute::Delete(name) => handle_prompt_delete(&self.registry, &name),
-                PromptRoute::NotFound => json_err(404, "not found"),
+                PromptRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -171,7 +171,7 @@ impl ServeHttp for WanakuManagementService {
                     Err(resp) => resp,
                 },
                 NamespaceRoute::Delete(name) => handle_namespace_delete(&self.registry, &name),
-                NamespaceRoute::NotFound => json_err(404, "not found"),
+                NamespaceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -186,7 +186,7 @@ impl ServeHttp for WanakuManagementService {
                 },
                 ForwardRoute::Delete(name) => handle_forward_delete(&self.registry, &name),
                 ForwardRoute::Refresh(name) => handle_forward_refresh(&self.registry, &name).await,
-                ForwardRoute::NotFound => json_err(404, "not found"),
+                ForwardRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };
         }
 
@@ -212,9 +212,9 @@ impl ServeHttp for WanakuManagementService {
             if let Some(proxy) = &self.proxy {
                 return proxy.forward(&method, &path, feature_body).await;
             }
-            return json_err(503, "Classic backend not configured (set WANAKU_CLASSIC_URL)");
+            return json_err(StatusCode::SERVICE_UNAVAILABLE, "Classic backend not configured (set WANAKU_CLASSIC_URL)");
         }
 
-        json_err(404, "not found")
+        json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default())
     }
 }

--- a/server/src/management/response.rs
+++ b/server/src/management/response.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 use pingora_core::protocols::http::ServerSession;
 use tracing::warn;
 
@@ -7,7 +7,7 @@ pub(super) const MAX_BODY_BYTES: usize = 1_048_576;
 #[expect(clippy::expect_used, reason = "valid static response")]
 pub(super) fn redirect_response(location: &str) -> Response<Vec<u8>> {
     Response::builder()
-        .status(301)
+        .status(StatusCode::MOVED_PERMANENTLY)
         .header("Location", location)
         .body(Vec::new())
         .expect("valid redirect")
@@ -16,7 +16,7 @@ pub(super) fn redirect_response(location: &str) -> Response<Vec<u8>> {
 #[expect(clippy::expect_used, reason = "valid static response")]
 pub(super) fn raw_json_response(body: Vec<u8>) -> Response<Vec<u8>> {
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", "application/json")
         .header("Content-Length", body.len())
         .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())
@@ -28,7 +28,7 @@ pub(super) fn json_ok(data: &serde_json::Value) -> Response<Vec<u8>> {
     crate::http_response::json_ok(data)
 }
 
-pub(super) fn json_err(status: u16, message: &str) -> Response<Vec<u8>> {
+pub(super) fn json_err(status: StatusCode, message: &str) -> Response<Vec<u8>> {
     crate::http_response::json_err(status, message)
 }
 
@@ -39,16 +39,16 @@ pub(super) async fn read_body(session: &mut ServerSession) -> Result<String, Res
             Ok(Some(chunk)) => {
                 if buf.len() + chunk.len() > MAX_BODY_BYTES {
                     warn!(limit = MAX_BODY_BYTES, "management request body exceeded size limit");
-                    return Err(json_err(413, "request body too large"));
+                    return Err(json_err(StatusCode::PAYLOAD_TOO_LARGE, "request body too large"));
                 }
                 buf.extend_from_slice(&chunk);
             }
             Ok(None) => break,
             Err(e) => {
                 warn!(error = %e, "management request body read failed");
-                return Err(json_err(502, "request body read failed"));
+                return Err(json_err(StatusCode::BAD_GATEWAY, "request body read failed"));
             }
         }
     }
-    String::from_utf8(buf).map_err(|_| json_err(400, "request body is not valid UTF-8"))
+    String::from_utf8(buf).map_err(|_| json_err(StatusCode::BAD_REQUEST, "request body is not valid UTF-8"))
 }

--- a/server/src/management/ui.rs
+++ b/server/src/management/ui.rs
@@ -1,4 +1,4 @@
-use http::Response;
+use http::{Response, StatusCode};
 use rust_embed::Embed;
 
 use super::response::json_err;
@@ -28,7 +28,7 @@ pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &
     if let Some(file) = AdminUi::get(asset_path) {
         let content_type = mime_for_path(asset_path);
         return Response::builder()
-            .status(200)
+            .status(StatusCode::OK)
             .header("Content-Type", content_type)
             .header("Content-Length", file.data.len())
             .body(file.data.into_owned())
@@ -38,7 +38,7 @@ pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &
     if !relative.contains('.') {
         if let Some(index) = AdminUi::get("index.html") {
             return Response::builder()
-                .status(200)
+                .status(StatusCode::OK)
                 .header("Content-Type", "text/html; charset=utf-8")
                 .header("Content-Length", index.data.len())
                 .body(index.data.into_owned())
@@ -46,7 +46,7 @@ pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &
         }
     }
 
-    json_err(404, "file not found")
+    json_err(StatusCode::NOT_FOUND, "file not found")
 }
 
 #[expect(clippy::expect_used, reason = "valid static response")]
@@ -63,35 +63,35 @@ fn serve_from_filesystem(ui_root: &std::path::Path, relative: &str) -> Response<
             if !relative.contains('.') {
                 if let Ok(index) = std::fs::read(ui_root.join("index.html")) {
                     return Response::builder()
-                        .status(200)
+                        .status(StatusCode::OK)
                         .header("Content-Type", "text/html; charset=utf-8")
                         .header("Content-Length", index.len())
                         .body(index)
                         .expect("valid static response");
                 }
             }
-            return json_err(404, "file not found");
+            return json_err(StatusCode::NOT_FOUND, "file not found");
         }
     };
 
     let canonical_root = match ui_root.canonicalize() {
         Ok(r) => r,
-        Err(_) => return json_err(500, "UI root path not found"),
+        Err(_) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, "UI root path not found"),
     };
 
     if !canonical.starts_with(&canonical_root) {
-        return json_err(403, "forbidden");
+        return json_err(StatusCode::FORBIDDEN, StatusCode::FORBIDDEN.canonical_reason().unwrap_or_default());
     }
 
     let body = match std::fs::read(&canonical) {
         Ok(b) => b,
-        Err(_) => return json_err(404, "file not found"),
+        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
     };
 
     let content_type = mime_for_path(canonical.to_str().unwrap_or(""));
 
     Response::builder()
-        .status(200)
+        .status(StatusCode::OK)
         .header("Content-Type", content_type)
         .header("Content-Length", body.len())
         .body(body)

--- a/server/src/proxy.rs
+++ b/server/src/proxy.rs
@@ -1,5 +1,5 @@
 
-use http::Response;
+use http::{Response, StatusCode};
 use reqwest::Client;
 
 const PROXIED_PREFIXES: &[&str] = &[
@@ -41,7 +41,7 @@ impl ClassicProxy {
 
         let req_method = match method.parse::<reqwest::Method>() {
             Ok(m) => m,
-            Err(_) => return json_err(400, &format!("unsupported method: {method}")),
+            Err(_) => return json_err(StatusCode::BAD_REQUEST, &format!("unsupported method: {method}")),
         };
 
         let mut request = self.client.request(req_method, &url);
@@ -56,7 +56,7 @@ impl ClassicProxy {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(url = %url, error = %e, "proxy request to Classic failed");
-                return json_err(502, "upstream request failed");
+                return json_err(StatusCode::BAD_GATEWAY, "upstream request failed");
             }
         };
 
@@ -66,7 +66,7 @@ impl ClassicProxy {
             Ok(b) => b.to_vec(),
             Err(e) => {
                 tracing::warn!(error = %e, "failed to read proxy response body");
-                return json_err(502, "upstream response read failed");
+                return json_err(StatusCode::BAD_GATEWAY, "upstream response read failed");
             }
         };
 
@@ -74,7 +74,7 @@ impl ClassicProxy {
     }
 }
 
-fn json_err(status: u16, message: &str) -> Response<Vec<u8>> {
+fn json_err(status: StatusCode, message: &str) -> Response<Vec<u8>> {
     crate::http_response::json_err(status, message)
 }
 


### PR DESCRIPTION
## Summary

- Replace all hard-coded HTTP status numbers (`400`, `404`, `502`, etc.) with named constants from `http::StatusCode` (`StatusCode::NOT_FOUND`, `StatusCode::BAD_REQUEST`, etc.) across 12 files
- Change `json_err` signature from `u16` to `StatusCode` to enforce typed status codes at compile time
- Use `StatusCode::canonical_reason()` for generic error messages that were just restating the status code (e.g., `"not found"` → derived from `StatusCode::NOT_FOUND`)
- Simplify `json_err(status.as_u16(), ...)` to `json_err(status, ...)` in chat routes since `reqwest::StatusCode` is `http::StatusCode`
- Dynamic/forwarded upstream status codes (proxy responses) remain `u16` as they carry runtime values

No new dependencies — the `http` crate was already a workspace dependency.

Follow-up: #1813 tracks pre-existing semantic issues surfaced by this refactoring.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — all 213 tests pass
- [ ] Verify management API returns correct status codes for error responses
- [ ] Verify MCP proxy forwards upstream status codes correctly

## Summary by Sourcery

Standardize HTTP status handling with named `StatusCode` constants and type-safe JSON error responses.

Enhancements:
- Replace hard-coded HTTP status values with typed `http::StatusCode` constants across API, management, proxy, chat, plugin, evaluator, and metadata responses.
- Update JSON error response helpers to accept `StatusCode` values and derive generic messages from canonical status reasons where appropriate.
- Preserve dynamic upstream status codes while using typed constants for locally generated responses.

Tests:
- Verify the project builds successfully and all 213 tests pass.