### PR TITLE
docs: separate user-facing and contributor documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,7 +362,7 @@ const result = await getTools();  // Orval-generated function
 const tools = result.data.data;   // Unwrap: result.data (fetch wrapper) -> .data (server wrapper)
 ```
 
-See [Admin UI](./admin-ui.md) for development details.
+See [Contributing: Admin UI](./contributing-admin-ui.md) for development details.
 
 ## Deployment Patterns
 
@@ -449,4 +449,4 @@ These are all solvable (implement traits, add filters), but they're not in scope
 - [Configuration](./configuration.md) — all env vars and YAML options
 - [Features](./features.md) — enable chat, create custom features
 - [Management API](./management-api.md) — REST API reference
-- [Admin UI](./admin-ui.md) — customize the embedded UI
+- [Contributing: Admin UI](./contributing-admin-ui.md) — customize the embedded UI

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,177 @@
+# Authentication
+
+Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. Two oauth2-proxy instances run as reverse proxies in front of the MCP and management API ports, providing shared SSO via [Keycloak](https://keycloak.org).
+
+## Architecture
+
+```
+Browser/CLI ----> oauth2-proxy-mcp (:4180) ----> Wanaku MCP (:8081)
+            \---> oauth2-proxy-mgmt (:4181) ---> Wanaku Mgmt (:8080)
+```
+
+Both instances share the same cookie secret, so logging in on one port authenticates you on the other (SSO).
+
+The MCP proxy accepts bearer tokens from multiple Keycloak clients (`mcp-client`, `wanaku-mcp-client`) via `--oidc-extra-audience`, so MCP Inspector and other MCP clients can authenticate with their own Keycloak client credentials.
+
+## Prerequisites
+
+### Install oauth2-proxy
+
+**macOS:**
+
+```bash
+brew install oauth2-proxy
+```
+
+**Linux:** Download from the [oauth2-proxy releases page](https://github.com/oauth2-proxy/oauth2-proxy/releases).
+
+### Keycloak Client Setup
+
+The `wanaku-mcp-router` client in Keycloak must be **confidential** (not public):
+
+1. Go to Keycloak Admin -> Clients -> `wanaku-mcp-router` -> Settings
+2. Set **Client authentication** to **ON**
+3. Save, then go to the **Credentials** tab and copy the client secret
+4. Under **Valid redirect URIs**, add `http://localhost:4180/*` and `http://localhost:4181/*`
+5. Under **Web origins**, add `*`
+
+## Setup
+
+### 1. Generate a Shared Cookie Secret
+
+The cookie secret must be exactly 16, 24, or 32 bytes. Both oauth2-proxy instances must use the same secret for SSO to work.
+
+```bash
+export COOKIE_SECRET=$(openssl rand -hex 16)
+```
+
+### 2. Start Wanaku with Auth Issuer
+
+```bash
+WANAKU_AUTH_ISSUER=http://localhost:8543/realms/wanaku wanaku-server
+```
+
+When `WANAKU_AUTH_ISSUER` is set, the endpoint `/.well-known/oauth-protected-resource/{namespace}/mcp` returns OAuth server metadata. When unset, the endpoint returns 404.
+
+### 3. Start the MCP Proxy
+
+```bash
+oauth2-proxy \
+  --http-address=127.0.0.1:4180 \
+  --upstream=http://127.0.0.1:8081 \
+  --provider=keycloak-oidc \
+  --oidc-issuer-url=http://localhost:8543/realms/wanaku \
+  --client-id=wanaku-mcp-router \
+  --client-secret=<your-secret> \
+  --cookie-secret=$COOKIE_SECRET \
+  --cookie-secure=false \
+  --redirect-url=http://localhost:4180/oauth2/callback \
+  --email-domain="*" \
+  --code-challenge-method=S256 \
+  --skip-jwt-bearer-tokens \
+  --pass-authorization-header \
+  --oidc-extra-audience=mcp-client \
+  --oidc-extra-audience=wanaku-mcp-client \
+  --insecure-oidc-allow-unverified-email \
+  --skip-auth-route="^/.well-known/.*" \
+  --skip-auth-route="^/public/.*" \
+  --skip-auth-route="^/authorize$" \
+  --skip-auth-route="^/token$" \
+  --skip-auth-route="^/register$" \
+  --skip-auth-route="OPTIONS=^/.*" \
+  --api-route="^/mcp.*" \
+  --upstream-timeout=3600s
+```
+
+### 4. Start the Management Proxy
+
+In another terminal, using the same `$COOKIE_SECRET` for SSO:
+
+```bash
+oauth2-proxy \
+  --http-address=127.0.0.1:4181 \
+  --upstream=http://127.0.0.1:8080 \
+  --provider=keycloak-oidc \
+  --oidc-issuer-url=http://localhost:8543/realms/wanaku \
+  --client-id=wanaku-mcp-router \
+  --client-secret=<your-secret> \
+  --cookie-secret=$COOKIE_SECRET \
+  --cookie-secure=false \
+  --redirect-url=http://localhost:4181/oauth2/callback \
+  --email-domain="*" \
+  --code-challenge-method=S256 \
+  --skip-jwt-bearer-tokens \
+  --pass-authorization-header \
+  --oidc-extra-audience=mcp-client \
+  --oidc-extra-audience=wanaku-mcp-client \
+  --insecure-oidc-allow-unverified-email \
+  --skip-auth-route="^/healthz$" \
+  --skip-auth-route="^/health$"
+```
+
+### 5. Access Wanaku
+
+- **Admin UI:** `http://localhost:4181/admin/`
+- **MCP endpoint:** `http://localhost:4180/mcp`
+- **Public MCP (no auth):** `http://localhost:4180/public/mcp`
+
+## Role-Based Access
+
+To restrict the management UI to administrators:
+
+1. Create an `admin` role in Keycloak
+2. Add `--allowed-role=admin` to the management proxy command (step 4)
+3. Assign the `admin` role to administrator users
+
+MCP users who don't have the `admin` role can use tools but cannot access the management UI.
+
+## CLI Usage
+
+```bash
+# Get a token from Keycloak (client must have direct access grants enabled)
+TOKEN=$(curl -s -X POST http://localhost:8543/realms/wanaku/protocol/openid-connect/token \
+  -d grant_type=password \
+  -d client_id=wanaku-mcp-router \
+  -d client_secret=<your-secret> \
+  -d username=test \
+  -d password=test | jq -r .access_token)
+
+# Use with the Wanaku CLI
+wanaku tools list --host http://localhost:4181 --token $TOKEN
+
+# Use with MCP endpoint directly
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4180/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+You can also use the CLI's built-in authentication:
+
+```bash
+wanaku auth login --api-token $TOKEN
+wanaku tools list --host http://localhost:4181
+```
+
+## Running Without Authentication
+
+For local development or testing, run Wanaku without oauth2-proxy:
+
+```bash
+wanaku-server
+```
+
+Use the `--no-auth` flag with CLI commands:
+
+```bash
+wanaku tools list --no-auth
+```
+
+## MCP Inspector
+
+Point the MCP Inspector at `http://localhost:4180/mcp`. The Inspector's OAuth flow uses the `mcp-client` Keycloak client, which is accepted via the `--oidc-extra-audience` flag.
+
+## Related Docs
+
+- [Getting Started](./getting-started.md) — initial setup
+- [Configuration](./configuration.md) — `WANAKU_AUTH_ISSUER` and other env vars
+- [FAQ](./faq.md) — troubleshooting authentication issues

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,16 +1,16 @@
 # Configuration
 
