### PR TITLE
refactor: remove direct creation of tools, resources, and prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,16 +78,18 @@ All tools execute via MCP forwarding:
 - Filter calls `mcp_client::call_tool(tool.uri, ...)` (rmcp crate, HTTP+SSE)
 - Non-MCP-forward types error
 
-**Forward discovery:** POST `/api/v1/forwards` → register forward → `mcp_client::list_tools(address)` → auto-register tools with `type_: "mcp-forward"`, `uri: address`. Refresh (`POST /forwards/{name}/refreshes`) removes old, re-discovers.
+**Forward discovery:** POST `/api/v1/forwards` → register forward → discover tools, resources, and prompts from upstream → auto-register with `type_: "mcp-forward"`. This is the **only** way to populate tools, resources, and prompts. Refresh (`POST /forwards/{name}/refreshes`) removes old, re-discovers.
 
 ### Management API (Port 8080)
 
 Uses Pingora `ServeHttp` (NOT axum) in `server/src/management/mod.rs`.
 
 **Core routes** (`server/src/management/`), all under `/api/v1/`:
-- `/tools`, `/resources`, `/prompts`, `/namespaces`, `/forwards` — each supports GET (list), GET `/{name}`, POST, DELETE `/{name}`
-- `/tools/{name}`, `/resources/{name}`, `/namespaces/{name}` also support PUT (update)
-- `/forwards/{name}/refreshes` — POST to re-discover tools
+- `/tools`, `/resources`, `/prompts` — GET (list), GET `/{name}`, DELETE `/{name}` (read-only; populated via forward discovery)
+- `/tools/{name}`, `/resources/{name}` — also support PUT (update metadata)
+- `/namespaces` — GET (list), GET `/{name}`, POST, PUT `/{name}`, DELETE `/{name}`
+- `/forwards` — GET (list), GET `/{name}`, POST, DELETE `/{name}`
+- `/forwards/{name}/refreshes` — POST to re-discover tools/resources/prompts
 
 **Feature routes** (via `Feature::handle_route`):
 - `/api/v1/chat/llms`, `/chat/{llm}/models`, `/chat/completions` (from `features/chat/`)

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -326,8 +326,8 @@ import { EmptyTableState } from '../../components/EmptyTableState';
 
 {tools.length === 0 ? (
   <EmptyTableState
-    title="No tools registered"
-    subtitle="Create your first tool to get started"
+    title="No tools discovered yet"
+    subtitle="Register a forwarded MCP server to auto-discover tools"
   />
 ) : (
   <DataTable rows={tools} headers={headers} />

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -278,7 +278,7 @@ If you reorder filters and requests start failing, check the logs. The filter th
 
 ## Wanaku Config File (wanaku.yaml)
 
-The Wanaku config bootstraps tools and forwards on startup. It's optional — if omitted, the registry starts empty. Resources, prompts, and namespaces must be registered via the management API.
+The Wanaku config bootstraps forwarded MCP servers on startup. It's optional — if omitted, the registry starts empty.
 
 **Location:** Pass with `--wanaku-config`:
 
@@ -289,25 +289,12 @@ cargo run -- --praxis-config /path/to/praxis.yaml --wanaku-config /path/to/wanak
 **Format:**
 
 ```yaml
-tools:
-  - name: "echo"
-    type: "mcp-forward"
-    uri: "http://echo-mcp:8080/mcp"
-    description: "Echoes a message"
-    namespace: "default"
-    input_schema:
-      type: object
-      properties:
-        message:
-          type: string
-      required: [message]
-
 forwards:
   - name: "upstream-mcp"
     address: "http://upstream:8080/mcp"
 ```
 
-**Note:** Only `tools`, `forwards`, and `evaluators` are loaded from wanaku.yaml at startup. Resources, prompts, and namespaces must be registered via the management API (POST `/api/v1/resources`, `/api/v1/prompts`, `/api/v1/namespaces`).
+**Note:** Only `forwards` and `evaluators` are loaded from wanaku.yaml at startup. Tools, resources, and prompts are discovered from the forwarded MCP servers.
 
 **Evaluator configuration** (see [Evaluator Engine](./evaluator-engine.md) for full details):
 
@@ -332,56 +319,6 @@ evaluators:
 ```
 
 When `result_schema` is set, the host validates LLM output against the schema and retries once with a correction prompt on mismatch.
-
-### Tool Definitions
-
-**All tools must have `type: "mcp-forward"`** — other tool types are not supported. The `uri` field points to the upstream MCP server that will execute the tool.
-
-**Minimal:**
-
-```yaml
-tools:
-  - name: "my-tool"
-    type: "mcp-forward"
-    uri: "http://my-mcp-server:8080/mcp"
-    description: "Does a thing"
-```
-
-**With input schema:**
-
-```yaml
-tools:
-  - name: "http-get"
-    type: "mcp-forward"
-    uri: "http://http-mcp-server:8080/mcp"
-    description: "HTTP GET request"
-    input_schema:
-      type: object
-      properties:
-        url:
-          type: string
-          description: "Target URL"
-      required: [url]
-```
-
-**Namespace isolation:**
-
-```yaml
-tools:
-  - name: "get-stock-price"
-    type: "mcp-forward"
-    uri: "http://market-mcp:8080/mcp"
-    namespace: "finance"
-    input_schema:
-      type: object
-      properties:
-        symbol:
-          type: string
-```
-
-This tool only appears in `/finance/mcp`, not `/mcp`.
-
-**Note:** When called, Praxis forwards the request to the upstream MCP server via HTTP POST and returns the result.
 
 ## Common Configuration Patterns
 
@@ -448,11 +385,9 @@ data:
           # ... rest of pipeline
 
   wanaku.yaml: |
-    tools:
-      - name: "echo"
-        type: "mcp-forward"
-        uri: "http://echo-mcp:8080/mcp"
-        description: "Echoes a message"
+    forwards:
+      - name: "upstream-mcp"
+        address: "http://upstream:8080/mcp"
 ```
 
 **Deployment:**

--- a/docs/evaluator-engine.md
+++ b/docs/evaluator-engine.md
@@ -683,7 +683,17 @@ curl -X DELETE http://localhost:8080/api/v1/evaluators/namespaces/finance-team
 
 ### Quick Local Test
 
-This script registers a forwarded MCP server (which auto-discovers tools), configures an evaluator, makes a tool call, and verifies the response.
+This script configures an evaluator, makes a tool call against a tool discovered from a forwarded MCP server, and verifies the response.
+
+**Prerequisites:** You need an upstream MCP server that exposes at least one tool. Register it as a forward before running this script:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/forwards \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-mcp-server","address":"http://<your-mcp-server>/mcp"}'
+```
+
+Replace `restart-database` in the script below with a tool name discovered from your forward (`curl http://localhost:8080/api/v1/tools` to see available tools).
 
 ```bash
 #!/usr/bin/env bash
@@ -692,10 +702,6 @@ set -euo pipefail
 MGMT=http://localhost:8080
 MCP=http://localhost:8081
 WASM="$(pwd)/actions/dist/safety-block.wasm"
-
-echo "Registering forward (auto-discovers tools)..."
-curl -sf -X POST $MGMT/api/v1/forwards -H "Content-Type: application/json" \
-  -d '{"name":"test-server","address":"http://localhost:8080/mcp"}' > /dev/null
 
 echo "Configuring evaluator with WASM action..."
 curl -sf -X PUT $MGMT/api/v1/evaluators -H "Content-Type: application/json" \
@@ -717,9 +723,8 @@ echo "Making tool call..."
 curl -sf -X POST $MCP/mcp -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"restart-database","arguments":{"target":"prod"}}}' | jq .
 
-echo "Cleaning up..."
+echo "Cleaning up evaluator..."
 curl -sf -X PUT $MGMT/api/v1/evaluators -H "Content-Type: application/json" -d '{"evaluators":[]}' > /dev/null
-curl -sf -X DELETE $MGMT/api/v1/forwards/test-server > /dev/null
 echo "Done."
 ```
 

--- a/docs/evaluator-engine.md
+++ b/docs/evaluator-engine.md
@@ -683,7 +683,7 @@ curl -X DELETE http://localhost:8080/api/v1/evaluators/namespaces/finance-team
 
 ### Quick Local Test
 
-This script registers a test tool, configures an evaluator, makes a tool call, and verifies the response.
+This script registers a forwarded MCP server (which auto-discovers tools), configures an evaluator, makes a tool call, and verifies the response.
 
 ```bash
 #!/usr/bin/env bash
@@ -693,9 +693,9 @@ MGMT=http://localhost:8080
 MCP=http://localhost:8081
 WASM="$(pwd)/actions/dist/safety-block.wasm"
 
-echo "Registering tool..."
-curl -sf -X POST $MGMT/api/v1/tools -H "Content-Type: application/json" \
-  -d '{"name":"restart-database","description":"Restart a production database","uri":"http://localhost:8080/mcp","type":"mcp-forward","inputSchema":{"type":"object","properties":{}}}' > /dev/null
+echo "Registering forward (auto-discovers tools)..."
+curl -sf -X POST $MGMT/api/v1/forwards -H "Content-Type: application/json" \
+  -d '{"name":"test-server","address":"http://localhost:8080/mcp"}' > /dev/null
 
 echo "Configuring evaluator with WASM action..."
 curl -sf -X PUT $MGMT/api/v1/evaluators -H "Content-Type: application/json" \
@@ -719,7 +719,7 @@ curl -sf -X POST $MCP/mcp -H "Content-Type: application/json" \
 
 echo "Cleaning up..."
 curl -sf -X PUT $MGMT/api/v1/evaluators -H "Content-Type: application/json" -d '{"evaluators":[]}' > /dev/null
-curl -sf -X DELETE $MGMT/api/v1/tools/restart-database > /dev/null
+curl -sf -X DELETE $MGMT/api/v1/forwards/test-server > /dev/null
 echo "Done."
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,37 +49,30 @@ Expected response:
 {"data": [], "error": null}
 ```
 
-That empty array means the server is running, but you haven't registered any tools yet. Let's fix that.
+That empty array means the server is running, but no tools have been discovered yet. Let's fix that.
 
-### 4. Register Your First Tool
+### 4. Register a Forward (Auto-Discover Tools)
 
-Create a simple echo tool (note: this registers the tool metadata, but it won't actually execute without an upstream MCP server):
+Tools are discovered automatically from upstream MCP servers. Register a forward to an MCP server:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/tools \
+curl -X POST http://localhost:8080/api/v1/forwards \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "echo",
-    "type": "mcp-forward",
-    "uri": "http://echo-mcp:8080/mcp",
-    "description": "Echoes back whatever you send it",
-    "input_schema": {
-      "type": "object",
-      "properties": {
-        "message": {"type": "string"}
-      },
-      "required": ["message"]
-    }
+    "name": "my-mcp-server",
+    "address": "http://localhost:8180/mcp"
   }'
 ```
 
-Now list tools again:
+Praxis connects to the upstream server, discovers all available tools, and registers them automatically with `type: "mcp-forward"`.
+
+List the discovered tools:
 
 ```bash
 curl http://localhost:8080/api/v1/tools
 ```
 
-You'll see your echo tool in the response. The server is ready to route MCP requests.
+You'll see the tools discovered from the upstream server. The server is now ready to route MCP requests to those tools.
 
 ### 5. Test the MCP Endpoint
 
@@ -91,7 +84,7 @@ curl -X POST http://localhost:8081/mcp \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 ```
 
-You'll get a JSON-RPC response listing your echo tool. The filter pipeline parsed your request, checked the namespace (defaulted to `"default"`), and returned the registered tools.
+You'll get a JSON-RPC response listing the tools discovered from your forward. The filter pipeline parsed your request, checked the namespace (defaulted to `"default"`), and returned the tools from the registry.
 
 ## What Just Happened?
 
@@ -107,43 +100,29 @@ No downstream services were called. The tool list is served directly from the in
 
 ## Next Steps
 
-### Forward to an Upstream MCP Server
+### Register Additional Forwards
 
-The echo tool above is registered locally but doesn't actually execute — there's no upstream server behind it. To connect to a real MCP server, register it as a forward:
-
-```bash
-curl -X POST http://localhost:8080/api/v1/forwards \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "my-mcp-server",
-    "address": "http://localhost:8180/mcp"
-  }'
-```
-
-Praxis auto-discovers all tools from that server and registers them with `type: "mcp-forward"`. Now when an LLM calls one of those tools, Praxis forwards the request transparently.
+To discover tools from additional MCP servers, register more forwards the same way you did in step 4. Each forward connects to an upstream MCP server and auto-discovers its tools, resources, and prompts.
 
 ### Explore Namespaces
 
-Namespaces isolate tools. Create a tool in the `"finance"` namespace:
+Namespaces isolate tools. Create a `"finance"` namespace and register a forward that assigns discovered tools to it:
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/namespaces \
   -H "Content-Type: application/json" \
   -d '{"name": "finance"}'
 
-curl -X POST http://localhost:8080/api/v1/tools \
+curl -X POST http://localhost:8080/api/v1/forwards \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "get-stock-price",
-    "namespace": "finance",
-    "type": "mcp-forward",
-    "uri": "http://market-data-mcp:8080/mcp",
-    "description": "Retrieves current stock prices",
-    "input_schema": {"type": "object", "properties": {"symbol": {"type": "string"}}}
+    "name": "market-data-server",
+    "address": "http://market-data-mcp:8080/mcp",
+    "namespace": "finance"
   }'
 ```
 
-Now query the finance namespace:
+Tools discovered from this forward inherit the `"finance"` namespace. Query the finance namespace:
 
 ```bash
 curl -X POST http://localhost:8081/finance/mcp \
@@ -151,7 +130,7 @@ curl -X POST http://localhost:8081/finance/mcp \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 ```
 
-Only the `get-stock-price` tool appears. The default namespace tools are invisible here.
+Only tools from the `market-data-server` forward appear. The default namespace tools are invisible here.
 
 ### Use the Admin UI
 
@@ -231,7 +210,7 @@ The server embeds `server/src/default.yaml` at compile time. To override:
 ```
 
 - **`--praxis-config`:** Praxis filter pipeline config (listeners, filter chains)
-- **`--wanaku-config`:** Wanaku bootstrap config (tools, forwards, namespaces)
+- **`--wanaku-config`:** Wanaku bootstrap config (forwards, namespaces)
 
 Both are optional. If omitted, embedded defaults are used.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,21 +128,23 @@ Server starts on:
 - MCP: `http://127.0.0.1:8081/mcp`
 - Management API: `http://0.0.0.0:8080/api/v1`
 
-### Register a Tool
+### Register a Forward
+
+Tools, resources, and prompts are obtained by registering a forwarded MCP server. When you register a forward, Wanaku auto-discovers all tools from the upstream server.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/tools \
+curl -X POST http://localhost:8080/api/v1/forwards \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "echo",
-    "type": "mcp-forward",
-    "uri": "http://echo-mcp:8080/mcp",
-    "description": "Echoes a message",
-    "input_schema": {
-      "type": "object",
-      "properties": {"message": {"type": "string"}}
-    }
+    "name": "echo-server",
+    "address": "http://echo-mcp:8080/mcp"
   }'
