### PR TITLE
chore: upgrade container images to Fedora 44

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ RUN yarn build
 # Stage 2: Build Rust binary
 # ------------------------------------------------------------------------------
 
-FROM registry.fedoraproject.org/fedora:42 AS builder
+FROM registry.fedoraproject.org/fedora:44 AS builder
 
 RUN dnf install -y gcc gcc-c++ openssl-devel pkgconf-pkg-config cmake make protobuf-compiler curl \
     && dnf clean all
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # Stage 3: Runtime
 # ------------------------------------------------------------------------------
 
-FROM registry.fedoraproject.org/fedora-minimal:42
+FROM registry.fedoraproject.org/fedora-minimal:44
 
 LABEL org.opencontainers.image.source="https://github.com/wanaku-ai/wanaku-praxis" \
     org.opencontainers.image.description="Wanaku Praxis MCP proxy server" \


### PR DESCRIPTION
## Summary
- Upgrade builder base image from `fedora:42` to `fedora:44`
- Upgrade runtime base image from `fedora-minimal:42` to `fedora-minimal:44`

## Test plan
- [ ] Build container image successfully with the updated base images
- [ ] Verify the runtime image starts and serves traffic on ports 8080/8081

## Summary by Sourcery

Enhancements:
- Upgrade the builder and runtime container base images from Fedora 42 to Fedora 44.