### PR TITLE
chore: fix all clippy warnings across the workspace

### DIFF
--- a/apis/src/config.rs
+++ b/apis/src/config.rs
@@ -69,7 +69,8 @@ pub static ENV: LazyLock<WanakuEnv> = LazyLock::new(WanakuEnv::from_env);
 
 impl WanakuEnv {
     #[must_use]
-    pub fn inference_proxy_port(&self) -> u16 {
+    #[expect(clippy::unused_self, reason = "stable API — may use self in future")]
+    pub const fn inference_proxy_port(&self) -> u16 {
         8083
     }
 

--- a/apis/src/feature.rs
+++ b/apis/src/feature.rs
@@ -9,6 +9,7 @@ pub trait Feature: Send + Sync {
 
     fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>>;
 
+    #[expect(clippy::too_many_arguments, reason = "trait method requires all context parameters")]
     async fn handle_route(
         &self,
         method: &str,

--- a/apis/src/interactions.rs
+++ b/apis/src/interactions.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_stack_frames, reason = "utoipa::ToSchema derive generates large stack frames")]
+
 use std::collections::VecDeque;
 use std::sync::{Arc, RwLock};
 

--- a/apis/src/llm.rs
+++ b/apis/src/llm.rs
@@ -43,6 +43,7 @@ impl LlmClient {
         })
     }
 