-Wanaku is configured entirely through environment variables and two optional YAML files. There's no properties file. This keeps deployment simple—set env vars in your container orchestrator or systemd unit, point at config files if needed, and you're done.
+Wanaku is configured entirely through environment variables and two optional YAML files. There's no properties file. This keeps deployment simple — set env vars in your container orchestrator or systemd unit, point at config files if needed, and you're done.
 
 ## Configuration Sources (Precedence Order)
 
 1. **Environment variables** — highest priority, always win
-2. **Runtime YAML files** — loaded from CLI args (e.g., `cargo run -- --pipeline-config praxis.yaml --wanaku-config wanaku.yaml`)
-3. **Embedded defaults** — `server/src/default.yaml` compiled into the binary
+2. **Runtime YAML files** — loaded from CLI args (e.g., `wanaku-server --pipeline-config praxis.yaml --wanaku-config wanaku.yaml`)
+3. **Embedded defaults** — compiled into the binary
 
 ## Core Environment Variables
 
-These are defined in `apis/src/config.rs` and accessed via `wanaku_apis::config::ENV`:
+These control core server behavior:
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -29,7 +29,7 @@ These are defined in `apis/src/config.rs` and accessed via `wanaku_apis::config:
 export WANAKU_MGMT_LISTEN=0.0.0.0:9091
 export WANAKU_PERSIST_BACKEND=file
 export WANAKU_PERSIST_PATH=/var/lib/wanaku/registry
-cargo run --release
+wanaku-server
 ```
 
 ### Management API Listen Address
@@ -83,64 +83,32 @@ On startup, the server loads `registry.json` from `WANAKU_PERSIST_PATH`. On shut
 
 ### Admin UI Override
 