+```
+
+This automatically discovers and registers all tools exposed by the upstream MCP server. To refresh the tool list after the upstream server changes, use the refresh endpoint:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/forwards/echo-server/refreshes
 ```
 
 ### Deploy to Kubernetes
@@ -179,7 +181,7 @@ See [Configuration](./configuration.md) for details.
 
 ### Standalone
 
-Run Praxis as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, executing via MCP forwarding to upstream servers.
+Run Praxis as the only MCP server. Tools are discovered from forwarded MCP servers registered via the management API or `wanaku.yaml`, executing via MCP forwarding to those upstream servers.
 
 **Pros:** Simple, no dependencies
 **Cons:** No persistence beyond file snapshots

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -39,6 +39,8 @@ This matches the classic Wanaku API format for CLI compatibility. The `data` fie
 
 ### Tools
 
+Tools are automatically discovered and registered when you add a forwarded MCP server via `POST /api/v1/forwards`. You cannot create tools directly — they are populated by querying upstream MCP servers.
+
 **List all tools:**
 
 ```bash
@@ -55,36 +57,6 @@ GET /api/v1/tools/{name}
 
 Returns a single tool by name. 404 if not found.
 
-**Create a tool:**
-
-```bash
-POST /api/v1/tools
-Content-Type: application/json
-
-{
-  "name": "echo",
-  "type": "mcp-forward",
-  "uri": "http://echo-mcp:8080/mcp",
-  "description": "Echoes a message",
-  "namespace": "default",
-  "input_schema": {
-    "type": "object",
-    "properties": {
-      "message": {"type": "string"}
-    },
-    "required": ["message"]
-  }
-}
-```
-
-Fields:
-- `name` (required) — unique tool identifier
-- `type` (required) — must be `"mcp-forward"` (only MCP-forwarded tools are supported)
-- `uri` (required) — upstream MCP server address (e.g., `http://server:8080/mcp`)
-- `description` (optional) — human-readable description
-- `namespace` (optional, defaults to `"default"`)
-- `input_schema` (optional) — JSON Schema for tool arguments
-
 **Delete a tool:**
 
 ```bash
@@ -94,6 +66,8 @@ DELETE /api/v1/tools/{name}
 Returns 204 on success, 404 if not found.
 
 ### Resources
+
+Resources are automatically discovered and registered when you add a forwarded MCP server via `POST /api/v1/forwards`. You cannot create resources directly — they are populated by querying upstream MCP servers.
 
 **List all resources:**
 
@@ -107,30 +81,6 @@ GET /api/v1/resources
 GET /api/v1/resources/{name}
 ```
 
-**Create a resource:**
-
-```bash
-POST /api/v1/resources
-Content-Type: application/json
-
-{
-  "name": "readme",
-  "type": "file",
-  "uri": "file:///README.md",
-  "description": "Project README",
-  "namespace": "default",
-  "mime_type": "text/markdown"
-}
-```
-
-Fields:
-- `name` (required)
-- `type` (required)
-- `uri` (required)
-- `description` (optional)
-- `namespace` (optional, defaults to `"default"`)
-- `mime_type` (optional)
-
 **Delete a resource:**
 
 ```bash
@@ -138,6 +88,8 @@ DELETE /api/v1/resources/{name}
 ```
 
 ### Prompts
+
+Prompts are automatically discovered and registered when you add a forwarded MCP server via `POST /api/v1/forwards`. You cannot create prompts directly — they are populated by querying upstream MCP servers.
 
 **List all prompts:**
 
@@ -150,42 +102,6 @@ GET /api/v1/prompts
 ```bash
 GET /api/v1/prompts/{name}
 ```
-
-**Create a prompt:**
-
-```bash
-POST /api/v1/prompts
-Content-Type: application/json
-
-{
-  "name": "code-review",
-  "description": "Review code for issues",
-  "namespace": "default",
-  "messages": [
-    {
-      "role": "user",
-      "content": {
-        "type": "text",
-        "text": "Review this code: {{code}}"
-      }
-    }
-  ],
-  "arguments": [
-    {
-      "name": "code",
-      "description": "Code to review",
-      "required": true
-    }
-  ]
-}
-```
-
-Fields:
-- `name` (required)
-- `description` (optional)
-- `namespace` (optional, defaults to `"default"`)
-- `messages` (required) — array of message objects (role + content)
-- `arguments` (optional) — array of argument schemas
 
 **Delete a prompt:**
 
@@ -404,7 +320,7 @@ None. The management API is unthrottled. In production, put it behind a reverse 
 
 ## Authentication
 
-**When auth is disabled** (default): The management API is unauthenticated. Anyone who can reach port 8080 can create/delete tools.
+**When auth is disabled** (default): The management API is unauthenticated. Anyone who can reach port 8080 can delete tools or manage forwards.
 
 **When auth is enabled** (via oauth2-proxy): All `/api/v1/*` routes require a valid Bearer token:
 
@@ -442,26 +358,19 @@ See [Configuration](./configuration.md) for details.
 
 ## Example Workflows
 
-### Register a Tool
+### Discover Tools via Forward
 
 ```bash
-# 1. Register the tool
-curl -X POST http://localhost:8080/api/v1/tools \
+# 1. Register a forward (auto-discovers tools)
+curl -X POST http://localhost:8080/api/v1/forwards \
   -H "Content-Type: application/json" \
-  -d '{
-    "name": "echo",
-    "type": "mcp-forward",
-    "uri": "http://localhost:8180/mcp",
-    "description": "Echoes a message",
-    "input_schema": {
-      "type": "object",
-      "properties": {"message": {"type": "string"}},
-      "required": ["message"]
-    }
-  }'
+  -d '{"name": "echo-server", "address": "http://localhost:8180/mcp"}'
 
-# 2. Verify
+# 2. List discovered tools
 curl http://localhost:8080/api/v1/tools
+
+# 3. Verify a specific tool
+curl http://localhost:8080/api/v1/tools/echo
 ```
 
 ### Forward to Upstream MCP Server
