### PR TITLE
ci: remove stale protobuf references from Containerfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,8 @@ curl -X POST http://localhost:8081/finance/mcp -d '{"jsonrpc":"2.0","method":"to
 
 ## Known Gotchas
 
+**Containerfile sync:** When adding/removing workspace crates, build scripts (`build.rs`), or source directories, update `Containerfile` to match — the cache-build stage copies `Cargo.toml` files and build inputs individually.
+
 **`include_str!` rebuilds:** editing `default.yaml` doesn't trigger rebuild — touch `server/src/lib.rs`, then `cargo build`.
 
 **Pingora workers:** `kill -9 <parent-pid>` may not kill workers. Use `lsof -ti :8081 | xargs kill -9` or `SIGTERM`.

--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ RUN yarn build
 
 FROM registry.fedoraproject.org/fedora:42 AS builder
 
-RUN dnf install -y gcc gcc-c++ openssl-devel pkgconf-pkg-config cmake make protobuf-compiler curl \
+RUN dnf install -y gcc gcc-c++ openssl-devel pkgconf-pkg-config cmake make curl \
     && dnf clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.96.0
@@ -38,9 +38,6 @@ COPY features/evaluator/Cargo.toml features/evaluator/Cargo.toml
 COPY features/intercept/Cargo.toml features/intercept/Cargo.toml
 COPY features/mcp-metadata/Cargo.toml features/mcp-metadata/Cargo.toml
 COPY features/plugins/Cargo.toml features/plugins/Cargo.toml
-
-COPY apis/build.rs apis/build.rs
-COPY apis/src/proto apis/src/proto
 
 RUN mkdir -p apis/src filters/src server/src \
     features/chat/src features/evaluator/src features/intercept/src features/mcp-metadata/src features/plugins/src \


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/wanaku-ai/wanaku/actions/runs/32057443113

### Errors Fixed
- `COPY apis/build.rs apis/build.rs`: file removed when gRPC support was dropped — removed stale COPY
- `COPY apis/src/proto apis/src/proto`: directory removed when gRPC support was dropped — removed stale COPY
- `protobuf-compiler` in `dnf install`: no longer needed without protobuf compilation — removed from package list

### Additional Changes
- Added "Containerfile sync" gotcha to CLAUDE.md to prevent similar drift in the future

## Summary by Sourcery

Synchronize the container build with the removal of protobuf support.

Bug Fixes:
- Remove obsolete protobuf build dependencies and source copies from the container build to restore compatibility with the current repository layout.

Enhancements:
- Document the need to keep the Containerfile cache-build inputs synchronized with workspace changes.

Documentation:
- Add a Containerfile synchronization gotcha to the contributor guidance.