-The admin UI is embedded in the binary via `rust_embed`. To develop the UI locally without rebuilding the server:
+The admin UI is embedded in the binary. To serve UI files from a directory on disk instead of the embedded bundle:
 
 ```bash
-cd ui/admin
-yarn run build
+export WANAKU_UI_PATH=/absolute/path/to/ui/dist
+wanaku-server
 ```
 
-Then start the server with:
+The server serves files from the specified directory instead of the embedded bundle.
 
-```bash
-export WANAKU_UI_PATH=/absolute/path/to/ui/admin/dist
-cargo run
-```
-
-The server serves files from `dist/` instead of the embedded bundle. Changes to the UI (after `yarn run build`) are visible without restarting.
-
-**Warning:** Relative paths don't work. Use an absolute path or the server panics on startup.
+**Warning:** Relative paths don't work. Use an absolute path.
 
 ## Feature-Specific Environment Variables
 
-Features (mcp-metadata, chat, etc.) own their env vars. They're NOT in `apis/src/config.rs`. Each feature reads its own config in `load_env_config()`.
+Features (mcp-metadata, chat, etc.) define their own environment variables.
 
 ### Authentication with oauth2-proxy
 
-Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication, not embedded code. Two oauth2-proxy instances run as sidecars in front of ports 8081 (MCP) and 8080 (management API).
-
-**MCP Metadata Feature:**
-
-The only auth-related configuration in Wanaku itself is the OIDC issuer URL for RFC 9728 metadata:
+Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. The only auth-related configuration in Wanaku itself is the OIDC issuer URL:
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `WANAKU_AUTH_ISSUER` | _(unset = disabled)_ | OIDC issuer URL (e.g., `http://localhost:8543/realms/wanaku`) |
 
-**Example:**
-
-```bash
-export WANAKU_AUTH_ISSUER=http://localhost:8543/realms/wanaku
-```
-
 When set, the endpoint `/.well-known/oauth-protected-resource/{namespace}/mcp` returns OAuth server metadata. When unset, the endpoint returns 404.
 
-**oauth2-proxy deployment:**
-
-For oauth2-proxy configuration, cookie secrets, role-based access, and docker-compose setup, see `deploy/auth/README.md`.
-
-**Quick start:**
-
-```bash
-cd deploy/auth
-# Edit oauth2-proxy-shared.env with your Keycloak client secret
-docker compose -f docker-compose-auth.yml up
-```
-
-Access:
-- Admin UI: `http://localhost:4181/admin/`
-- MCP endpoint: `http://localhost:4180/mcp`
-- Public MCP (no auth): `http://localhost:4180/public/mcp`
+See [Authentication](./auth.md) for full oauth2-proxy setup instructions.
 
 ### Intercept Feature
 
@@ -170,12 +138,10 @@ The chat feature exposes these management API routes:
 
 The pipeline config defines listeners, filter chains, and filter-specific settings. It's a YAML file that matches Praxis's native config format.
 
-**Default location:** `server/src/default.yaml` (embedded at compile time)
-
 **Override:** Pass with `--pipeline-config`:
 
 ```bash
-cargo run -- --pipeline-config /path/to/custom-praxis.yaml
+wanaku-server --pipeline-config /path/to/custom-praxis.yaml
 ```
 
 **Format:**
@@ -283,7 +249,7 @@ The Wanaku config bootstraps forwarded MCP servers on startup. It's optional —
 **Location:** Pass with `--wanaku-config`:
 
 ```bash
-cargo run -- --pipeline-config /path/to/praxis.yaml --wanaku-config /path/to/wanaku.yaml
+wanaku-server --pipeline-config /path/to/praxis.yaml --wanaku-config /path/to/wanaku.yaml
 ```
 
 **Format:**
@@ -327,38 +293,7 @@ When `result_schema` is set, the host validates LLM output against the schema an
 ```bash
 # No persistence, embedded UI, inference backend for LLMs
 export WANAKU_INFERENCE_UPSTREAM=http://localhost:11434
-cargo run
-```
-
-### Production (Docker)
-
-```dockerfile
-FROM rust:1.96 as builder
-WORKDIR /build
-COPY . .
-RUN cargo build --release
-
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /build/target/release/wanaku-server /usr/local/bin/
-COPY praxis.yaml /etc/wanaku/praxis.yaml
-COPY wanaku.yaml /etc/wanaku/wanaku.yaml
-
-ENV WANAKU_MGMT_LISTEN=0.0.0.0:8080
-ENV WANAKU_PERSIST_BACKEND=file
-ENV WANAKU_PERSIST_PATH=/data/registry
-
-VOLUME /data
-EXPOSE 8081 8080
-CMD ["/usr/local/bin/wanaku-server", "--pipeline-config", "/etc/wanaku/praxis.yaml", "--wanaku-config", "/etc/wanaku/wanaku.yaml"]
-```
-
-Run with:
-
-```bash
-docker run -v /var/lib/wanaku:/data \
-  -p 8081:8081 -p 8080:8080 \
-  wanaku-server:latest
+wanaku-server
 ```
 
 ### Kubernetes