@@ -487,21 +396,18 @@ curl -X POST http://localhost:8080/api/v1/namespaces \
   -H "Content-Type: application/json" \
   -d '{"name": "finance", "description": "Financial tools"}'
 
-# 2. Create tool in namespace
-curl -X POST http://localhost:8080/api/v1/tools \
+# 2. Register a forward (tools inherit the namespace from the forward configuration)
+curl -X POST http://localhost:8080/api/v1/forwards \
   -H "Content-Type: application/json" \
-  -d '{
-    "name": "get-stock-price",
-    "type": "mcp-forward",
-    "uri": "http://market-data-mcp:8080/mcp",
-    "namespace": "finance"
-  }'
+  -d '{"name": "market-data", "address": "http://market-data-mcp:8080/mcp", "namespace": "finance"}'
 
 # 3. Query finance namespace via MCP
 curl -X POST http://localhost:8081/finance/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 ```
+
+Tools discovered from the forward will be registered in the `finance` namespace. Namespace assignment happens through the forward configuration, not by creating tools directly.
 
 ## Related Docs
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,8 +16,7 @@ use tracing::info;
 use wanaku_praxis_apis::feature::Feature;
 use wanaku_praxis_apis::persistence::FilePersistence;
 use wanaku_praxis_apis::registry::{
-    ForwardEntry, ForwardRegistry, InMemoryRegistry, ToolEntry,
-    ToolRegistry,
+    ForwardEntry, ForwardRegistry, InMemoryRegistry,
 };
 
 fn main() {
@@ -165,20 +164,6 @@ fn load_wanaku_yaml(path: &str) -> Option<serde_yaml::Value> {
 }
 
 fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
-    if let Some(tools) = config.get("tools").and_then(|t| t.as_sequence()) {
-        for tool_value in tools {
-            match serde_yaml::from_value::<ToolEntry>(tool_value.clone()) {
-                Ok(tool) => {
-                    info!(tool = %tool.name, "registered tool from config");
-                    registry.register_tool(tool);
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to deserialize tool entry from config");
-                }
-            }
-        }
-    }
-
     let mut forwards = Vec::new();
     if let Some(fwd_list) = config.get("forwards").and_then(|f| f.as_sequence()) {
         for fwd_value in fwd_list {

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -20,31 +20,6 @@ pub(super) fn handle_tool_get(registry: &InMemoryRegistry, name: &str) -> Respon
     }
 }
 
-pub(super) fn handle_tool_create(registry: &InMemoryRegistry, body: &str) -> Response<Vec<u8>> {
-    tracing::debug!(body = %body, "tool create request body");
-    let mut tool: ToolEntry = match serde_json::from_str(body) {
-        Ok(t) => t,
-        Err(e) => {
-            warn!(error = %e, "invalid tool JSON");
-            return json_err(StatusCode::BAD_REQUEST, &format!("invalid tool JSON: {e}"));
-        }
-    };
-
-    tool.name = tool.name.trim().to_owned();
-    if tool.name.is_empty() {
-        warn!("rejected tool with empty name");
-        return json_err(StatusCode::BAD_REQUEST, "tool name must not be empty");
-    }
-
-    let name = tool.name.clone();
-    registry.register_tool(tool);
-    info!(tool = %name, "registered tool via management API");
-    match registry.get_tool(&name) {
-        Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(StatusCode::NOT_FOUND, &format!("tool not found after registration: {name}")),
-    }
-}
-
 pub(super) fn handle_tool_update(registry: &InMemoryRegistry, path_name: &str, body: &str) -> Response<Vec<u8>> {
     tracing::debug!(body = %body, name = %path_name, "tool update request body");
     let mut tool: ToolEntry = match serde_json::from_str(body) {
@@ -90,25 +65,6 @@ pub(super) fn handle_resource_get(registry: &InMemoryRegistry, name: &str) -> Re
     match registry.get_resource(name) {
         Some(resource) => json_ok(&serde_json::json!(resource)),
         None => json_err(StatusCode::NOT_FOUND, &format!("resource not found: {name}")),
-    }
-}
-
-pub(super) fn handle_resource_create(registry: &InMemoryRegistry, body: &str) -> Response<Vec<u8>> {
-    tracing::debug!(body = %body, "resource create request body");
-    let resource: ResourceEntry = match serde_json::from_str(body) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(error = %e, "invalid resource JSON");
-            return json_err(StatusCode::BAD_REQUEST, &format!("invalid resource JSON: {e}"));
-        }
-    };
-
-    let name = resource.name.clone();
-    registry.register_resource(resource);
-    info!(resource = %name, "registered resource via management API");
-    match registry.get_resource(&name) {
-        Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(StatusCode::NOT_FOUND, &format!("resource not found after registration: {name}")),
     }
 }
 
@@ -165,25 +121,6 @@ pub(super) fn handle_prompt_get(registry: &InMemoryRegistry, name: &str) -> Resp
     match registry.get_prompt(name) {
         Some(prompt) => json_ok(&serde_json::json!(prompt)),
         None => json_err(StatusCode::NOT_FOUND, &format!("prompt not found: {name}")),
-    }
-}
-
-pub(super) fn handle_prompt_create(registry: &InMemoryRegistry, body: &str) -> Response<Vec<u8>> {
-    tracing::debug!(body = %body, "prompt create request body");
-    let prompt: PromptEntry = match serde_json::from_str(body) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!(error = %e, "invalid prompt JSON");
-            return json_err(StatusCode::BAD_REQUEST, &format!("invalid prompt JSON: {e}"));
-        }
-    };
-
-    let name = prompt.name.clone();
-    registry.register_prompt(prompt);
-    info!(prompt = %name, "registered prompt via management API");
-    match registry.get_prompt(&name) {
-        Some(entry) => json_ok(&serde_json::json!(entry)),
-        None => json_err(StatusCode::NOT_FOUND, &format!("prompt not found after registration: {name}")),
     }
 }
 
