### PR TITLE
chore: enable file persistence by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,8 @@ cd ../safety-warn && cargo component build --release && cp target/wasm32-wasip1/
 |---|---|---|
 | `WANAKU_MGMT_LISTEN` | `0.0.0.0:8080` | Mgmt API address |
 | `WANAKU_INFERENCE_UPSTREAM` | `127.0.0.1:11434` | Inference backend |
-| `WANAKU_PERSIST_BACKEND` | unset | `"file"` enables persistence |
-| `WANAKU_PERSIST_PATH` | `/data/registry` | `registry.json` dir |
+| `WANAKU_PERSIST_BACKEND` | `"file"` | Persistence backend; `"none"` disables |
+| `WANAKU_PERSIST_PATH` | `$HOME/.wanaku/server` | `registry.json` dir |
 | `WANAKU_UI_PATH` | unset | FS path to UI override |
 | `WANAKU_AUTH_ISSUER` | unset | OIDC issuer (RFC 9728) |
 | `WANAKU_INFERENCE_API_KEY` | unset | Bearer token for upstream |

--- a/apis/src/config.rs
+++ b/apis/src/config.rs
@@ -19,11 +19,11 @@ const WANAKU_INFERENCE_UPSTREAM: &str = "WANAKU_INFERENCE_UPSTREAM";
 /// Bearer token API key for the inference upstream. Empty means no auth.
 const WANAKU_INFERENCE_API_KEY: &str = "WANAKU_INFERENCE_API_KEY";
 
-/// Persistence backend selector. Set to `"file"` to enable file-based persistence.
-/// Unset or any other value disables persistence.
+/// Persistence backend selector. Defaults to `"file"` (file-based persistence).
+/// Set to `"none"` to disable persistence entirely.
 const WANAKU_PERSIST_BACKEND: &str = "WANAKU_PERSIST_BACKEND";
 
-/// Directory where `registry.json` is stored (default `/data/registry`).
+/// Directory where `registry.json` is stored (default `$HOME/.wanaku/server`).
 /// Only used when [`WANAKU_PERSIST_BACKEND`] is `"file"`.
 const WANAKU_PERSIST_PATH: &str = "WANAKU_PERSIST_PATH";
 
@@ -75,16 +75,17 @@ impl WanakuEnv {
     }
 
     fn from_env() -> Self {
-        let persist = std::env::var(WANAKU_PERSIST_BACKEND)
-            .ok()
-            .filter(|b| b == "file")
-            .map(|_| {
-                let dir = std::env::var(WANAKU_PERSIST_PATH)
-                    .unwrap_or_else(|_| "/data/registry".to_owned());
-                PersistEnv {
-                    dir: PathBuf::from(dir),
-                }
+        let backend = std::env::var(WANAKU_PERSIST_BACKEND)
+            .unwrap_or_else(|_| "file".to_owned());
+        let persist = (backend != "none").then(|| {
+            let dir = std::env::var(WANAKU_PERSIST_PATH).unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_owned());
+                format!("{home}/.wanaku/server")
             });
+            PersistEnv {
+                dir: PathBuf::from(dir),
+            }
+        });
 
         let parsed = parse_upstream(
             &std::env::var(WANAKU_INFERENCE_UPSTREAM)

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -350,11 +350,16 @@ impl InMemoryRegistry {
         if let Some(backend) = &self.persistence {
             let snapshot = self.snapshot();
             let backend = Arc::clone(backend);
-            tokio::task::spawn_blocking(move || {
+            let save = move || {
                 if let Err(e) = backend.save(&snapshot) {
                     tracing::warn!(error = %e, "failed to persist registry");
                 }
-            });
+            };
+            if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::task::spawn_blocking(save);
+            } else {
+                save();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Registry data is now persisted to `$HOME/.wanaku/server/registry.json` by default
- Previously required setting `WANAKU_PERSIST_BACKEND=file` to enable persistence
- Set `WANAKU_PERSIST_BACKEND=none` to disable persistence entirely

## Test plan

- [x] `cargo test -p wanaku-apis` — all 47 tests pass
- [ ] Start server without env vars, verify `~/.wanaku/server/registry.json` is created on first mutation
- [ ] Set `WANAKU_PERSIST_BACKEND=none`, verify no file is created
- [ ] Set `WANAKU_PERSIST_PATH=/tmp/test`, verify custom path is used

## Summary by Sourcery

Make registry data persist to a local file by default while supporting explicit opt-out through configuration.

Bug Fixes:
- Ensure registry persistence also works when mutations occur outside an active Tokio runtime.

Enhancements:
- Enable file-based registry persistence by default, allow it to be disabled explicitly, and use `$HOME/.wanaku/server` as the default storage directory.

Documentation:
- Update the environment variable reference to document the new persistence defaults and disable option.