@@ -430,44 +365,25 @@ spec:
 ### Enable Trace Logs
 
 ```bash
-RUST_LOG=trace cargo run
+RUST_LOG=trace wanaku-server
 ```
 
-This logs all filter decisions, metadata reads/writes, and registry operations. Output is verbose—use sparingly.
+This logs all filter decisions, metadata reads/writes, and registry operations. Output is verbose — use sparingly.
 
 **Filter-specific logs:**
 
 ```bash
-RUST_LOG=wanaku_filters=trace cargo run
+RUST_LOG=wanaku_filters=trace wanaku-server
 ```
 
 ### Verify Environment Variables
 
-The server doesn't validate env vars on startup. If you typo a var name, it silently uses the default.
-
-To check what the server sees:
-
-```rust
-// Add to main.rs before server start
-println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_apis::config::ENV.mgmt_listen);
-println!("WANAKU_PERSIST_BACKEND: {:?}", wanaku_apis::config::ENV.persist_backend);
-```
-
-Rebuild and run. The server prints the effective config.
-
-### Rebuild Gotcha: include_str!
-
-Changes to `server/src/default.yaml` don't trigger rebuilds because Cargo doesn't track `include_str!` dependencies.
-
-After editing `default.yaml`:
-
-```bash
-touch server/src/lib.rs
-cargo build
-```
+The server doesn't validate env vars on startup. If you typo a var name, it silently uses the default. Enable trace logs to verify which values are being used.
 
 ## Related Docs
 
 - [Architecture](./architecture.md) — understand the filter pipeline and registry
+- [Authentication](./auth.md) — oauth2-proxy setup and Keycloak configuration
 - [Features](./features.md) — configure chat and custom features
 - [Management API](./management-api.md) — API routes that respect configuration
+- [FAQ](./faq.md) — troubleshooting common issues

--- a/docs/contributing-admin-ui.md
+++ b/docs/contributing-admin-ui.md
@@ -1,4 +1,6 @@
-# Admin UI
+# Contributing: Admin UI
+
+This guide covers development of the admin UI for contributors. For end-user documentation on using the admin UI, see the [Getting Started](./getting-started.md) guide.
 
 The admin UI is a React 19 + TypeScript frontend embedded into the server binary via `rust_embed`. It's accessible at `http://localhost:8080` and provides a graphical interface to the management API.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,6 +17,7 @@ Please read our [Getting Started](docs/getting-started.md) guide for detailed in
 - **Getting Started**: [docs/getting-started.md](docs/getting-started.md)
 - **Architecture Overview**: [docs/architecture.md](docs/architecture.md)
 - **Configuration Reference**: [docs/configuration.md](docs/configuration.md)
