### PR TITLE
refactor: rebrand Wanaku Praxis to Wanaku

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -90,16 +90,16 @@ jobs:
         run: cargo test --workspace --locked --verbose
 
       - name: Build release binary
-        run: cargo build --release --locked -p wanaku-praxis-proxy
+        run: cargo build --release --locked -p wanaku-server
 
       - name: Package release binary (Unix)
         if: runner.os != 'Windows'
         env:
           PLATFORM: ${{ matrix.platform }}
         run: |
-          archive="wanaku-praxis-${VERSION}-${PLATFORM}"
+          archive="wanaku-server-${VERSION}-${PLATFORM}"
           mkdir -p "dist/$archive"
-          install -m 0755 target/release/wanaku-praxis "dist/$archive/wanaku-praxis"
+          install -m 0755 target/release/wanaku-server "dist/$archive/wanaku-server"
           cp LICENSE README.md wanaku.yaml "dist/$archive/"
           tar -C dist -czf "dist/$archive.tar.gz" "$archive"
           rm -rf "dist/$archive"
@@ -110,9 +110,9 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
         shell: pwsh
         run: |
-          $archive = "wanaku-praxis-$env:VERSION-$env:PLATFORM"
+          $archive = "wanaku-server-$env:VERSION-$env:PLATFORM"
           New-Item -ItemType Directory -Path "dist/$archive" -Force
-          Copy-Item target/release/wanaku-praxis.exe "dist/$archive/wanaku-praxis.exe"
+          Copy-Item target/release/wanaku-server.exe "dist/$archive/wanaku-server.exe"
           Copy-Item LICENSE, README.md, wanaku.yaml "dist/$archive/"
           Compress-Archive -Path "dist/$archive" -DestinationPath "dist/$archive.zip"
           Remove-Item -Recurse -Force "dist/$archive"
@@ -120,7 +120,7 @@ jobs:
       - name: Upload release archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wanaku-praxis-${{ matrix.platform }}