@@ -833,18 +770,19 @@ mod tests {
     use http::Response;
     use wanaku_praxis_apis::registry::{
         ForwardEntry, ForwardRegistry, InMemoryRegistry,
-        ToolRegistry,
+        PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry,
+        ToolEntry, ToolRegistry,
     };
 
     use super::{
         handle_forward_delete, handle_forward_get, handle_forward_list,
         handle_namespace_create, handle_namespace_delete, handle_namespace_get,
         handle_namespace_list, handle_namespace_update,
-        handle_prompt_create, handle_prompt_delete, handle_prompt_get, handle_prompt_list,
-        handle_resource_create, handle_resource_delete, handle_resource_get, handle_resource_list,
+        handle_prompt_delete, handle_prompt_get, handle_prompt_list,
+        handle_resource_delete, handle_resource_get, handle_resource_list,
         handle_resource_update,
         handle_statistics,
-        handle_tool_create, handle_tool_delete, handle_tool_get, handle_tool_list,
+        handle_tool_delete, handle_tool_get, handle_tool_list,
         handle_tool_update,
     };
 
@@ -857,39 +795,49 @@ mod tests {
         body.get("data").cloned().unwrap_or_default()
     }
 
-    fn error_message(resp: &Response<Vec<u8>>) -> Option<String> {
-        let body = parse_body(resp);
-        body.get("error")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_owned())
+    fn test_tool(name: &str) -> ToolEntry {
+        ToolEntry {
+            name: name.to_owned(),
+            description: String::new(),
+            uri: "u".to_owned(),
+            type_: "x".to_owned(),
+            input_schema: serde_json::json!({"type": "object"}),
+            labels: HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        }
+    }
+
+    fn test_resource(name: &str) -> ResourceEntry {
+        ResourceEntry {
+            name: name.to_owned(),
+            description: String::new(),
+            location: "/x".to_owned(),
+            type_: "file".to_owned(),
+            mime_type: String::new(),
+            labels: HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        }
+    }
+
+    fn test_prompt(name: &str) -> PromptEntry {
+        PromptEntry {
+            name: name.to_owned(),
+            description: String::new(),
+            arguments: Vec::new(),
+            messages: Vec::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+        }
     }
 
     // ---- Tool handlers ----
-
-    #[test]
-    fn tool_create_and_get_roundtrip() {
-        let registry = InMemoryRegistry::new();
-        let body = r#"{
-            "name":"my-tool",
-            "description":"desc",
-            "uri":"echo://t",
-            "type":"echo",
-            "input_schema":{"type":"object"}
-        }"#;
-
-        let create_resp = handle_tool_create(&registry, body);
-        assert_eq!(create_resp.status(), 200);
-
-        let get_resp = handle_tool_get(&registry, "my-tool");
-        assert_eq!(get_resp.status(), 200);
-
-        let data = data_field(&get_resp);
-        assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("my-tool"));
-        assert_eq!(
-            data.get("description").and_then(|v| v.as_str()),
-            Some("desc")
-        );
-    }
 
     #[test]
     fn tool_list_empty_then_populated() {
@@ -898,9 +846,7 @@ mod tests {
         assert_eq!(resp.status(), 200);
         assert_eq!(data_field(&resp).as_array().map(|a| a.len()), Some(0));
 
-        let body =
-            r#"{"name":"t1","description":"","uri":"u","type":"x","input_schema":{"type":"object"}}"#;
-        handle_tool_create(&registry, body);
+        registry.register_tool(test_tool("t1"));
 
         let resp = handle_tool_list(&registry);
         assert_eq!(data_field(&resp).as_array().map(|a| a.len()), Some(1));
@@ -916,9 +862,7 @@ mod tests {
     #[test]
     fn tool_delete_existing() {
         let registry = InMemoryRegistry::new();
-        let body =
-            r#"{"name":"to-delete","description":"","uri":"u","type":"x","input_schema":{"type":"object"}}"#;
-        handle_tool_create(&registry, body);
+        registry.register_tool(test_tool("to-delete"));
 
         let resp = handle_tool_delete(&registry, "to-delete");
         assert_eq!(resp.status(), 200);
@@ -933,61 +877,11 @@ mod tests {
     }
 
     #[test]
-    fn tool_create_invalid_json_returns_400() {
-        let registry = InMemoryRegistry::new();
-        let resp = handle_tool_create(&registry, "not valid json");
-        assert_eq!(resp.status(), 400);
-        assert!(error_message(&resp).is_some());
-    }
-
-    #[test]
-    fn tool_create_empty_name_returns_400() {
-        let registry = InMemoryRegistry::new();
-        let resp = handle_tool_create(
-            &registry,
-            r#"{"name":"","description":"d","uri":"u","type":"x","input_schema":{"type":"object"}}"#,
-        );
-        assert_eq!(resp.status(), 400);
-        assert!(error_message(&resp)
-            .map(|m| m.contains("empty"))
-            .unwrap_or(false));
-    }
-
-    #[test]
-    fn tool_create_whitespace_name_returns_400() {
-        let registry = InMemoryRegistry::new();
-        let resp = handle_tool_create(
-            &registry,
-            r#"{"name":"  ","description":"d","uri":"u","type":"x","input_schema":{"type":"object"}}"#,
-        );
-        assert_eq!(resp.status(), 400);
-        assert!(error_message(&resp)
-            .map(|m| m.contains("empty"))
-            .unwrap_or(false));
-    }
-
-    #[test]
-    fn tool_create_with_input_schema_alias() {
-        let registry = InMemoryRegistry::new();
-        let body = r#"{
-            "name":"alias-tool",
-            "description":"",
-            "uri":"u",
-            "type":"x",
-            "inputSchema":{"type":"object","properties":{"msg":{"type":"string"}}}
-        }"#;
-
-        let resp = handle_tool_create(&registry, body);
-        assert_eq!(resp.status(), 200);
-        assert!(registry.get_tool("alias-tool").is_some());
-    }
-
-    #[test]
     fn tool_update_changes_description() {
         let registry = InMemoryRegistry::new();
-        let body =
-            r#"{"name":"upd","description":"old","uri":"u","type":"x","input_schema":{"type":"object"}}"#;
-        handle_tool_create(&registry, body);
+        let mut tool = test_tool("upd");
+        tool.description = "old".to_owned();
+        registry.register_tool(tool);
 
         let update_body =
             r#"{"name":"upd","description":"new","uri":"u2","type":"y","input_schema":{"type":"object"}}"#;
@@ -1005,9 +899,7 @@ mod tests {
     #[test]
     fn tool_update_rename_removes_old_entry() {
         let registry = InMemoryRegistry::new();
-        let body =
-            r#"{"name":"old-name","description":"d","uri":"u","type":"x","input_schema":{"type":"object"}}"#;
-        handle_tool_create(&registry, body);
+        registry.register_tool(test_tool("old-name"));
 
         let update_body =
             r#"{"name":"new-name","description":"d","uri":"u","type":"x","input_schema":{"type":"object"}}"#;
@@ -1030,31 +922,6 @@ mod tests {
     // ---- Resource handlers ----
 
     #[test]
-    fn resource_create_and_get_roundtrip() {
-        let registry = InMemoryRegistry::new();
-        let body = r#"{
-            "name":"my-res",
-            "description":"d",
-            "location":"/tmp/f",
-            "type":"file",
-            "mime_type":"text/plain"
-        }"#;
-
-        let create_resp = handle_resource_create(&registry, body);
-        assert_eq!(create_resp.status(), 200);
-
-        let get_resp = handle_resource_get(&registry, "my-res");
-        assert_eq!(get_resp.status(), 200);
-
-        let data = data_field(&get_resp);
-        assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("my-res"));
-        assert_eq!(
-            data.get("location").and_then(|v| v.as_str()),
-            Some("/tmp/f")
-        );
-    }
-
-    #[test]
     fn resource_list_empty_then_populated() {
         let registry = InMemoryRegistry::new();
         assert_eq!(
@@ -1064,7 +931,7 @@ mod tests {
             Some(0)
         );
 
-        handle_resource_create(&registry, r#"{"name":"r1","location":"/x","type":"file"}"#);
+        registry.register_resource(test_resource("r1"));
         assert_eq!(
             data_field(&handle_resource_list(&registry))
                 .as_array()
@@ -1082,7 +949,7 @@ mod tests {
     #[test]
     fn resource_delete_existing() {
         let registry = InMemoryRegistry::new();
-        handle_resource_create(&registry, r#"{"name":"del-res","location":"/x","type":"file"}"#);
+        registry.register_resource(test_resource("del-res"));
 
         assert_eq!(handle_resource_delete(&registry, "del-res").status(), 200);
         assert_eq!(handle_resource_get(&registry, "del-res").status(), 404);
@@ -1095,15 +962,12 @@ mod tests {
     }
 
     #[test]
-    fn resource_create_invalid_json_returns_400() {
-        let registry = InMemoryRegistry::new();
-        assert_eq!(handle_resource_create(&registry, "{bad}").status(), 400);
-    }
-
-    #[test]
     fn resource_update_changes_description() {
         let registry = InMemoryRegistry::new();
-        handle_resource_create(&registry, r#"{"name":"res","description":"old","location":"/a","type":"file"}"#);
+        let mut res = test_resource("res");
+        res.description = "old".to_owned();
+        res.location = "/a".to_owned();
+        registry.register_resource(res);
 
         let resp = handle_resource_update(
             &registry, "res",
@@ -1119,7 +983,7 @@ mod tests {
     #[test]
     fn resource_update_rename_removes_old_entry() {
         let registry = InMemoryRegistry::new();
-        handle_resource_create(&registry, r#"{"name":"old-res","description":"d","location":"/x","type":"file"}"#);
+        registry.register_resource(test_resource("old-res"));
 
         let resp = handle_resource_update(
             &registry, "old-res",
@@ -1139,10 +1003,12 @@ mod tests {
     #[test]
     fn resource_update_preserves_internal_labels() {
         let registry = InMemoryRegistry::new();
-        handle_resource_create(
-            &registry,
-            r#"{"name":"fwd-res","description":"old","location":"file:///data","type":"mcp-forward","labels":{"wanaku.forward_address":"http://remote:8080"}}"#,
-        );
+        let mut res = test_resource("fwd-res");
+        res.description = "old".to_owned();
+        res.location = "file:///data".to_owned();
+        res.type_ = "mcp-forward".to_owned();
+        res.labels.insert("wanaku.forward_address".to_owned(), "http://remote:8080".to_owned());
+        registry.register_resource(res);
 
         let resp = handle_resource_update(
             &registry, "fwd-res",
@@ -1162,23 +1028,6 @@ mod tests {
     // ---- Prompt handlers ----
 
     #[test]
-    fn prompt_create_and_get_roundtrip() {
-        let registry = InMemoryRegistry::new();
-        let body = r#"{"name":"my-prompt","description":"A prompt"}"#;
-
-        assert_eq!(handle_prompt_create(&registry, body).status(), 200);
-
-        let get_resp = handle_prompt_get(&registry, "my-prompt");
-        assert_eq!(get_resp.status(), 200);
-
-        let data = data_field(&get_resp);
-        assert_eq!(
-            data.get("name").and_then(|v| v.as_str()),
-            Some("my-prompt")
-        );
-    }
-
-    #[test]
     fn prompt_list_empty_then_populated() {
         let registry = InMemoryRegistry::new();
         assert_eq!(
@@ -1188,7 +1037,7 @@ mod tests {
             Some(0)
         );
 
-        handle_prompt_create(&registry, r#"{"name":"p1","description":"x"}"#);
+        registry.register_prompt(test_prompt("p1"));
         assert_eq!(
             data_field(&handle_prompt_list(&registry))
                 .as_array()
@@ -1206,7 +1055,7 @@ mod tests {
     #[test]
     fn prompt_delete_existing() {
         let registry = InMemoryRegistry::new();
-        handle_prompt_create(&registry, r#"{"name":"del-p","description":""}"#);
+        registry.register_prompt(test_prompt("del-p"));
         assert_eq!(handle_prompt_delete(&registry, "del-p").status(), 200);
         assert_eq!(handle_prompt_get(&registry, "del-p").status(), 404);
     }
@@ -1215,12 +1064,6 @@ mod tests {
     fn prompt_delete_nonexistent_returns_404() {
         let registry = InMemoryRegistry::new();
         assert_eq!(handle_prompt_delete(&registry, "nope").status(), 404);
-    }
-
-    #[test]
-    fn prompt_create_invalid_json_returns_400() {
-        let registry = InMemoryRegistry::new();
-        assert_eq!(handle_prompt_create(&registry, "[]").status(), 400);
     }
 
     // ---- Namespace handlers ----
@@ -1396,16 +1239,10 @@ mod tests {
     fn statistics_populated_registry() {
         let registry = InMemoryRegistry::new();
 
-        handle_tool_create(
-            &registry,
-            r#"{"name":"t1","description":"","uri":"u","type":"x","input_schema":{"type":"object"}}"#,
-        );
-        handle_tool_create(
-            &registry,
-            r#"{"name":"t2","description":"","uri":"u","type":"x","input_schema":{"type":"object"}}"#,
-        );
-        handle_resource_create(&registry, r#"{"name":"r1","location":"/x","type":"file"}"#);
-        handle_prompt_create(&registry, r#"{"name":"p1","description":""}"#);
+        registry.register_tool(test_tool("t1"));
+        registry.register_tool(test_tool("t2"));
+        registry.register_resource(test_resource("r1"));
+        registry.register_prompt(test_prompt("p1"));
         registry.register_forward(ForwardEntry {
             name: "f1".to_owned(),
             address: "http://x:1".to_owned(),
@@ -1435,10 +1272,9 @@ mod tests {
     #[test]
     fn tool_serializes_camel_case_keys() {
         let registry = InMemoryRegistry::new();
-        handle_tool_create(
-            &registry,
-            r#"{"name":"cc","description":"","uri":"u","type":"x","input_schema":{"type":"object","properties":{"msg":{"type":"string"}}}}"#,
-        );
+        let mut tool = test_tool("cc");
+        tool.input_schema = serde_json::json!({"type":"object","properties":{"msg":{"type":"string"}}});
+        registry.register_tool(tool);
 
         let data = data_field(&handle_tool_get(&registry, "cc"));
         assert!(
@@ -1454,10 +1290,10 @@ mod tests {
     #[test]
     fn tool_serializes_optional_camel_case_keys() {
         let registry = InMemoryRegistry::new();
-        handle_tool_create(
-            &registry,
-            r#"{"name":"cc-opt","description":"","uri":"u","type":"x","input_schema":{"type":"object"},"configurationURI":"cfg://a","secretsURI":"sec://b"}"#,
-        );
+        let mut tool = test_tool("cc-opt");
+        tool.configuration_uri = Some("cfg://a".to_owned());
+        tool.secrets_uri = Some("sec://b".to_owned());
+        registry.register_tool(tool);
 
         let data = data_field(&handle_tool_get(&registry, "cc-opt"));
         assert!(data.get("configurationURI").is_some());
@@ -1469,10 +1305,9 @@ mod tests {
     #[test]
     fn resource_serializes_camel_case_keys() {
         let registry = InMemoryRegistry::new();
-        handle_resource_create(
-            &registry,
-            r#"{"name":"cc-res","location":"/x","type":"file","mime_type":"text/plain"}"#,
-        );
+        let mut res = test_resource("cc-res");
+        res.mime_type = "text/plain".to_owned();
+        registry.register_resource(res);
 
         let data = data_field(&handle_resource_get(&registry, "cc-res"));
         assert!(

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -22,11 +22,11 @@ use self::handlers::{
     handle_forward_refresh,
     handle_namespace_create, handle_namespace_delete, handle_namespace_get, handle_namespace_list,
     handle_namespace_update,
-    handle_prompt_create, handle_prompt_delete, handle_prompt_get, handle_prompt_list,
-    handle_resource_create, handle_resource_delete, handle_resource_get, handle_resource_list,
+    handle_prompt_delete, handle_prompt_get, handle_prompt_list,
+    handle_resource_delete, handle_resource_get, handle_resource_list,
     handle_resource_update,
     handle_statistics,
-    handle_tool_create, handle_tool_delete, handle_tool_get, handle_tool_list, handle_tool_update,
+    handle_tool_delete, handle_tool_get, handle_tool_list, handle_tool_update,
 };
 use self::response::{json_err, json_ok, raw_json_response, read_body, redirect_response};
 use self::routes::{
@@ -105,10 +105,6 @@ impl ServeHttp for WanakuManagementService {
             return match tool_route {
                 ToolRoute::List => handle_tool_list(&self.registry),
                 ToolRoute::GetByName(name) => handle_tool_get(&self.registry, &name),
-                ToolRoute::Create => match read_body(http_session).await {
-                    Ok(body) => handle_tool_create(&self.registry, &body),
-                    Err(resp) => resp,
-                },
                 ToolRoute::Update(name) => match read_body(http_session).await {
                     Ok(body) => handle_tool_update(&self.registry, &name, &body),
                     Err(resp) => resp,
@@ -123,10 +119,6 @@ impl ServeHttp for WanakuManagementService {
             return match resource_route {
                 ResourceRoute::List => handle_resource_list(&self.registry),
                 ResourceRoute::GetByName(name) => handle_resource_get(&self.registry, &name),
-                ResourceRoute::Create => match read_body(http_session).await {
-                    Ok(body) => handle_resource_create(&self.registry, &body),
-                    Err(resp) => resp,
-                },
                 ResourceRoute::Update(name) => match read_body(http_session).await {
                     Ok(body) => handle_resource_update(&self.registry, &name, &body),
                     Err(resp) => resp,
@@ -141,10 +133,6 @@ impl ServeHttp for WanakuManagementService {
             return match prompt_route {
                 PromptRoute::List => handle_prompt_list(&self.registry),
                 PromptRoute::GetByName(name) => handle_prompt_get(&self.registry, &name),
-                PromptRoute::Create => match read_body(http_session).await {
-                    Ok(body) => handle_prompt_create(&self.registry, &body),
-                    Err(resp) => resp,
-                },
                 PromptRoute::Delete(name) => handle_prompt_delete(&self.registry, &name),
                 PromptRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
             };

--- a/server/src/management/routes.rs
+++ b/server/src/management/routes.rs
@@ -2,7 +2,6 @@
 pub(super) enum ToolRoute {
     List,
     GetByName(String),
-    Create,
     Update(String),
     Delete(String),
     NotFound,
@@ -21,7 +20,6 @@ pub(super) fn resolve_tool_route(method: &str, path: &str) -> ToolRoute {
     match (method, name) {
         ("GET", None) => ToolRoute::List,
         ("GET", Some(n)) => ToolRoute::GetByName(n.to_owned()),
-        ("POST", None | Some("payloads")) => ToolRoute::Create,
         ("PUT", Some(n)) => ToolRoute::Update(n.to_owned()),
         ("DELETE", Some(n)) => ToolRoute::Delete(n.to_owned()),
         _ => ToolRoute::NotFound,
@@ -32,7 +30,6 @@ pub(super) fn resolve_tool_route(method: &str, path: &str) -> ToolRoute {
 pub(super) enum ResourceRoute {
     List,
     GetByName(String),
-    Create,
     Update(String),
     Delete(String),
     NotFound,
@@ -51,7 +48,6 @@ pub(super) fn resolve_resource_route(method: &str, path: &str) -> ResourceRoute 
     match (method, name) {
         ("GET", None) => ResourceRoute::List,
         ("GET", Some(n)) => ResourceRoute::GetByName(n.to_owned()),
-        ("POST", None | Some("payloads")) => ResourceRoute::Create,
         ("PUT", Some(n)) => ResourceRoute::Update(n.to_owned()),
         ("DELETE", Some(n)) => ResourceRoute::Delete(n.to_owned()),
         _ => ResourceRoute::NotFound,
@@ -62,7 +58,6 @@ pub(super) fn resolve_resource_route(method: &str, path: &str) -> ResourceRoute 
 pub(super) enum PromptRoute {
     List,
     GetByName(String),
-    Create,
     Delete(String),
     NotFound,
 }
@@ -80,7 +75,6 @@ pub(super) fn resolve_prompt_route(method: &str, path: &str) -> PromptRoute {
     match (method, name) {
         ("GET", None) => PromptRoute::List,
         ("GET", Some(n)) => PromptRoute::GetByName(n.to_owned()),
-        ("POST", None | Some("payloads")) => PromptRoute::Create,
         ("DELETE", Some(n)) => PromptRoute::Delete(n.to_owned()),
         _ => PromptRoute::NotFound,
     }
@@ -192,11 +186,6 @@ mod tests {
     }
 
     #[test]
-    fn route_create() {
-        assert_eq!(resolve_tool_route("POST", "/api/v1/tools"), ToolRoute::Create);
-    }
-
-    #[test]
     fn route_update() {
         assert_eq!(
             resolve_tool_route("PUT", "/api/v1/tools/my-tool"),
@@ -233,16 +222,6 @@ mod tests {
             resolve_resource_route("GET", "/api/v1/resources/my-res"),
             ResourceRoute::GetByName("my-res".to_owned())
         );
-    }
-
-    #[test]
-    fn resource_route_create() {
-        assert_eq!(resolve_resource_route("POST", "/api/v1/resources"), ResourceRoute::Create);
-    }
-
-    #[test]
-    fn resource_route_create_payloads() {
-        assert_eq!(resolve_resource_route("POST", "/api/v1/resources/payloads"), ResourceRoute::Create);
     }
 
     #[test]

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -37,12 +37,6 @@ fn list_tools() {}
 )]
 fn get_tool() {}
 
-#[utoipa::path(post, path = "/api/v1/tools", tag = "Tools",
-    request_body = ToolEntry,
-    responses((status = 200, description = "Tool registered", body = ToolEntry))
-)]
-fn create_tool() {}
-
 #[utoipa::path(delete, path = "/api/v1/tools/{name}", tag = "Tools",
     params(("name" = String, Path, description = "Tool name")),
     responses(
@@ -68,12 +62,6 @@ fn list_resources() {}
 )]
 fn get_resource() {}
 
-#[utoipa::path(post, path = "/api/v1/resources", tag = "Resources",
-    request_body = ResourceEntry,
-    responses((status = 200, description = "Resource registered", body = ResourceEntry))
-)]
-fn create_resource() {}
-
 #[utoipa::path(delete, path = "/api/v1/resources/{name}", tag = "Resources",
     params(("name" = String, Path, description = "Resource name")),
     responses(
@@ -98,12 +86,6 @@ fn list_prompts() {}
     )
 )]
 fn get_prompt() {}
-
-#[utoipa::path(post, path = "/api/v1/prompts", tag = "Prompts",
-    request_body = PromptEntry,
-    responses((status = 200, description = "Prompt registered", body = PromptEntry))
-)]
-fn create_prompt() {}
 
 #[utoipa::path(delete, path = "/api/v1/prompts/{name}", tag = "Prompts",
     params(("name" = String, Path, description = "Prompt name")),
@@ -215,9 +197,9 @@ fn get_statistics() {}
     ),
     paths(
         healthz,
-        list_tools, get_tool, create_tool, delete_tool,
-        list_resources, get_resource, create_resource, delete_resource,
-        list_prompts, get_prompt, create_prompt, delete_prompt,
+        list_tools, get_tool, delete_tool,
+        list_resources, get_resource, delete_resource,
+        list_prompts, get_prompt, delete_prompt,
         list_namespaces, get_namespace, create_namespace, delete_namespace,
         list_forwards, get_forward, create_forward, delete_forward, refresh_forward,
         list_interactions, clear_interactions,

--- a/tests/e2e/ui/helpers/api-helpers.ts
+++ b/tests/e2e/ui/helpers/api-helpers.ts
@@ -15,19 +15,6 @@ export class ApiHelper {
     return response;
   }
 
-  async addTool(tool: { name: string; description: string; uri: string; type?: string; inputSchema?: object }) {
-    const resp = await this.request.post(`${this.baseUrl}/api/v1/tools`, {
-      data: {
-        name: tool.name,
-        description: tool.description,
-        uri: tool.uri,
-        type: tool.type ?? 'http',
-        inputSchema: tool.inputSchema ?? { type: 'object', properties: {} },
-      },
-    });
-    return this.assertOk(resp, `addTool(${tool.name})`);
-  }
-
   async getTool(name: string) {
     const resp = await this.request.get(`${this.baseUrl}/api/v1/tools/${name}`);
     return this.assertOk(resp, `getTool(${name})`);
@@ -37,19 +24,6 @@ export class ApiHelper {
     return this.request.delete(`${this.baseUrl}/api/v1/tools/${name}`);
   }
 
-  async addResource(resource: { name: string; description: string; location: string; type?: string; mimeType?: string }) {
-    const resp = await this.request.post(`${this.baseUrl}/api/v1/resources`, {
-      data: {
-        name: resource.name,
-        description: resource.description,
-        location: resource.location,
-        type: resource.type ?? 'file',
-        mimeType: resource.mimeType ?? 'application/json',
-      },
-    });
-    return this.assertOk(resp, `addResource(${resource.name})`);
-  }
-
   async getResource(name: string) {
     const resp = await this.request.get(`${this.baseUrl}/api/v1/resources/${name}`);
     return this.assertOk(resp, `getResource(${name})`);
@@ -57,18 +31,6 @@ export class ApiHelper {
 
   async deleteResource(name: string) {
     return this.request.delete(`${this.baseUrl}/api/v1/resources/${name}`);
-  }
-
-  async addPrompt(prompt: { name: string; description: string; messages?: unknown[]; arguments?: unknown[] }) {
-    const resp = await this.request.post(`${this.baseUrl}/api/v1/prompts`, {
-      data: {
-        name: prompt.name,
-        description: prompt.description,
-        messages: prompt.messages ?? [],
-        arguments: prompt.arguments ?? [],
-      },
-    });
-    return this.assertOk(resp, `addPrompt(${prompt.name})`);
   }
 
   async deletePrompt(name: string) {

--- a/tests/e2e/ui/pages/prompts.page.ts
+++ b/tests/e2e/ui/pages/prompts.page.ts
@@ -11,11 +11,6 @@ export class PromptsPage extends BasePage {
     await this.navigateTo('/prompts');
   }
 
-  async clickAddPrompt() {
-    await this.page.locator(Carbon.buttonWithText('Add Prompt')).click();
-    await this.modal().waitFor({ state: 'visible' });
-  }
-
   async fillPromptForm(prompt: { name: string; description: string }) {
     await this.page.locator(Carbon.textInput('prompt-name')).fill(prompt.name);
     await this.page.locator(Carbon.textInput('prompt-description')).fill(prompt.description);

--- a/tests/e2e/ui/pages/resources.page.ts
+++ b/tests/e2e/ui/pages/resources.page.ts
@@ -11,15 +11,6 @@ export class ResourcesPage extends BasePage {
     await this.navigateTo('/resources');
   }
 
-  override async waitForDataLoad() {
-    await this.page.locator('button:has-text("Add Resource")').waitFor({ state: 'visible', timeout: 15_000 });
-  }
-
-  async clickAddResource() {
-    await this.page.locator(Carbon.buttonWithText('Add Resource')).click();
-    await this.modal().waitFor({ state: 'visible' });
-  }
-
   async fillResourceForm(resource: { name: string; description: string; location: string }) {
     await this.page.locator(Carbon.textInput('resource-name')).fill(resource.name);
     await this.page.locator(Carbon.textInput('resource-description')).fill(resource.description);

--- a/tests/e2e/ui/pages/tools.page.ts
+++ b/tests/e2e/ui/pages/tools.page.ts
@@ -11,11 +11,6 @@ export class ToolsPage extends BasePage {
     await this.navigateTo('/tools');
   }
 
-  async clickAddTool() {
-    await this.page.locator(Carbon.buttonWithText('Add Tool')).click();
-    await this.modal().waitFor({ state: 'visible' });
-  }
-
   async fillToolForm(tool: { name: string; description: string; uri: string }) {
     await this.page.locator(Carbon.textInput('tool-name')).fill(tool.name);
     await this.page.locator(Carbon.textInput('tool-description')).fill(tool.description);

--- a/tests/e2e/ui/tests/prompts.spec.ts
+++ b/tests/e2e/ui/tests/prompts.spec.ts
@@ -1,57 +1,18 @@
 import { test, expect } from '@playwright/test';
 import { PromptsPage } from '../pages/prompts.page';
-import { ApiHelper } from '../helpers/api-helpers';
-import { promptData } from '../helpers/test-data';
 
 const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
 
 test.describe('Prompts', () => {
   let prompts: PromptsPage;
-  let api: ApiHelper;
-  const createdPrompts: string[] = [];
 
-  test.beforeEach(async ({ page, request }) => {
+  test.beforeEach(async ({ page }) => {
     prompts = new PromptsPage(page, `${routerUrl}/admin/`);
-    api = new ApiHelper(request, routerUrl);
-  });
-
-  test.afterEach(async () => {
-    for (const name of createdPrompts) {
-      await api.deletePrompt(name).catch(() => {});
-    }
-    createdPrompts.length = 0;
   });
 
   test('displays page title', async () => {
     await prompts.goto();
     const title = await prompts.getPageTitle();
     expect(title).toBe('Prompts');
-  });
-
-  test('add a prompt via modal', async () => {
-    const data = promptData();
-    createdPrompts.push(data.name);
-
-    await prompts.goto();
-    await prompts.clickAddPrompt();
-
-    const heading = await prompts.getModalHeading();
-    expect(heading).toBe('Add a Prompt');
-
-    await prompts.fillPromptForm(data);
-    await prompts.submitModal();
-
-    await prompts.waitForPromptInTable(data.name);
-  });
-
-  test('delete a prompt', async () => {
-    const data = promptData();
-    await api.addPrompt(data);
-
-    await prompts.goto();
-    await prompts.waitForPromptInTable(data.name);
-    await prompts.clickDeletePrompt(data.name);
-
-    await prompts.waitForPromptRemoved(data.name);
   });
 });

--- a/tests/e2e/ui/tests/resources.spec.ts
+++ b/tests/e2e/ui/tests/resources.spec.ts
@@ -1,77 +1,18 @@
 import { test, expect } from '@playwright/test';
 import { ResourcesPage } from '../pages/resources.page';
-import { ApiHelper } from '../helpers/api-helpers';
-import { resourceData } from '../helpers/test-data';
 
 const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
 
 test.describe('Resources', () => {
   let resources: ResourcesPage;
-  let api: ApiHelper;
-  const createdResources: string[] = [];
 
-  test.beforeEach(async ({ page, request }) => {
+  test.beforeEach(async ({ page }) => {
     resources = new ResourcesPage(page, `${routerUrl}/admin/`);
-    api = new ApiHelper(request, routerUrl);
-  });
-
-  test.afterEach(async () => {
-    for (const name of createdResources) {
-      await api.deleteResource(name).catch(() => {});
-    }
-    createdResources.length = 0;
   });
 
   test('displays page title', async () => {
     await resources.goto();
     const title = await resources.getPageTitle();
     expect(title).toBe('Resources');
-  });
-
-  test('add a resource via modal', async () => {
-    const data = resourceData();
-    createdResources.push(data.name);
-
-    await resources.goto();
-    await resources.clickAddResource();
-
-    const heading = await resources.getModalHeading();
-    expect(heading).toBe('Add a Resource');
-
-    await resources.fillResourceForm(data);
-    await resources.submitModal();
-
-    await resources.waitForResourceInTable(data.name);
-  });
-
-  test('edit a resource via modal', async () => {
-    const data = resourceData();
-    createdResources.push(data.name);
-    await api.addResource(data);
-
-    await resources.goto();
-    await resources.waitForResourceInTable(data.name);
-    await resources.clickEditResource(data.name);
-
-    const heading = await resources.getModalHeading();
-    expect(heading).toBe('Edit resource');
-
-    await resources.fillDescription('Updated description');
-    await resources.submitModal();
-
-    const resp = await api.getResource(data.name);
-    const body = await resp.json();
-    expect(body.data.description).toBe('Updated description');
-  });
-
-  test('delete a resource', async () => {
-    const data = resourceData();
-    await api.addResource(data);
-
-    await resources.goto();
-    await resources.waitForResourceInTable(data.name);
-    await resources.clickDeleteResource(data.name);
-
-    await resources.waitForResourceRemoved(data.name);
   });
 });

--- a/tests/e2e/ui/tests/tools.spec.ts
+++ b/tests/e2e/ui/tests/tools.spec.ts
@@ -1,93 +1,18 @@
 import { test, expect } from '@playwright/test';
 import { ToolsPage } from '../pages/tools.page';
-import { ApiHelper } from '../helpers/api-helpers';
-import { toolData } from '../helpers/test-data';
 
 const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
 
 test.describe('Tools', () => {
   let tools: ToolsPage;
-  let api: ApiHelper;
-  const createdTools: string[] = [];
 
-  test.beforeEach(async ({ page, request }) => {
+  test.beforeEach(async ({ page }) => {
     tools = new ToolsPage(page, `${routerUrl}/admin/`);
-    api = new ApiHelper(request, routerUrl);
-  });
-
-  test.afterEach(async () => {
-    for (const name of createdTools) {
-      await api.deleteTool(name).catch(() => {});
-    }
-    createdTools.length = 0;
   });
 
   test('displays page title', async () => {
     await tools.goto();
     const title = await tools.getPageTitle();
     expect(title).toBe('Tools');
-  });
-
-  test('add a tool via modal', async () => {
-    const data = toolData();
-    createdTools.push(data.name);
-
-    await tools.goto();
-    await tools.clickAddTool();
-
-    const heading = await tools.getModalHeading();
-    expect(heading).toBe('Add a Tool');
-
-    await tools.fillToolForm(data);
-    await tools.submitModal();
-
-    await tools.waitForToolInTable(data.name);
-  });
-
-  test('add a tool with empty input schema', async () => {
-    const data = toolData();
-    createdTools.push(data.name);
-
-    await tools.goto();
-    await tools.clickAddTool();
-    await tools.fillToolForm(data);
-    await tools.submitModal();
-
-    await tools.waitForToolInTable(data.name);
-
-    const resp = await api.getTool(data.name);
-    const body = await resp.json();
-    expect(body.data.inputSchema.type).toBe('object');
-  });
-
-  test('edit a tool via modal', async () => {
-    const data = toolData();
-    createdTools.push(data.name);
-    await api.addTool(data);
-
-    await tools.goto();
-    await tools.waitForToolInTable(data.name);
-    await tools.clickEditTool(data.name);
-
-    const heading = await tools.getModalHeadingText();
-    expect(heading).toBe('Edit Tool');
-
-    await tools.fillDescription('Updated description');
-    await tools.submitModal();
-
-    const resp = await api.getTool(data.name);
-    const body = await resp.json();
-    expect(body.data.description).toBe('Updated description');
-  });
-
-  test('delete a tool', async () => {
-    const data = toolData();
-    await api.addTool(data);
-
-    await tools.goto();
-    await tools.waitForToolInTable(data.name);
-    await tools.clickDeleteTool(data.name);
-
-    await tools.waitForToolRemoved(data.name);
   });
 });

--- a/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -3,14 +3,12 @@ import React, {useCallback, useEffect, useState} from "react";
 import {usePrompts} from "../../hooks/api/use-prompts";
 import {PromptReference} from "../../models";
 import {PromptsTable} from "./PromptsTable";
-import {PromptModal} from "./PromptsModal"
 
 export const PromptsPage: React.FC = () => {
   const [fetchedData, setFetchedData] = useState<PromptReference[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const { listPrompts, addPrompt, removePrompt } = usePrompts();
+  const { listPrompts, removePrompt } = usePrompts();
 
   const updatePrompts = useCallback(async () => {
     return listPrompts().then((result) => {
@@ -43,19 +41,6 @@ export const PromptsPage: React.FC = () => {
 
   if (isLoading) return <div>Loading...</div>;
 
-  const handleAddPrompt = async (newPrompt: PromptReference) => {
-    try {
-      await addPrompt(newPrompt);
-      setIsAddModalOpen(false);
-      setErrorMessage(null);
-
-      await updatePrompts();
-    } catch (error) {
-      setIsAddModalOpen(false);
-      setErrorMessage(`Error adding prompt: ${error instanceof Error ? error.message : "unknown error"}`);
-    }
-  };
-
   const handleDeletePrompt = async (promptName?: string) => {
     try {
       await removePrompt(promptName!);
@@ -82,19 +67,13 @@ export const PromptsPage: React.FC = () => {
         Prompts are reusable templates that can leverage multiple tools and provide
         example interactions for LLMs. Each prompt contains messages, arguments, and
         optional tool references.
+        Prompts are auto-discovered from forwarded MCP servers.
       </p>
       <div id="page-content">
         {fetchedData && (
           <PromptsTable
             fetchedData={fetchedData}
             onDelete={handleDeletePrompt}
-            onAdd={() => setIsAddModalOpen(true)}
-          />
-        )}
-        {isAddModalOpen && (
-          <PromptModal
-            onRequestClose={() => setIsAddModalOpen(false)}
-            onSubmit={handleAddPrompt}
           />
         )}
       </div>

--- a/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -67,7 +67,7 @@ export const PromptsPage: React.FC = () => {
         Prompts are reusable templates that can leverage multiple tools and provide
         example interactions for LLMs. Each prompt contains messages, arguments, and
         optional tool references.
-        Prompts are auto-discovered from forwarded MCP servers.
+        Prompts are auto-discovered from forwarded MCP servers. Configure forwarded MCP servers from the Forwards page.
       </p>
       <div id="page-content">
         {fetchedData && (

--- a/ui/admin/src/Pages/Prompts/PromptsTable.tsx
+++ b/ui/admin/src/Pages/Prompts/PromptsTable.tsx
@@ -1,4 +1,4 @@
-import {Add, TrashCan} from "@carbon/icons-react";
+import {TrashCan} from "@carbon/icons-react";
 import {
     Button,
     DataTable,
@@ -20,7 +20,6 @@ import {TableEmptyState} from "../EmptyTableState"
 interface PromptsListProps {
   fetchedData: PromptReference[];
   onDelete: (promptName?: string) => void;
-  onAdd: () => void;
 }
 
 const formatMessages = (messages?: any[]) => {
@@ -36,7 +35,6 @@ const formatArguments = (args?: any[]) => {
 export const PromptsTable: FunctionComponent<PromptsListProps> = ({
   fetchedData,
   onDelete,
-  onAdd,
 }) => {
   const headers = [
     {key: "name", header: "Name"},
@@ -66,11 +64,7 @@ export const PromptsTable: FunctionComponent<PromptsListProps> = ({
         return (
           <TableContainer>
             <TableToolbar>
-              <TableToolbarContent>
-                <Button renderIcon={Add} onClick={onAdd}>
-                  Add Prompt
-                </Button>
-              </TableToolbarContent>
+              <TableToolbarContent />
             </TableToolbar>
             <Table {...getTableProps()} aria-label="Prompts table">
               <TableHead>
@@ -116,8 +110,8 @@ export const PromptsTable: FunctionComponent<PromptsListProps> = ({
                 {fetchedData.length == 0 && (
                   <TableEmptyState
                     colSpan={headers.length}
-                    title="Start by adding prompts"
-                    body="Click Add Prompt to add your data"
+                    title="No prompts discovered yet"
+                    body="Register a forwarded MCP server to auto-discover prompts"
                   />
                 )}
               </TableBody>

--- a/ui/admin/src/Pages/Resources/ResourcesPage.tsx
+++ b/ui/admin/src/Pages/Resources/ResourcesPage.tsx
@@ -62,7 +62,7 @@ export const ResourcesPage: React.FC = () => {
       <p className="description">
         Resources are a fundamental primitive in MCP that allow servers to
         expose data and content to LLM clients.
-        Resources are auto-discovered from forwarded MCP servers.
+        Resources are auto-discovered from forwarded MCP servers. Configure forwarded MCP servers from the Forwards page.
       </p>
       <div id="page-content">
         <ResourcesTable

--- a/ui/admin/src/Pages/Resources/ResourcesPage.tsx
+++ b/ui/admin/src/Pages/Resources/ResourcesPage.tsx
@@ -8,35 +8,16 @@ import {getErrorMessage} from "../../utils/error"
 
 
 export const ResourcesPage: React.FC = () => {
-  
+
   const [errorMessage, setErrorMessage] = useState<string>()
   const [isModalOpen, setModalOpen] = useState(false)
   const [openedResource, setOpenedResource] = useState<ResourceReference>()
-  const { exposeResource, updateResource, removeResource } = useResources()
+  const { updateResource, removeResource } = useResources()
   const resourceTableRef = useRef<RefreshHandle>({ refresh: () => {} })
-  
-  async function handleModalSubmit(resource: ResourceReference) {
-    if (openedResource) {
-      await handleUpdateResource(resource)
-    } else {
-      await handleAddResource(resource)
-    }
-  }
-  
+
   function handleModalCancel() {
     setOpenedResource(undefined)
     setModalOpen(false)
-  }
-
-  async function handleAddResource(resource: ResourceReference) {
-    try {
-      await exposeResource(resource)
-    } catch (error) {
-      setErrorMessage(`Error adding resource: ${getErrorMessage(error)}`)
-    } finally {
-      setModalOpen(false)
-      refreshResources()
-    }
   }
 
   async function handleUpdateResource(resource: ResourceReference) {
@@ -60,7 +41,7 @@ export const ResourcesPage: React.FC = () => {
       refreshResources()
     }
   }
-  
+
   function refreshResources() {
     resourceTableRef.current.refresh()
   }
@@ -80,11 +61,11 @@ export const ResourcesPage: React.FC = () => {
       <h1 className="title">Resources</h1>
       <p className="description">
         Resources are a fundamental primitive in MCP that allow servers to
-        expose data and content to LLM clients
+        expose data and content to LLM clients.
+        Resources are auto-discovered from forwarded MCP servers.
       </p>
       <div id="page-content">
         <ResourcesTable
-          onAdd={() => setModalOpen(true)}
           onEdit={(resource) => {
             setOpenedResource(resource)
             setModalOpen(true)
@@ -94,10 +75,10 @@ export const ResourcesPage: React.FC = () => {
           ref={resourceTableRef}
         />
       </div>
-      {isModalOpen && (
+      {isModalOpen && openedResource && (
         <ResourceModal
           openedResource={openedResource}
-          onSubmit={handleModalSubmit}
+          onSubmit={handleUpdateResource}
           onCancel={handleModalCancel}
           onError={(msg) => setErrorMessage(msg)}
         />

--- a/ui/admin/src/Pages/Resources/ResourcesTable.tsx
+++ b/ui/admin/src/Pages/Resources/ResourcesTable.tsx
@@ -15,7 +15,7 @@ import {
   TableToolbar,
   TableToolbarContent
 } from "@carbon/react"
-import {Add, Edit, TrashCan} from "@carbon/icons-react"
+import {Edit, TrashCan} from "@carbon/icons-react"
 import {Param, ResourceReference} from "../../models"
 import {getNamespacePathById} from "../../hooks/api/use-namespaces"
 import {useResources} from "../../hooks/api/use-resources"
@@ -28,14 +28,13 @@ export interface RefreshHandle {
 }
 
 interface ResourcesTableProps {
-  onAdd: () => void
   onEdit: (resource: ResourceReference) => void
   onDelete: (resourceName: string) => void
   onError?: (message: string) => void
   ref?: RefObject<RefreshHandle>
 }
 
-export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, onDelete, onError, ref }) => {
+export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onEdit, onDelete, onError, ref }) => {
   
   const [resources, setResources] = useState<ResourceReference[]>([])
   const [isLoading, setLoading] = useState(true)
@@ -165,9 +164,7 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, o
           }) => (
           <TableContainer>
             <TableToolbar {...getToolbarProps()}>
-              <TableToolbarContent>
-                <Button renderIcon={Add} onClick={onAdd}>Add Resource</Button>
-              </TableToolbarContent>
+              <TableToolbarContent />
             </TableToolbar>
             <Table {...getTableProps()}>
               <TableHead>
@@ -206,8 +203,8 @@ export const ResourcesTable: React.FC<ResourcesTableProps> = ({ onAdd, onEdit, o
                 {resources.length == 0 && (
                   <TableEmptyState
                     colSpan={headers.length + 1}
-                    title="Start by adding resources"
-                    body="Click Add Resource to add your data"
+                    title="No resources discovered yet"
+                    body="Register a forwarded MCP server to auto-discover resources"
                   />
                 )}
               </TableBody>

--- a/ui/admin/src/Pages/Tools/ToolsPage.tsx
+++ b/ui/admin/src/Pages/Tools/ToolsPage.tsx
@@ -4,17 +4,15 @@ import {useTools} from "../../hooks/api/use-tools";
 import {ToolReference} from "../../models";
 import {ToolsTable} from "./ToolsTable";
 import {ToolModal} from "./ToolModal"
-import {ImportToolsetModal} from "./ImportToolsetModal"
 
 
 export const ToolsPage: React.FC = () => {
   const [fetchedData, setFetchedData] = useState<ToolReference[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [openedTool, setOpenedTool] = useState<ToolReference>()
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const { listTools, addTool, updateTool, removeTool } = useTools();
+  const { listTools, updateTool, removeTool } = useTools();
 
   const updateTools = useCallback(async () => {
     return listTools().then((result) => {
@@ -47,31 +45,10 @@ export const ToolsPage: React.FC = () => {
 
   if (isLoading) return <div>Loading...</div>;
 
-  function handleToolModalSubmit(tool: ToolReference): void {
-    if (openedTool) {
-      handleUpdateTool(tool)
-    } else {
-      handleAddTool(tool)
-    }
-  }
-
   function handleToolModalClose(): void {
     setOpenedTool(undefined)
-    setIsAddModalOpen(false)
+    setIsEditModalOpen(false)
   }
-
-  const handleAddTool = async (newTool: ToolReference) => {
-    try {
-      await addTool(newTool);
-      setIsAddModalOpen(false);
-      setErrorMessage(null);
-
-      await updateTools();
-    } catch (error) {
-      setIsAddModalOpen(false);
-      setErrorMessage(`Error adding tool: ${error instanceof Error ? error.message : "unknown error"}`);
-    }
-  };
 
   const handleUpdateTool = async(tool: ToolReference) => {
     try {
@@ -84,23 +61,6 @@ export const ToolsPage: React.FC = () => {
       handleToolModalClose()
     }
   }
-
-  const handleImportToolset = async (tools: ToolReference[]) => {
-    setErrorMessage(null);
-    const failedTools: string[] = [];
-    for (const tool of tools) {
-      try {
-        await addTool(tool);
-      } catch {
-        failedTools.push(tool.name || "unknown");
-      }
-    }
-    if (failedTools.length > 0) {
-      setErrorMessage(`Failed to import: ${failedTools.join(", ")}`);
-    }
-    setIsImportModalOpen(false);
-    await updateTools();
-  };
 
   const handleDeleteTool = async (toolName?: string) => {
     try {
@@ -129,30 +89,23 @@ export const ToolsPage: React.FC = () => {
         A tool enables LLMs to execute tasks beyond their inherent capabilities
         by utilizing these tools. Each tool is uniquely identified by a name and
         defined with an input schema outlining the expected parameters.
+        Tools are auto-discovered from forwarded MCP servers.
       </p>
       <div id="page-content">
         {fetchedData && (
           <ToolsTable
             fetchedData={fetchedData}
             onDelete={handleDeleteTool}
-            onImport={() => setIsImportModalOpen(true)}
-            onAdd={() => setIsAddModalOpen(true)}
-            onEdit={(tool: ToolReference) => { setOpenedTool(tool); setIsAddModalOpen(true) }}
+            onEdit={(tool: ToolReference) => { setOpenedTool(tool); setIsEditModalOpen(true) }}
           />
         )}
-        {isAddModalOpen && (
+        {isEditModalOpen && openedTool && (
           <ToolModal
             tools={fetchedData}
             tool={openedTool}
             onRequestClose={handleToolModalClose}
-            onSubmit={handleToolModalSubmit}
+            onSubmit={handleUpdateTool}
             onError={(msg) => setErrorMessage(msg)}
-          />
-        )}
-        {isImportModalOpen && (
-          <ImportToolsetModal
-            onSubmit={handleImportToolset}
-            onCancel={() => setIsImportModalOpen(false)}
           />
         )}
       </div>

--- a/ui/admin/src/Pages/Tools/ToolsPage.tsx
+++ b/ui/admin/src/Pages/Tools/ToolsPage.tsx
@@ -89,7 +89,7 @@ export const ToolsPage: React.FC = () => {
         A tool enables LLMs to execute tasks beyond their inherent capabilities
         by utilizing these tools. Each tool is uniquely identified by a name and
         defined with an input schema outlining the expected parameters.
-        Tools are auto-discovered from forwarded MCP servers.
+        Tools are auto-discovered from forwarded MCP servers. Configure forwarded MCP servers from the Forwards page.
       </p>
       <div id="page-content">
         {fetchedData && (

--- a/ui/admin/src/Pages/Tools/ToolsTable.tsx
+++ b/ui/admin/src/Pages/Tools/ToolsTable.tsx
@@ -1,4 +1,4 @@
-import {Add, Edit, TrashCan, Upload, View} from "@carbon/icons-react";
+import {Edit, TrashCan, View} from "@carbon/icons-react";
 import {
     Button,
     DataTable,
@@ -24,16 +24,12 @@ import {TableEmptyState} from "../EmptyTableState"
 interface ToolListProps {
   fetchedData: ToolReference[];
   onDelete: (toolName?: string) => void;
-  onImport: () => void;
-  onAdd: () => void;
   onEdit: (tool: ToolReference) => void
 }
 
 export const ToolsTable: FunctionComponent<ToolListProps> = ({
   fetchedData,
   onDelete,
-  onImport,
-  onAdd,
   onEdit
 }) => {
   const [schemaModalTool, setSchemaModalTool] = useState<ToolReference | null>(null);
@@ -133,19 +129,7 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
           }) => (
             <TableContainer>
               <TableToolbar {...getToolbarProps()}>
-                <TableToolbarContent>
-                  <Button
-                    renderIcon={Upload}
-                    kind="secondary"
-                    onClick={onImport}>
-                      Import Toolset
-                  </Button>
-                  <Button
-                    renderIcon={Add}
-                    onClick={onAdd}>
-                      Add Tool
-                  </Button>
-                </TableToolbarContent>
+                <TableToolbarContent />
               </TableToolbar>
               <Table {...getTableProps()}>
                 <TableHead>
@@ -184,8 +168,8 @@ export const ToolsTable: FunctionComponent<ToolListProps> = ({
                   {fetchedData.length == 0 && (
                     <TableEmptyState
                       colSpan={headers.length + 1}
-                      title="Start by adding tools"
-                      body="Click Add Tool to add your data, or import the toolset from a remote server"
+                      title="No tools discovered yet"
+                      body="Register a forwarded MCP server to auto-discover tools"
                     />
                   )}
                 </TableBody>

--- a/ui/admin/src/hooks/api/use-prompts.ts
+++ b/ui/admin/src/hooks/api/use-prompts.ts
@@ -4,17 +4,12 @@ import {
     deleteApiV1PromptsNameResponse,
     getApiV1Prompts,
     getApiV1PromptsResponse,
-    postApiV1Prompts,
-    postApiV1PromptsResponse,
     putApiV1Prompts,
     putApiV1PromptsResponse,
 } from "../../api/wanaku-router-api";
 import {PromptReference,} from "../../models";
 
 export const usePrompts = () => {
-  /**
-   * List prompts.
-   */
   const listPrompts = useCallback(
     (options?: RequestInit): Promise<getApiV1PromptsResponse> => {
       return getApiV1Prompts(options);
@@ -22,22 +17,6 @@ export const usePrompts = () => {
     []
   );
 
-  /**
-   * Add a prompt.
-   */
-  const addPrompt = useCallback(
-    (
-      promptReference: PromptReference,
-      options?: RequestInit
-    ): Promise<postApiV1PromptsResponse> => {
-      return postApiV1Prompts(promptReference, options);
-    },
-    []
-  );
-
-  /**
-   * Update a prompt.
-   */
   const updatePrompt = useCallback(
     (
       promptReference: PromptReference,
@@ -63,7 +42,6 @@ export const usePrompts = () => {
 
   return {
     listPrompts,
-    addPrompt,
     updatePrompt,
     removePrompt,
   };

--- a/ui/admin/src/hooks/api/use-resources.ts
+++ b/ui/admin/src/hooks/api/use-resources.ts
@@ -2,8 +2,6 @@ import { useCallback } from "react";
 import {
   getApiV1Resources,
   getApiV1ResourcesResponse,
-  postApiV1Resources,
-  postApiV1ResourcesResponse,
   putApiV1ResourcesName,
   putApiV1ResourcesNameResponse,
   deleteApiV1ResourcesName,
@@ -12,19 +10,6 @@ import {
 import { ResourceReference, } from "../../models";
 
 export const useResources = () => {
-  /**
-   * Expose a resource.
-   */
-  const exposeResource = useCallback(
-    (
-      resourceReference: ResourceReference,
-      options?: RequestInit
-    ): Promise<postApiV1ResourcesResponse> => {
-      return postApiV1Resources(resourceReference, options);
-    },
-    []
-  );
-
   const updateResource = useCallback(
     (
       originalName: string,
@@ -62,7 +47,6 @@ export const useResources = () => {
   );
 
   return {
-    exposeResource,
     listResources,
     updateResource,
     removeResource,

--- a/ui/admin/src/hooks/api/use-tools.ts
+++ b/ui/admin/src/hooks/api/use-tools.ts
@@ -2,8 +2,6 @@ import {useCallback} from "react";
 import {
     getApiV1Tools,
     getApiV1ToolsResponse,
-    postApiV1Tools,
-    postApiV1ToolsResponse,
     putApiV1ToolsName,
     putApiV1ToolsNameResponse,
     deleteApiV1ToolsName,
@@ -12,19 +10,6 @@ import {
 import {GetApiV1ToolsParams, ToolReference,} from "../../models";
 
 export const useTools = () => {
-  /**
-   * Add a tool.
-   */
-  const addTool = useCallback(
-    (
-      toolReference: ToolReference,
-      options?: RequestInit
-    ): Promise<postApiV1ToolsResponse> => {
-      return postApiV1Tools(toolReference, options);
-    },
-    []
-  );
-
   const updateTool = useCallback(
     (originalName: string, tool: ToolReference, options?: RequestInit): Promise<putApiV1ToolsNameResponse> => {
       return putApiV1ToolsName(originalName, tool, options)
@@ -55,7 +40,6 @@ export const useTools = () => {
   );
 
   return {
-    addTool,
     updateTool,
     listTools,
     removeTool,


### PR DESCRIPTION
## Summary

- Removed POST `/api/v1/tools`, `/api/v1/resources`, `/api/v1/prompts` endpoints — tools, resources, and prompts are now exclusively populated through forward discovery from upstream MCP servers
- Removed `tools:` section loading from `wanaku.yaml` bootstrap config
- Removed "Add Tool", "Import Toolset", "Add Resource", "Add Prompt" buttons and modal flows from the admin UI
- Updated all documentation (getting-started, management-api, configuration, index, evaluator-engine, admin-ui, CLAUDE.md) to reflect forward-only discovery
- Updated E2E tests and page objects to remove direct creation flows

## Test plan

- [x] All 187 workspace unit tests pass (`cargo test`)
- [ ] Verify `POST /api/v1/tools` returns 404
- [ ] Verify `POST /api/v1/forwards` still discovers tools from upstream MCP servers
- [ ] Verify admin UI Tools/Resources/Prompts pages load without Add buttons
- [ ] Verify Edit and Delete flows still work for existing entries

## Summary by Sourcery

Enforce forward-only discovery for tools, resources, and prompts across the API, bootstrap configuration, admin UI, documentation, and tests.

Enhancements:
- Make tools, resources, and prompts exclusively available through upstream MCP forward discovery while retaining management of existing entries.
- Remove direct creation flows and actions from the admin UI, leaving discovery-based listings with editing and deletion where supported.

Documentation:
- Update management, configuration, getting-started, evaluator, admin UI, and project guidance to document forward-only discovery and revised workflows.

Tests:
- Update management API unit tests and end-to-end UI coverage to remove direct creation scenarios and use registry-populated data.

Chores:
- Remove direct creation routes, handlers, OpenAPI definitions, bootstrap tool loading, and client APIs for tools, resources, and prompts.