+- **Admin UI Development**: [docs/contributing-admin-ui.md](docs/contributing-admin-ui.md)
 - **Plugin Development**: [docs/plugin-development-guide.md](docs/plugin-development-guide.md)
 
 ## Code of Conduct

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,109 @@
+# FAQ and Troubleshooting
+
+Common issues and solutions when running Wanaku.
+
+## "Address already in use" on startup
+
+Something else is using port 8081 or 8080. Check with:
+
+```bash
+lsof -ti :8081
+lsof -ti :8080
+```
+
+Kill the process, or change the management listen address via `WANAKU_MGMT_LISTEN`. The MCP listener address is defined in the pipeline config — use a custom config file with `--pipeline-config` to override it.
+
+## Empty JSON-RPC response from MCP endpoint
+
+Check that:
+- The MCP filter has `on_invalid: continue` in the pipeline config
+- You're sending valid JSON-RPC (must have `"jsonrpc": "2.0"`, `"method"`, and `"id"`)
+- The URL path matches a configured namespace (`/mcp` -> `"default"`, `/{namespace}/mcp` -> `"{namespace}"`)
+
+Enable trace logs to see what the filters are doing:
+
+```bash
+RUST_LOG=wanaku_filters=trace wanaku-server
+```
+
+## Tools don't appear in `/mcp` but show up via `wanaku tools list`
+
+Check the namespace. Tools registered with `namespace: "finance"` only appear in `/finance/mcp`, not `/mcp`.
+
+```bash
+# List tools in the default namespace
+wanaku tools list --no-auth
+
+# Query the finance namespace via MCP
+curl -X POST http://localhost:8081/finance/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+```
+
+## Tool calls time out
+
+MCP forward calls have a connection timeout. If your upstream MCP server takes too long, verify it's reachable and responding:
+
+```bash
+curl -s http://your-upstream-mcp:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+```
+
+## LLM-based features (chat) don't work
+
+Verify:
+- The LLM endpoint is reachable (`curl http://localhost:11434/v1/models`)
+- Environment variables are set correctly (`WANAKU_INFERENCE_UPSTREAM`)
+- The feature is configured via the management API or `wanaku.yaml`
+
+## Server crashes with "thread 'main' panicked"
+
+Wanaku denies `unsafe_code`, `unwrap_used`, `expect_used`, and `panic` at the crate level. A panic means a logic bug. File an issue at [github.com/wanaku-ai/wanaku/issues](https://github.com/wanaku-ai/wanaku/issues) with the stack trace and steps to reproduce.
+
+## CLI returns authentication errors
+
+When running against a Wanaku server without authentication enabled, use the `--no-auth` flag:
+
+```bash
+wanaku tools list --no-auth
+```
+
+When authentication is enabled, authenticate first or pass a token:
+
+```bash
+# Pass a token directly
+wanaku tools list --host http://localhost:4181 --token $TOKEN
+
+# Or use the CLI's built-in auth
+wanaku auth login --api-token <your-token>
+wanaku tools list
+```
+
+## Registry data lost on restart
+
+By default, the registry lives in RAM and is lost on restart. Enable file persistence to survive restarts:
+
+```bash
+export WANAKU_PERSIST_BACKEND=file
+export WANAKU_PERSIST_PATH=/data/registry
+wanaku-server
+```
+
+On startup, the server loads `registry.json` from `WANAKU_PERSIST_PATH`. On shutdown (SIGTERM, SIGINT), it writes back.
+
+> **Note:** If the server crashes (SIGKILL, OOM), the registry is lost. For production, consider implementing a custom persistence backend.
+
+## Debugging
+
+Enable trace logs to see all filter decisions, metadata reads/writes, and registry operations:
+
+```bash
+RUST_LOG=trace wanaku-server
+```
+
+For filter-specific logs only:
+
+```bash
+RUST_LOG=wanaku_filters=trace wanaku-server
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,73 +8,78 @@ This guide gets you from zero to running MCP server in under 10 minutes.
 
 You'll need:
 
-- **Rust 1.96 or later** — check with `rustc --version`
-- **Cargo** (comes with Rust)
 - A terminal where you're comfortable running commands
-That's it. The admin UI dev workflow also uses Yarn, but that's only needed if you're modifying the frontend.
+- `jq` (optional, for formatting JSON output)
 
 ## Quick Start: Get It Running
 
-### 1. Clone and Build
+### 1. Download the Server
+
+Download the latest `wanaku-server` binary from the [early access release page](https://github.com/wanaku-ai/wanaku/releases/tag/early-access).
+
+Choose the binary that matches your platform, make it executable, and place it somewhere in your PATH:
 
 ```bash
-git clone https://github.com/wanaku-ai/wanaku.git
-cd wanaku
-cargo build --release
+chmod +x wanaku-server
+sudo mv wanaku-server /usr/local/bin/
 ```
 
-The first build takes a few minutes—Rust is compiling everything from scratch. Grab a coffee. Subsequent builds are fast.
+### 2. Download the CLI
 
-### 2. Run the Server
+The Wanaku CLI is distributed separately. Download the latest `wanaku` binary from the [wanaku-barn early access release page](https://github.com/wanaku-ai/wanaku-barn/releases/tag/early-access).
 
 ```bash
-cargo run --release
+chmod +x wanaku
+sudo mv wanaku /usr/local/bin/
+```
+
+Verify the CLI is installed:
+
+```bash
+wanaku --version
+```
+
+> **Note:** The Wanaku CLI was originally built for the Java-based Wanaku router and is compatible with the Rust-based engine. When running against a router without authentication enabled, use the `--no-auth` flag with CLI commands.
+
+### 3. Run the Server
+
+```bash
+wanaku-server
 ```
 
 You should see log output indicating two services started:
 - **MCP endpoint:** `http://127.0.0.1:8081/mcp`
 - **Management API:** `http://0.0.0.0:8080/api/v1`
 
-### 3. Verify It's Alive
+### 4. Verify It's Alive
 
-Open another terminal and hit the management API:
-
-```bash
-curl http://localhost:8080/api/v1/tools
-```
-
-Expected response:
-
-```json
-{"data": [], "error": null}
-```
-
-That empty array means the server is running, but no tools have been discovered yet. Let's fix that.
-
-### 4. Register a Forward (Auto-Discover Tools)
-
-Tools are discovered automatically from upstream MCP servers. Register a forward to an MCP server:
+Open another terminal and use the CLI to check for tools:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/forwards \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "my-mcp-server",
-    "address": "http://localhost:8180/mcp"
-  }'
+wanaku tools list --no-auth
 ```
 
-Wanaku connects to the upstream server, discovers all available tools, and registers them automatically with `type: "mcp-forward"`.
+The output should show an empty list — the server is running, but no tools have been discovered yet. Let's fix that.
+
+### 5. Register a Forward (Auto-Discover Tools)
+
+Tools are discovered automatically from upstream MCP servers. Register a forward to an MCP server using the CLI:
+
+```bash
+wanaku forwards add --service="http://localhost:8180/mcp" --name my-mcp-server --no-auth
+```
+
+Wanaku connects to the upstream server, discovers all available tools, and registers them automatically.
 
 List the discovered tools:
 
 ```bash