+          name: wanaku-server-${{ matrix.platform }}
           path: |
             dist/*.tar.gz
             dist/*.zip
@@ -139,7 +139,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
         run: |
-          image="${CONTAINER_REGISTRY}/${CONTAINER_GROUP}/wanaku-praxis"
+          image="${CONTAINER_REGISTRY}/${CONTAINER_GROUP}/wanaku-server"
           docker build -f Containerfile \
             -t "$image:${VERSION}-${ARCH}" \
             -t "$image:early-access-${ARCH}" \
@@ -193,7 +193,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
-          pattern: wanaku-praxis-*
+          pattern: wanaku-server-*
           merge-multiple: true
 
       - name: Generate checksums
@@ -216,5 +216,5 @@ jobs:
           gh release create early-access dist/* \
             --prerelease \
             --target "$GITHUB_SHA" \
-            --title "Wanaku Praxis ${VERSION} early access" \
-            --notes "Early-access build of Wanaku Praxis ${VERSION} from commit ${GITHUB_SHA}. This build is intended for testing and is not a stable release."
+            --title "Wanaku ${VERSION} early access" \
+            --notes "Early-access build of Wanaku ${VERSION} from commit ${GITHUB_SHA}. This build is intended for testing and is not a stable release."

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -66,13 +66,13 @@ jobs:
         if: env.QUAY_USERNAME != '' && env.QUAY_PASSWORD != ''
         run: |
           docker build -f Containerfile \
-            -t ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_GROUP }}/wanaku-praxis:${{ github.ref_name }}-${{ steps.arch.outputs.arch }} \
+            -t ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_GROUP }}/wanaku-server:${{ github.ref_name }}-${{ steps.arch.outputs.arch }} \
             .
 
       - name: Push container image
         if: env.QUAY_USERNAME != '' && env.QUAY_PASSWORD != ''
         run: |
-          docker push ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_GROUP }}/wanaku-praxis:${{ github.ref_name }}-${{ steps.arch.outputs.arch }}
+          docker push ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_GROUP }}/wanaku-server:${{ github.ref_name }}-${{ steps.arch.outputs.arch }}
 
   createManifests:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Wanaku Praxis
+# Wanaku
 
-Rust MCP server on Praxis proxy. Routes MCP requests through a filter pipeline for namespace isolation, tool/resource/prompt management, and MCP-to-MCP forwarding.
+Rust MCP server built on the Praxis proxy framework. Routes MCP requests through a filter pipeline for namespace isolation, tool/resource/prompt management, and MCP-to-MCP forwarding.
 
 ## Core Guidelines
 
@@ -11,7 +11,7 @@ Think before you write. Don't create abstractions unnecessarily. Simplicity matt
 ```bash
 cargo build && cargo test
 cargo run  # MCP :8081, management API :8080
-cargo run -- --praxis-config praxis.yaml --wanaku-config wanaku.yaml  # custom configs
+cargo run -- --pipeline-config pipeline.yaml --wanaku-config wanaku.yaml  # custom configs
 ```
 
 Default configs: `server/src/default.yaml` (embedded, pipeline), `wanaku.yaml` (optional, forward registry bootstrap).
@@ -51,7 +51,7 @@ Feature filters (e.g., `wanaku_evaluator`) registered via `Feature::register_fil
 
 ### Metadata Contract
 
-**praxis-ai MCP filter sets** (`on_request_body` pre-read):
+**MCP filter (from praxis-ai) sets** (`on_request_body` pre-read):
 - `mcp.method` — JSON-RPC method (`"tools/list"`, `"tools/call"`)
 - `mcp.name` — tool/resource/prompt name (from `params.name` or `params.arguments`)
 
@@ -178,7 +178,7 @@ Three test tiers, none require an LLM:
 # WASM engine tests skip automatically if actions aren't built
 cargo test -p wanaku-feature-evaluator
 
-# E2e tests (require a running wanaku-praxis server)
+# E2e tests (require a running wanaku server)
 cargo test -p wanaku-feature-evaluator --test e2e -- --ignored
 
 # Classification e2e (require server + Ollama on localhost:11434)
@@ -205,7 +205,7 @@ cd ../safety-warn && cargo component build --release && cp target/wasm32-wasip1/
 | `WANAKU_AUTH_ISSUER` | unset | OIDC issuer (RFC 9728) |
 | `WANAKU_INFERENCE_API_KEY` | unset | Bearer token for upstream |
 
-**Praxis config** (`server/src/default.yaml`): listener, filter chains. **Wanaku config** (`wanaku.yaml`): forwards bootstrap (optional).
+**Pipeline config** (`server/src/default.yaml`): listener, filter chains. **Wanaku config** (`wanaku.yaml`): forwards bootstrap (optional).
 
 ### Evaluator Config (in wanaku.yaml)
 
@@ -258,7 +258,7 @@ The distinction between `block` and `reject-malformed` matters: `block` means th
 ## Common Tasks
 
 **Add feature:**
-1. `mkdir features/myfeature` + `Cargo.toml` — depend on `wanaku-praxis-apis` (Feature, registry, llm), `wanaku-praxis-filters` (boilerplate, response helpers), `praxis-filter` (HttpFilter)
+1. `mkdir features/myfeature` + `Cargo.toml` — depend on `wanaku-apis` (Feature, registry, llm), `wanaku-filters` (boilerplate, response helpers), `praxis-filter` (HttpFilter)
 2. Implement `Feature` trait: `register_filters`, `pipeline_extensions`, `handle_route`, `load_yaml_config`, `load_env_config`
 3. Add to workspace `Cargo.toml` (members + deps)
 4. Add dep in `server/Cargo.toml`, `Box::new(MyFeature::new())` in `main.rs`
@@ -314,7 +314,7 @@ Pin to a specific `rev` — HEAD may break.
 
 ```bash
 RUST_LOG=trace cargo run
-RUST_LOG=wanaku_praxis_filters=trace cargo run  # metadata flow
+RUST_LOG=wanaku_filters=trace cargo run  # metadata flow
 ```
 
 In filters:
@@ -334,7 +334,7 @@ tracing::debug!(method = ?ctx.get_metadata("mcp.method"), namespace = ?ctx.get_m
 
 ```bash
 cargo test                         # all
-cargo test -p wanaku-praxis-apis   # single crate
+cargo test -p wanaku-apis   # single crate
 cargo test -- --nocapture          # tracing output
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5023,87 +5023,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wanaku-feature-chat"
-version = "0.3.0"
-dependencies = [
- "async-trait",
- "http",
- "praxis-proxy-filter",
- "reqwest 0.12.28",
- "serde_json",
- "tracing",
- "wanaku-praxis-apis",
- "yaml_serde",
-]
-
-[[package]]
-name = "wanaku-feature-evaluator"
-version = "0.3.0"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "jsonschema",
- "praxis-proxy-filter",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serial_test",
- "tracing",
- "wanaku-praxis-apis",
- "wanaku-praxis-filters",
- "wasmtime",
- "wasmtime-wasi",
- "yaml_serde",
-]
-
-[[package]]
-name = "wanaku-feature-intercept"
-version = "0.3.0"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "praxis-proxy-filter",
- "serde_json",
- "tracing",
- "wanaku-praxis-apis",
- "yaml_serde",
-]
-
-[[package]]
-name = "wanaku-feature-mcp-metadata"
-version = "0.3.0"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "praxis-proxy-filter",
- "reqwest 0.12.28",
- "serde_json",
- "tracing",
- "wanaku-praxis-apis",
- "wanaku-praxis-filters",
- "yaml_serde",
-]
-
-[[package]]
-name = "wanaku-feature-plugins"
-version = "0.3.0"
-dependencies = [
- "async-trait",
- "http",
- "praxis-proxy-filter",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tracing",
- "wanaku-praxis-apis",
- "yaml_serde",
-]
-
-[[package]]
-name = "wanaku-praxis-apis"
+name = "wanaku-apis"
 version = "0.3.0"
 dependencies = [
  "async-trait",
@@ -5123,7 +5043,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "wanaku-praxis-filters"
+name = "wanaku-feature-chat"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "http",
+ "praxis-proxy-filter",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tracing",
+ "wanaku-apis",
+ "yaml_serde",
+]
+
+[[package]]
+name = "wanaku-feature-evaluator"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "jsonschema",
+ "praxis-proxy-filter",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tracing",
+ "wanaku-apis",
+ "wanaku-filters",
+ "wasmtime",
+ "wasmtime-wasi",
+ "yaml_serde",
+]
+
+[[package]]
+name = "wanaku-feature-intercept"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "praxis-proxy-filter",
+ "serde_json",
+ "tracing",
+ "wanaku-apis",
+ "yaml_serde",
+]
+
+[[package]]
+name = "wanaku-feature-mcp-metadata"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "praxis-proxy-filter",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tracing",
+ "wanaku-apis",
+ "wanaku-filters",
+ "yaml_serde",
+]
+
+[[package]]
+name = "wanaku-feature-plugins"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "http",
+ "praxis-proxy-filter",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tracing",
+ "wanaku-apis",
+ "yaml_serde",
+]
+
+[[package]]
+name = "wanaku-filters"
 version = "0.3.0"
 dependencies = [
  "async-trait",
@@ -5133,12 +5133,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tracing",
- "wanaku-praxis-apis",
+ "wanaku-apis",
  "yaml_serde",
 ]
 
 [[package]]
-name = "wanaku-praxis-proxy"
+name = "wanaku-server"
 version = "0.3.0"
 dependencies = [
  "async-trait",
@@ -5157,13 +5157,13 @@ dependencies = [
  "tokio",
  "tracing",
  "utoipa",
+ "wanaku-apis",
  "wanaku-feature-chat",
  "wanaku-feature-evaluator",
  "wanaku-feature-intercept",
  "wanaku-feature-mcp-metadata",
  "wanaku-feature-plugins",
- "wanaku-praxis-apis",
- "wanaku-praxis-filters",
+ "wanaku-filters",
  "yaml_serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ praxis-proxy = { version = "0.5.1", package = "praxis-proxy" }
 praxis-ai-apis = { git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
 praxis-ai-filters = { git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
 
-wanaku-praxis-apis = { version = "0.3.0", path = "apis" }
-wanaku-praxis-filters = { version = "0.3.0", path = "filters" }
+wanaku-apis = { version = "0.3.0", path = "apis" }
+wanaku-filters = { version = "0.3.0", path = "filters" }
 wanaku-feature-chat = { version = "0.3.0", path = "features/chat" }
 wanaku-feature-evaluator = { version = "0.3.0", path = "features/evaluator" }
 wanaku-feature-intercept = { version = "0.3.0", path = "features/intercept" }

--- a/Containerfile
+++ b/Containerfile
@@ -53,7 +53,7 @@ RUN mkdir -p apis/src filters/src server/src \
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release -p wanaku-praxis-proxy
+    cargo build --release -p wanaku-server
 
 # ------------------------------------------------------------------------------
 # Real Build
@@ -70,8 +70,8 @@ RUN find apis/src filters/src server/src features \
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release -p wanaku-praxis-proxy \
-    && cp target/release/wanaku-praxis /usr/local/bin/wanaku-praxis
+    cargo build --release -p wanaku-server \
+    && cp target/release/wanaku-server /usr/local/bin/wanaku-server
 
 # ------------------------------------------------------------------------------
 # Stage 3: Runtime
@@ -79,28 +79,28 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 
 FROM registry.fedoraproject.org/fedora-minimal:44
 
-LABEL org.opencontainers.image.source="https://github.com/wanaku-ai/wanaku-praxis" \
-    org.opencontainers.image.description="Wanaku Praxis MCP proxy server" \
+LABEL org.opencontainers.image.source="https://github.com/wanaku-ai/wanaku" \
+    org.opencontainers.image.description="Wanaku MCP proxy server" \
     org.opencontainers.image.licenses="Apache-2.0"
 
 RUN microdnf install -y ca-certificates shadow-utils \
     && microdnf clean all \
     && groupadd -r wanaku \
     && useradd -r -g wanaku -d /nonexistent -s /sbin/nologin wanaku \
-    && mkdir -p /etc/wanaku-praxis /data/registry
+    && mkdir -p /etc/wanaku /data/registry
 
 COPY --from=builder --chown=root:root --chmod=0555 \
-    /usr/local/bin/wanaku-praxis /usr/local/bin/wanaku-praxis
+    /usr/local/bin/wanaku-server /usr/local/bin/wanaku-server
 
 RUN chown wanaku:wanaku /data/registry
 
 USER wanaku:wanaku
 
-WORKDIR /etc/wanaku-praxis
+WORKDIR /etc/wanaku
 
 EXPOSE 8080 8081 8083
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s \
     CMD curl -sf http://127.0.0.1:8080/healthz || exit 1
 
-ENTRYPOINT ["wanaku-praxis"]
+ENTRYPOINT ["wanaku-server"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ui:
 	cd ui/admin && yarn install && yarn build
 
 build: ui
-	cargo build --release -p wanaku-praxis-proxy
+	cargo build --release -p wanaku-server
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ South America.
 Download the latest early-access build on Linux or macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wanaku-ai/wanaku/main/get-wanaku-praxis.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wanaku-ai/wanaku/main/get-wanaku.sh | bash
 ```
 
-The installer detects the host platform, verifies the release checksum, and installs `wanaku-praxis` into `$HOME/bin`. Override the destination with `WANAKU_PRAXIS_INSTALL_DIR`.
+The installer detects the host platform, verifies the release checksum, and installs `wanaku-server` into `$HOME/bin`. Override the destination with `WANAKU_INSTALL_DIR`.
 
 ### Container
 
 ```bash
-podman run -p 8080:8080 -p 8081:8081 quay.io/wanaku/wanaku-praxis
+podman run -p 8080:8080 -p 8081:8081 quay.io/wanaku/wanaku-server
 ```
 
 To preload forwards, mount a `wanaku.yaml`:
 
 ```bash
 podman run -p 8080:8080 -p 8081:8081 \
-  -v ./wanaku.yaml:/etc/wanaku-praxis/wanaku.yaml \
-  quay.io/wanaku/wanaku-praxis \
-  --wanaku-config /etc/wanaku-praxis/wanaku.yaml
+  -v ./wanaku.yaml:/etc/wanaku/wanaku.yaml \
+  quay.io/wanaku/wanaku-server \
+  --wanaku-config /etc/wanaku/wanaku.yaml
 ```
 
 ### From Source

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "wanaku-praxis-apis"
+name = "wanaku-apis"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
 [lib]
-name = "wanaku_praxis_apis"
+name = "wanaku_apis"
 
 [lints]
 workspace = true

--- a/apis/src/config.rs
+++ b/apis/src/config.rs
@@ -1,4 +1,4 @@
-//! Centralized environment variable configuration for Wanaku Praxis.
+//! Centralized environment variable configuration for Wanaku.
 //!
 //! All `WANAKU_*` environment variables are read once at startup via
 //! [`LazyLock`] and exposed through the [`ENV`] static. No other module
@@ -13,7 +13,7 @@ use std::sync::LazyLock;
 /// Management API listen address (default `0.0.0.0:8080`).
 const WANAKU_MGMT_LISTEN: &str = "WANAKU_MGMT_LISTEN";
 
-/// Inference backend address used in the default Praxis config (default `127.0.0.1:11434`).
+/// Inference backend address (default `127.0.0.1:11434`).
 const WANAKU_INFERENCE_UPSTREAM: &str = "WANAKU_INFERENCE_UPSTREAM";
 
 /// Bearer token API key for the inference upstream. Empty means no auth.
@@ -47,7 +47,7 @@ pub struct PersistEnv {
 pub struct WanakuEnv {
     /// Management API listen address.
     pub mgmt_listen: String,
-    /// Inference upstream `host:port` for the Praxis proxy load-balancer endpoint.
+    /// Inference upstream `host:port` for the proxy load-balancer endpoint.
     pub inference_upstream: String,
     /// Path prefix extracted from the upstream URL (e.g. `/api` from `https://host/api`).
     /// Empty when the upstream is a bare `host:port`.

--- a/deploy/auth/README.md
+++ b/deploy/auth/README.md
@@ -1,6 +1,6 @@
 # Authentication with oauth2-proxy
 
-Wanaku Praxis uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. Two oauth2-proxy instances protect the MCP and management ports with shared SSO.
+Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. Two oauth2-proxy instances protect the MCP and management ports with shared SSO.
 
 ## Prerequisites
 
@@ -40,8 +40,8 @@ The `wanaku-mcp-router` client in Keycloak must be **confidential** (not public)
 ## Architecture
 
 ```
-Browser/CLI ──► oauth2-proxy-mcp (:4180) ──► Praxis MCP (:8081)
-            └─► oauth2-proxy-mgmt (:4181) ──► Praxis Mgmt (:8080)
+Browser/CLI ──► oauth2-proxy-mcp (:4180) ──► Wanaku MCP (:8081)
+            └─► oauth2-proxy-mgmt (:4181) ──► Wanaku Mgmt (:8080)
 ```
 
 Both instances share the same cookie secret, so logging in on one port authenticates you on the other (SSO).
@@ -87,7 +87,7 @@ Generate a shared cookie secret (must be exactly 16, 24, or 32 bytes):
 export COOKIE_SECRET=$(openssl rand -hex 16)
 ```
 
-Start Praxis with the auth issuer configured:
+Start Wanaku with the auth issuer configured:
 ```bash
 WANAKU_AUTH_ISSUER=http://localhost:8543/realms/wanaku cargo run
 ```

--- a/deploy/auth/docker-compose-auth.yml
+++ b/deploy/auth/docker-compose-auth.yml
@@ -37,7 +37,7 @@ services:
       keycloak:
         condition: service_healthy
 
-  wanaku-praxis:
+  wanaku-server:
     build:
       context: ../..
       dockerfile: Containerfile

--- a/deploy/auth/oauth2-proxy-mcp.env
+++ b/deploy/auth/oauth2-proxy-mcp.env
@@ -1,6 +1,6 @@
 # MCP proxy — authenticates MCP clients (tools, resources, prompts)
 OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:4180
-OAUTH2_PROXY_UPSTREAMS=http://wanaku-praxis:8081
+OAUTH2_PROXY_UPSTREAMS=http://wanaku-server:8081
 OAUTH2_PROXY_REDIRECT_URL=http://localhost:4180/oauth2/callback
 
 # Accept tokens from MCP clients (audience may differ from our client-id)

--- a/deploy/auth/oauth2-proxy-mgmt.env
+++ b/deploy/auth/oauth2-proxy-mgmt.env
@@ -1,6 +1,6 @@
 # Management proxy — authenticates admin UI and REST API access
 OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:4181
-OAUTH2_PROXY_UPSTREAMS=http://wanaku-praxis:8080
+OAUTH2_PROXY_UPSTREAMS=http://wanaku-server:8080
 OAUTH2_PROXY_REDIRECT_URL=http://localhost:4181/oauth2/callback
 
 # Accept tokens from MCP clients (audience may differ from our client-id)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Wanaku Praxis is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. At its core, it's a sophisticated HTTP filter pipeline that routes AI agent requests to the right tools, enforces security policies, and manages namespaces.
+Wanaku is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. At its core, it's a sophisticated HTTP filter pipeline that routes AI agent requests to the right tools, enforces security policies, and manages namespaces.
 
 This isn't your typical REST API. It's a proxy. Requests flow through a chain of filters, each responsible for a specific concern—CORS, protocol parsing, namespace isolation, tool dispatch. Think of it as middleware, but composable and pluggable.
 
@@ -13,7 +13,7 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
                  │ MCP (JSON-RPC over HTTP)
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              Wanaku Praxis Server (Port 8081)                │
+│              Wanaku Server (Port 8081)                │
 │  ┌────────────────────────────────────────────────────────┐ │
 │  │              Filter Pipeline (Praxis)                   │ │
 │  │  CORS → MCP Parse → Namespace → Evaluator →            │ │
@@ -219,7 +219,7 @@ On startup, the server loads `registry.json` from `WANAKU_PERSIST_PATH`. On shut
 
 ## Tool Routing
 
-All tool execution in Praxis happens via MCP forwarding. When a tool call arrives (`tools/call`), the tool_call filter:
+All tool execution in Wanaku happens via MCP forwarding. When a tool call arrives (`tools/call`), the tool_call filter:
 
 1. Looks up the tool in the registry by name
 2. Calls `mcp_client::call_tool(tool.uri, name, arguments)` to forward the request to the upstream MCP server
@@ -246,7 +246,7 @@ The management API:
 2. Calls `mcp_client::list_tools(address)` to discover tools
 3. Auto-registers each tool with `type: "mcp-forward"` and `uri: <forward.address>`
 
-Now when an LLM calls one of those tools, Praxis forwards the request to the upstream server transparently.
+Now when an LLM calls one of those tools, Wanaku forwards the request to the upstream server transparently.
 
 **Refreshing:**
 
@@ -260,7 +260,7 @@ This removes all tools previously discovered from that forward and re-queries th
 
 ## The Feature System
 
-Features are self-contained modules that extend Praxis with new capabilities. They live in `features/<name>/` and implement the `Feature` trait from `apis/src/feature.rs`:
+Features are self-contained modules that extend Wanaku with new capabilities. They live in `features/<name>/` and implement the `Feature` trait from `apis/src/feature.rs`:
 
 ```rust
 #[async_trait::async_trait]
@@ -368,14 +368,14 @@ See [Admin UI](./admin-ui.md) for development details.
 
 ### Standalone
 
-Run Praxis as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, and execute via MCP forwarding to upstream servers.
+Run Wanaku as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, and execute via MCP forwarding to upstream servers.
 
 **Pros:** Simple, no dependencies
 **Cons:** No persistence beyond file snapshots
 
 ### Kubernetes
 
-Deploy Praxis as a `Deployment` with:
+Deploy Wanaku as a `Deployment` with:
 
 - **Service:** ClusterIP for MCP endpoint (port 8081)
 - **Service:** LoadBalancer for management API (port 8080)
@@ -388,7 +388,7 @@ Mount `WANAKU_PERSIST_PATH` to a `PersistentVolume` for registry persistence acr
 
 **Throughput:**
 
-Praxis uses Pingora's async worker pool. Each worker handles requests concurrently. Throughput scales linearly with worker count (default: CPU core count).
+Wanaku uses Pingora's async worker pool. Each worker handles requests concurrently. Throughput scales linearly with worker count (default: CPU core count).
 
 **Latency breakdown:**
 
@@ -405,7 +405,7 @@ Registry is in-memory. Each tool/resource/prompt is ~1KB. A deployment with 10,0
 
 **Authentication:**
 
-Wanaku Praxis delegates authentication to [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), an external reverse proxy that sits in front of the MCP and management API ports. Praxis itself contains zero authentication code.
+Wanaku delegates authentication to [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), an external reverse proxy that sits in front of the MCP and management API ports. Wanaku itself contains zero authentication code.
 
 **oauth2-proxy sidecar pattern:**
 
@@ -414,15 +414,15 @@ Two oauth2-proxy instances with a shared cookie provide SSO across both endpoint
 - **oauth2-proxy-mcp** (port 4180 → 8081) — protects MCP endpoints, requires `mcp-user` role
 - **oauth2-proxy-mgmt** (port 4181 → 8080) — protects admin UI and REST API, requires `admin` role
 
-Users authenticate via oauth2-proxy's browser-based login flow (PKCE). CLI clients obtain tokens from Keycloak and pass them as `Authorization: Bearer <token>` headers — oauth2-proxy validates them before proxying to Praxis.
+Users authenticate via oauth2-proxy's browser-based login flow (PKCE). CLI clients obtain tokens from Keycloak and pass them as `Authorization: Bearer <token>` headers — oauth2-proxy validates them before proxying to Wanaku.
 
-**Praxis-side metadata:**
+**Wanaku-side metadata:**
 
 The `features/mcp-metadata/` crate exposes RFC 9728 OAuth Protected Resource Metadata at `/.well-known/oauth-protected-resource/{namespace}/mcp`. This endpoint is read-only and simply returns the OIDC issuer URL configured via `WANAKU_AUTH_ISSUER`.
 
 When auth is disabled:
 
-- Run Praxis standalone on ports 8081/8080 without oauth2-proxy
+- Run Wanaku standalone on ports 8081/8080 without oauth2-proxy
 - **No authentication** on either endpoint
 
 **CORS:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,16 +1,16 @@
 # Configuration
 
-Wanaku Praxis is configured entirely through environment variables and two optional YAML files. There's no properties file. This keeps deployment simple—set env vars in your container orchestrator or systemd unit, point at config files if needed, and you're done.
+Wanaku is configured entirely through environment variables and two optional YAML files. There's no properties file. This keeps deployment simple—set env vars in your container orchestrator or systemd unit, point at config files if needed, and you're done.
 
 ## Configuration Sources (Precedence Order)
 
 1. **Environment variables** — highest priority, always win
-2. **Runtime YAML files** — loaded from CLI args (e.g., `cargo run -- --praxis-config praxis.yaml --wanaku-config wanaku.yaml`)
+2. **Runtime YAML files** — loaded from CLI args (e.g., `cargo run -- --pipeline-config praxis.yaml --wanaku-config wanaku.yaml`)
 3. **Embedded defaults** — `server/src/default.yaml` compiled into the binary
 
 ## Core Environment Variables
 
-These are defined in `apis/src/config.rs` and accessed via `wanaku_praxis_apis::config::ENV`:
+These are defined in `apis/src/config.rs` and accessed via `wanaku_apis::config::ENV`:
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -48,7 +48,7 @@ export WANAKU_MGMT_LISTEN=0.0.0.0:8080
 export WANAKU_MGMT_LISTEN=127.0.0.1:8080
 ```
 
-Useful when running Praxis behind a reverse proxy (nginx, Envoy) that handles external traffic.
+Useful when running Wanaku behind a reverse proxy (nginx, Envoy) that handles external traffic.
 
 **Bind to specific IP:**
 
@@ -107,11 +107,11 @@ Features (mcp-metadata, chat, etc.) own their env vars. They're NOT in `apis/src
 
 ### Authentication with oauth2-proxy
 
-Wanaku Praxis uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication, not embedded code. Two oauth2-proxy instances run as sidecars in front of ports 8081 (MCP) and 8080 (management API).
+Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication, not embedded code. Two oauth2-proxy instances run as sidecars in front of ports 8081 (MCP) and 8080 (management API).
 
 **MCP Metadata Feature:**
 
-The only auth-related configuration in Praxis itself is the OIDC issuer URL for RFC 9728 metadata:
+The only auth-related configuration in Wanaku itself is the OIDC issuer URL for RFC 9728 metadata:
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -166,16 +166,16 @@ The chat feature exposes these management API routes:
 - `GET /api/v1/chat/{llm}/models` — list models for an LLM
 - `POST /api/v1/chat/completions` — proxy chat completion request
 
-## Praxis Config File (praxis.yaml)
+## Pipeline Config File (praxis.yaml)
 
-The Praxis config defines listeners, filter chains, and filter-specific settings. It's a YAML file that matches Praxis's native config format.
+The pipeline config defines listeners, filter chains, and filter-specific settings. It's a YAML file that matches Praxis's native config format.
 
 **Default location:** `server/src/default.yaml` (embedded at compile time)
 
-**Override:** Pass with `--praxis-config`:
+**Override:** Pass with `--pipeline-config`:
 
 ```bash
-cargo run -- --praxis-config /path/to/custom-praxis.yaml
+cargo run -- --pipeline-config /path/to/custom-praxis.yaml
 ```
 
 **Format:**
@@ -224,8 +224,8 @@ listeners:
   - name: mcp
     address: "0.0.0.0:8081"
     tls:
-      cert_path: /etc/praxis/cert.pem
-      key_path: /etc/praxis/key.pem
+      cert_path: /etc/wanaku/cert.pem
+      key_path: /etc/wanaku/key.pem
     filter_chains: [mcp_router]
 ```
 
@@ -283,7 +283,7 @@ The Wanaku config bootstraps forwarded MCP servers on startup. It's optional —
 **Location:** Pass with `--wanaku-config`:
 
 ```bash
-cargo run -- --praxis-config /path/to/praxis.yaml --wanaku-config /path/to/wanaku.yaml
+cargo run -- --pipeline-config /path/to/praxis.yaml --wanaku-config /path/to/wanaku.yaml
 ```
 
 **Format:**
@@ -340,9 +340,9 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /build/target/release/wanaku-praxis /usr/local/bin/
-COPY praxis.yaml /etc/praxis/praxis.yaml
-COPY wanaku.yaml /etc/praxis/wanaku.yaml
+COPY --from=builder /build/target/release/wanaku-server /usr/local/bin/
+COPY praxis.yaml /etc/wanaku/praxis.yaml
+COPY wanaku.yaml /etc/wanaku/wanaku.yaml
 
 ENV WANAKU_MGMT_LISTEN=0.0.0.0:8080
 ENV WANAKU_PERSIST_BACKEND=file
@@ -350,7 +350,7 @@ ENV WANAKU_PERSIST_PATH=/data/registry
 
 VOLUME /data
 EXPOSE 8081 8080
-CMD ["/usr/local/bin/wanaku-praxis", "--praxis-config", "/etc/praxis/praxis.yaml", "--wanaku-config", "/etc/praxis/wanaku.yaml"]
+CMD ["/usr/local/bin/wanaku-server", "--pipeline-config", "/etc/wanaku/praxis.yaml", "--wanaku-config", "/etc/wanaku/wanaku.yaml"]
 ```
 
 Run with:
@@ -358,7 +358,7 @@ Run with:
 ```bash
 docker run -v /var/lib/wanaku:/data \
   -p 8081:8081 -p 8080:8080 \
-  wanaku-praxis:latest
+  wanaku-server:latest
 ```
 
 ### Kubernetes
@@ -396,14 +396,14 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wanaku-praxis
+  name: wanaku-server
 spec:
   replicas: 1  # each replica has its own in-memory registry; scale only with external persistence
   template:
     spec:
       containers:
       - name: wanaku
-        image: wanaku-praxis:latest
+        image: wanaku-server:latest
         env:
         - name: WANAKU_MGMT_LISTEN
           value: "0.0.0.0:8080"
@@ -413,7 +413,7 @@ spec:
           value: "/data/registry"
         volumeMounts:
         - name: config
-          mountPath: /etc/praxis
+          mountPath: /etc/wanaku
         - name: data
           mountPath: /data
       volumes:
@@ -438,7 +438,7 @@ This logs all filter decisions, metadata reads/writes, and registry operations. 
 **Filter-specific logs:**
 
 ```bash
-RUST_LOG=wanaku_praxis_filters=trace cargo run
+RUST_LOG=wanaku_filters=trace cargo run
 ```
 
 ### Verify Environment Variables
@@ -449,8 +449,8 @@ To check what the server sees:
 
 ```rust
 // Add to main.rs before server start
-println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_praxis_apis::config::ENV.mgmt_listen);
-println!("WANAKU_PERSIST_BACKEND: {:?}", wanaku_praxis_apis::config::ENV.persist_backend);
+println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_apis::config::ENV.mgmt_listen);
+println!("WANAKU_PERSIST_BACKEND: {:?}", wanaku_apis::config::ENV.persist_backend);
 ```
 
 Rebuild and run. The server prints the effective config.

--- a/docs/evaluator-engine.md
+++ b/docs/evaluator-engine.md
@@ -454,7 +454,7 @@ world = "evaluator-action"
 Copy the WIT file into your crate:
 
 ```bash
-cp /path/to/wanaku-praxis/features/evaluator/wit/evaluator.wit wit/evaluator.wit
+cp /path/to/wanaku/features/evaluator/wit/evaluator.wit wit/evaluator.wit
 ```
 
 ### Step 2: Use wit-bindgen
@@ -750,7 +750,7 @@ Tests cover: config parsing (including `result_schema`), trigger matching, evalu
 End-to-end tests that hit the management API and MCP endpoint against a running server. These replace the shell scripts and are gated with `#[ignore]`.
 
 ```bash
-# Start wanaku-praxis first, then:
+# Start wanaku-server first, then:
 cargo test -p wanaku-feature-evaluator --test e2e -- --ignored
 ```
 
@@ -913,7 +913,7 @@ Downstream filters can read this metadata and make decisions (e.g., extra loggin
 2. Verify `trigger.method` matches `mcp.method` metadata (e.g., `tools/call` not `tool/call`)
 3. If using `trigger.namespace`, verify the request URL is `/namespace/mcp`, not `/mcp`
 
-Enable trace logs: `RUST_LOG=wanaku_praxis_evaluator=trace`
+Enable trace logs: `RUST_LOG=wanaku_feature_evaluator=trace`
 
 ### "LLM returned garbage"
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,12 +1,12 @@
 # Features
 
-Features are self-contained modules that extend Wanaku Praxis with new capabilities. They're not just configuration options—they're full-fledged Rust crates that can register filters into the pipeline, expose management API routes, and manage their own state.
+Features are self-contained modules that extend Wanaku with new capabilities. They're not just configuration options—they're full-fledged Rust crates that can register filters into the pipeline, expose management API routes, and manage their own state.
 
 Think of features as plugins. The core server provides the infrastructure (filter pipeline, registry, management API), and features build on top of it.
 
 ## Built-in Features
 
-Wanaku Praxis ships with five features:
+Wanaku ships with five features:
 
 ### Intercept Feature (`features/intercept/`)
 
@@ -32,7 +32,7 @@ Exposes RFC 9728 OAuth Protected Resource Metadata to advertise authentication r
 **How it works:**
 
 1. MCP client queries `GET /.well-known/oauth-protected-resource/{namespace}/mcp`
-2. Praxis returns JSON metadata with the OIDC issuer URL configured via `WANAKU_AUTH_ISSUER`
+2. Wanaku returns JSON metadata with the OIDC issuer URL configured via `WANAKU_AUTH_ISSUER`
 3. MCP client uses the issuer URL to discover the authorization server and token endpoints
 
 **Configuration:**
@@ -57,13 +57,13 @@ If `WANAKU_AUTH_ISSUER` is unset, the metadata endpoint returns a 404 (feature d
 
 **Authentication architecture:**
 
-Praxis does NOT validate tokens or enforce authentication. That's handled by [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), which runs as a reverse proxy in front of Praxis ports 8081 (MCP) and 8080 (management API).
+Wanaku does NOT validate tokens or enforce authentication. That's handled by [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), which runs as a reverse proxy in front of Wanaku ports 8081 (MCP) and 8080 (management API).
 
 For deployment details, see `deploy/auth/README.md` and [Configuration](./configuration.md#authentication-with-oauth2-proxy).
 
 ### Chat Feature (`features/chat/`)
 
-Proxies LLM chat completion requests to an inference backend (any OpenAI-compatible endpoint). This lets you use Praxis as a unified API gateway for both MCP tools and raw LLM chat.
+Proxies LLM chat completion requests to an inference backend (any OpenAI-compatible endpoint). This lets you use Wanaku as a unified API gateway for both MCP tools and raw LLM chat.
 
 **How it works:**
 
@@ -149,8 +149,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-wanaku-praxis-apis = { path = "../../apis" }
-wanaku-praxis-filters = { path = "../../filters" }
+wanaku-apis = { path = "../../apis" }
+wanaku-filters = { path = "../../filters" }
 praxis-filter = "0.4.1"
 async-trait = "0.1"
 http = "1"
@@ -164,7 +164,7 @@ tracing = "0.1"
 Create `src/lib.rs`:
 
 ```rust
-use wanaku_praxis_apis::feature::Feature;
+use wanaku_apis::feature::Feature;
 use praxis_filter::{FilterRegistry, PipelineExtension};
 use http::Response;
 use std::sync::Arc;
@@ -210,7 +210,7 @@ impl Feature for ToolStatsFeature {
                 "data": {"tool_calls": count},
                 "error": null
             });
-            Some(wanaku_praxis_apis::http_response::json_ok(&body))
+            Some(wanaku_apis::http_response::json_ok(&body))
         } else {
             None
         }
@@ -227,7 +227,7 @@ impl Feature for ToolStatsFeature {
 Add to `src/lib.rs`:
 
 ```rust
-use wanaku_praxis_filters::body_filter_boilerplate;
+use wanaku_filters::body_filter_boilerplate;
 use praxis_filter::{HttpFilterContext, FilterAction, FilterError};
 use bytes::Bytes;
 
@@ -342,10 +342,10 @@ let counter = ctx.extensions.get::<Arc<AtomicU64>>();
 
 ### Hot-Reloadable Config
 
-Use `HotSwap<T>` from `wanaku_praxis_apis::llm` for runtime-reconfigurable state:
+Use `HotSwap<T>` from `wanaku_apis::llm` for runtime-reconfigurable state:
 
 ```rust
-use wanaku_praxis_apis::llm::HotSwap;
+use wanaku_apis::llm::HotSwap;
 
 pub struct MyFeature {
     config: HotSwap<MyConfig>,
@@ -367,10 +367,10 @@ let config = feature_state.config.read();
 
 ### LLM Integration
 
-Use `LlmClient` from `wanaku_praxis_apis::llm` for OpenAI-compatible LLM calls:
+Use `LlmClient` from `wanaku_apis::llm` for OpenAI-compatible LLM calls:
 
 ```rust
-use wanaku_praxis_apis::llm::LlmClient;
+use wanaku_apis::llm::LlmClient;
 
 let client = LlmClient::new("http://localhost:11434/v1");
 let response = client.chat_completion("llama3.1:8b", &messages, 30).await?;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
-# Getting Started with Wanaku Praxis
+# Getting Started with Wanaku
 
-Wanaku Praxis is a Rust-based MCP (Model Context Protocol) server that routes AI agent requests through a sophisticated filter pipeline. Think of it as the bouncer at the club: it checks IDs, enforces the rules, and makes sure everyone gets to the right place.
+Wanaku is a Rust-based MCP (Model Context Protocol) server that routes AI agent requests through a sophisticated filter pipeline. Think of it as the bouncer at the club: it checks IDs, enforces the rules, and makes sure everyone gets to the right place.
 
 This guide gets you from zero to running MCP server in under 10 minutes.
 
@@ -18,8 +18,8 @@ That's it. The admin UI dev workflow also uses Yarn, but that's only needed if y
 ### 1. Clone and Build
 
 ```bash
-git clone https://github.com/wanaku-ai/wanaku-praxis.git
-cd wanaku-praxis
+git clone https://github.com/wanaku-ai/wanaku.git
+cd wanaku
 cargo build --release
 ```
 
@@ -64,7 +64,7 @@ curl -X POST http://localhost:8080/api/v1/forwards \
   }'
 ```
 
-Praxis connects to the upstream server, discovers all available tools, and registers them automatically with `type: "mcp-forward"`.
+Wanaku connects to the upstream server, discovers all available tools, and registers them automatically with `type: "mcp-forward"`.
 
 List the discovered tools:
 
@@ -140,7 +140,7 @@ From here you can view and manage tools, namespaces, resources, prompts, and for
 
 ### Enable Authentication
 
-Wanaku Praxis uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. oauth2-proxy runs as a reverse proxy in front of the MCP and management API ports.
+Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. oauth2-proxy runs as a reverse proxy in front of the MCP and management API ports.
 
 **Quick start with docker-compose:**
 
@@ -156,7 +156,7 @@ openssl rand -base64 32
 
 # Place your Keycloak realm export as wanaku-realm.json in this directory
 
-# Start the stack (Keycloak + oauth2-proxy + Praxis)
+# Start the stack (Keycloak + oauth2-proxy + Wanaku)
 docker compose -f docker-compose-auth.yml up
 ```
 
@@ -195,7 +195,7 @@ The `cargo run` command uses the debug build. For production, use:
 
 ```bash
 cargo build --release
-./target/release/wanaku-praxis
+./target/release/wanaku-server
 ```
 
 The release binary is optimized compared to debug builds.
@@ -205,11 +205,11 @@ The release binary is optimized compared to debug builds.
 The server embeds `server/src/default.yaml` at compile time. To override:
 
 ```bash
-./target/release/wanaku-praxis --praxis-config /path/to/custom-praxis.yaml \
+./target/release/wanaku-server --pipeline-config /path/to/custom-praxis.yaml \
   --wanaku-config /path/to/wanaku.yaml
 ```
 
-- **`--praxis-config`:** Praxis filter pipeline config (listeners, filter chains)
+- **`--pipeline-config`:** Praxis filter pipeline config (listeners, filter chains)
 - **`--wanaku-config`:** Wanaku bootstrap config (forwards, namespaces)
 
 Both are optional. If omitted, embedded defaults are used.
@@ -257,7 +257,7 @@ Check that:
 Enable trace logs to see what the filters are doing:
 
 ```bash
-RUST_LOG=wanaku_praxis_filters=trace cargo run
+RUST_LOG=wanaku_filters=trace cargo run
 ```
 
 ### 4. Management API returns 404 for valid routes
@@ -270,7 +270,7 @@ Check the route enum in `routes.rs` and the `dispatch` function in `mod.rs`.
 
 **Server crashes with "thread 'main' panicked":**
 
-Praxis denies `unsafe_code`, `unwrap_used`, `expect_used`, and `panic` at the crate level. A panic means a logic bug. File an issue with the stack trace and steps to reproduce.
+Wanaku denies `unsafe_code`, `unwrap_used`, `expect_used`, and `panic` at the crate level. A panic means a logic bug. File an issue with the stack trace and steps to reproduce.
 
 **Tool calls time out:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
-# Wanaku Praxis Documentation
+# Wanaku Documentation
 
-Wanaku Praxis is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. It routes AI agent requests through a filter pipeline to provide namespace isolation, tool/resource/prompt management, and MCP-to-MCP tool forwarding.
+Wanaku is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. It routes AI agent requests through a filter pipeline to provide namespace isolation, tool/resource/prompt management, and MCP-to-MCP tool forwarding.
 
-## Why Praxis?
+## Why Rust?
 
-The classic Wanaku MCP Router (Java + Quarkus) is a fully-featured MCP server with service catalogs, Camel routes, Infinispan persistence, and OIDC integration. Praxis expands on that foundation with a composable filter pipeline architecture built on the Praxis proxy framework — enabling pluggable feature crates that would be difficult to express in the classic architecture.
+The classic Wanaku MCP Router (Java + Quarkus) is a fully-featured MCP server with service catalogs, Camel routes, Infinispan persistence, and OIDC integration. Wanaku expands on that foundation with a composable filter pipeline architecture built on the Praxis proxy framework — enabling pluggable feature crates that would be difficult to express in the classic architecture.
 
-Praxis shares the same MCP protocol and management API as classic Wanaku.
+Wanaku shares the same MCP protocol and management API as classic Wanaku.
 
 ## What You Get
 
@@ -45,7 +45,7 @@ All in a single binary with no runtime dependencies (except libc).
 
 ## Who This Isn't For (Yet)
 
-- **You need clustering** — Praxis is single-node only
+- **You need clustering** — Wanaku is single-node only
 - **You need metrics/tracing** — no Prometheus or OpenTelemetry integration
 
 These are solvable, but they're not in scope for the initial release.
@@ -103,7 +103,7 @@ Namespaces isolate tools. A tool registered with `namespace: "finance"` only app
 
 ### Tool Routing
 
-Tools execute via MCP forwarding. When an LLM calls a tool, Praxis forwards the request to the upstream MCP server specified in the tool's `uri` field. The upstream server handles actual execution and returns the result, which Praxis wraps in a JSON-RPC response.
+Tools execute via MCP forwarding. When an LLM calls a tool, Wanaku forwards the request to the upstream MCP server specified in the tool's `uri` field. The upstream server handles actual execution and returns the result, which Wanaku wraps in a JSON-RPC response.
 
 ### Features
 
@@ -119,8 +119,8 @@ Features are Rust crates that implement the `Feature` trait. They can:
 ### Run Locally
 
 ```bash
-git clone https://github.com/wanaku-ai/wanaku-praxis.git
-cd wanaku-praxis
+git clone https://github.com/wanaku-ai/wanaku.git
+cd wanaku
 cargo run --release
 ```
 
@@ -153,14 +153,14 @@ curl -X POST http://localhost:8080/api/v1/forwards/echo-server/refreshes
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wanaku-praxis
+  name: wanaku-server
 spec:
   replicas: 1  # each replica has its own in-memory registry; scale only with external persistence
   template:
     spec:
       containers:
       - name: wanaku
-        image: wanaku-praxis:latest
+        image: wanaku-server:latest
         env:
         - name: WANAKU_PERSIST_BACKEND
           value: "file"
@@ -181,21 +181,21 @@ See [Configuration](./configuration.md) for details.
 
 ### Standalone
 
-Run Praxis as the only MCP server. Tools are discovered from forwarded MCP servers registered via the management API or `wanaku.yaml`, executing via MCP forwarding to those upstream servers.
+Run Wanaku as the only MCP server. Tools are discovered from forwarded MCP servers registered via the management API or `wanaku.yaml`, executing via MCP forwarding to those upstream servers.
 
 **Pros:** Simple, no dependencies
 **Cons:** No persistence beyond file snapshots
 
 ### Kubernetes
 
-Deploy Praxis as a `Deployment` with a `PersistentVolume` for the registry. Use `ConfigMap` for `wanaku.yaml` and `Secret` for LLM API keys.
+Deploy Wanaku as a `Deployment` with a `PersistentVolume` for the registry. Use `ConfigMap` for `wanaku.yaml` and `Secret` for LLM API keys.
 
 **Pros:** Horizontal scaling, declarative config
 **Cons:** Requires k8s infrastructure
 
 ## What's Different from Classic Wanaku?
 
-| Feature | Classic (Java) | Praxis (Rust) |
+| Feature | Classic (Java) | Wanaku (Rust) |
 |---|---|---|
 | **MCP protocol** | ✅ Full support | ✅ Full support |
 | **Namespace isolation** | ✅ Yes | ✅ Yes |
@@ -211,7 +211,7 @@ Deploy Praxis as a `Deployment` with a `PersistentVolume` for the registry. Use 
 
 ## Performance Characteristics
 
-Praxis is built on Pingora (Cloudflare's proxy framework) and uses async I/O throughout. The filter pipeline adds minimal overhead to each request. Actual throughput and latency depend on your downstream services (upstream MCP servers, LLM endpoints).
+Wanaku is built on Pingora (Cloudflare's proxy framework) and uses async I/O throughout. The filter pipeline adds minimal overhead to each request. Actual throughput and latency depend on your downstream services (upstream MCP servers, LLM endpoints).
 
 The binary is a single statically-linked executable with low memory footprint.
 
@@ -226,19 +226,19 @@ RUST_LOG=trace cargo run
 Check what filters see:
 
 ```bash
-RUST_LOG=wanaku_praxis_filters=trace cargo run
+RUST_LOG=wanaku_filters=trace cargo run
 ```
 
 Verify environment variables:
 
 ```rust
 // Add to main.rs
-println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_praxis_apis::config::ENV.mgmt_listen);
+println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_apis::config::ENV.mgmt_listen);
 ```
 
 ## Contributing
 
-Praxis is open source (Apache 2.0). Contributions welcome.
+Wanaku is open source (Apache 2.0). Contributions welcome.
 
 **Code style:**
 - `cargo fmt` before committing
@@ -256,8 +256,8 @@ Praxis is open source (Apache 2.0). Contributions welcome.
 
 ## Support and Community
 
-- **GitHub:** https://github.com/wanaku-ai/wanaku-praxis
-- **Issues:** https://github.com/wanaku-ai/wanaku-praxis/issues
+- **GitHub:** https://github.com/wanaku-ai/wanaku
+- **Issues:** https://github.com/wanaku-ai/wanaku/issues
 - **Classic Wanaku:** https://github.com/wanaku-ai/wanaku
 
 ## License
@@ -268,7 +268,7 @@ Apache 2.0. See LICENSE for details.
 
 **Next Steps:**
 
-- New to Praxis? Start with [Getting Started](./getting-started.md)
+- New to Wanaku? Start with [Getting Started](./getting-started.md)
 - Want to understand the internals? Read [Architecture](./architecture.md)
 - Need to configure it? See [Configuration](./configuration.md)
 - Building custom features? Check [Features](./features.md)

--- a/docs/plugin-development-guide.md
+++ b/docs/plugin-development-guide.md
@@ -1,6 +1,6 @@
-# Wanaku Praxis Plugin Development Guide
+# Wanaku Plugin Development Guide
 
-Plugins extend the Wanaku Praxis admin UI by adding pages, navigation entries, and backend service integration without modifying the core application. This guide shows you how to build one.
+Plugins extend the Wanaku admin UI by adding pages, navigation entries, and backend service integration without modifying the core application. This guide shows you how to build one.
 
 ## Overview
 
@@ -621,4 +621,4 @@ The nav entry disappears immediately. You don't have to wait for the plugin to u
 
 ---
 
-**That's the guide.** You now know how to build, configure, and test a plugin for Wanaku Praxis. Start with the Quick Start example, experiment with the host APIs, and check the `examples/hello-plugin/` directory for a working reference implementation.
+**That's the guide.** You now know how to build, configure, and test a plugin for Wanaku. Start with the Quick Start example, experiment with the host APIs, and check the `examples/hello-plugin/` directory for a working reference implementation.

--- a/features/chat/Cargo.toml
+++ b/features/chat/Cargo.toml
@@ -19,4 +19,4 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
+wanaku-apis = { workspace = true }

--- a/features/chat/src/lib.rs
+++ b/features/chat/src/lib.rs
@@ -6,7 +6,7 @@ mod routes;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension};
 
-use wanaku_praxis_apis::feature::Feature;
+use wanaku_apis::feature::Feature;
 
 use crate::routes::{
     ChatRoute, handle_chat_completions, handle_chat_list_llms, handle_chat_list_models,

--- a/features/chat/src/routes.rs
+++ b/features/chat/src/routes.rs
@@ -1,6 +1,6 @@
 use http::{Response, StatusCode};
 use tracing::warn;
-use wanaku_praxis_apis::http_response::json_err;
+use wanaku_apis::http_response::json_err;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ChatRoute {
@@ -35,7 +35,7 @@ fn raw_json_response(body: Vec<u8>) -> Response<Vec<u8>> {
         .status(StatusCode::OK)
         .header("Content-Type", "application/json")
         .header("Content-Length", body.len())
-        .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())
+        .header("Access-Control-Allow-Origin", wanaku_apis::config::ENV.cors_origin.as_str())
         .body(body)
         .expect("valid json response")
 }
@@ -213,7 +213,7 @@ pub(crate) async fn handle_chat_completions(
         .status(StatusCode::OK)
         .header("Content-Type", "text/plain")
         .header("Content-Length", response_body.len())
-        .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())
+        .header("Access-Control-Allow-Origin", wanaku_apis::config::ENV.cors_origin.as_str())
         .body(response_body)
         .unwrap_or_default()
 }

--- a/features/evaluator/Cargo.toml
+++ b/features/evaluator/Cargo.toml
@@ -23,8 +23,8 @@ serde_yaml = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { version = "47", features = ["component-model"] }
 wasmtime-wasi = "47"
-wanaku-praxis-apis = { workspace = true }
-wanaku-praxis-filters = { workspace = true }
+wanaku-apis = { workspace = true }
+wanaku-filters = { workspace = true }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/features/evaluator/src/engine.rs
+++ b/features/evaluator/src/engine.rs
@@ -8,8 +8,8 @@ use wasmtime_wasi::{WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::schema::CompiledSchema;
 
-use wanaku_praxis_apis::interactions::InMemoryInteractionStore;
-use wanaku_praxis_apis::registry::InMemoryRegistry;
+use wanaku_apis::interactions::InMemoryInteractionStore;
+use wanaku_apis::registry::InMemoryRegistry;
 
 use crate::action::ActionResult;
 use crate::host::{self, EvaluatorAction, HostState};

--- a/features/evaluator/src/filter.rs
+++ b/features/evaluator/src/filter.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
-use wanaku_praxis_apis::interactions::{InMemoryInteractionStore, InteractionStore};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolRegistry};
+use wanaku_apis::interactions::{InMemoryInteractionStore, InteractionStore};
+use wanaku_apis::registry::{InMemoryRegistry, ToolRegistry};
 
 use crate::action::ActionResult;
 use crate::config::{ErrorPolicy, EvaluatorDef, LlmOperation};
 use crate::state::EvaluatorState;
 
-wanaku_praxis_filters::body_filter_boilerplate!(EvaluatorFilter, "wanaku_evaluator");
+wanaku_filters::body_filter_boilerplate!(EvaluatorFilter, "wanaku_evaluator");
 
 impl EvaluatorFilter {
     #[expect(clippy::too_many_lines, clippy::cognitive_complexity, clippy::large_stack_frames, reason = "evaluator pipeline with multiple validation steps")]
@@ -18,7 +18,7 @@ impl EvaluatorFilter {
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(wanaku_praxis_filters::MCP_METHOD_KEY) {
+        let method = match ctx.get_metadata(wanaku_filters::MCP_METHOD_KEY) {
             Some(m) => m.to_owned(),
             None => return Ok(FilterAction::Continue),
         };
@@ -29,8 +29,8 @@ impl EvaluatorFilter {
         };
 
         let namespace = ctx
-            .get_metadata(wanaku_praxis_apis::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE)
+            .get_metadata(wanaku_apis::NAMESPACE_METADATA_KEY)
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE)
             .to_owned();
 
         let Some(evaluator) = state.find_matching(&method, &namespace) else {
@@ -55,13 +55,13 @@ impl EvaluatorFilter {
         };
 
         let tool_name = ctx
-            .get_metadata(wanaku_praxis_filters::MCP_NAME_KEY)
+            .get_metadata(wanaku_filters::MCP_NAME_KEY)
             .map(std::borrow::ToOwned::to_owned);
 
         let arguments = parse_arguments(body);
 
         let conversation_id = arguments
-            .get(wanaku_praxis_apis::correlation::REQUEST_ID_ARG)
+            .get(wanaku_apis::correlation::REQUEST_ID_ARG)
             .cloned()
             .or_else(|| state.get_binding(&namespace));
 
@@ -114,8 +114,8 @@ impl EvaluatorFilter {
             );
             return match evaluator.on_error {
                 ErrorPolicy::Continue => Ok(FilterAction::Continue),
-                ErrorPolicy::Block => Ok(wanaku_praxis_filters::response::json_rpc_error(
-                    &wanaku_praxis_filters::response::extract_json_rpc_id(body),
+                ErrorPolicy::Block => Ok(wanaku_filters::response::json_rpc_error(
+                    &wanaku_filters::response::extract_json_rpc_id(body),
                     -32603,
                     "evaluator processor module not available",
                 )),
@@ -156,13 +156,13 @@ fn dispatch_action(
     method: &str,
     evaluator_name: &str,
 ) -> Result<FilterAction, FilterError> {
-    let json_rpc_id = wanaku_praxis_filters::response::extract_json_rpc_id(body);
+    let json_rpc_id = wanaku_filters::response::extract_json_rpc_id(body);
 
     match result {
         ActionResult::Pass => Ok(FilterAction::Continue),
         ActionResult::Block(reason) => {
             tracing::warn!(evaluator = %evaluator_name, reason = %reason, "request blocked");
-            Ok(wanaku_praxis_filters::response::json_rpc_error(
+            Ok(wanaku_filters::response::json_rpc_error(
                 &json_rpc_id,
                 -32001,
                 &format!("blocked by evaluator {evaluator_name}: {reason}"),
@@ -170,7 +170,7 @@ fn dispatch_action(
         }
         ActionResult::RejectMalformed(reason) => {
             tracing::warn!(evaluator = %evaluator_name, reason = %reason, "rejected: malformed input");
-            Ok(wanaku_praxis_filters::response::json_rpc_error(
+            Ok(wanaku_filters::response::json_rpc_error(
                 &json_rpc_id,
                 -32002,
                 &format!("evaluator {evaluator_name}: malformed input — {reason}"),
@@ -210,7 +210,7 @@ fn dispatch_action(
                 "result": { "tools": mcp_tools }
             });
             Ok(FilterAction::Reject(
-                wanaku_praxis_filters::response::json_response(Bytes::from(response.to_string())),
+                wanaku_filters::response::json_response(Bytes::from(response.to_string())),
             ))
         }
         ActionResult::SetMetadata(key, value) => {
@@ -229,8 +229,8 @@ async fn validate_and_retry_if_needed(
     method: &str,
     tool_name: Option<&str>,
     arguments: &HashMap<String, String>,
-    tools: &[wanaku_praxis_apis::registry::ToolEntry],
-    history: &[wanaku_praxis_apis::interactions::Interaction],
+    tools: &[wanaku_apis::registry::ToolEntry],
+    history: &[wanaku_apis::interactions::Interaction],
 ) -> String {
     let Some(schema) = compiled_schema else {
         return raw_result.to_owned();

--- a/features/evaluator/src/host.rs
+++ b/features/evaluator/src/host.rs
@@ -7,8 +7,8 @@ bindgen!({
 
 pub use wanaku::evaluator::types;
 
-use wanaku_praxis_apis::interactions::{InMemoryInteractionStore, InteractionStore};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolRegistry};
+use wanaku_apis::interactions::{InMemoryInteractionStore, InteractionStore};
+use wanaku_apis::registry::{InMemoryRegistry, ToolRegistry};
 
 use std::sync::Arc;
 
@@ -148,7 +148,7 @@ pub fn link(linker: &mut wasmtime::component::Linker<HostState>) -> Result<(), S
         .map_err(|e| format!("failed to link host functions: {e}"))
 }
 
-fn tool_entry_to_wit(t: wanaku_praxis_apis::registry::ToolEntry) -> types::ToolEntry {
+fn tool_entry_to_wit(t: wanaku_apis::registry::ToolEntry) -> types::ToolEntry {
     types::ToolEntry {
         name: t.name,
         description: t.description,

--- a/features/evaluator/src/lib.rs
+++ b/features/evaluator/src/lib.rs
@@ -15,7 +15,7 @@ pub mod state;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_praxis_apis::feature::Feature;
+use wanaku_apis::feature::Feature;
 
 use crate::config::EvaluatorsConfig;
 use crate::routes::{

--- a/features/evaluator/src/llm_op.rs
+++ b/features/evaluator/src/llm_op.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use wanaku_praxis_apis::interactions::Interaction;
-use wanaku_praxis_apis::llm::{self, LlmClient};
-use wanaku_praxis_apis::registry::ToolEntry;
+use wanaku_apis::interactions::Interaction;
+use wanaku_apis::llm::{self, LlmClient};
+use wanaku_apis::registry::ToolEntry;
 
 use crate::config::LlmDef;
 

--- a/features/evaluator/src/routes.rs
+++ b/features/evaluator/src/routes.rs
@@ -1,6 +1,6 @@
 use http::{Response, StatusCode};
 use tracing::info;
-use wanaku_praxis_apis::http_response::{json_err, json_ok};
+use wanaku_apis::http_response::{json_err, json_ok};
 
 use crate::config::EvaluatorsConfig;
 use crate::state::EvaluatorState;

--- a/features/evaluator/tests/e2e.rs
+++ b/features/evaluator/tests/e2e.rs
@@ -168,11 +168,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server"]
+    #[ignore = "requires running wanaku server"]
     fn evaluators_api_crud() {
         let harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -212,11 +212,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server and pre-built WASM actions"]
+    #[ignore = "requires running wanaku server and pre-built WASM actions"]
     fn safety_block_wasm_blocks_tool_call() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -256,11 +256,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server and pre-built WASM actions"]
+    #[ignore = "requires running wanaku server and pre-built WASM actions"]
     fn safety_warn_wasm_does_not_block() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -299,11 +299,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server and pre-built WASM actions"]
+    #[ignore = "requires running wanaku server and pre-built WASM actions"]
     fn cleared_evaluator_does_not_block() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -342,11 +342,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server and pre-built WASM actions"]
+    #[ignore = "requires running wanaku server and pre-built WASM actions"]
     fn evaluator_with_result_schema_config() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -400,11 +400,11 @@ mod engine {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server and pre-built WASM actions"]
+    #[ignore = "requires running wanaku server and pre-built WASM actions"]
     fn namespace_scoped_evaluator() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() {
-            eprintln!("SKIP: wanaku-praxis not running");
+            eprintln!("SKIP: wanaku server not running");
             return;
         }
 
@@ -492,7 +492,7 @@ mod classification {
 
     #[test]
     #[serial]
-    #[ignore = "requires running wanaku-praxis server, pre-built WASM actions, and Ollama"]
+    #[ignore = "requires running wanaku server, pre-built WASM actions, and Ollama"]
     fn dangerous_restart_is_blocked() {
         let mut harness = TestHarness::new();
         if !harness.server_is_reachable() || !harness.ollama_is_reachable() {

--- a/features/evaluator/tests/integration.rs
+++ b/features/evaluator/tests/integration.rs
@@ -506,8 +506,8 @@ mod engine {
     use std::sync::Arc;
     use wanaku_feature_evaluator::engine::CompiledEvaluator;
     use wanaku_feature_evaluator::schema::CompiledSchema;
-    use wanaku_praxis_apis::interactions::InMemoryInteractionStore;
-    use wanaku_praxis_apis::registry::InMemoryRegistry;
+    use wanaku_apis::interactions::InMemoryInteractionStore;
+    use wanaku_apis::registry::InMemoryRegistry;
 
     macro_rules! require_wasm {
         ($name:expr) => {{

--- a/features/intercept/Cargo.toml
+++ b/features/intercept/Cargo.toml
@@ -19,4 +19,4 @@ praxis-filter = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
+wanaku-apis = { workspace = true }

--- a/features/intercept/src/filter.rs
+++ b/features/intercept/src/filter.rs
@@ -6,8 +6,8 @@ use bytes::Bytes;
 use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, HttpFilter, HttpFilterContext,
 };
-use wanaku_praxis_apis::correlation::{self, REQUEST_ID_ARG};
-use wanaku_praxis_apis::interactions::{InMemoryInteractionStore, Interaction, InteractionStore};
+use wanaku_apis::correlation::{self, REQUEST_ID_ARG};
+use wanaku_apis::interactions::{InMemoryInteractionStore, Interaction, InteractionStore};
 
 struct InterceptState {
     path: String,

--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -6,8 +6,8 @@ mod routes;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_praxis_apis::feature::Feature;
-use wanaku_praxis_apis::interactions::InMemoryInteractionStore;
+use wanaku_apis::feature::Feature;
+use wanaku_apis::interactions::InMemoryInteractionStore;
 
 use crate::routes::{
     InteractionRoute, handle_interaction_clear, handle_interaction_list,

--- a/features/intercept/src/routes.rs
+++ b/features/intercept/src/routes.rs
@@ -1,7 +1,7 @@
 use http::Response;
 use tracing::info;
-use wanaku_praxis_apis::http_response::json_ok;
-use wanaku_praxis_apis::interactions::{InMemoryInteractionStore, InteractionStore};
+use wanaku_apis::http_response::json_ok;
+use wanaku_apis::interactions::{InMemoryInteractionStore, InteractionStore};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum InteractionRoute {

--- a/features/mcp-metadata/Cargo.toml
+++ b/features/mcp-metadata/Cargo.toml
@@ -20,5 +20,5 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
-wanaku-praxis-filters = { workspace = true }
+wanaku-apis = { workspace = true }
+wanaku-filters = { workspace = true }

--- a/features/mcp-metadata/src/filter.rs
+++ b/features/mcp-metadata/src/filter.rs
@@ -4,7 +4,7 @@ use praxis_filter::{FilterAction, FilterError, HttpFilterContext, Rejection};
 
 use crate::IssuerConfig;
 
-wanaku_praxis_filters::body_filter_boilerplate!(WellKnownFilter, "wanaku_well_known");
+wanaku_filters::body_filter_boilerplate!(WellKnownFilter, "wanaku_well_known");
 
 const WELL_KNOWN_PREFIX: &str = "/.well-known/oauth-protected-resource/";
 

--- a/features/mcp-metadata/src/lib.rs
+++ b/features/mcp-metadata/src/lib.rs
@@ -5,7 +5,7 @@ pub mod filter;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_praxis_apis::feature::Feature;
+use wanaku_apis::feature::Feature;
 
 const WANAKU_AUTH_ISSUER: &str = "WANAKU_AUTH_ISSUER";
 

--- a/features/plugins/Cargo.toml
+++ b/features/plugins/Cargo.toml
@@ -20,4 +20,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
+wanaku-apis = { workspace = true }

--- a/features/plugins/src/handlers.rs
+++ b/features/plugins/src/handlers.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use http::{Response, StatusCode};
 use tracing::warn;
-use wanaku_praxis_apis::http_response::{json_err, json_ok};
+use wanaku_apis::http_response::{json_err, json_ok};
 
 use crate::manifest::PluginManifest;
 

--- a/features/plugins/src/lib.rs
+++ b/features/plugins/src/lib.rs
@@ -11,8 +11,8 @@ use std::sync::RwLock;
 
 use http::{Response, StatusCode};
 use praxis_filter::{FilterRegistry, PipelineExtension};
-use wanaku_praxis_apis::feature::Feature;
-use wanaku_praxis_apis::http_response::json_err;
+use wanaku_apis::feature::Feature;
+use wanaku_apis::http_response::json_err;
 
 use crate::manifest::PluginManifest;
 use crate::routes::{PluginRoute, resolve_plugin_route};

--- a/filters/Cargo.toml
+++ b/filters/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "wanaku-praxis-filters"
+name = "wanaku-filters"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
 [lib]
-name = "wanaku_praxis_filters"
+name = "wanaku_filters"
 
 [lints]
 workspace = true
@@ -18,6 +18,6 @@ http = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
+wanaku-apis = { workspace = true }
 praxis-filter = { workspace = true }
 serde_yaml = { workspace = true }

--- a/filters/src/mcp_init.rs
+++ b/filters/src/mcp_init.rs
@@ -44,7 +44,7 @@ impl McpInitFilter {
                     }
                 },
                 "serverInfo": {
-                    "name": "wanaku-praxis",
+                    "name": "wanaku-server",
                     "version": "0.3.0"
                 }
             }

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -1,8 +1,8 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
-use wanaku_praxis_apis::registry::DEFAULT_NAMESPACE;
+use wanaku_apis::registry::DEFAULT_NAMESPACE;
 
-pub use wanaku_praxis_apis::NAMESPACE_METADATA_KEY;
+pub use wanaku_apis::NAMESPACE_METADATA_KEY;
 
 crate::body_filter_boilerplate!(NamespaceFilter, "wanaku_namespace");
 

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::{trace, warn};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, PromptRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, PromptRegistry};
 
 crate::body_filter_boilerplate!(PromptGetFilter, "wanaku_prompt_get");
 
@@ -66,7 +66,7 @@ impl PromptGetFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         let parsed = parse_body(body);
 
@@ -153,7 +153,7 @@ impl PromptGetFilter {
             Some(parsed.arguments.clone())
         };
 
-        match wanaku_praxis_apis::mcp_client::get_prompt(forward_address, prompt_name, arguments).await {
+        match wanaku_apis::mcp_client::get_prompt(forward_address, prompt_name, arguments).await {
             Ok(result) => {
                 let response = serde_json::json!({
                     "jsonrpc": "2.0",

--- a/filters/src/prompt_list.rs
+++ b/filters/src/prompt_list.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::trace;
-use wanaku_praxis_apis::registry::{InMemoryRegistry, PromptRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, PromptRegistry};
 
 crate::body_filter_boilerplate!(PromptListFilter, "wanaku_prompt_list");
 
@@ -22,7 +22,7 @@ impl PromptListFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         trace!(namespace = %namespace, "handling MCP prompts/list request");
 

--- a/filters/src/resource_list.rs
+++ b/filters/src/resource_list.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::trace;
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, ResourceRegistry};
 
 crate::body_filter_boilerplate!(ResourceListFilter, "wanaku_resource_list");
 
@@ -24,7 +24,7 @@ impl ResourceListFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         trace!(namespace = %namespace, "handling MCP resources/list request");
 

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::{trace, warn};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, ResourceRegistry};
 
 crate::body_filter_boilerplate!(ResourceReadFilter, "wanaku_resource_read");
 
@@ -105,7 +105,7 @@ impl ResourceReadFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         trace!(uri = %resource_uri, namespace = %namespace, "handling MCP resources/read request");
 
@@ -144,7 +144,7 @@ impl ResourceReadFilter {
 
     async fn handle_forwarded_read(
         &self,
-        resource: &wanaku_praxis_apis::registry::ResourceEntry,
+        resource: &wanaku_apis::registry::ResourceEntry,
         resource_uri: &str,
         parsed: &ParsedBody,
     ) -> Result<FilterAction, FilterError> {
@@ -159,7 +159,7 @@ impl ResourceReadFilter {
 
         trace!(uri = %resource_uri, forward = %forward_address, "forwarding resources/read to remote MCP server");
 
-        match wanaku_praxis_apis::mcp_client::read_resource(forward_address, resource_uri).await {
+        match wanaku_apis::mcp_client::read_resource(forward_address, resource_uri).await {
             Ok(contents) => {
                 let response = serde_json::json!({
                     "jsonrpc": "2.0",

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::{trace, warn};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry};
 
 crate::body_filter_boilerplate!(ToolCallFilter, "wanaku_tool_call");
 
@@ -71,12 +71,12 @@ impl ToolCallFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         let mut parsed = parse_body(body);
 
         let conversation_id = parsed.arguments
-            .remove(wanaku_praxis_apis::correlation::REQUEST_ID_ARG)
+            .remove(wanaku_apis::correlation::REQUEST_ID_ARG)
             .map_or_else(|| "-".to_owned(), |v| match v {
                 serde_json::Value::String(s) => s,
                 other => other.to_string(),
@@ -158,7 +158,7 @@ impl ToolCallFilter {
                 .collect(),
         );
 
-        match wanaku_praxis_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments).await {
+        match wanaku_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments).await {
             Ok(call_result) => {
                 let mcp_content: Vec<serde_json::Value> = call_result.content
                     .iter()

--- a/filters/src/tool_list.rs
+++ b/filters/src/tool_list.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
-use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolRegistry};
+use wanaku_apis::registry::{InMemoryRegistry, ToolRegistry};
 
 crate::body_filter_boilerplate!(ToolListFilter, "wanaku_tool_list");
 
@@ -21,7 +21,7 @@ impl ToolListFilter {
 
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
-            .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+            .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
         tracing::debug!(namespace = %namespace, "handling MCP tools/list request");
 

--- a/get-wanaku.sh
+++ b/get-wanaku.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="wanaku-ai/wanaku-praxis"
-RELEASE_TAG="${WANAKU_PRAXIS_RELEASE:-early-access}"
-INSTALL_DIR="${WANAKU_PRAXIS_INSTALL_DIR:-$HOME/bin}"
+REPO="wanaku-ai/wanaku"
+RELEASE_TAG="${WANAKU_RELEASE:-early-access}"
+INSTALL_DIR="${WANAKU_INSTALL_DIR:-$HOME/bin}"
 
 info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn()  { printf '\033[1;33mWARN:\033[0m %s\n' "$*"; }
@@ -23,12 +23,12 @@ detect_platform() {
         Linux/aarch64|Linux/arm64) PLATFORM="linux-aarch64" ;;
         Darwin/x86_64|Darwin/amd64) PLATFORM="macos-x86_64" ;;
         Darwin/arm64|Darwin/aarch64) PLATFORM="macos-aarch64" ;;
-        *) error "Wanaku Praxis does not provide a release for ${os}/${arch}" ;;
+        *) error "Wanaku does not provide a release for ${os}/${arch}" ;;
     esac
 }
 
 resolve_release() {
-    info "Resolving Wanaku Praxis ${RELEASE_TAG} for ${PLATFORM}..."
+    info "Resolving Wanaku ${RELEASE_TAG} for ${PLATFORM}..."
     local response urls
     response="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG}")" \
         || error "Could not fetch release ${RELEASE_TAG}"
@@ -70,22 +70,22 @@ download_and_verify() {
     fi
 }
 
-install_wanaku_praxis() {
+install_wanaku() {
     local binary
     mkdir -p "${INSTALL_TMP}/extract" "$INSTALL_DIR"
     tar -xzf "${INSTALL_TMP}/${ARTIFACT}" -C "${INSTALL_TMP}/extract"
-    binary="$(find "${INSTALL_TMP}/extract" -type f -name wanaku-praxis -print | head -n 1)"
-    [ -n "$binary" ] || error "Unexpected archive layout: wanaku-praxis binary not found"
+    binary="$(find "${INSTALL_TMP}/extract" -type f -name wanaku-server -print | head -n 1)"
+    [ -n "$binary" ] || error "Unexpected archive layout: wanaku-server binary not found"
 
-    install -m 0755 "$binary" "${INSTALL_DIR}/wanaku-praxis"
-    info "Wanaku Praxis installed at ${INSTALL_DIR}/wanaku-praxis"
+    install -m 0755 "$binary" "${INSTALL_DIR}/wanaku-server"
+    info "Wanaku installed at ${INSTALL_DIR}/wanaku-server"
 
     if ! printf '%s' "$PATH" | tr ':' '\n' | grep -Fxq "$INSTALL_DIR"; then
         warn "$INSTALL_DIR is not in your PATH. Add it with:"
         warn "  export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
 
-    "${INSTALL_DIR}/wanaku-praxis" --version 2>/dev/null || true
+    "${INSTALL_DIR}/wanaku-server" --version 2>/dev/null || true
 }
 
 main() {
@@ -95,7 +95,7 @@ main() {
     detect_platform
     resolve_release
     download_and_verify
-    install_wanaku_praxis
+    install_wanaku
 }
 
 main "$@"

--- a/images.txt
+++ b/images.txt
@@ -1,1 +1,1 @@
-wanaku-praxis:latest
+wanaku-server:latest

--- a/jreleaser/changelog.tpl
+++ b/jreleaser/changelog.tpl
@@ -1,21 +1,21 @@
 ## Downloads
 
-### Wanaku Praxis
+### Wanaku
 
-The Wanaku Praxis MCP Router binary.
+The Wanaku MCP Router binary.
 
 | Platform | File |
 |---|---|
-| **Linux (x86_64)** | [wanaku-praxis-{{projectVersion}}-linux-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-linux-x86_64.tar.gz) |
-| **Linux (aarch64)** | [wanaku-praxis-{{projectVersion}}-linux-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-linux-aarch64.tar.gz) |
-| **macOS (Apple Silicon)** | [wanaku-praxis-{{projectVersion}}-macos-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-macos-aarch64.tar.gz) |
-| **macOS (x86_64)** | [wanaku-praxis-{{projectVersion}}-macos-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-macos-x86_64.tar.gz) |
-| **Windows (x86_64)** | [wanaku-praxis-{{projectVersion}}-windows-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-praxis-{{projectVersion}}-windows-x86_64.zip) |
+| **Linux (x86_64)** | [wanaku-server-{{projectVersion}}-linux-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-server-{{projectVersion}}-linux-x86_64.tar.gz) |
+| **Linux (aarch64)** | [wanaku-server-{{projectVersion}}-linux-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-server-{{projectVersion}}-linux-aarch64.tar.gz) |
+| **macOS (Apple Silicon)** | [wanaku-server-{{projectVersion}}-macos-aarch64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-server-{{projectVersion}}-macos-aarch64.tar.gz) |
+| **macOS (x86_64)** | [wanaku-server-{{projectVersion}}-macos-x86_64.tar.gz](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-server-{{projectVersion}}-macos-x86_64.tar.gz) |
+| **Windows (x86_64)** | [wanaku-server-{{projectVersion}}-windows-x86_64.zip](https://github.com/wanaku-ai/wanaku/releases/download/{{tagName}}/wanaku-server-{{projectVersion}}-windows-x86_64.zip) |
 
 ### Container Images
 
 ```
-docker pull quay.io/wanaku/wanaku-praxis:{{projectVersion}}
+docker pull quay.io/wanaku/wanaku-server:{{projectVersion}}
 ```
 
 ---

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "wanaku-praxis-proxy"
+name = "wanaku-server"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
 [lib]
-name = "wanaku_praxis"
+name = "wanaku_server"
 path = "src/lib.rs"
 
 [[bin]]
-name = "wanaku-praxis"
+name = "wanaku-server"
 path = "src/main.rs"
 
 [lints]
@@ -32,8 +32,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time", "fs"] }
 tracing = { workspace = true }
-wanaku-praxis-apis = { workspace = true }
-wanaku-praxis-filters = { workspace = true }
+wanaku-apis = { workspace = true }
+wanaku-filters = { workspace = true }
 wanaku-feature-chat = { workspace = true }
 wanaku-feature-evaluator = { workspace = true }
 wanaku-feature-intercept = { workspace = true }

--- a/server/src/http_response.rs
+++ b/server/src/http_response.rs
@@ -1,1 +1,1 @@
-pub use wanaku_praxis_apis::http_response::{json_err, json_ok};
+pub use wanaku_apis::http_response::{json_err, json_ok};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -6,7 +6,7 @@ pub mod pipelines;
 
 const DEFAULT_CONFIG: &str = include_str!("default.yaml");
 
-/// Load configuration, falling back to `praxis.yaml` then the built-in default.
+/// Load configuration, falling back to the built-in default.
 ///
 /// # Errors
 ///
@@ -14,7 +14,7 @@ const DEFAULT_CONFIG: &str = include_str!("default.yaml");
 pub fn load_config(
     explicit_path: Option<&str>,
 ) -> Result<praxis_core::config::Config, praxis_core::errors::ProxyError> {
-    let env = &wanaku_praxis_apis::config::ENV;
+    let env = &wanaku_apis::config::ENV;
     let mut config = DEFAULT_CONFIG.replace("127.0.0.1:11434", &env.inference_upstream);
     if let Some(sni) = &env.inference_tls_sni {
         config = config.replace(
@@ -25,7 +25,7 @@ pub fn load_config(
     praxis_core::config::Config::load(explicit_path, &config)
 }
 
-/// Build a filter registry with praxis builtins, praxis-ai MCP, and wanaku filters.
+/// Build a filter registry with builtins, MCP, and wanaku filters.
 #[must_use]
 pub fn build_full_registry() -> praxis_filter::FilterRegistry {
     let mut registry = praxis_filter::FilterRegistry::with_builtins();
@@ -41,34 +41,34 @@ fn register_wanaku_filters(registry: &mut praxis_filter::FilterRegistry) {
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_namespace" => wanaku_praxis_filters::NamespaceFilter::from_config
+        http "wanaku_namespace" => wanaku_filters::NamespaceFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_mcp_init" => wanaku_praxis_filters::McpInitFilter::from_config
+        http "wanaku_mcp_init" => wanaku_filters::McpInitFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_tool_list" => wanaku_praxis_filters::ToolListFilter::from_config
+        http "wanaku_tool_list" => wanaku_filters::ToolListFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_tool_call" => wanaku_praxis_filters::ToolCallFilter::from_config
+        http "wanaku_tool_call" => wanaku_filters::ToolCallFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_resource_list" => wanaku_praxis_filters::ResourceListFilter::from_config
+        http "wanaku_resource_list" => wanaku_filters::ResourceListFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_resource_read" => wanaku_praxis_filters::ResourceReadFilter::from_config
+        http "wanaku_resource_read" => wanaku_filters::ResourceReadFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_prompt_list" => wanaku_praxis_filters::PromptListFilter::from_config
+        http "wanaku_prompt_list" => wanaku_filters::PromptListFilter::from_config
     );
     praxis_filter::register_filters!(
         @register registry,
-        http "wanaku_prompt_get" => wanaku_praxis_filters::PromptGetFilter::from_config
+        http "wanaku_prompt_get" => wanaku_filters::PromptGetFilter::from_config
     );
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,16 +13,16 @@ use praxis_protocol::Protocol as _;
 use praxis_protocol::http::PingoraHttp;
 use tracing::info;
 
-use wanaku_praxis_apis::feature::Feature;
-use wanaku_praxis_apis::persistence::FilePersistence;
-use wanaku_praxis_apis::registry::{
+use wanaku_apis::feature::Feature;
+use wanaku_apis::persistence::FilePersistence;
+use wanaku_apis::registry::{
     ForwardEntry, ForwardRegistry, InMemoryRegistry,
 };
 
 #[expect(clippy::cognitive_complexity, clippy::too_many_lines, reason = "server bootstrap")]
 fn main() {
     let args = ServerArgs::parse();
-    let config = wanaku_praxis::load_config(args.praxis_config.as_deref())
+    let config = wanaku_server::load_config(args.pipeline_config.as_deref())
         .unwrap_or_else(|e| fatal(&e));
 
     praxis_core::logging::init_tracing(&config)
@@ -48,11 +48,11 @@ fn main() {
         Box::new(wanaku_feature_chat::ChatFeature::new(
             format!(
                 "http://127.0.0.1:{}{}",
-                wanaku_praxis_apis::config::ENV.inference_proxy_port(),
-                wanaku_praxis_apis::config::ENV.inference_path_prefix,
+                wanaku_apis::config::ENV.inference_proxy_port(),
+                wanaku_apis::config::ENV.inference_path_prefix,
             ),
-            wanaku_praxis_apis::config::ENV.inference_tls_sni.clone(),
-            wanaku_praxis_apis::config::ENV.inference_api_key.clone(),
+            wanaku_apis::config::ENV.inference_tls_sni.clone(),
+            wanaku_apis::config::ENV.inference_api_key.clone(),
         )),
         Box::new(wanaku_feature_plugins::PluginsFeature::new(args.plugins_path.as_deref())),
     ];
@@ -69,7 +69,7 @@ fn main() {
         feature.load_env_config();
     }
 
-    let mut filter_registry = wanaku_praxis::build_full_registry();
+    let mut filter_registry = wanaku_server::build_full_registry();
     for feature in &features {
         feature.register_filters(&mut filter_registry);
     }
@@ -80,7 +80,7 @@ fn main() {
     let mgmt_registry = wanaku_registry.clone();
 
     info!("building wanaku pipelines");
-    let pipelines = wanaku_praxis::pipelines::resolve_pipelines(
+    let pipelines = wanaku_server::pipelines::resolve_pipelines(
         &config,
         &filter_registry,
         &health_registry,
@@ -113,8 +113,8 @@ fn main() {
         );
     }
 
-    let mgmt_addr = &wanaku_praxis_apis::config::ENV.mgmt_listen;
-    let mgmt = wanaku_praxis::management::WanakuManagementService::new(
+    let mgmt_addr = &wanaku_apis::config::ENV.mgmt_listen;
+    let mgmt = wanaku_server::management::WanakuManagementService::new(
         mgmt_registry,
         features,
     );
@@ -126,16 +126,16 @@ fn main() {
     server.server_mut().add_service(mgmt_service);
     info!(address = %mgmt_addr, "management API enabled");
 
-    info!("starting wanaku-praxis server");
+    info!("starting wanaku server");
     server.run()
 }
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
 struct ServerArgs {
-    /// Praxis pipeline configuration file. Uses the embedded configuration when omitted.
+    /// Pipeline configuration file. Uses the embedded configuration when omitted.
     #[arg(long, value_name = "PATH")]
-    praxis_config: Option<String>,
+    pipeline_config: Option<String>,
 
     /// Wanaku bootstrap configuration file.
     #[arg(long, value_name = "PATH", default_value = "wanaku.yaml")]
@@ -197,7 +197,7 @@ fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
         rt.block_on(async {
             for fwd in &forwards {
                 info!(forward = %fwd.name, address = %fwd.address, "discovering from forward");
-                wanaku_praxis::management::discover_and_update_forward(registry, fwd).await;
+                wanaku_server::management::discover_and_update_forward(registry, fwd).await;
             }
         });
     }

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -1,7 +1,7 @@
 use http::{Response, StatusCode};
 use tracing::{info, warn};
 
-use wanaku_praxis_apis::registry::{
+use wanaku_apis::registry::{
     ForwardEntry, ForwardRegistry, InMemoryRegistry, NamespaceEntry, NamespaceRegistry,
     PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry,
     ToolEntry, ToolRegistry, MCP_FORWARD_TYPE,
@@ -215,7 +215,7 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
         }
     };
 
-    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "forward discovery failed");
@@ -271,7 +271,7 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
     remove_forwarded_resources(registry, &forward.address);
     remove_forwarded_prompts(registry, &forward.address);
 
-    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %name, error = %e, "forward refresh discovery failed");
@@ -291,7 +291,7 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
 }
 
 pub async fn discover_and_update_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) {
-    let discovery = match wanaku_praxis_apis::mcp_client::discover_forward(&forward.address).await {
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "forward discovery failed at startup");
@@ -317,7 +317,7 @@ pub async fn discover_and_update_forward(registry: &InMemoryRegistry, forward: &
 }
 
 pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let tools = match wanaku_praxis_apis::mcp_client::list_tools(&forward.address).await {
+    let tools = match wanaku_apis::mcp_client::list_tools(&forward.address).await {
         Ok(t) => t,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover tools from forward");
@@ -330,7 +330,7 @@ pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &
 
 #[expect(clippy::too_many_lines, reason = "sequential tool registration")]
 fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry, tools: &[serde_json::Value]) -> usize {
-    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
     for tool_json in tools {
@@ -372,7 +372,7 @@ fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry
 }
 
 pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let resources = match wanaku_praxis_apis::mcp_client::list_resources(&forward.address).await {
+    let resources = match wanaku_apis::mcp_client::list_resources(&forward.address).await {
         Ok(r) => r,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover resources from forward");
@@ -380,7 +380,7 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
         }
     };
 
-    let templates = match wanaku_praxis_apis::mcp_client::list_resource_templates(&forward.address).await {
+    let templates = match wanaku_apis::mcp_client::list_resource_templates(&forward.address).await {
         Ok(t) => t,
         Err(e) => {
             tracing::debug!(forward = %forward.name, error = %e, "no resource templates from forward (may not be supported)");
@@ -398,7 +398,7 @@ fn register_discovered_resources(
     resources: &[serde_json::Value],
     templates: &[serde_json::Value],
 ) -> usize {
-    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
     for res_json in resources {
@@ -427,7 +427,7 @@ fn register_discovered_resources(
 
         let mut labels = std::collections::HashMap::new();
         labels.insert(
-            wanaku_praxis_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
+            wanaku_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
             forward.address.clone(),
         );
 
@@ -475,11 +475,11 @@ fn register_discovered_resources(
 
         let mut labels = std::collections::HashMap::new();
         labels.insert(
-            wanaku_praxis_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
+            wanaku_apis::registry::FORWARD_ADDRESS_LABEL.to_owned(),
             forward.address.clone(),
         );
         labels.insert(
-            wanaku_praxis_apis::registry::IS_TEMPLATE_LABEL.to_owned(),
+            wanaku_apis::registry::IS_TEMPLATE_LABEL.to_owned(),
             "true".to_owned(),
         );
 
@@ -527,7 +527,7 @@ fn remove_forwarded_tools(registry: &InMemoryRegistry, address: &str) {
 }
 
 pub async fn discover_prompts_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let prompts = match wanaku_praxis_apis::mcp_client::list_prompts(&forward.address).await {
+    let prompts = match wanaku_apis::mcp_client::list_prompts(&forward.address).await {
         Ok(p) => p,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover prompts from forward");
@@ -544,7 +544,7 @@ fn register_discovered_prompts(
     forward: &ForwardEntry,
     prompts: &[serde_json::Value],
 ) -> usize {
-    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
+    let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
 
     for prompt_json in prompts {
@@ -560,14 +560,14 @@ fn register_discovered_prompts(
             .and_then(|d| d.as_str())
             .unwrap_or_default();
 
-        let arguments: Vec<wanaku_praxis_apis::registry::PromptArgument> = prompt_json
+        let arguments: Vec<wanaku_apis::registry::PromptArgument> = prompt_json
             .get("arguments")
             .and_then(|a| a.as_array())
             .map(|arr| {
                 arr.iter()
                     .filter_map(|arg| {
                         let arg_name = arg.get("name")?.as_str()?;
-                        Some(wanaku_praxis_apis::registry::PromptArgument {
+                        Some(wanaku_apis::registry::PromptArgument {
                             name: arg_name.to_owned(),
                             description: arg
                                 .get("description")
@@ -616,8 +616,8 @@ fn remove_forwarded_prompts(registry: &InMemoryRegistry, address: &str) {
 #[cfg(test)]
 mod forward_helpers_tests {
     use super::*;
-    use wanaku_praxis_apis::registry::{InMemoryRegistry, PromptEntry, PromptRegistry, ToolEntry, ToolRegistry, ResourceRegistry, FORWARD_ADDRESS_LABEL};
-    use wanaku_praxis_apis::registry::{PromptMessage, PromptRole};
+    use wanaku_apis::registry::{InMemoryRegistry, PromptEntry, PromptRegistry, ToolEntry, ToolRegistry, ResourceRegistry, FORWARD_ADDRESS_LABEL};
+    use wanaku_apis::registry::{PromptMessage, PromptRole};
     use std::collections::HashMap;
 
     #[test]
@@ -773,7 +773,7 @@ mod tests {
     use std::collections::HashMap;
 
     use http::Response;
-    use wanaku_praxis_apis::registry::{
+    use wanaku_apis::registry::{
         ForwardEntry, ForwardRegistry, InMemoryRegistry,
         PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry,
         ToolEntry, ToolRegistry,

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -14,8 +14,8 @@ use pingora_core::apps::http_app::ServeHttp;
 use pingora_core::protocols::http::ServerSession;
 use tracing::info;
 
-use wanaku_praxis_apis::feature::Feature;
-use wanaku_praxis_apis::registry::InMemoryRegistry;
+use wanaku_apis::feature::Feature;
+use wanaku_apis::registry::InMemoryRegistry;
 
 use self::handlers::{
     handle_forward_create, handle_forward_delete, handle_forward_get, handle_forward_list,
@@ -50,7 +50,7 @@ impl WanakuManagementService {
         registry: InMemoryRegistry,
         features: Vec<Box<dyn Feature>>,
     ) -> Self {
-        let ui_path = wanaku_praxis_apis::config::ENV.ui_path.clone();
+        let ui_path = wanaku_apis::config::ENV.ui_path.clone();
         if let Some(p) = &ui_path {
             info!(path = %p.display(), "Admin UI serving enabled");
         }

--- a/server/src/management/response.rs
+++ b/server/src/management/response.rs
@@ -19,7 +19,7 @@ pub(super) fn raw_json_response(body: Vec<u8>) -> Response<Vec<u8>> {
         .status(StatusCode::OK)
         .header("Content-Type", "application/json")
         .header("Content-Length", body.len())
-        .header("Access-Control-Allow-Origin", wanaku_praxis_apis::config::ENV.cors_origin.as_str())
+        .header("Access-Control-Allow-Origin", wanaku_apis::config::ENV.cors_origin.as_str())
         .body(body)
         .expect("valid json response")
 }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -2,8 +2,8 @@
 
 use utoipa::OpenApi;
 
-use wanaku_praxis_apis::interactions::Interaction;
-use wanaku_praxis_apis::registry::{
+use wanaku_apis::interactions::Interaction;
+use wanaku_apis::registry::{
     ForwardEntry, McpServerInfo, NamespaceEntry, PromptArgument, PromptEntry, PromptMessage,
     ResourceEntry, ToolEntry,
 };
@@ -191,9 +191,9 @@ const fn get_statistics() {}
 #[derive(OpenApi)]
 #[openapi(
     info(
-        title = "Wanaku Praxis API",
+        title = "Wanaku API",
         version = "0.3.0",
-        description = "Wanaku Praxis MCP proxy management API"
+        description = "Wanaku MCP proxy management API"
     ),
     paths(
         healthz,

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -6,8 +6,8 @@ use praxis_filter::{FilterPipeline, FilterRegistry, PipelineExtension, RequestEx
 use praxis_protocol::ListenerPipelines;
 use tracing::info;
 
-use wanaku_praxis_apis::feature::Feature;
-use wanaku_praxis_apis::registry::InMemoryRegistry;
+use wanaku_apis::feature::Feature;
+use wanaku_apis::registry::InMemoryRegistry;
 
 struct RegistryExtension {
     registry: InMemoryRegistry,

--- a/tests/e2e/ui/package.json
+++ b/tests/e2e/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wanaku-praxis-e2e-ui",
+  "name": "wanaku-e2e-ui",
   "private": true,
   "scripts": {
     "test": "npx playwright test",

--- a/wanaku-praxis.md
+++ b/wanaku-praxis.md
@@ -1,13 +1,13 @@
 ---
-name: wanaku-praxis
-description: "Bootstrap plan for a new Rust project built on praxis framework — architecture, extension points, and future goals (MCP→gRPC, admin API)"
+name: wanaku
+description: "Bootstrap plan for the Wanaku Rust project built on praxis framework — architecture, extension points, and future goals (MCP→gRPC, admin API)"
 metadata: 
   node_type: memory
   type: project
   originSessionId: b3abf2a3-5e91-43a6-8064-823d4c268b85
 ---
 
-New project ("wanaku-praxis") that builds on the praxis proxy framework to add custom protocol handling, starting with MCP→gRPC transformation and eventually a management API.
+New project ("wanaku") that builds on the praxis proxy framework to add custom protocol handling, starting with MCP→gRPC transformation and eventually a management API.
 
 **Why:** Praxis is designed as a framework — praxis-ai demonstrates the pattern. A new project follows the same model: depend on praxis core crates, implement domain-specific filters, register them, and call `run_server_with_registry()`.
 
@@ -28,9 +28,9 @@ Praxis is a general-purpose high-performance reverse proxy framework built on Pi
 ## Project Structure (follow praxis-ai's pattern)
 
 ```
-wanaku-praxis/
+wanaku/
 ├── Cargo.toml              # workspace root
-├── server/                 # binary crate (wanaku-praxis binary)
+├── server/                 # binary crate (wanaku-server binary)
 │   └── src/
 │       ├── main.rs         # entry point, CLI
 │       ├── lib.rs          # register_filters! macro, build_full_registry()


### PR DESCRIPTION
## Summary

- Remove the "Praxis" branding from the project name — the project is now simply "Wanaku"
- Rename crates: `wanaku-praxis-apis` → `wanaku-apis`, `wanaku-praxis-filters` → `wanaku-filters`, `wanaku-praxis-proxy` → `wanaku-server`
- Rename server binary from `wanaku-praxis` to `wanaku-server`
- Rename CLI flag `--praxis-config` → `--pipeline-config`
- Update container image name, paths, installer script, CI workflows, deploy configs, JReleaser template, and all documentation
- Upstream Praxis proxy framework references (`praxis-proxy`, `praxis-filter`, `praxis-ai`, etc.) are preserved unchanged

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (226 tests: 219 run + 7 ignored e2e)
- [x] `grep --fixed-strings "wanaku-praxis"` returns zero matches across the codebase
- [x] Adversarial code review completed — all findings addressed
- [ ] Verify `make build` works with new package name
- [ ] Verify container build with updated Containerfile

## Summary by Sourcery

Rebrand the project as Wanaku and propagate the new crate, binary, configuration, release, and deployment names throughout the repository.

Enhancements:
- Rebrand the project from Wanaku Praxis to Wanaku while retaining Praxis framework references.
- Rename the core crates and server binary to the Wanaku-specific names and replace the pipeline configuration flag with `--pipeline-config`.
- Align container images, release artifacts, installer tooling, deployment definitions, and package metadata with the new Wanaku naming.

Build:
- Update build and packaging targets to use `wanaku-server`.
- Rename the standalone installer script and its environment variables for the Wanaku release artifacts.

CI:
- Update CI workflows to build, package, publish, and reference `wanaku-server` artifacts and images.

Deployment:
- Update container, Kubernetes, and authentication deployment configurations for the renamed server and `/etc/wanaku` paths.

Documentation:
- Update user-facing documentation, examples, links, and API metadata to use the Wanaku branding and renamed interfaces.

Chores:
- Update internal crate references, logging targets, test messages, and project metadata to match the renamed crates and server.