+    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "sequential HTTP request/response handling")]
     pub async fn chat(
         &self,
         system_prompt: &str,
@@ -118,8 +119,7 @@ pub fn sanitize(s: &str, max_len: usize) -> String {
     let truncated = if s.len() > max_len { &s[..s.floor_char_boundary(max_len)] } else { s };
     truncated
         .replace('#', "")
-        .replace('\n', " ")
-        .replace('\r', " ")
+        .replace(['\n', '\r'], " ")
 }
 
 /// Generic hot-swappable state wrapper. Stores a value behind Arc<RwLock>
@@ -130,12 +130,18 @@ pub struct HotSwap<T: Clone> {
     inner: Arc<RwLock<Option<T>>>,
 }
 
-impl<T: Clone> HotSwap<T> {
-    #[must_use]
-    pub fn new() -> Self {
+impl<T: Clone> Default for HotSwap<T> {
+    fn default() -> Self {
         Self {
             inner: Arc::new(RwLock::new(None)),
         }
+    }
+}
+
+impl<T: Clone> HotSwap<T> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn set(&self, value: T) {

--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -68,6 +68,7 @@ fn build_transport(url: &str) -> impl rmcp::transport::Transport<rmcp::RoleClien
     StreamableHttpClientTransport::from_config(config)
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
 pub async fn list_tools(url: &str) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
@@ -75,10 +76,10 @@ pub async fn list_tools(url: &str) -> Result<Vec<Value>, McpClientError> {
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout {
-            url: url.to_owned(),
+            url: url.clone(),
         })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -95,10 +96,10 @@ pub async fn list_tools(url: &str) -> Result<Vec<Value>, McpClientError> {
         )
         .await
         .map_err(|_| McpClientError::Timeout {
-            url: url.to_owned(),
+            url: url.clone(),
         })?
         .map_err(|e| McpClientError::ListTools {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -120,7 +121,7 @@ pub async fn list_tools(url: &str) -> Result<Vec<Value>, McpClientError> {
     all_tools
         .into_iter()
         .map(|t| serde_json::to_value(t).map_err(|e| McpClientError::ListTools {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         }))
         .collect()
@@ -132,6 +133,7 @@ pub struct CallToolResponse {
     pub is_error: bool,
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP client call with argument mapping")]
 pub async fn call_tool(
     url: &str,
     tool_name: &str,
@@ -143,10 +145,10 @@ pub async fn call_tool(
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout {
-            url: url.to_owned(),
+            url: url.clone(),
         })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -158,10 +160,10 @@ pub async fn call_tool(
     let result = tokio::time::timeout(TIMEOUT, Box::pin(client.call_tool(params)))
         .await
         .map_err(|_| McpClientError::Timeout {
-            url: url.to_owned(),
+            url: url.clone(),
         })?
         .map_err(|e| McpClientError::CallTool {
-            url: url.to_owned(),
+            url: url.clone(),
             tool_name: tool_name.to_owned(),
             message: e.to_string(),
         })?;
@@ -181,15 +183,16 @@ pub async fn call_tool(
     })
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
 pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -205,9 +208,9 @@ pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
             Box::pin(client.list_resources(Some(params))),
         )
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::ListResources {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -229,12 +232,13 @@ pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
     all_resources
         .into_iter()
         .map(|r| serde_json::to_value(r).map_err(|e| McpClientError::ListResources {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         }))
         .collect()
 }
 
+#[expect(clippy::large_stack_frames, reason = "MCP client call")]
 pub async fn read_resource(
     url: &str,
     resource_uri: &str,
@@ -244,9 +248,9 @@ pub async fn read_resource(
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -254,9 +258,9 @@ pub async fn read_resource(
 
     let result = tokio::time::timeout(TIMEOUT, Box::pin(client.read_resource(params)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::ReadResource {
-            url: url.to_owned(),
+            url: url.clone(),
             resource_uri: resource_uri.to_owned(),
             message: e.to_string(),
         })?;
@@ -265,22 +269,23 @@ pub async fn read_resource(
         .contents
         .into_iter()
         .map(|c| serde_json::to_value(c).map_err(|e| McpClientError::ReadResource {
-            url: url.to_owned(),
+            url: url.clone(),
             resource_uri: resource_uri.to_owned(),
             message: e.to_string(),
         }))
         .collect()
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
 pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -296,9 +301,9 @@ pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientE
             Box::pin(client.list_resource_templates(Some(params))),
         )
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::ListResourceTemplates {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -320,21 +325,22 @@ pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientE
     all_templates
         .into_iter()
         .map(|t| serde_json::to_value(t).map_err(|e| McpClientError::ListResourceTemplates {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         }))
         .collect()
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
 pub async fn list_prompts(url: &str) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -350,9 +356,9 @@ pub async fn list_prompts(url: &str) -> Result<Vec<Value>, McpClientError> {
             Box::pin(client.list_prompts(Some(params))),
         )
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::ListPrompts {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -374,12 +380,13 @@ pub async fn list_prompts(url: &str) -> Result<Vec<Value>, McpClientError> {
     all_prompts
         .into_iter()
         .map(|p| serde_json::to_value(p).map_err(|e| McpClientError::ListPrompts {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         }))
         .collect()
 }
 
+#[expect(clippy::large_stack_frames, reason = "MCP client call")]
 pub async fn get_prompt(
     url: &str,
     prompt_name: &str,
@@ -390,9 +397,9 @@ pub async fn get_prompt(
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -403,15 +410,15 @@ pub async fn get_prompt(
 
     let result = tokio::time::timeout(TIMEOUT, Box::pin(client.get_prompt(params)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::GetPrompt {
-            url: url.to_owned(),
+            url: url.clone(),
             prompt_name: prompt_name.to_owned(),
             message: e.to_string(),
         })?;
 
     serde_json::to_value(result).map_err(|e| McpClientError::GetPrompt {
-        url: url.to_owned(),
+        url: url.clone(),
         prompt_name: prompt_name.to_owned(),
         message: e.to_string(),
     })
@@ -426,15 +433,16 @@ pub struct ForwardDiscovery {
     pub prompts: Vec<Value>,
 }
 
+#[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP forward discovery aggregating multiple calls")]
 pub async fn discover_forward(url: &str) -> Result<ForwardDiscovery, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await
-        .map_err(|_| McpClientError::Timeout { url: url.to_owned() })?
+        .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
-            url: url.to_owned(),
+            url: url.clone(),
             message: e.to_string(),
         })?;
 
@@ -501,6 +509,7 @@ pub async fn discover_forward(url: &str) -> Result<ForwardDiscovery, McpClientEr
     })
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP paginated discovery with error handling")]
 async fn discover_tools_on_session(
     client: &rmcp::service::Peer<rmcp::RoleClient>,
     url: &str,
@@ -544,6 +553,7 @@ async fn discover_tools_on_session(
         .collect()
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP paginated discovery with error handling")]
 async fn discover_resources_on_session(
     client: &rmcp::service::Peer<rmcp::RoleClient>,
     url: &str,
@@ -588,6 +598,7 @@ async fn discover_resources_on_session(
         .collect()
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP paginated discovery with error handling")]
 async fn discover_resource_templates_on_session(
     client: &rmcp::service::Peer<rmcp::RoleClient>,
     url: &str,
@@ -634,6 +645,7 @@ async fn discover_resource_templates_on_session(
         .collect()
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP paginated discovery with error handling")]
 async fn discover_prompts_on_session(
     client: &rmcp::service::Peer<rmcp::RoleClient>,
     url: &str,

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_stack_frames, reason = "utoipa::ToSchema derive generates large stack frames")]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -153,11 +155,11 @@ impl ResourceEntry {
     }
 
     pub fn is_template(&self) -> bool {
-        self.labels.get(IS_TEMPLATE_LABEL).map(|v| v == "true").unwrap_or(false)
+        self.labels.get(IS_TEMPLATE_LABEL).is_some_and(|v| v == "true")
     }
 
     pub fn forward_address(&self) -> Option<&str> {
-        self.labels.get(FORWARD_ADDRESS_LABEL).map(|s| s.as_str())
+        self.labels.get(FORWARD_ADDRESS_LABEL).map(std::string::String::as_str)
     }
 }
 
@@ -288,10 +290,10 @@ impl InMemoryRegistry {
     ///
     /// Inserts directly into the DashMaps to avoid triggering
     /// `persist()` on every entry (the data already came from disk).
+    #[expect(clippy::too_many_lines, reason = "sequential loading of all registry types")]
     pub fn load_persisted(&self) {
-        let backend = match &self.persistence {
-            Some(b) => b,
-            None => return,
+        let Some(backend) = &self.persistence else {
+            return;
         };
 
         let snapshot = match backend.load() {

--- a/features/chat/src/routes.rs
+++ b/features/chat/src/routes.rs
@@ -11,9 +11,8 @@ pub(crate) enum ChatRoute {
 }
 
 pub(crate) fn resolve_chat_route(method: &str, path: &str) -> ChatRoute {
-    let suffix = match path.strip_prefix("/api/v1/chat") {
-        Some(s) => s,
-        None => return ChatRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/chat") else {
+        return ChatRoute::NotFound;
     };
 
     match (method, suffix) {
@@ -45,6 +44,7 @@ pub(crate) fn handle_chat_list_llms() -> Response<Vec<u8>> {
     raw_json_response(serde_json::to_vec(&serde_json::json!(["Inference"])).unwrap_or_default())
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "sequential HTTP request handling")]
 pub(crate) async fn handle_chat_list_models(
     client: &reqwest::Client,
     base_url: &str,
@@ -105,6 +105,7 @@ pub(crate) async fn handle_chat_list_models(
     raw_json_response(serde_json::to_vec(&serde_json::json!(models)).unwrap_or_default())
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, clippy::large_stack_frames, reason = "sequential HTTP request/response handling")]
 pub(crate) async fn handle_chat_completions(
     client: &reqwest::Client,
     base_url: &str,

--- a/features/evaluator/build.rs
+++ b/features/evaluator/build.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::process::Command;
 
+#[expect(clippy::too_many_lines, reason = "build script with sequential WASM compilation steps")]
 fn main() {
     let actions_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../actions");
     let dist_dir = actions_dir.join("dist");

--- a/features/evaluator/src/config.rs
+++ b/features/evaluator/src/config.rs
@@ -64,7 +64,7 @@ pub enum ErrorPolicy {
     Block,
 }
 
-fn default_on_error() -> ErrorPolicy {
+const fn default_on_error() -> ErrorPolicy {
     ErrorPolicy::Continue
 }
 
@@ -73,11 +73,10 @@ impl TriggerDef {
         if self.method != method {
             return false;
         }
-        if let Some(ref ns) = self.namespace {
-            if ns != namespace {
+        if let Some(ref ns) = self.namespace
+            && ns != namespace {
                 return false;
             }
-        }
         true
     }
 }

--- a/features/evaluator/src/engine.rs
+++ b/features/evaluator/src/engine.rs
@@ -57,6 +57,8 @@ impl CompiledEvaluator {
 
     /// Execute the evaluator with the given context.
     /// Creates a fresh WASM instance per call — no state sharing.
+    #[expect(clippy::too_many_lines, reason = "WASM instantiation and execution pipeline")]
+    #[expect(clippy::needless_pass_by_value, reason = "ctx is moved into the WASM store")]
     pub fn evaluate(
         &self,
         registry: InMemoryRegistry,

--- a/features/evaluator/src/filter.rs
+++ b/features/evaluator/src/filter.rs
@@ -12,6 +12,7 @@ use crate::state::EvaluatorState;
 wanaku_praxis_filters::body_filter_boilerplate!(EvaluatorFilter, "wanaku_evaluator");
 
 impl EvaluatorFilter {
+    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, clippy::large_stack_frames, reason = "evaluator pipeline with multiple validation steps")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -32,9 +33,8 @@ impl EvaluatorFilter {
             .unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE)
             .to_owned();
 
-        let evaluator = match state.find_matching(&method, &namespace) {
-            Some(e) => e,
-            None => return Ok(FilterAction::Continue),
+        let Some(evaluator) = state.find_matching(&method, &namespace) else {
+            return Ok(FilterAction::Continue);
         };
 
         tracing::info!(
@@ -56,7 +56,7 @@ impl EvaluatorFilter {
 
         let tool_name = ctx
             .get_metadata(wanaku_praxis_filters::MCP_NAME_KEY)
-            .map(|s| s.to_owned());
+            .map(std::borrow::ToOwned::to_owned);
 
         let arguments = parse_arguments(body);
 
@@ -106,23 +106,20 @@ impl EvaluatorFilter {
             "LLM operation result"
         );
 
-        let compiled = match state.get_compiled(&evaluator.processor.path) {
-            Some(c) => c,
-            None => {
-                tracing::warn!(
-                    evaluator = %evaluator.name,
-                    path = %evaluator.processor.path.display(),
-                    "WASM processor not found or not compiled"
-                );
-                return match evaluator.on_error {
-                    ErrorPolicy::Continue => Ok(FilterAction::Continue),
-                    ErrorPolicy::Block => Ok(wanaku_praxis_filters::response::json_rpc_error(
-                        &wanaku_praxis_filters::response::extract_json_rpc_id(body),
-                        -32603,
-                        "evaluator processor module not available",
-                    )),
-                };
-            }
+        let Some(compiled) = state.get_compiled(&evaluator.processor.path) else {
+            tracing::warn!(
+                evaluator = %evaluator.name,
+                path = %evaluator.processor.path.display(),
+                "WASM processor not found or not compiled"
+            );
+            return match evaluator.on_error {
+                ErrorPolicy::Continue => Ok(FilterAction::Continue),
+                ErrorPolicy::Block => Ok(wanaku_praxis_filters::response::json_rpc_error(
+                    &wanaku_praxis_filters::response::extract_json_rpc_id(body),
+                    -32603,
+                    "evaluator processor module not available",
+                )),
+            };
         };
 
         let eval_ctx = crate::host::types::EvaluationContext {
@@ -151,6 +148,7 @@ impl EvaluatorFilter {
     }
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "action dispatch with multiple variants")]
 fn dispatch_action(
     ctx: &mut HttpFilterContext<'_>,
     body: &mut Option<Bytes>,
@@ -181,7 +179,7 @@ fn dispatch_action(
         ActionResult::Warn(message) => {
             tracing::warn!(evaluator = %evaluator_name, message = %message, "evaluator warning");
             ctx.set_metadata(
-                &format!("wanaku.evaluator.{evaluator_name}.warning"),
+                format!("wanaku.evaluator.{evaluator_name}.warning"),
                 &message,
             );
             Ok(FilterAction::Continue)
@@ -222,6 +220,8 @@ fn dispatch_action(
     }
 }
 
+#[expect(clippy::too_many_arguments, reason = "retry requires original request context")]
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "schema validation with retry logic")]
 async fn validate_and_retry_if_needed(
     raw_result: &str,
     evaluator: &EvaluatorDef,

--- a/features/evaluator/src/lib.rs
+++ b/features/evaluator/src/lib.rs
@@ -37,6 +37,12 @@ impl EvaluatorFeature {
     }
 }
 
+impl Default for EvaluatorFeature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 struct EvaluatorStateExtension {
     state: EvaluatorState,
 }

--- a/features/evaluator/src/llm_op.rs
+++ b/features/evaluator/src/llm_op.rs
@@ -8,6 +8,7 @@ use crate::config::LlmDef;
 
 /// Execute the LLM operation and return the raw result string.
 /// The processor WASM module is responsible for parsing and acting on this.
+#[expect(clippy::too_many_arguments, reason = "LLM operation requires full request context")]
 pub async fn run_llm_operation(
     llm_def: &LlmDef,
     method: &str,
@@ -23,6 +24,7 @@ pub async fn run_llm_operation(
     client.chat(&llm_def.prompt, &user_prompt).await
 }
 
+#[expect(clippy::too_many_lines, reason = "prompt assembly with multiple optional sections")]
 fn build_context_prompt(
     method: &str,
     tool_name: Option<&str>,
@@ -40,8 +42,8 @@ fn build_context_prompt(
             history
         };
         for interaction in capped {
-            if let Some(messages) = interaction.request_body.get("messages") {
-                if let Some(arr) = messages.as_array() {
+            if let Some(messages) = interaction.request_body.get("messages")
+                && let Some(arr) = messages.as_array() {
                     for msg in arr {
                         let role = msg
                             .get("role")
@@ -59,7 +61,6 @@ fn build_context_prompt(
                         }
                     }
                 }
-            }
             prompt.push('\n');
         }
     }
@@ -97,6 +98,7 @@ fn build_context_prompt(
 
 /// Retry an LLM operation with a correction prompt that includes
 /// the schema and the previous (invalid) response.
+#[expect(clippy::too_many_arguments, reason = "retry requires original context plus correction data")]
 pub async fn retry_with_schema_correction(
     llm_def: &LlmDef,
     method: &str,

--- a/features/evaluator/src/routes.rs
+++ b/features/evaluator/src/routes.rs
@@ -16,9 +16,8 @@ pub(crate) enum EvaluatorRoute {
 }
 
 pub(crate) fn resolve_evaluator_route(method: &str, path: &str) -> EvaluatorRoute {
-    let suffix = match path.strip_prefix("/api/v1/evaluators") {
-        Some(s) => s,
-        None => return EvaluatorRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/evaluators") else {
+        return EvaluatorRoute::NotFound;
     };
 
     if suffix.is_empty() || suffix == "/" {
@@ -29,9 +28,8 @@ pub(crate) fn resolve_evaluator_route(method: &str, path: &str) -> EvaluatorRout
         };
     }
 
-    let ns_suffix = match suffix.strip_prefix("/namespaces") {
-        Some(s) => s,
-        None => return EvaluatorRoute::NotFound,
+    let Some(ns_suffix) = suffix.strip_prefix("/namespaces") else {
+        return EvaluatorRoute::NotFound;
     };
 
     if ns_suffix.is_empty() || ns_suffix == "/" {

--- a/features/evaluator/src/state.rs
+++ b/features/evaluator/src/state.rs
@@ -28,6 +28,15 @@ impl EvaluatorState {
         }
     }
 
+}
+
+impl Default for EvaluatorState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EvaluatorState {
     pub fn load_evaluators(&self, defs: Vec<EvaluatorDef>) {
         self.compile_modules(&defs);
         self.compile_schemas(&defs);
@@ -129,15 +138,14 @@ impl EvaluatorState {
         let mut schemas = HashMap::new();
 
         for def in defs {
-            if let Some(ref schema_val) = def.llm.result_schema {
-                if let Some(compiled) = CompiledSchema::compile(schema_val) {
+            if let Some(ref schema_val) = def.llm.result_schema
+                && let Some(compiled) = CompiledSchema::compile(schema_val) {
                     tracing::info!(
                         evaluator = %def.name,
                         "compiled result schema"
                     );
                     schemas.insert(def.name.clone(), Arc::new(compiled));
                 }
-            }
         }
 
         if let Ok(mut guard) = self.schemas.write() {

--- a/features/intercept/src/filter.rs
+++ b/features/intercept/src/filter.rs
@@ -22,6 +22,7 @@ pub struct InterceptFilter {
 }
 
 impl InterceptFilter {
+    #[expect(clippy::cast_possible_truncation, reason = "u64 config value fits in usize")]
     pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         let max_body_bytes = config
             .get("max_body_bytes")
@@ -173,6 +174,8 @@ impl HttpFilter for InterceptFilter {
         Ok(FilterAction::Continue)
     }
 
+    #[expect(clippy::too_many_lines, reason = "interaction recording with multiple field extractions")]
+    #[expect(clippy::cast_possible_truncation, reason = "duration and epoch millis within u64 range")]
     fn on_response_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -183,15 +186,14 @@ impl HttpFilter for InterceptFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let state = match ctx.get_filter_state::<InterceptState>() {
-            Some(s) => s,
-            None => return Ok(FilterAction::Continue),
+        let Some(state) = ctx.get_filter_state::<InterceptState>() else {
+            return Ok(FilterAction::Continue);
         };
 
         let status_code = state.status.load(Ordering::Relaxed);
         let duration_ms = state.start.elapsed().as_millis() as u64;
 
-        let response_bytes = body.as_ref().map(|b| b.as_ref()).unwrap_or_default();
+        let response_bytes = body.as_ref().map(std::convert::AsRef::as_ref).unwrap_or_default();
 
         let request_body = parse_body(&state.body);
         let response_body = parse_body(response_bytes);

--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -33,6 +33,12 @@ impl InterceptFeature {
     }
 }
 
+impl Default for InterceptFeature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 struct InteractionStoreExtension {
     store: InMemoryInteractionStore,
 }

--- a/features/intercept/src/routes.rs
+++ b/features/intercept/src/routes.rs
@@ -11,9 +11,8 @@ pub(crate) enum InteractionRoute {
 }
 
 pub(crate) fn resolve_interaction_route(method: &str, path: &str) -> InteractionRoute {
-    let suffix = match path.strip_prefix("/api/v1/interactions") {
-        Some(s) => s,
-        None => return InteractionRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/interactions") else {
+        return InteractionRoute::NotFound;
     };
 
     if !suffix.is_empty() && suffix != "/" {

--- a/features/mcp-metadata/src/filter.rs
+++ b/features/mcp-metadata/src/filter.rs
@@ -9,6 +9,7 @@ wanaku_praxis_filters::body_filter_boilerplate!(WellKnownFilter, "wanaku_well_kn
 const WELL_KNOWN_PREFIX: &str = "/.well-known/oauth-protected-resource/";
 
 impl WellKnownFilter {
+    #[expect(clippy::too_many_lines, reason = "route dispatch with multiple well-known endpoints")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -58,6 +59,7 @@ impl WellKnownFilter {
         }
     }
 
+    #[expect(clippy::unused_self, reason = "method on impl for consistency with other handlers")]
     fn serve_discovery(&self, base: &str, config: &IssuerConfig) -> Rejection {
         let doc = serde_json::json!({
             "issuer": config.issuer,
@@ -77,6 +79,8 @@ impl WellKnownFilter {
         json_response(StatusCode::OK, &doc)
     }
 
+    #[expect(clippy::unused_self, reason = "method on impl for consistency with other handlers")]
+    #[expect(clippy::too_many_lines, reason = "RFC 9728 protected resource metadata assembly")]
     fn handle_protected_resource_metadata(
         &self,
         ctx: &HttpFilterContext<'_>,
@@ -103,8 +107,7 @@ impl WellKnownFilter {
 
         let issuer_config = ctx.extensions.get::<IssuerConfig>();
         let has_issuer = issuer_config
-            .map(|c| !c.issuer.is_empty())
-            .unwrap_or(false);
+            .is_some_and(|c| !c.issuer.is_empty());
 
         let host_str = format!("http://{host}");
         let auth_servers: Vec<&str> = if has_issuer {
@@ -124,6 +127,7 @@ impl WellKnownFilter {
     }
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "HTTP proxy with error handling")]
 async fn proxy_token_endpoint(issuer: &str, body: &Option<Bytes>) -> Rejection {
     let url = format!("{issuer}/protocol/openid-connect/token");
 

--- a/features/mcp-metadata/src/lib.rs
+++ b/features/mcp-metadata/src/lib.rs
@@ -28,8 +28,14 @@ pub struct McpMetadataFeature;
 
 impl McpMetadataFeature {
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
+    }
+}
+
+impl Default for McpMetadataFeature {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -67,10 +73,9 @@ impl Feature for McpMetadataFeature {
     fn load_yaml_config(&self, _root: &serde_yaml::Value) {}
 
     fn load_env_config(&self) {
-        if let Ok(issuer) = std::env::var(WANAKU_AUTH_ISSUER) {
-            if !issuer.is_empty() {
+        if let Ok(issuer) = std::env::var(WANAKU_AUTH_ISSUER)
+            && !issuer.is_empty() {
                 tracing::info!(issuer = %issuer, "MCP metadata configured with auth issuer");
             }
-        }
     }
 }

--- a/features/plugins/src/handlers.rs
+++ b/features/plugins/src/handlers.rs
@@ -25,23 +25,20 @@ pub(crate) fn handle_serve_file(
         plugin_root.join(file_path)
     };
 
-    let canonical = match target.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
+    let Ok(canonical) = target.canonicalize() else {
+        return json_err(StatusCode::NOT_FOUND, "file not found");
     };
 
-    let canonical_root = match plugin_root.canonicalize() {
-        Ok(r) => r,
-        Err(_) => return json_err(StatusCode::NOT_FOUND, "plugin not found"),
+    let Ok(canonical_root) = plugin_root.canonicalize() else {
+        return json_err(StatusCode::NOT_FOUND, "plugin not found");
     };
 
     if !canonical.starts_with(&canonical_root) {
         return json_err(StatusCode::FORBIDDEN, "forbidden");
     }
 
-    let body = match std::fs::read(&canonical) {
-        Ok(b) => b,
-        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
+    let Ok(body) = std::fs::read(&canonical) else {
+        return json_err(StatusCode::NOT_FOUND, "file not found");
     };
 
     let content_type = mime_for_path(canonical.to_str().unwrap_or(""));
@@ -54,6 +51,8 @@ pub(crate) fn handle_serve_file(
         .expect("valid static response")
 }
 
+#[expect(clippy::too_many_arguments, reason = "proxy handler requires full HTTP context")]
+#[expect(clippy::too_many_lines, reason = "HTTP proxy with request/response handling")]
 pub(crate) async fn handle_proxy_service(
     client: &reqwest::Client,
     target_url: &str,
@@ -68,9 +67,8 @@ pub(crate) async fn handle_proxy_service(
         None => format!("{target_url}{path}"),
     };
 
-    let req_method = match method.parse::<reqwest::Method>() {
-        Ok(m) => m,
-        Err(_) => return json_err(StatusCode::BAD_REQUEST, &format!("unsupported method: {method}")),
+    let Ok(req_method) = method.parse::<reqwest::Method>() else {
+        return json_err(StatusCode::BAD_REQUEST, &format!("unsupported method: {method}"));
     };
 
     let mut request = client.request(req_method, &url);
@@ -126,7 +124,7 @@ fn build_proxy_response(status: u16, content_type: &str, body: Vec<u8>) -> Respo
 fn mime_for_path(path: &str) -> &'static str {
     match path.rsplit('.').next() {
         Some("html") => "text/html; charset=utf-8",
-        Some("js") | Some("mjs") => "application/javascript",
+        Some("js" | "mjs") => "application/javascript",
         Some("css") => "text/css",
         Some("json") => "application/json",
         Some("svg") => "image/svg+xml",

--- a/features/plugins/src/lib.rs
+++ b/features/plugins/src/lib.rs
@@ -45,6 +45,7 @@ impl PluginsFeature {
     }
 }
 
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, clippy::large_stack_frames, reason = "plugin discovery with validation")]
 fn discover_plugins(plugins_dir: &PathBuf) -> Vec<PluginManifest> {
     if !plugins_dir.is_dir() {
         tracing::warn!(path = %plugins_dir.display(), "plugins directory does not exist");
@@ -67,9 +68,8 @@ fn discover_plugins(plugins_dir: &PathBuf) -> Vec<PluginManifest> {
         }
 
         let manifest_path = entry_path.join("plugin.json");
-        let content = match std::fs::read_to_string(&manifest_path) {
-            Ok(c) => c,
-            Err(_) => continue,
+        let Ok(content) = std::fs::read_to_string(&manifest_path) else {
+            continue;
         };
 
         let manifest: PluginManifest = match serde_json::from_str(&content) {
@@ -116,6 +116,7 @@ impl Feature for PluginsFeature {
         vec![]
     }
 
+    #[expect(clippy::too_many_lines, reason = "route dispatch with plugin proxy logic")]
     async fn handle_route(
         &self,
         method: &str,
@@ -167,6 +168,7 @@ impl Feature for PluginsFeature {
         })
     }
 
+    #[expect(clippy::too_many_lines, reason = "YAML config parsing with nested plugin/service structure")]
     fn load_yaml_config(&self, root: &serde_yaml::Value) {
         let Some(plugins_val) = root.get("plugins") else {
             return;

--- a/features/plugins/src/routes.rs
+++ b/features/plugins/src/routes.rs
@@ -15,6 +15,7 @@ fn is_valid_segment(s: &str) -> bool {
     !s.is_empty() && s != "." && s != ".." && !s.contains('/') && !s.contains('\\')
 }
 
+#[expect(clippy::too_many_lines, reason = "route resolution with multiple path prefix checks")]
 pub(crate) fn resolve_plugin_route(method: &str, path: &str) -> PluginRoute {
     if let Some(suffix) = path.strip_prefix("/api/v1/plugins") {
         return match (method, suffix) {
@@ -37,9 +38,8 @@ pub(crate) fn resolve_plugin_route(method: &str, path: &str) -> PluginRoute {
     }
 
     if let Some(rest) = path.strip_prefix("/api/plugins/") {
-        let (id, remainder) = match rest.split_once('/') {
-            Some((id, r)) => (id, r),
-            None => return PluginRoute::NotFound,
+        let Some((id, remainder)) = rest.split_once('/') else {
+            return PluginRoute::NotFound;
         };
         if !is_valid_segment(id) {
             return PluginRoute::NotFound;
@@ -69,6 +69,7 @@ pub(crate) fn handle_file(
     handlers::handle_serve_file(plugins_path, plugin_id, file_path)
 }
 
+#[expect(clippy::too_many_arguments, reason = "proxy handler requires full HTTP context")]
 pub(crate) async fn handle_proxy(
     client: &reqwest::Client,
     target_url: &str,

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -14,6 +14,7 @@ macro_rules! body_filter_boilerplate {
             pub fn from_config(
                 config: &serde_yaml::Value,
             ) -> Result<Box<dyn praxis_filter::HttpFilter>, praxis_filter::FilterError> {
+                #[expect(clippy::cast_possible_truncation, reason = "body size limited by max_body_bytes config; values above usize::MAX are unreachable")]
                 let max_body_bytes = config
                     .get("max_body_bytes")
                     .and_then(serde_yaml::Value::as_u64)

--- a/filters/src/mcp_init.rs
+++ b/filters/src/mcp_init.rs
@@ -10,9 +10,8 @@ impl McpInitFilter {
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         match method {
@@ -23,6 +22,7 @@ impl McpInitFilter {
         }
     }
 
+    #[expect(clippy::unused_self, reason = "consistent signature across filter handler methods")]
     fn handle_initialize(&self, body: &Option<Bytes>) -> Result<FilterAction, FilterError> {
         trace!("handling MCP initialize");
 

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -17,18 +17,16 @@ fn extract_namespace(path: &str) -> &str {
     }
 
     // /{namespace}/mcp
-    if let Some(ns) = trimmed.strip_suffix("/mcp") {
-        if !ns.is_empty() && !ns.contains('/') {
+    if let Some(ns) = trimmed.strip_suffix("/mcp")
+        && !ns.is_empty() && !ns.contains('/') {
             return ns;
         }
-    }
 
     // /mcp/{namespace}
-    if let Some(ns) = trimmed.strip_prefix("mcp/") {
-        if !ns.is_empty() && !ns.contains('/') {
+    if let Some(ns) = trimmed.strip_prefix("mcp/")
+        && !ns.is_empty() && !ns.contains('/') {
             return ns;
         }
-    }
 
     DEFAULT_NAMESPACE
 }

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -50,14 +50,14 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
 }
 
 impl PromptGetFilter {
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         if method != "prompts/get" {
@@ -79,31 +79,24 @@ impl PromptGetFilter {
 
         trace!(prompt = %prompt_name, namespace = %namespace, "handling MCP prompts/get request");
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
         };
 
-        let prompt = match registry.get_prompt_in_namespace(namespace, &prompt_name) {
-            Some(p) => p,
-            None => {
-                warn!(prompt = %prompt_name, "prompt not found in registry");
-                return Ok(crate::response::json_rpc_error(
-                    &parsed.id,
-                    crate::response::JSONRPC_INVALID_PARAMS,
-                    &format!("prompt not found: {prompt_name}"),
-                ));
-            }
+        let Some(prompt) = registry.get_prompt_in_namespace(namespace, &prompt_name) else {
+            warn!(prompt = %prompt_name, "prompt not found in registry");
+            return Ok(crate::response::json_rpc_error(
+                &parsed.id,
+                crate::response::JSONRPC_INVALID_PARAMS,
+                &format!("prompt not found: {prompt_name}"),
+            ));
         };
 
-        if prompt.messages.is_empty() {
-            if let Some(ref uri) = prompt.configuration_uri {
+        if prompt.messages.is_empty()
+            && let Some(ref uri) = prompt.configuration_uri {
                 return self.handle_forwarded_get(uri, &prompt_name, &parsed).await;
             }
-        }
 
         let messages: Vec<serde_json::Value> = prompt
             .messages

--- a/filters/src/prompt_list.rs
+++ b/filters/src/prompt_list.rs
@@ -6,14 +6,14 @@ use wanaku_praxis_apis::registry::{InMemoryRegistry, PromptRegistry};
 crate::body_filter_boilerplate!(PromptListFilter, "wanaku_prompt_list");
 
 impl PromptListFilter {
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         if method != "prompts/list" {
@@ -26,17 +26,14 @@ impl PromptListFilter {
 
         trace!(namespace = %namespace, "handling MCP prompts/list request");
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                let json_rpc_id = crate::response::extract_json_rpc_id(body);
-                return Ok(crate::response::json_rpc_error(
-                    &json_rpc_id,
-                    crate::response::JSONRPC_INTERNAL_ERROR,
-                    "internal error: registry unavailable",
-                ));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            let json_rpc_id = crate::response::extract_json_rpc_id(body);
+            return Ok(crate::response::json_rpc_error(
+                &json_rpc_id,
+                crate::response::JSONRPC_INTERNAL_ERROR,
+                "internal error: registry unavailable",
+            ));
         };
 
         let prompts = registry.list_prompts_in_namespace(namespace);

--- a/filters/src/resource_list.rs
+++ b/filters/src/resource_list.rs
@@ -6,14 +6,14 @@ use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
 crate::body_filter_boilerplate!(ResourceListFilter, "wanaku_resource_list");
 
 impl ResourceListFilter {
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         let is_list = method == "resources/list";
@@ -28,17 +28,14 @@ impl ResourceListFilter {
 
         trace!(namespace = %namespace, "handling MCP resources/list request");
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                let json_rpc_id = crate::response::extract_json_rpc_id(body);
-                return Ok(crate::response::json_rpc_error(
-                    &json_rpc_id,
-                    crate::response::JSONRPC_INTERNAL_ERROR,
-                    "internal error: registry unavailable",
-                ));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            let json_rpc_id = crate::response::extract_json_rpc_id(body);
+            return Ok(crate::response::json_rpc_error(
+                &json_rpc_id,
+                crate::response::JSONRPC_INTERNAL_ERROR,
+                "internal error: registry unavailable",
+            ));
         };
 
         let all_resources = registry.list_resources_in_namespace(namespace);

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -5,6 +5,7 @@ use wanaku_praxis_apis::registry::{InMemoryRegistry, ResourceRegistry};
 
 crate::body_filter_boilerplate!(ResourceReadFilter, "wanaku_resource_read");
 
+#[expect(clippy::too_many_lines, reason = "URI template matching with segment iteration")]
 fn matches_uri_template(template: &str, uri: &str) -> bool {
     let mut parts = Vec::new();
     let mut rest = template;
@@ -79,14 +80,14 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
 }
 
 impl ResourceReadFilter {
+    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         if method != "resources/read" {
@@ -108,12 +109,9 @@ impl ResourceReadFilter {
 
         trace!(uri = %resource_uri, namespace = %namespace, "handling MCP resources/read request");
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
         };
 
         let resources = registry.list_resources_in_namespace(namespace);
@@ -150,16 +148,13 @@ impl ResourceReadFilter {
         resource_uri: &str,
         parsed: &ParsedBody,
     ) -> Result<FilterAction, FilterError> {
-        let forward_address = match resource.forward_address() {
-            Some(addr) => addr,
-            None => {
-                warn!(uri = %resource_uri, "forwarded resource missing forward address label");
-                return Ok(crate::response::json_rpc_error(
-                    &parsed.id,
-                    crate::response::JSONRPC_INTERNAL_ERROR,
-                    "forwarded resource has no upstream address configured",
-                ));
-            }
+        let Some(forward_address) = resource.forward_address() else {
+            warn!(uri = %resource_uri, "forwarded resource missing forward address label");
+            return Ok(crate::response::json_rpc_error(
+                &parsed.id,
+                crate::response::JSONRPC_INTERNAL_ERROR,
+                "forwarded resource has no upstream address configured",
+            ));
         };
 
         trace!(uri = %resource_uri, forward = %forward_address, "forwarding resources/read to remote MCP server");

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -47,14 +47,14 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
 }
 
 impl ToolCallFilter {
+    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         if method != "tools/call" {
@@ -77,11 +77,10 @@ impl ToolCallFilter {
 
         let conversation_id = parsed.arguments
             .remove(wanaku_praxis_apis::correlation::REQUEST_ID_ARG)
-            .and_then(|v| match v {
-                serde_json::Value::String(s) => Some(s),
-                other => Some(other.to_string()),
-            })
-            .unwrap_or_else(|| "-".to_owned());
+            .map_or_else(|| "-".to_owned(), |v| match v {
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
+            });
 
         let request_id = ctx.request.headers.get("x-request-id")
             .and_then(|v| v.to_str().ok())
@@ -105,12 +104,9 @@ impl ToolCallFilter {
             "parsed tools/call request body (x-request-id stripped)"
         );
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
         };
 
         let tool = match registry.get_tool_in_namespace(namespace, &tool_name) {
@@ -145,6 +141,7 @@ impl ToolCallFilter {
         ))
     }
 
+    #[expect(clippy::too_many_lines, reason = "MCP forwarding handler with error paths")]
     async fn handle_forwarded_call(
         &self,
         tool: &ToolEntry,

--- a/filters/src/tool_list.rs
+++ b/filters/src/tool_list.rs
@@ -5,14 +5,14 @@ use wanaku_praxis_apis::registry::{InMemoryRegistry, ToolRegistry};
 crate::body_filter_boilerplate!(ToolListFilter, "wanaku_tool_list");
 
 impl ToolListFilter {
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
-        let method = match ctx.get_metadata(crate::MCP_METHOD_KEY) {
-            Some(m) => m,
-            None => return Ok(FilterAction::Continue),
+        let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
         };
 
         if method != "tools/list" {
@@ -25,17 +25,14 @@ impl ToolListFilter {
 
         tracing::debug!(namespace = %namespace, "handling MCP tools/list request");
 
-        let registry = match ctx.extensions.get::<InMemoryRegistry>() {
-            Some(r) => r,
-            None => {
-                tracing::error!("InMemoryRegistry not found in request extensions");
-                let json_rpc_id = crate::response::extract_json_rpc_id(body);
-                return Ok(crate::response::json_rpc_error(
-                    &json_rpc_id,
-                    crate::response::JSONRPC_INTERNAL_ERROR,
-                    "internal error: registry unavailable",
-                ));
-            }
+        let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+            tracing::error!("InMemoryRegistry not found in request extensions");
+            let json_rpc_id = crate::response::extract_json_rpc_id(body);
+            return Ok(crate::response::json_rpc_error(
+                &json_rpc_id,
+                crate::response::JSONRPC_INTERNAL_ERROR,
+                "internal error: registry unavailable",
+            ));
         };
 
         let tools = registry.list_tools_in_namespace(namespace);

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::process::Command;
 
+#[expect(clippy::too_many_lines, reason = "build script entry point")]
 fn main() {
     let ui_dir = Path::new("../ui/admin");
     let dist_index = ui_dir.join("dist/index.html");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -33,6 +33,7 @@ pub fn build_full_registry() -> praxis_filter::FilterRegistry {
     registry
 }
 
+#[expect(clippy::too_many_lines, reason = "filter registration is sequential and repetitive")]
 fn register_wanaku_filters(registry: &mut praxis_filter::FilterRegistry) {
     praxis_filter::register_filters!(
         @register registry,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,6 +19,7 @@ use wanaku_praxis_apis::registry::{
     ForwardEntry, ForwardRegistry, InMemoryRegistry,
 };
 
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines, reason = "server bootstrap")]
 fn main() {
     let args = ServerArgs::parse();
     let config = wanaku_praxis::load_config(args.praxis_config.as_deref())
@@ -84,7 +85,7 @@ fn main() {
         &filter_registry,
         &health_registry,
         &kv_stores,
-        wanaku_registry,
+        &wanaku_registry,
         &features,
     )
     .unwrap_or_else(|e| fatal(&e));
@@ -121,7 +122,7 @@ fn main() {
         "wanaku-management".to_owned(),
         mgmt,
     );
-    mgmt_service.add_tcp(&mgmt_addr);
+    mgmt_service.add_tcp(mgmt_addr);
     server.server_mut().add_service(mgmt_service);
     info!(address = %mgmt_addr, "management API enabled");
 
@@ -163,6 +164,7 @@ fn load_wanaku_yaml(path: &str) -> Option<serde_yaml::Value> {
     }
 }
 
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines, reason = "config loading requires sequential steps")]
 fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
     let mut forwards = Vec::new();
     if let Some(fwd_list) = config.get("forwards").and_then(|f| f.as_sequence()) {

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -68,6 +68,7 @@ pub(super) fn handle_resource_get(registry: &InMemoryRegistry, name: &str) -> Re
     }
 }
 
+#[expect(clippy::cognitive_complexity, reason = "sequential validation steps")]
 pub(super) fn handle_resource_update(registry: &InMemoryRegistry, path_name: &str, body: &str) -> Response<Vec<u8>> {
     tracing::debug!(body = %body, name = %path_name, "resource update request body");
     let mut resource: ResourceEntry = match serde_json::from_str(body) {
@@ -203,6 +204,7 @@ pub(super) fn handle_forward_get(registry: &InMemoryRegistry, name: &str) -> Res
     }
 }
 
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines, reason = "sequential discovery and registration")]
 pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &str) -> Response<Vec<u8>> {
     tracing::debug!(body = %body, "forward create request body");
     let mut forward: ForwardEntry = match serde_json::from_str(body) {
@@ -261,9 +263,8 @@ pub(super) fn handle_forward_delete(registry: &InMemoryRegistry, name: &str) -> 
 }
 
 pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &str) -> Response<Vec<u8>> {
-    let mut forward = match registry.get_forward(name) {
-        Some(f) => f,
-        None => return json_err(StatusCode::NOT_FOUND, &format!("forward not found: {name}")),
+    let Some(mut forward) = registry.get_forward(name) else {
+        return json_err(StatusCode::NOT_FOUND, &format!("forward not found: {name}"));
     };
 
     remove_forwarded_tools(registry, &forward.address);
@@ -327,6 +328,7 @@ pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &
     register_discovered_tools(registry, forward, &tools)
 }
 
+#[expect(clippy::too_many_lines, reason = "sequential tool registration")]
 fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry, tools: &[serde_json::Value]) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_praxis_apis::registry::DEFAULT_NAMESPACE);
     let mut count = 0;
@@ -389,6 +391,7 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
     register_discovered_resources(registry, forward, &resources, &templates)
 }
 
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines, reason = "sequential resource and template registration")]
 fn register_discovered_resources(
     registry: &InMemoryRegistry,
     forward: &ForwardEntry,
@@ -535,6 +538,7 @@ pub async fn discover_prompts_from_forward(registry: &InMemoryRegistry, forward:
     register_discovered_prompts(registry, forward, &prompts)
 }
 
+#[expect(clippy::too_many_lines, reason = "sequential prompt registration")]
 fn register_discovered_prompts(
     registry: &InMemoryRegistry,
     forward: &ForwardEntry,
@@ -572,7 +576,7 @@ fn register_discovered_prompts(
                                 .to_owned(),
                             required: arg
                                 .get("required")
-                                .and_then(|r| r.as_bool())
+                                .and_then(serde_json::Value::as_bool)
                                 .unwrap_or(false),
                         })
                     })
@@ -748,6 +752,7 @@ mod forward_helpers_tests {
     }
 }
 
+#[expect(clippy::cast_possible_wrap, reason = "registry counts won't exceed i64::MAX")]
 pub(super) fn handle_statistics(registry: &InMemoryRegistry) -> Response<Vec<u8>> {
     let tools_count = registry.tool_count() as i64;
     let resources_count = registry.resource_count() as i64;

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -65,11 +65,12 @@ impl WanakuManagementService {
 
 #[async_trait]
 impl ServeHttp for WanakuManagementService {
+    #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "route dispatch requires sequential matching")]
     async fn response(&self, http_session: &mut ServerSession) -> Response<Vec<u8>> {
         let req = http_session.req_header();
         let uri = &req.uri;
         let path = uri.path().to_owned();
-        let query = uri.query().map(|q| q.to_owned());
+        let query = uri.query().map(std::borrow::ToOwned::to_owned);
         let method = req.method.as_str().to_owned();
         let headers = req.headers.clone();
 

--- a/server/src/management/routes.rs
+++ b/server/src/management/routes.rs
@@ -8,9 +8,8 @@ pub(super) enum ToolRoute {
 }
 
 pub(super) fn resolve_tool_route(method: &str, path: &str) -> ToolRoute {
-    let suffix = match path.strip_prefix("/api/v1/tools") {
-        Some(s) => s,
-        None => return ToolRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/tools") else {
+        return ToolRoute::NotFound;
     };
 
     let name = suffix
@@ -36,9 +35,8 @@ pub(super) enum ResourceRoute {
 }
 
 pub(super) fn resolve_resource_route(method: &str, path: &str) -> ResourceRoute {
-    let suffix = match path.strip_prefix("/api/v1/resources") {
-        Some(s) => s,
-        None => return ResourceRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/resources") else {
+        return ResourceRoute::NotFound;
     };
 
     let name = suffix
@@ -63,9 +61,8 @@ pub(super) enum PromptRoute {
 }
 
 pub(super) fn resolve_prompt_route(method: &str, path: &str) -> PromptRoute {
-    let suffix = match path.strip_prefix("/api/v1/prompts") {
-        Some(s) => s,
-        None => return PromptRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/prompts") else {
+        return PromptRoute::NotFound;
     };
 
     let name = suffix
@@ -87,9 +84,8 @@ pub(super) enum ManagementRoute {
 }
 
 pub(super) fn resolve_management_route(method: &str, path: &str) -> ManagementRoute {
-    let suffix = match path.strip_prefix("/api/v1/management") {
-        Some(s) => s,
-        None => return ManagementRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/management") else {
+        return ManagementRoute::NotFound;
     };
 
     match (method, suffix) {
@@ -109,9 +105,8 @@ pub(super) enum ForwardRoute {
 }
 
 pub(super) fn resolve_forward_route(method: &str, path: &str) -> ForwardRoute {
-    let suffix = match path.strip_prefix("/api/v1/forwards") {
-        Some(s) => s,
-        None => return ForwardRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/forwards") else {
+        return ForwardRoute::NotFound;
     };
 
     let name = suffix
@@ -125,10 +120,10 @@ pub(super) fn resolve_forward_route(method: &str, path: &str) -> ForwardRoute {
         ("DELETE", Some(n)) if !n.contains('/') => ForwardRoute::Delete(n.to_owned()),
         ("POST", Some(n)) => {
             if let Some(name) = n.strip_suffix("/refreshes") {
-                if !name.contains('/') {
-                    ForwardRoute::Refresh(name.to_owned())
-                } else {
+                if name.contains('/') {
                     ForwardRoute::NotFound
+                } else {
+                    ForwardRoute::Refresh(name.to_owned())
                 }
             } else {
                 ForwardRoute::NotFound
@@ -149,9 +144,8 @@ pub(super) enum NamespaceRoute {
 }
 
 pub(super) fn resolve_namespace_route(method: &str, path: &str) -> NamespaceRoute {
-    let suffix = match path.strip_prefix("/api/v1/namespaces") {
-        Some(s) => s,
-        None => return NamespaceRoute::NotFound,
+    let Some(suffix) = path.strip_prefix("/api/v1/namespaces") else {
+        return NamespaceRoute::NotFound;
     };
 
     let name = suffix

--- a/server/src/management/ui.rs
+++ b/server/src/management/ui.rs
@@ -8,7 +8,7 @@ use super::response::json_err;
 #[prefix = ""]
 struct AdminUi;
 
-#[expect(clippy::expect_used, reason = "valid static response")]
+#[expect(clippy::expect_used, clippy::too_many_lines, reason = "valid static response")]
 pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &str) -> Response<Vec<u8>> {
     let relative = request_path
         .strip_prefix("/admin")
@@ -35,8 +35,8 @@ pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &
             .expect("valid static response");
     }
 
-    if !relative.contains('.') {
-        if let Some(index) = AdminUi::get("index.html") {
+    if !relative.contains('.')
+        && let Some(index) = AdminUi::get("index.html") {
             return Response::builder()
                 .status(StatusCode::OK)
                 .header("Content-Type", "text/html; charset=utf-8")
@@ -44,12 +44,11 @@ pub(super) fn serve_ui(ui_override: &Option<std::path::PathBuf>, request_path: &
                 .body(index.data.into_owned())
                 .expect("valid static response");
         }
-    }
 
     json_err(StatusCode::NOT_FOUND, "file not found")
 }
 
-#[expect(clippy::expect_used, reason = "valid static response")]
+#[expect(clippy::expect_used, clippy::too_many_lines, reason = "valid static response")]
 fn serve_from_filesystem(ui_root: &std::path::Path, relative: &str) -> Response<Vec<u8>> {
     let file_path = if relative.is_empty() {
         ui_root.join("index.html")
@@ -57,35 +56,29 @@ fn serve_from_filesystem(ui_root: &std::path::Path, relative: &str) -> Response<
         ui_root.join(relative)
     };
 
-    let canonical = match file_path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            if !relative.contains('.') {
-                if let Ok(index) = std::fs::read(ui_root.join("index.html")) {
-                    return Response::builder()
-                        .status(StatusCode::OK)
-                        .header("Content-Type", "text/html; charset=utf-8")
-                        .header("Content-Length", index.len())
-                        .body(index)
-                        .expect("valid static response");
-                }
+    let Ok(canonical) = file_path.canonicalize() else {
+        if !relative.contains('.')
+            && let Ok(index) = std::fs::read(ui_root.join("index.html")) {
+                return Response::builder()
+                    .status(StatusCode::OK)
+                    .header("Content-Type", "text/html; charset=utf-8")
+                    .header("Content-Length", index.len())
+                    .body(index)
+                    .expect("valid static response");
             }
-            return json_err(StatusCode::NOT_FOUND, "file not found");
-        }
+        return json_err(StatusCode::NOT_FOUND, "file not found");
     };
 
-    let canonical_root = match ui_root.canonicalize() {
-        Ok(r) => r,
-        Err(_) => return json_err(StatusCode::INTERNAL_SERVER_ERROR, "UI root path not found"),
+    let Ok(canonical_root) = ui_root.canonicalize() else {
+        return json_err(StatusCode::INTERNAL_SERVER_ERROR, "UI root path not found");
     };
 
     if !canonical.starts_with(&canonical_root) {
         return json_err(StatusCode::FORBIDDEN, StatusCode::FORBIDDEN.canonical_reason().unwrap_or_default());
     }
 
-    let body = match std::fs::read(&canonical) {
-        Ok(b) => b,
-        Err(_) => return json_err(StatusCode::NOT_FOUND, "file not found"),
+    let Ok(body) = std::fs::read(&canonical) else {
+        return json_err(StatusCode::NOT_FOUND, "file not found");
     };
 
     let content_type = mime_for_path(canonical.to_str().unwrap_or(""));
@@ -101,7 +94,7 @@ fn serve_from_filesystem(ui_root: &std::path::Path, relative: &str) -> Response<
 fn mime_for_path(path: &str) -> &'static str {
     match path.rsplit('.').next() {
         Some("html") => "text/html; charset=utf-8",
-        Some("js") | Some("mjs") => "application/javascript",
+        Some("js" | "mjs") => "application/javascript",
         Some("css") => "text/css",
         Some("json") => "application/json",
         Some("svg") => "image/svg+xml",

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -19,14 +19,14 @@ struct WanakuResponse<T: utoipa::ToSchema> {
 #[utoipa::path(get, path = "/healthz", tag = "Health",
     responses((status = 200, description = "Server is healthy", body = serde_json::Value))
 )]
-fn healthz() {}
+const fn healthz() {}
 
 // -- Tools --------------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/tools", tag = "Tools",
     responses((status = 200, description = "List all tools", body = Vec<ToolEntry>))
 )]
-fn list_tools() {}
+const fn list_tools() {}
 
 #[utoipa::path(get, path = "/api/v1/tools/{name}", tag = "Tools",
     params(("name" = String, Path, description = "Tool name")),
@@ -35,7 +35,7 @@ fn list_tools() {}
         (status = 404, description = "Tool not found"),
     )
 )]
-fn get_tool() {}
+const fn get_tool() {}
 
 #[utoipa::path(delete, path = "/api/v1/tools/{name}", tag = "Tools",
     params(("name" = String, Path, description = "Tool name")),
@@ -44,14 +44,14 @@ fn get_tool() {}
         (status = 404, description = "Tool not found"),
     )
 )]
-fn delete_tool() {}
+const fn delete_tool() {}
 
 // -- Resources ----------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/resources", tag = "Resources",
     responses((status = 200, description = "List all resources", body = Vec<ResourceEntry>))
 )]
-fn list_resources() {}
+const fn list_resources() {}
 
 #[utoipa::path(get, path = "/api/v1/resources/{name}", tag = "Resources",
     params(("name" = String, Path, description = "Resource name")),
@@ -60,7 +60,7 @@ fn list_resources() {}
         (status = 404, description = "Resource not found"),
     )
 )]
-fn get_resource() {}
+const fn get_resource() {}
 
 #[utoipa::path(delete, path = "/api/v1/resources/{name}", tag = "Resources",
     params(("name" = String, Path, description = "Resource name")),
@@ -69,14 +69,14 @@ fn get_resource() {}
         (status = 404, description = "Resource not found"),
     )
 )]
-fn delete_resource() {}
+const fn delete_resource() {}
 
 // -- Prompts ------------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/prompts", tag = "Prompts",
     responses((status = 200, description = "List all prompts", body = Vec<PromptEntry>))
 )]
-fn list_prompts() {}
+const fn list_prompts() {}
 
 #[utoipa::path(get, path = "/api/v1/prompts/{name}", tag = "Prompts",
     params(("name" = String, Path, description = "Prompt name")),
@@ -85,7 +85,7 @@ fn list_prompts() {}
         (status = 404, description = "Prompt not found"),
     )
 )]
-fn get_prompt() {}
+const fn get_prompt() {}
 
 #[utoipa::path(delete, path = "/api/v1/prompts/{name}", tag = "Prompts",
     params(("name" = String, Path, description = "Prompt name")),
@@ -94,14 +94,14 @@ fn get_prompt() {}
         (status = 404, description = "Prompt not found"),
     )
 )]
-fn delete_prompt() {}
+const fn delete_prompt() {}
 
 // -- Namespaces ---------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/namespaces", tag = "Namespaces",
     responses((status = 200, description = "List all namespaces", body = Vec<NamespaceEntry>))
 )]
-fn list_namespaces() {}
+const fn list_namespaces() {}
 
 #[utoipa::path(get, path = "/api/v1/namespaces/{name}", tag = "Namespaces",
     params(("name" = String, Path, description = "Namespace name")),
@@ -110,13 +110,13 @@ fn list_namespaces() {}
         (status = 404, description = "Namespace not found"),
     )
 )]
-fn get_namespace() {}
+const fn get_namespace() {}
 
 #[utoipa::path(post, path = "/api/v1/namespaces", tag = "Namespaces",
     request_body = NamespaceEntry,
     responses((status = 200, description = "Namespace registered", body = NamespaceEntry))
 )]
-fn create_namespace() {}
+const fn create_namespace() {}
 
 #[utoipa::path(delete, path = "/api/v1/namespaces/{name}", tag = "Namespaces",
     params(("name" = String, Path, description = "Namespace name")),
@@ -125,14 +125,14 @@ fn create_namespace() {}
         (status = 404, description = "Namespace not found"),
     )
 )]
-fn delete_namespace() {}
+const fn delete_namespace() {}
 
 // -- Forwards -----------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/forwards", tag = "Forwards",
     responses((status = 200, description = "List all forwards", body = Vec<ForwardEntry>))
 )]
-fn list_forwards() {}
+const fn list_forwards() {}
 
 #[utoipa::path(get, path = "/api/v1/forwards/{name}", tag = "Forwards",
     params(("name" = String, Path, description = "Forward name")),
@@ -141,13 +141,13 @@ fn list_forwards() {}
         (status = 404, description = "Forward not found"),
     )
 )]
-fn get_forward() {}
+const fn get_forward() {}
 
 #[utoipa::path(post, path = "/api/v1/forwards", tag = "Forwards",
     request_body = ForwardEntry,
     responses((status = 200, description = "Forward created and tools discovered", body = serde_json::Value))
 )]
-fn create_forward() {}
+const fn create_forward() {}
 
 #[utoipa::path(delete, path = "/api/v1/forwards/{name}", tag = "Forwards",
     params(("name" = String, Path, description = "Forward name")),
@@ -156,7 +156,7 @@ fn create_forward() {}
         (status = 404, description = "Forward not found"),
     )
 )]
-fn delete_forward() {}
+const fn delete_forward() {}
 
 #[utoipa::path(post, path = "/api/v1/forwards/{name}/refreshes", tag = "Forwards",
     params(("name" = String, Path, description = "Forward name")),
@@ -165,26 +165,26 @@ fn delete_forward() {}
         (status = 404, description = "Forward not found"),
     )
 )]
-fn refresh_forward() {}
+const fn refresh_forward() {}
 
 // -- Interactions -------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/interactions", tag = "Interactions",
     responses((status = 200, description = "List recorded interactions", body = Vec<Interaction>))
 )]
-fn list_interactions() {}
+const fn list_interactions() {}
 
 #[utoipa::path(delete, path = "/api/v1/interactions", tag = "Interactions",
     responses((status = 200, description = "Interactions cleared"))
 )]
-fn clear_interactions() {}
+const fn clear_interactions() {}
 
 // -- Statistics ---------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/management/statistics", tag = "Management",
     responses((status = 200, description = "Registry statistics", body = serde_json::Value))
 )]
-fn get_statistics() {}
+const fn get_statistics() {}
 
 // -- OpenAPI Aggregation ------------------------------------------------------
 

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -24,12 +24,13 @@ impl PipelineExtension for RegistryExtension {
 /// # Errors
 ///
 /// Returns an error if pipeline construction fails.
+#[expect(clippy::too_many_arguments, clippy::too_many_lines, reason = "pipeline construction requires all dependencies")]
 pub fn resolve_pipelines(
     config: &Config,
     registry: &FilterRegistry,
     health_registry: &praxis_core::health::HealthRegistry,
     kv_stores: &praxis_core::kv::KvStoreRegistry,
-    wanaku_registry: InMemoryRegistry,
+    wanaku_registry: &InMemoryRegistry,
     features: &[Box<dyn Feature>],
 ) -> Result<ListenerPipelines, Box<dyn std::error::Error + Send + Sync>> {
     let chains: HashMap<&str, &[_]> = config


### PR DESCRIPTION
## Summary
- Convert 39 `if let`/`match` patterns to idiomatic `let...else`
- Add `Default` implementations for `HotSwap<T>`, `EvaluatorFeature`, `EvaluatorState`, `InterceptFeature`, `McpMetadataFeature`
- Add `#[expect]` annotations for structural lints (`too_many_lines`, `cognitive_complexity`, `large_stack_frames`, `too_many_arguments`, `unused_self`, `cast_possible_truncation`)
- Fix `map().unwrap_or_else()` → `map_or_else()`, redundant closures, implicit clones, and other minor clippy suggestions
- Zero clippy warnings remain, all tests pass

## Test plan
- [x] `cargo clippy` produces zero warnings
- [x] `cargo test` — all 226 tests pass

## Summary by Sourcery

Eliminate workspace-wide Clippy warnings while preserving existing behavior and validating the result with the full test suite.

Enhancements:
- Apply idiomatic Rust patterns and simplify redundant expressions throughout the workspace.
- Add appropriate default constructors and const qualifications where supported.
- Document intentional exceptions for remaining structural and conversion lints.

Tests:
- Validate the workspace with a clean Clippy run and the full test suite.

Chores:
- Resolve Clippy warnings across the workspace without changing application behavior.