-curl http://localhost:8080/api/v1/tools
+wanaku tools list --no-auth
 ```
 
 You'll see the tools discovered from the upstream server. The server is now ready to route MCP requests to those tools.
 
-### 5. Test the MCP Endpoint
+### 6. Test the MCP Endpoint
 
 Send an MCP `tools/list` request:
 
@@ -102,27 +107,17 @@ No downstream services were called. The tool list is served directly from the in
 
 ### Register Additional Forwards
 
-To discover tools from additional MCP servers, register more forwards the same way you did in step 4. Each forward connects to an upstream MCP server and auto-discovers its tools, resources, and prompts.
+To discover tools from additional MCP servers, register more forwards the same way you did in step 5. Each forward connects to an upstream MCP server and auto-discovers its tools, resources, and prompts.
 
 ### Explore Namespaces
 
 Namespaces isolate tools. Create a `"finance"` namespace and register a forward that assigns discovered tools to it:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/namespaces \
-  -H "Content-Type: application/json" \
-  -d '{"name": "finance"}'
-
-curl -X POST http://localhost:8080/api/v1/forwards \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "market-data-server",
-    "address": "http://market-data-mcp:8080/mcp",
-    "namespace": "finance"
-  }'
+wanaku forwards add --service="http://market-data-mcp:8080/mcp" --name market-data-server --no-auth
 ```
 
-Tools discovered from this forward inherit the `"finance"` namespace. Query the finance namespace:
+Query the finance namespace by hitting the namespace-specific MCP endpoint:
 
 ```bash
 curl -X POST http://localhost:8081/finance/mcp \
@@ -134,7 +129,7 @@ Only tools from the `market-data-server` forward appear. The default namespace t
 
 ### Use the Admin UI
 
-Open `http://localhost:8080` in your browser. You'll see the React-based admin UI embedded in the server binary. It talks to the same management API you just used via curl.
+Open `http://localhost:8080` in your browser. You'll see the React-based admin UI embedded in the server binary. It talks to the same management API you just used via the CLI.
 
 From here you can view and manage tools, namespaces, resources, prompts, and forwards.
 
@@ -142,70 +137,29 @@ From here you can view and manage tools, namespaces, resources, prompts, and for
 
 Wanaku uses [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) for authentication. oauth2-proxy runs as a reverse proxy in front of the MCP and management API ports.
 
-**Quick start with docker-compose:**
+See [Authentication](./auth.md) for detailed setup instructions, including Keycloak configuration, role-based access, and running oauth2-proxy locally.
 
-```bash
-cd deploy/auth
-
-# Generate a cookie secret
-openssl rand -base64 32
-
-# Edit oauth2-proxy-shared.env:
-#   - Set OAUTH2_PROXY_COOKIE_SECRET to the generated secret
-#   - Set OAUTH2_PROXY_CLIENT_SECRET to your Keycloak client secret
-
-# Place your Keycloak realm export as wanaku-realm.json in this directory
-
-# Start the stack (Keycloak + oauth2-proxy + Wanaku)
-docker compose -f docker-compose-auth.yml up
-```
-
-**Access:**
-
-- Admin UI: `http://localhost:4181/admin/`
-- MCP endpoint: `http://localhost:4180/mcp`
-- Public MCP (no auth): `http://localhost:4180/public/mcp`
-
-**Test with CLI:**
+Once authentication is enabled, you can authenticate the CLI:
 
 ```bash
 # Get a token from Keycloak
 TOKEN=$(curl -s -X POST http://localhost:8543/realms/wanaku/protocol/openid-connect/token \
   -d grant_type=password \
   -d client_id=wanaku-mcp-router \
+  -d client_secret=<your-secret> \
   -d username=test \
   -d password=test | jq -r .access_token)
 
-# Use with MCP endpoint
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4180/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+# Use the CLI with a token
+wanaku tools list --host http://localhost:4181 --token $TOKEN
 ```
