### PR TITLE
Fix index.md links to match actual documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,19 +8,19 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      LLM / AI Agent                          │
+│                      LLM / AI Agent                         │
 └────────────────┬────────────────────────────────────────────┘
                  │ MCP (JSON-RPC over HTTP)
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              Wanaku Server (Port 8081)                │
+│              Wanaku Server (Port 8081)                      │
 │  ┌────────────────────────────────────────────────────────┐ │
-│  │              Filter Pipeline (Praxis)                   │ │
+│  │              Filter Pipeline (Praxis)                  │ │
 │  │  CORS → MCP Parse → Namespace → Evaluator →            │ │
-│  │  Tool List/Call → Resource → Prompt → Static Response   │ │
+│  │  Tool List/Call → Resource → Prompt → Static Response  │ │
 │  └────────────────────────────────────────────────────────┘ │
 │  ┌────────────────────────────────────────────────────────┐ │
-│  │              In-Memory Registry (DashMap)               │ │
+│  │              In-Memory Registry (DashMap)              │ │
 │  │  Tools │ Resources │ Prompts │ Forwards │ Namespaces   │ │
 │  └────────────────────────────────────────────────────────┘ │
 └────────────────────────────────┬────────────────────────────┘
@@ -29,7 +29,7 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
                                  │
                                  ▼
                    ┌───────────────────────┐
-                   │ Upstream MCP Servers   │
+                   │ Upstream MCP Servers  │
                    └───────────────────────┘
 ```
 

--- a/index.md
+++ b/index.md
@@ -7,33 +7,27 @@ hero:
   tagline: Documentation guides to help you learn and use the Wanaku MCP Router.
   actions:
     - theme: brand
-      text: Read the Usage Guide
-      link: ./docs/usage
+      text: Getting Started
+      link: ./docs/getting-started
 
 features:
-  - title: Builtin Providers
-    details: View builtin resource providers available in this version of Wanaku
-    link: ./capabilities/providers/README
-  - title: Builtin Tools
-    details: View builtin tool services available in this version of Wanaku
-    link: ./capabilities/tools/README
   - title: Architecture
-    details: Learn about Wanaku system architecture
+    details: Learn about the filter pipeline, registry, tool routing, and deployment patterns
     link: ./docs/architecture
   - title: Configuration Guide
-    details: A list of all configuration parameters for Wanaku
-    link: ./docs/configurations
-  - title: Building
-    details: Learn how to build and package this capability
-    link: ./docs/building
+    details: Environment variables, YAML config, and feature configuration
+    link: ./docs/configuration
+  - title: Management API
+    details: REST API reference for tools, resources, prompts, namespaces, and forwards
+    link: ./docs/management-api
+  - title: Features
+    details: Learn about the feature system and how to create custom features
+    link: ./docs/features
+  - title: Admin UI
+    details: React and Carbon Design System frontend development
+    link: ./docs/admin-ui
   - title: Contributing
     details: Learn how to contribute to Wanaku
-    link: ./docs/contributing
-  - title: Wanaku Internals
-    details: Learn about the internals of Wanaku
-    link: ./docs/wanaku-router-internals
-  - title: Label Expression
-    details: Learn how to filter entities using label expressions and logical operators
-    link: ./cli/src/main/resources/docs/LABEL_EXPRESSIONS
+    link: ./CONTRIBUTING
 
 ---


### PR DESCRIPTION
## Summary

- Replaced stale Java-era links in root `index.md` with links to the actual Rust documentation pages
- All 7 link targets verified to exist in the repo

## Broken links removed

| Old link | Issue |
|---|---|
| `./docs/usage` | Java-only, doesn't exist |
| `./capabilities/providers/README` | Java-only |
| `./capabilities/tools/README` | Java-only |
| `./docs/configurations` | Typo, should be `configuration` |
| `./docs/building` | Java-only |
| `./docs/wanaku-router-internals` | Java-only |
| `./cli/src/main/resources/docs/LABEL_EXPRESSIONS` | Java classpath |

## Test plan

- [ ] Verify VitePress renders the home page with working links
- [ ] Verify website sync picks up the corrected links

## Summary by Sourcery

Update the documentation home page to point users to the current Rust guides and accurately describe available documentation.

New Features:
- Update the documentation home page with links and descriptions for getting started, management API, features, and admin UI guides.

Bug Fixes:
- Replace stale or invalid home-page documentation links with valid Rust documentation targets.

Enhancements:
- Refresh the home-page feature list and descriptions to reflect the current documentation structure.
- Align the architecture diagram formatting for consistent visual presentation.

Documentation:
- Correct the contributing link and update documentation navigation content on the root home page.