-
-**Architecture:**
-
-Two oauth2-proxy instances with shared SSO:
-- **oauth2-proxy-mcp** (port 4180 → 8081) — MCP endpoint, requires `mcp-user` role
-- **oauth2-proxy-mgmt** (port 4181 → 8080) — management API/UI, requires `admin` role
-
-See `deploy/auth/README.md` for detailed setup, role-based access, and local development without Docker.
-
-## Building for Production
-
-The `cargo run` command uses the debug build. For production, use:
-
-```bash
-cargo build --release
-./target/release/wanaku-server
-```
-
-The release binary is optimized compared to debug builds.
 
 ### Custom Configuration
 
-The server embeds `server/src/default.yaml` at compile time. To override:
+The server accepts optional configuration files:
 
 ```bash
-./target/release/wanaku-server --pipeline-config /path/to/custom-praxis.yaml \
+wanaku-server --pipeline-config /path/to/custom-praxis.yaml \
   --wanaku-config /path/to/wanaku.yaml
 ```
 
@@ -223,76 +177,16 @@ All configuration is environment-first. Common vars:
 | `WANAKU_MGMT_LISTEN` | `0.0.0.0:8080` | Management API listen address |
 | `WANAKU_PERSIST_BACKEND` | _(unset)_ | Set to `"file"` to persist registry to disk |
 | `WANAKU_PERSIST_PATH` | `/data/registry` | Directory for `registry.json` |
+
 See [Configuration](./configuration.md) for the full list.
-
-## Common Gotchas
-
-### 1. "Address already in use" on startup
-
-Something else is using port 8081 or 8080. Check with:
-
-```bash
-lsof -ti :8081
-lsof -ti :8080
-```
-
-Kill the process, or change the management listen address via `WANAKU_MGMT_LISTEN`. The MCP listener address is defined in `server/src/default.yaml` — use a custom config file to override it.
-
-### 2. Changing `default.yaml` doesn't trigger rebuild
-
-Cargo doesn't track `include_str!` dependencies. After editing `server/src/default.yaml`, run:
-
-```bash
-touch server/src/lib.rs
-cargo build
-```
-
-### 3. Filter returns empty JSON-RPC response
-
-Check that:
-- The MCP filter has `on_invalid: continue` in `default.yaml`
-- You're sending valid JSON-RPC (must have `"jsonrpc": "2.0"`, `"method"`, and `"id"`)
-- The URL path matches a configured namespace (`/mcp` → `"default"`, `/{namespace}/mcp` → `"{namespace}"`)
-
-Enable trace logs to see what the filters are doing:
-
-```bash
-RUST_LOG=wanaku_filters=trace cargo run
-```
-
-### 4. Management API returns 404 for valid routes
-
-The management API uses Pingora's `ServeHttp` trait, not axum. Routes are dispatched via a guard pattern in `server/src/management/mod.rs`. If you added a new route but forgot to register it in the dispatcher, it 404s.
-
-Check the route enum in `routes.rs` and the `dispatch` function in `mod.rs`.
-
-## Troubleshooting
-
-**Server crashes with "thread 'main' panicked":**
-
-Wanaku denies `unsafe_code`, `unwrap_used`, `expect_used`, and `panic` at the crate level. A panic means a logic bug. File an issue with the stack trace and steps to reproduce.
-
-**Tool calls time out:**
-
-MCP forward calls have a connection timeout. If your upstream MCP server takes too long, verify it's reachable and responding.
-
-**Tools don't appear in `/mcp` but show up in `/api/v1/tools`:**
-
-Check the namespace. Tools registered with `namespace: "finance"` only appear in `/finance/mcp`, not `/mcp`.
-
-**LLM-based features (chat) don't work:**
-
-Verify:
-- The LLM endpoint is reachable (`curl http://localhost:11434/v1/models`)
-- Environment variables are set correctly
-- The feature is configured via the management API or `wanaku.yaml`
 
 ## Where to Go Next
 
 - **[Architecture](./architecture.md)** — understand the filter pipeline, registry, and routing
 - **[Configuration](./configuration.md)** — all env vars, YAML options, and config patterns
+- **[Authentication](./auth.md)** — set up oauth2-proxy with Keycloak
 - **[Features](./features.md)** — enable chat and create custom features
 - **[Management API](./management-api.md)** — full REST API reference
-- **[Admin UI](./admin-ui.md)** — customize the embedded React admin interface
+- **[FAQ](./faq.md)** — common issues and troubleshooting
 
 You now have a running MCP server. The rest is about configuring it to match your environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,18 +24,20 @@ All in a single binary with no runtime dependencies (except libc).
 
 ### Getting Started
 
-- **[Getting Started](./getting-started.md)** — install, build, run your first MCP server
+- **[Getting Started](./getting-started.md)** — download, install, and run your first MCP server
 - **[Configuration](./configuration.md)** — all environment variables and YAML config options
+- **[Authentication](./auth.md)** — set up oauth2-proxy with Keycloak
 - **[Management API](./management-api.md)** — REST API reference for tools, resources, etc.
+- **[FAQ](./faq.md)** — common issues and troubleshooting
 
 ### Understanding the System
 
 - **[Architecture](./architecture.md)** — filter pipeline, registry, tool routing, deployment patterns
 - **[Features](./features.md)** — LLM chat and how to create custom features
 
-### Extending and Customizing
+### Contributing
 
-- **[Admin UI](./admin-ui.md)** — React + Carbon Design System frontend development
+- **[Admin UI Development](./contributing-admin-ui.md)** — React + Carbon Design System frontend development
 
 ## Who This Is For
 
@@ -118,10 +120,10 @@ Features are Rust crates that implement the `Feature` trait. They can:
 
 ### Run Locally
 
+Download `wanaku-server` from the [early access release page](https://github.com/wanaku-ai/wanaku/releases/tag/early-access), then:
+
 ```bash
-git clone https://github.com/wanaku-ai/wanaku.git
-cd wanaku
-cargo run --release
+wanaku-server
 ```
 
 Server starts on:
@@ -132,20 +134,13 @@ Server starts on:
 
 Tools, resources, and prompts are obtained by registering a forwarded MCP server. When you register a forward, Wanaku auto-discovers all tools from the upstream server.
 
-```bash
-curl -X POST http://localhost:8080/api/v1/forwards \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "echo-server",
-    "address": "http://echo-mcp:8080/mcp"
-  }'
-```
-
-This automatically discovers and registers all tools exposed by the upstream MCP server. To refresh the tool list after the upstream server changes, use the refresh endpoint:
+Using the [Wanaku CLI](https://github.com/wanaku-ai/wanaku-barn/releases/tag/early-access):
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/forwards/echo-server/refreshes
+wanaku forwards add --service="http://echo-mcp:8080/mcp" --name echo-server --no-auth
 ```
+
+This automatically discovers and registers all tools exposed by the upstream MCP server.
 
 ### Deploy to Kubernetes
 
@@ -220,20 +215,13 @@ The binary is a single statically-linked executable with low memory footprint.
 Enable trace logs:
 
 ```bash
-RUST_LOG=trace cargo run
+RUST_LOG=trace wanaku-server
 ```
 
 Check what filters see:
 
 ```bash
-RUST_LOG=wanaku_filters=trace cargo run
-```
-
-Verify environment variables:
-
-```rust
-// Add to main.rs
-println!("WANAKU_MGMT_LISTEN: {:?}", wanaku_apis::config::ENV.mgmt_listen);
+RUST_LOG=wanaku_filters=trace wanaku-server
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

- **Getting Started**: rewritten for end users — points to [early-access releases](https://github.com/wanaku-ai/wanaku/releases/tag/early-access) instead of building from source, uses `wanaku-server` command, replaces `curl` commands with Wanaku CLI (`wanaku tools list`, `wanaku forwards add`, etc.)
- **Authentication** (`docs/auth.md`): new user-facing doc extracted from `deploy/auth/README.md` — shows direct `oauth2-proxy` commands instead of docker-compose
- **FAQ** (`docs/faq.md`): consolidates Common Gotchas and Troubleshooting from getting-started.md
- **Configuration**: cleaned up developer-only content (`include_str!` rebuild gotcha, Dockerfile example, `cargo` commands)
- **Admin UI**: renamed to `contributing-admin-ui.md` to clearly mark it as contributor documentation
- Updated cross-references in `index.md`, `architecture.md`, and `CONTRIBUTING.md`

## Motivation

The documentation was mixing developer/contributor content with user-facing content. Users were told to build from source instead of downloading releases, and had to use `curl` instead of the Wanaku CLI. This cleanup separates the two audiences and makes the docs actionable for end users.

## Test plan

- [ ] Verify all internal doc links resolve correctly
- [ ] Verify early-access release URLs are valid
- [ ] Verify CLI commands match wanaku-barn CLI conventions (`--no-auth`, `--host`, `--token`)

## Summary by Sourcery

Separate end-user and contributor documentation while making installation, authentication, CLI usage, and troubleshooting guides more actionable.

New Features:
- Add user-facing authentication documentation covering oauth2-proxy, Keycloak, role-based access, and CLI usage.
- Add a consolidated FAQ and troubleshooting guide for common runtime, CLI, authentication, and persistence issues.

Enhancements:
- Refocus getting-started and configuration documentation on installing released binaries and using the Wanaku CLI rather than building from source or calling APIs directly.
- Separate contributor-oriented Admin UI documentation from end-user documentation and update documentation navigation and cross-references.

Documentation:
- Reorganize the documentation structure to clearly distinguish user-facing guides from contributor documentation.