### PR TITLE
chore: harden namespace validation and simplify to path-only model

### DIFF
--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -125,17 +125,44 @@ pub struct ForwardEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct NamespaceEntry {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    #[serde(alias = "path")]
     pub name: String,
-    #[serde(default)]
-    pub path: String,
     #[serde(default)]
     pub labels: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "authRequired", alias = "auth_required")]
     pub auth_required: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audience: Option<String>,
+}
+
+/// Validates that a namespace name follows DNS-label conventions:
+/// lowercase alphanumeric and hyphens, 1-63 chars, must start and end
+/// with an alphanumeric character. The name doubles as the URL path
+/// segment and unique identifier.
+pub fn validate_namespace_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("namespace name must not be empty".to_owned());
+    }
+
+    if name.len() > 63 {
+        return Err(format!(
+            "namespace name must be at most 63 characters, got {}",
+            name.len()
+        ));
+    }
+
+    if !name.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+        return Err(
+            "namespace name must contain only lowercase alphanumeric characters and hyphens"
+                .to_owned(),
+        );
+    }
+
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err("namespace name must not start or end with a hyphen".to_owned());
+    }
+
+    Ok(())
 }
 
 pub const MCP_FORWARD_TYPE: &str = "mcp-forward";
@@ -226,9 +253,9 @@ pub trait PromptRegistry: Send + Sync {
 
 pub trait NamespaceRegistry: Send + Sync {
     fn list_namespaces(&self) -> Vec<NamespaceEntry>;
-    fn get_namespace(&self, name: &str) -> Option<NamespaceEntry>;
+    fn get_namespace(&self, path: &str) -> Option<NamespaceEntry>;
     fn register_namespace(&self, namespace: NamespaceEntry);
-    fn remove_namespace(&self, name: &str) -> bool;
+    fn remove_namespace(&self, path: &str) -> bool;
 }
 
 pub trait ForwardRegistry: Send + Sync {
@@ -255,9 +282,7 @@ impl InMemoryRegistry {
         namespaces.insert(
             DEFAULT_NAMESPACE.to_owned(),
             NamespaceEntry {
-                id: Some(DEFAULT_NAMESPACE.to_owned()),
                 name: DEFAULT_NAMESPACE.to_owned(),
-                path: DEFAULT_NAMESPACE.to_owned(),
                 labels: HashMap::new(),
                 auth_required: None,
                 audience: None,
@@ -326,10 +351,7 @@ impl InMemoryRegistry {
         for forward in snapshot.forwards {
             self.forwards.insert(forward.name.clone(), forward);
         }
-        for mut namespace in snapshot.namespaces {
-            if namespace.id.is_none() {
-                namespace.id = Some(namespace.name.clone());
-            }
+        for namespace in snapshot.namespaces {
             self.namespaces.insert(namespace.name.clone(), namespace);
         }
 
@@ -560,10 +582,7 @@ impl NamespaceRegistry for InMemoryRegistry {
         self.namespaces.get(name).map(|entry| entry.value().clone())
     }
 
-    fn register_namespace(&self, mut namespace: NamespaceEntry) {
-        if namespace.id.is_none() {
-            namespace.id = Some(namespace.name.clone());
-        }
+    fn register_namespace(&self, namespace: NamespaceEntry) {
         self.namespaces.insert(namespace.name.clone(), namespace);
         self.persist();
     }
@@ -920,5 +939,57 @@ mod tests {
         assert_eq!(entry.name, "legacy");
         assert!(entry.server_info.is_none());
         assert!(entry.labels.is_empty());
+    }
+
+    #[test]
+    fn validate_namespace_name_valid() {
+        assert!(validate_namespace_name("finance").is_ok());
+        assert!(validate_namespace_name("my-ns").is_ok());
+        assert!(validate_namespace_name("team-42").is_ok());
+        assert!(validate_namespace_name("a").is_ok());
+        assert!(validate_namespace_name("default").is_ok());
+    }
+
+    #[test]
+    fn validate_namespace_name_empty() {
+        assert!(validate_namespace_name("").is_err());
+    }
+
+    #[test]
+    fn validate_namespace_name_too_long() {
+        let long = "a".repeat(64);
+        assert!(validate_namespace_name(&long).is_err());
+        let max = "a".repeat(63);
+        assert!(validate_namespace_name(&max).is_ok());
+    }
+
+    #[test]
+    fn validate_namespace_name_invalid_chars() {
+        assert!(validate_namespace_name("Finance").is_err());
+        assert!(validate_namespace_name("my ns").is_err());
+        assert!(validate_namespace_name("my_ns").is_err());
+        assert!(validate_namespace_name("a.b").is_err());
+        assert!(validate_namespace_name("ns!").is_err());
+    }
+
+    #[test]
+    fn validate_namespace_name_leading_trailing_hyphen() {
+        assert!(validate_namespace_name("-start").is_err());
+        assert!(validate_namespace_name("end-").is_err());
+        assert!(validate_namespace_name("-both-").is_err());
+    }
+
+    #[test]
+    fn namespace_backward_compat_path_alias() {
+        let json = r#"{"path": "finance"}"#;
+        let ns: NamespaceEntry = serde_json::from_str(json).expect("should deserialize with path alias");
+        assert_eq!(ns.name, "finance");
+    }
+
+    #[test]
+    fn namespace_name_field() {
+        let json = r#"{"name": "finance"}"#;
+        let ns: NamespaceEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(ns.name, "finance");
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ wanaku-server
 ```
 
 You should see log output indicating two services started:
-- **MCP endpoint:** `http://127.0.0.1:8081/mcp`
+- **MCP endpoint:** `http://127.0.0.1:8081/default/mcp` (default namespace)
 - **Management API:** `http://0.0.0.0:8080/api/v1`
 
 ### 4. Verify It's Alive
@@ -103,20 +103,20 @@ You'll see the tools discovered from the upstream server. The server is now read
 Send an MCP `tools/list` request:
 
 ```bash
-curl -X POST http://localhost:8081/mcp \
+curl -X POST http://localhost:8081/default/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 ```
 
-You'll get a JSON-RPC response listing the tools discovered from your forward. The filter pipeline parsed your request, checked the namespace (defaulted to `"default"`), and returned the tools from the registry.
+You'll get a JSON-RPC response listing the tools discovered from your forward. The filter pipeline parsed your request, extracted the namespace from the URL path, and returned the tools from the registry.
 
 ## What Just Happened?
 
-When you hit `/mcp`, your request flowed through this pipeline:
+When you hit `/default/mcp`, your request flowed through this pipeline:
 
 1. **CORS filter** — added CORS headers
 2. **MCP filter (praxis-ai)** — parsed JSON-RPC, set metadata (`mcp.method = "tools/list"`)
-3. **Namespace filter** — extracted namespace from URL path (default: `"default"`)
+3. **Namespace filter** — extracted namespace `"default"` from URL path
 4. **Tool list filter** — queried the registry for tools in the `"default"` namespace
 5. **Static response** — synthetic JSON-RPC reply
 
@@ -158,7 +158,7 @@ curl -X POST http://localhost:8081/finance/mcp \
 
 Only tools from the `market-data-server` forward appear. The default namespace tools are invisible here.
 
-Note: the MCP endpoint path must include `/mcp` — bare namespace paths like `/finance` (without `/mcp`) are rejected.
+All MCP endpoints follow the `/{namespace}/mcp` pattern — there is no shortcut. Bare paths like `/finance` or `/mcp` are rejected.
 
 ### Use the Admin UI
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,9 +130,21 @@ To discover tools from additional MCP servers, register more forwards the same w
 
 ### Explore Namespaces
 
-Namespaces isolate tools. Create a `"finance"` namespace and register a forward that assigns discovered tools to it:
+Namespaces isolate tools and resources. Each namespace is identified by a **name** that doubles as its URL path segment.
+
+**Namespace naming rules:**
+- Lowercase letters, numbers, and hyphens only
+- Must start and end with a letter or number
+- 1 to 63 characters long
+- Examples: `finance`, `my-team`, `staging-42`
+
+Create a `"finance"` namespace and register a forward that assigns discovered tools to it:
 
 ```bash
+curl -X POST http://localhost:8080/api/v1/namespaces \
+  -H "Content-Type: application/json" \
+  -d '{"name": "finance"}'
+
 wanaku forwards add --service="http://market-data-mcp:8080/mcp" --name market-data-server --no-auth
 ```
 
@@ -145,6 +157,8 @@ curl -X POST http://localhost:8081/finance/mcp \
 ```
 
 Only tools from the `market-data-server` forward appear. The default namespace tools are invisible here.
+
+Note: the MCP endpoint path must include `/mcp` — bare namespace paths like `/finance` (without `/mcp`) are rejected.
 
 ### Use the Admin UI
 

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -6,44 +6,59 @@ pub use wanaku_apis::NAMESPACE_METADATA_KEY;
 
 crate::body_filter_boilerplate!(NamespaceFilter, "wanaku_namespace");
 
-fn extract_namespace(path: &str) -> &str {
+fn extract_namespace(path: &str) -> Option<&str> {
     let trimmed = path
         .strip_prefix('/')
         .unwrap_or(path)
         .trim_end_matches('/');
 
     if trimmed == "mcp" || trimmed.is_empty() {
-        return DEFAULT_NAMESPACE;
+        return Some(DEFAULT_NAMESPACE);
     }
 
     // /{namespace}/mcp
     if let Some(ns) = trimmed.strip_suffix("/mcp")
         && !ns.is_empty() && !ns.contains('/') {
-            return ns;
+            return Some(ns);
         }
 
     // /mcp/{namespace}
     if let Some(ns) = trimmed.strip_prefix("mcp/")
         && !ns.is_empty() && !ns.contains('/') {
-            return ns;
+            return Some(ns);
         }
 
-    DEFAULT_NAMESPACE
+    None
 }
 
 impl NamespaceFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        _body: &mut Option<Bytes>,
+        body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let path = ctx.request.uri.path();
-        let namespace = extract_namespace(path);
 
-        tracing::debug!(namespace = %namespace, path = %path, "resolved namespace from path");
-        ctx.set_metadata(NAMESPACE_METADATA_KEY, namespace);
-
-        Ok(FilterAction::Continue)
+        match extract_namespace(path) {
+            Some(namespace) => {
+                tracing::debug!(namespace = %namespace, path = %path, "resolved namespace from path");
+                ctx.set_metadata(NAMESPACE_METADATA_KEY, namespace);
+                Ok(FilterAction::Continue)
+            }
+            None => {
+                if ctx.get_metadata(crate::MCP_METHOD_KEY).is_some() {
+                    tracing::warn!(path = %path, "rejected MCP request on invalid path");
+                    let id = crate::response::extract_json_rpc_id(body);
+                    Ok(crate::response::json_rpc_error(
+                        &id,
+                        crate::response::JSONRPC_INVALID_REQUEST,
+                        "invalid MCP endpoint path: use /mcp, /{namespace}/mcp, or /mcp/{namespace}",
+                    ))
+                } else {
+                    Ok(FilterAction::Continue)
+                }
+            }
+        }
     }
 }
 
@@ -53,56 +68,66 @@ mod tests {
 
     #[test]
     fn root_mcp_is_default() {
-        assert_eq!(extract_namespace("/mcp"), "default");
+        assert_eq!(extract_namespace("/mcp"), Some("default"));
     }
 
     #[test]
     fn namespace_from_path() {
-        assert_eq!(extract_namespace("/finance/mcp"), "finance");
+        assert_eq!(extract_namespace("/finance/mcp"), Some("finance"));
     }
 
     #[test]
     fn another_namespace() {
-        assert_eq!(extract_namespace("/engineering/mcp"), "engineering");
+        assert_eq!(extract_namespace("/engineering/mcp"), Some("engineering"));
     }
 
     #[test]
-    fn nested_path_is_default() {
-        assert_eq!(extract_namespace("/a/b/mcp"), "default");
+    fn nested_path_is_none() {
+        assert_eq!(extract_namespace("/a/b/mcp"), None);
     }
 
     #[test]
-    fn no_mcp_suffix_is_default() {
-        assert_eq!(extract_namespace("/finance/other"), "default");
+    fn no_mcp_suffix_is_none() {
+        assert_eq!(extract_namespace("/finance/other"), None);
     }
 
     #[test]
     fn empty_path_is_default() {
-        assert_eq!(extract_namespace("/"), "default");
+        assert_eq!(extract_namespace("/"), Some("default"));
     }
 
     #[test]
     fn mcp_prefix_namespace() {
-        assert_eq!(extract_namespace("/mcp/test-ns"), "test-ns");
+        assert_eq!(extract_namespace("/mcp/test-ns"), Some("test-ns"));
     }
 
     #[test]
     fn mcp_prefix_another() {
-        assert_eq!(extract_namespace("/mcp/finance"), "finance");
+        assert_eq!(extract_namespace("/mcp/finance"), Some("finance"));
     }
 
     #[test]
-    fn mcp_prefix_nested_is_default() {
-        assert_eq!(extract_namespace("/mcp/a/b"), "default");
+    fn mcp_prefix_nested_is_none() {
+        assert_eq!(extract_namespace("/mcp/a/b"), None);
     }
 
     #[test]
     fn trailing_slash_namespace_mcp() {
-        assert_eq!(extract_namespace("/test-ns2/mcp/"), "test-ns2");
+        assert_eq!(extract_namespace("/test-ns2/mcp/"), Some("test-ns2"));
     }
 
     #[test]
     fn trailing_slash_mcp_namespace() {
-        assert_eq!(extract_namespace("/mcp/test-ns2/"), "test-ns2");
+        assert_eq!(extract_namespace("/mcp/test-ns2/"), Some("test-ns2"));
+    }
+
+    #[test]
+    fn bare_namespace_is_none() {
+        assert_eq!(extract_namespace("/finance"), None);
+    }
+
+    #[test]
+    fn bare_namespace_with_trailing_slash_is_none() {
+        assert_eq!(extract_namespace("/finance/"), None);
     }
 }

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
-use wanaku_apis::registry::DEFAULT_NAMESPACE;
 
 pub use wanaku_apis::NAMESPACE_METADATA_KEY;
 
@@ -12,17 +11,13 @@ fn extract_namespace(path: &str) -> Option<&str> {
         .unwrap_or(path)
         .trim_end_matches('/');
 
-    if trimmed == "mcp" || trimmed.is_empty() {
-        return Some(DEFAULT_NAMESPACE);
-    }
-
-    // /{namespace}/mcp
+    // /{namespace}/mcp — the canonical format
     if let Some(ns) = trimmed.strip_suffix("/mcp")
         && !ns.is_empty() && !ns.contains('/') {
             return Some(ns);
         }
 
-    // /mcp/{namespace}
+    // /mcp/{namespace} — alternate format
     if let Some(ns) = trimmed.strip_prefix("mcp/")
         && !ns.is_empty() && !ns.contains('/') {
             return Some(ns);
@@ -67,8 +62,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn root_mcp_is_default() {
-        assert_eq!(extract_namespace("/mcp"), Some("default"));
+    fn bare_mcp_is_none() {
+        assert_eq!(extract_namespace("/mcp"), None);
+    }
+
+    #[test]
+    fn default_namespace_explicit() {
+        assert_eq!(extract_namespace("/default/mcp"), Some("default"));
     }
 
     #[test]
@@ -92,8 +92,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_path_is_default() {
-        assert_eq!(extract_namespace("/"), Some("default"));
+    fn empty_path_is_none() {
+        assert_eq!(extract_namespace("/"), None);
     }
 
     #[test]
@@ -102,8 +102,8 @@ mod tests {
     }
 
     #[test]
-    fn mcp_prefix_another() {
-        assert_eq!(extract_namespace("/mcp/finance"), Some("finance"));
+    fn mcp_prefix_default() {
+        assert_eq!(extract_namespace("/mcp/default"), Some("default"));
     }
 
     #[test]

--- a/filters/src/response.rs
+++ b/filters/src/response.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use http::StatusCode;
 use praxis_filter::Rejection;
 
+pub const JSONRPC_INVALID_REQUEST: i32 = -32600;
 pub const JSONRPC_INVALID_PARAMS: i32 = -32602;
 pub const JSONRPC_INTERNAL_ERROR: i32 = -32603;
 

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -155,6 +155,11 @@ pub(super) fn handle_namespace_create(registry: &InMemoryRegistry, body: &str) -
         }
     };
 
+    if let Err(reason) = wanaku_apis::registry::validate_namespace_name(&namespace.name) {
+        warn!(name = %namespace.name, reason = %reason, "namespace name validation failed");
+        return json_err(StatusCode::BAD_REQUEST, &reason);
+    }
+
     let name = namespace.name.clone();
     registry.register_namespace(namespace);
     info!(namespace = %name, "registered namespace via management API");
@@ -174,7 +179,6 @@ pub(super) fn handle_namespace_update(registry: &InMemoryRegistry, path_name: &s
     };
 
     namespace.name = path_name.to_owned();
-    namespace.id = None;
     registry.register_namespace(namespace);
     info!(namespace = %path_name, "updated namespace via management API");
     match registry.get_namespace(path_name) {
@@ -1076,7 +1080,7 @@ mod tests {
     #[test]
     fn namespace_create_and_get_roundtrip() {
         let registry = InMemoryRegistry::new();
-        let body = r#"{"name":"finance","path":"/finance"}"#;
+        let body = r#"{"name":"finance"}"#;
 
         assert_eq!(handle_namespace_create(&registry, body).status(), 200);
 
@@ -1085,25 +1089,39 @@ mod tests {
 
         let data = data_field(&get_resp);
         assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("finance"));
-        assert_eq!(data.get("path").and_then(|v| v.as_str()), Some("/finance"));
-        assert_eq!(data.get("id").and_then(|v| v.as_str()), Some("finance"));
     }
 
     #[test]
-    fn namespace_update_uses_path_parameter_for_name() {
+    fn namespace_create_with_legacy_path_field() {
         let registry = InMemoryRegistry::new();
-        handle_namespace_create(&registry, r#"{"name":"original","path":"/orig"}"#);
+        let body = r#"{"path":"finance"}"#;
 
-        let update_body = r#"{"name":"ignored","path":"/updated"}"#;
+        assert_eq!(handle_namespace_create(&registry, body).status(), 200);
+
+        let get_resp = handle_namespace_get(&registry, "finance");
+        assert_eq!(get_resp.status(), 200);
+    }
+
+    #[test]
+    fn namespace_create_validates_name() {
+        let registry = InMemoryRegistry::new();
+        assert_eq!(handle_namespace_create(&registry, r#"{"name":"Bad Name"}"#).status(), 400);
+        assert_eq!(handle_namespace_create(&registry, r#"{"name":"-leading"}"#).status(), 400);
+        assert_eq!(handle_namespace_create(&registry, r#"{"name":"trailing-"}"#).status(), 400);
+        assert_eq!(handle_namespace_create(&registry, r#"{"name":""}"#).status(), 400);
+    }
+
+    #[test]
+    fn namespace_update_uses_url_parameter() {
+        let registry = InMemoryRegistry::new();
+        handle_namespace_create(&registry, r#"{"name":"original"}"#);
+
+        let update_body = r#"{"name":"ignored"}"#;
         let resp = handle_namespace_update(&registry, "original", update_body);
         assert_eq!(resp.status(), 200);
 
         let data = data_field(&handle_namespace_get(&registry, "original"));
-        assert_eq!(data.get("path").and_then(|v| v.as_str()), Some("/updated"));
-        assert_eq!(
-            data.get("name").and_then(|v| v.as_str()),
-            Some("original")
-        );
+        assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("original"));
     }
 
     #[test]
@@ -1116,7 +1134,7 @@ mod tests {
             Some(1)
         );
 
-        handle_namespace_create(&registry, r#"{"name":"ns1","path":"/ns1"}"#);
+        handle_namespace_create(&registry, r#"{"name":"ns1"}"#);
         assert_eq!(
             data_field(&handle_namespace_list(&registry))
                 .as_array()
@@ -1134,7 +1152,7 @@ mod tests {
     #[test]
     fn namespace_delete_existing() {
         let registry = InMemoryRegistry::new();
-        handle_namespace_create(&registry, r#"{"name":"del-ns","path":"/"}"#);
+        handle_namespace_create(&registry, r#"{"name":"del-ns"}"#);
         assert_eq!(handle_namespace_delete(&registry, "del-ns").status(), 200);
         assert_eq!(handle_namespace_get(&registry, "del-ns").status(), 404);
     }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -114,7 +114,10 @@ const fn get_namespace() {}
 
 #[utoipa::path(post, path = "/api/v1/namespaces", tag = "Namespaces",
     request_body = NamespaceEntry,
-    responses((status = 200, description = "Namespace registered", body = NamespaceEntry))
+    responses(
+        (status = 200, description = "Namespace registered", body = NamespaceEntry),
+        (status = 400, description = "Invalid namespace name"),
+    )
 )]
 const fn create_namespace() {}
 

--- a/tests/e2e/ui/helpers/api-helpers.ts
+++ b/tests/e2e/ui/helpers/api-helpers.ts
@@ -56,4 +56,15 @@ export class ApiHelper {
   async deleteForward(name: string) {
     return this.request.delete(`${this.baseUrl}/api/v1/forwards/${name}`);
   }
+
+  async addNamespace(namespace: { name: string }) {
+    const resp = await this.request.post(`${this.baseUrl}/api/v1/namespaces`, {
+      data: { name: namespace.name },
+    });
+    return this.assertOk(resp, `addNamespace(${namespace.name})`);
+  }
+
+  async deleteNamespace(name: string) {
+    return this.request.delete(`${this.baseUrl}/api/v1/namespaces/${name}`);
+  }
 }

--- a/tests/e2e/ui/helpers/test-data.ts
+++ b/tests/e2e/ui/helpers/test-data.ts
@@ -33,3 +33,9 @@ export function forwardData(overrides?: Partial<{ name: string; address: string 
     address: overrides?.address ?? 'http://localhost:19999/mcp',
   };
 }
+
+export function namespaceData(overrides?: Partial<{ name: string }>) {
+  return {
+    name: overrides?.name ?? `e2e-ns-${suffix()}`,
+  };
+}

--- a/tests/e2e/ui/pages/namespaces.page.ts
+++ b/tests/e2e/ui/pages/namespaces.page.ts
@@ -1,0 +1,43 @@
+import { type Page, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+import { Carbon } from '../helpers/carbon';
+
+export class NamespacesPage extends BasePage {
+  constructor(page: Page, baseUrl: string) {
+    super(page, baseUrl);
+  }
+
+  async goto() {
+    await this.navigateTo('/namespaces');
+  }
+
+  async clickAddNamespace() {
+    await this.page.locator(Carbon.buttonWithText('Create Namespace')).click();
+    await this.modal().waitFor({ state: 'visible' });
+  }
+
+  async fillNamespaceForm(name: string) {
+    await this.page.locator(Carbon.textInput('namespace-name')).fill(name);
+  }
+
+  async isSubmitDisabled(): Promise<boolean> {
+    const btn = this.modal().locator(Carbon.modalFooterPrimary);
+    return btn.isDisabled();
+  }
+
+  async clickDeleteNamespace(name: string) {
+    await this.rowWithText(name).getByRole('button', { name: 'Delete' }).click();
+  }
+
+  async waitForNamespaceInTable(name: string) {
+    await expect(this.rowWithText(name)).toBeVisible({ timeout: 5_000 });
+  }
+
+  async waitForNamespaceRemoved(name: string) {
+    await expect(this.rowWithText(name)).toBeHidden({ timeout: 5_000 });
+  }
+
+  async getColumnHeaders(): Promise<string[]> {
+    return this.page.locator('th').allInnerTexts();
+  }
+}

--- a/tests/e2e/ui/tests/namespaces.spec.ts
+++ b/tests/e2e/ui/tests/namespaces.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+import { NamespacesPage } from '../pages/namespaces.page';
+import { ApiHelper } from '../helpers/api-helpers';
+import { namespaceData } from '../helpers/test-data';
+
+const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
+
+test.describe('Namespaces', () => {
+  let namespaces: NamespacesPage;
+  let api: ApiHelper;
+  const createdNamespaces: string[] = [];
+
+  test.beforeEach(async ({ page, request }) => {
+    namespaces = new NamespacesPage(page, `${routerUrl}/admin/`);
+    api = new ApiHelper(request, routerUrl);
+  });
+
+  test.afterEach(async () => {
+    for (const name of createdNamespaces) {
+      await api.deleteNamespace(name).catch(() => {});
+    }
+    createdNamespaces.length = 0;
+  });
+
+  test('displays page title', async () => {
+    await namespaces.goto();
+    const title = await namespaces.getPageTitle();
+    expect(title).toBe('Namespaces');
+  });
+
+  test('table has expected columns', async () => {
+    await namespaces.goto();
+    const headers = await namespaces.getColumnHeaders();
+    expect(headers.some(h => h.includes('Name'))).toBeTruthy();
+    expect(headers.some(h => h.includes('Status'))).toBeTruthy();
+    expect(headers.some(h => h.includes('Address'))).toBeTruthy();
+    expect(headers.some(h => h.includes('Actions'))).toBeTruthy();
+  });
+
+  test('default namespace is present', async () => {
+    await namespaces.goto();
+    await namespaces.waitForNamespaceInTable('default');
+  });
+
+  test('add a namespace via modal', async () => {
+    const data = namespaceData();
+    createdNamespaces.push(data.name);
+
+    await namespaces.goto();
+    await namespaces.clickAddNamespace();
+
+    const heading = await namespaces.getModalHeading();
+    expect(heading).toBe('Create Namespace');
+
+    await namespaces.fillNamespaceForm(data.name);
+    await namespaces.submitModal();
+
+    await namespaces.waitForNamespaceInTable(data.name);
+  });
+
+  test('modal rejects invalid namespace name', async () => {
+    await namespaces.goto();
+    await namespaces.clickAddNamespace();
+
+    await namespaces.fillNamespaceForm('Bad Name');
+    expect(await namespaces.isSubmitDisabled()).toBeTruthy();
+
+    await namespaces.fillNamespaceForm('-leading');
+    expect(await namespaces.isSubmitDisabled()).toBeTruthy();
+
+    await namespaces.cancelModal();
+  });
+
+  test('delete a namespace', async () => {
+    const data = namespaceData();
+    await api.addNamespace(data);
+
+    await namespaces.goto();
+    await namespaces.waitForNamespaceInTable(data.name);
+    await namespaces.clickDeleteNamespace(data.name);
+
+    await namespaces.waitForNamespaceRemoved(data.name);
+  });
+
+  test('address column shows MCP endpoint', async () => {
+    const data = namespaceData();
+    createdNamespaces.push(data.name);
+    await api.addNamespace(data);
+
+    await namespaces.goto();
+    await namespaces.waitForNamespaceInTable(data.name);
+
+    const row = namespaces.rowWithText(data.name);
+    const rowText = await row.innerText();
+    expect(rowText).toContain(`/${data.name}/mcp`);
+  });
+});

--- a/ui/admin/src/Pages/Namespaces/NamespaceModal.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespaceModal.tsx
@@ -16,27 +16,23 @@ export const NamespaceModal: React.FC<NamespaceModalProps> = ({
   onRequestClose,
 }) => {
   const [name, setName] = useState(openedNamespace?.name);
-  const [path, setPath] = useState(openedNamespace?.path);
   const [invalidName, setInvalidName] = useState(false)
-  const [invalidPath, setInvalidPath] = useState(false)
 
   function otherNamespaces(): Namespace[] {
-    return namespaces.filter(namespace => namespace.id !== openedNamespace?.id)
+    return namespaces.filter(namespace => namespace.name !== openedNamespace?.name)
   }
-  
-  function isInvalidName(name: string): boolean {
+
+  function isDuplicate(name: string): boolean {
     return otherNamespaces().some(namespace => namespace.name === name)
   }
-  
-  function isInvalidPath(path: string): boolean {
-    return otherNamespaces().some(namespace => namespace.path === path)
+
+  function isDnsLabelValid(name: string): boolean {
+    return /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(name);
   }
-  
+
   const handleSubmit = () => {
     onSubmit({
-      id: openedNamespace?.id,
       name: name,
-      path: path,
       labels: openedNamespace?.labels,
     });
   };
@@ -46,7 +42,7 @@ export const NamespaceModal: React.FC<NamespaceModalProps> = ({
       open={true}
       modalHeading={openedNamespace ? "Edit Namespace" : "Create Namespace"}
       primaryButtonText={openedNamespace ? "Save" : "Create"}
-      primaryButtonDisabled={invalidName || invalidPath}
+      primaryButtonDisabled={invalidName}
       secondaryButtonText="Cancel"
       onRequestSubmit={handleSubmit}
       onRequestClose={onRequestClose}
@@ -55,29 +51,19 @@ export const NamespaceModal: React.FC<NamespaceModalProps> = ({
         <TextInput
           id="namespace-name"
           labelText="Name"
-          placeholder="e.g. my-namespace"
-          helperText="A human-readable name for this namespace. Leave empty for a preallocated slot."
+          placeholder="e.g. finance, my-namespace"
+          helperText="Lowercase letters, numbers, and hyphens only. Must start and end with a letter or number (1-63 characters). The name is also the URL path segment."
           value={name}
           invalid={invalidName}
-          invalidText={`Invalid namespace name: ${name} is already in use.`}
+          invalidText={
+            name && !isDnsLabelValid(name)
+              ? "Must contain only lowercase letters, numbers, and hyphens, and must start and end with a letter or number"
+              : `Namespace "${name}" already exists.`
+          }
           onChange={(e) => {
-            const name = e.target.value
-            setName(name)
-            setInvalidName(isInvalidName(name))
-          }}
-        />
-        <TextInput
-          id="namespace-path"
-          labelText="Path"
-          placeholder="e.g. ns-0"
-          helperText="The physical path identifier for this namespace."
-          value={path}
-          invalid={invalidPath}
-          invalidText={`Invalid namespace path: ${path} is already in use.`}
-          onChange={(e) => {
-            const path = e.target.value
-            setPath(path)
-            setInvalidPath(isInvalidPath(path))
+            const val = e.target.value
+            setName(val)
+            setInvalidName(!isDnsLabelValid(val) || isDuplicate(val))
           }}
           disabled={!!openedNamespace}
         />

--- a/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
@@ -62,7 +62,7 @@ export const NamespacesPage: React.FC = () => {
       await refreshNamespaces();
     } catch {
       setIsModalOpen(false);
-      setErrorMessage("Error creating namespace. The name or path may already be in use.");
+      setErrorMessage("Error creating namespace. The path may already be in use or is invalid.");
     }
   };
 
@@ -80,11 +80,11 @@ export const NamespacesPage: React.FC = () => {
 
   const handleDelete = async (namespace: Namespace) => {
     try {
-      if (!namespace.id) return;
-      await removeNamespace(namespace.id);
+      if (!namespace.name) return;
+      await removeNamespace(namespace.name);
       await refreshNamespaces();
     } catch {
-      setErrorMessage(`Failed to delete namespace: ${namespace.name || namespace.path}`);
+      setErrorMessage(`Failed to delete namespace: ${namespace.path}`);
     }
   };
 
@@ -102,9 +102,8 @@ export const NamespacesPage: React.FC = () => {
       )}
       <h1 className="title">Namespaces</h1>
       <p className="description">
-        Namespaces help organize and isolate tools and resources, preventing LLM context bloat and improving deployment efficiency.
-        Wanaku provides up to 10 namespace slots (ns-0 to ns-9) plus a default namespace for general use.
-        Each namespace acts as a separate logical container to ensure tools don't interfere with each other.
+        Namespaces help organize and isolate tools and resources, preventing LLM context bloat.
+        Each namespace acts as a separate container accessible via its own MCP endpoint path.
       </p>
       <div id="page-content">
         <NamespaceTable

--- a/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
@@ -54,13 +54,23 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
   const headers = [
     { key: "name", header: "Name" },
     { key: "status", header: "Status" },
+    { key: "address", header: "Address" },
     { key: "actions", header: "Actions" },
   ];
+
+  function mcpAddress(name?: string): string {
+    const host = window.location.hostname;
+    const protocol = window.location.protocol;
+    const base = `${protocol}//${host}:8081`;
+    if (!name || name === "default") return `${base}/mcp`;
+    return `${base}/${name}/mcp`;
+  }
 
   const rows = namespaces.map((namespace, index) => ({
     id: namespace.name || `namespace-${index}`,
     name: namespace.name || "N/A",
     status: namespace.name ? "Allocated" : "Available",
+    address: mcpAddress(namespace.name),
     actions: "",
   }));
 
@@ -105,6 +115,7 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
                   <React.Fragment>
                     <TableCell>{namespace.name || "N/A"}</TableCell>
                     <TableCell>{namespace.name ? "Allocated" : "Available"}</TableCell>
+                    <TableCell>{mcpAddress(namespace.name)}</TableCell>
                     <TableCell>
                       <Button
                         kind="ghost"

--- a/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
@@ -28,7 +28,7 @@ interface NamespaceTableProps {
 }
 
 function isProtected(namespace: Namespace): boolean {
-  return PROTECTED_PATHS.includes(namespace.path || "") || PROTECTED_PATHS.includes(namespace.name || "");
+  return PROTECTED_PATHS.includes(namespace.name || "");
 }
 
 function hasLabels(namespace: Namespace): boolean {
@@ -52,18 +52,14 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
   onDelete,
 }) => {
   const headers = [
-    { key: "namespaceid", header: "ID" },
     { key: "name", header: "Name" },
-    { key: "path", header: "Path" },
     { key: "status", header: "Status" },
     { key: "actions", header: "Actions" },
   ];
 
   const rows = namespaces.map((namespace, index) => ({
-    id: namespace.id || `namespace-${index}`,
-    namespaceid: namespace.id || "N/A",
+    id: namespace.name || `namespace-${index}`,
     name: namespace.name || "N/A",
-    path: namespace.path || "N/A",
     status: namespace.name ? "Allocated" : "Available",
     actions: "",
   }));
@@ -100,16 +96,14 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
             </TableHead>
             <TableBody>
               {rows.map((row) => {
-                const namespace = namespaces.find((ns) => ns.id === row.id);
+                const namespace = namespaces.find((ns) => ns.name === row.id);
                 if (!namespace) return null;
                 const expandable = hasLabels(namespace);
                 const nsProtected = isProtected(namespace);
 
                 const cells = (
                   <React.Fragment>
-                    <TableCell>{namespace.id || "N/A"}</TableCell>
                     <TableCell>{namespace.name || "N/A"}</TableCell>
-                    <TableCell>{namespace.path || "N/A"}</TableCell>
                     <TableCell>{namespace.name ? "Allocated" : "Available"}</TableCell>
                     <TableCell>
                       <Button
@@ -134,7 +128,7 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
 
                 if (expandable) {
                   return (
-                    <React.Fragment key={namespace.id}>
+                    <React.Fragment key={namespace.name}>
                       <TableExpandRow expandIconDescription="Show labels" {...getRowProps({ row })}>
                         {cells}
                       </TableExpandRow>
@@ -155,7 +149,7 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
                 }
 
                 return (
-                  <TableRow {...getRowProps({ row })} key={namespace.id}>
+                  <TableRow {...getRowProps({ row })} key={namespace.name}>
                     <TableCell />
                     {cells}
                   </TableRow>

--- a/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespacesTable.tsx
@@ -62,8 +62,7 @@ export const NamespaceTable: React.FC<NamespaceTableProps> = ({
     const host = window.location.hostname;
     const protocol = window.location.protocol;
     const base = `${protocol}//${host}:8081`;
-    if (!name || name === "default") return `${base}/mcp`;
-    return `${base}/${name}/mcp`;
+    return `${base}/${name || "default"}/mcp`;
   }
 
   const rows = namespaces.map((namespace, index) => ({

--- a/ui/admin/src/Pages/Namespaces/namespaces.ts
+++ b/ui/admin/src/Pages/Namespaces/namespaces.ts
@@ -3,22 +3,11 @@ import {Namespace} from "../../models"
 export function sortedNamespaces(namespaces: readonly Namespace[]): Namespace[] {
   const result = [...namespaces]
   result.sort((a, b) => {
-    // First is default namespace
-    if (a.path === "default") {
-      return -1
-    }
-    if (b.path === "default") {
-      return 1
-    }
-    // Second is public namespace
-    if (a.path === "public") {
-      return -1
-    }
-    if (b.path === "public") {
-      return 1
-    }
-    // Rest are sorte
-    return a.path!.localeCompare(b.path!)
+    if (a.name === "default") return -1
+    if (b.name === "default") return 1
+    if (a.name === "public") return -1
+    if (b.name === "public") return 1
+    return (a.name ?? "").localeCompare(b.name ?? "")
   })
   return result
 }

--- a/ui/admin/src/hooks/api/use-namespaces.ts
+++ b/ui/admin/src/hooks/api/use-namespaces.ts
@@ -34,11 +34,11 @@ export const useNamespaces = () => {
 
   const updateNamespace = useCallback(
     (namespace: Namespace, options?: RequestInit): Promise<putApiV1NamespacesIdResponse> => {
-      if (!namespace.id) {
-        throw new Error("Namespace ID is required for update");
+      if (!namespace.name) {
+        throw new Error("Namespace name is required for update");
       }
       clearNamespacesCache();
-      return putApiV1NamespacesId(namespace.id, namespace, options);
+      return putApiV1NamespacesId(namespace.name, namespace, options);
     },
     []
   );
@@ -87,14 +87,14 @@ export const clearNamespacesCache = () => {
   namespacesCache = null;
 };
 
-export const getNamespacePathById = (id?: string): string => {
-  if (!id) {
+export const getNamespacePathById = (name?: string): string => {
+  if (!name) {
     return "default"
   }
   if (namespacesCache) {
     const data = namespacesCache.data.data.data as Namespace[]
-    const found = data.find(namespace => namespace.id === id)?.path
+    const found = data.find(namespace => namespace.name === name)?.name
     if (found) return found
   }
-  return id;
+  return name;
 }


### PR DESCRIPTION
## Summary

- Bare namespace paths like `/finance` (without `/mcp`) were silently routed to the default namespace, causing confusion
- Changed `extract_namespace` to return `Option<&str>`, returning `None` for invalid paths instead of defaulting to `"default"`
- The namespace filter now rejects with a JSON-RPC `-32600` (Invalid Request) error when a path is invalid and the request is an MCP request (`mcp.method` metadata is set)
- Non-MCP traffic (OAuth endpoints like `/authorize`, `/token`, well-known OIDC paths) passes through unaffected since those don't have `mcp.method` set

## Test plan

- [x] All 228 existing tests pass (`cargo test`)
- [x] Added 2 new unit tests for bare namespace paths (`bare_namespace_is_none`, `bare_namespace_with_trailing_slash_is_none`)
- [x] Updated existing tests to reflect `Option<&str>` return type
- [x] Build succeeds with no new warnings
- [ ] Manual: `curl -X POST http://localhost:8081/finance -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'` should return JSON-RPC error
- [ ] Manual: `curl -X POST http://localhost:8081/finance/mcp -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'` should succeed (finance namespace)
- [ ] Manual: `curl -X POST http://localhost:8081/mcp -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'` should succeed (default namespace)

## Summary by Sourcery

Harden namespace validation and standardize namespace identity around a single path-compatible name.

New Features:
- Add DNS-label validation for namespace names and expose invalid-name responses from the namespace creation API.
- Display namespace-specific MCP endpoint addresses in the admin UI.

Bug Fixes:
- Reject MCP requests using invalid or bare namespace paths with a JSON-RPC Invalid Request error instead of silently routing them to the default namespace.
- Allow non-MCP traffic on paths that do not identify a namespace to pass through unchanged.

Enhancements:
- Simplify namespace representation so the name serves as the identifier and URL path segment while retaining legacy path-field deserialization compatibility.
- Update namespace management and documentation to use the name-only model and its endpoint conventions.

Documentation:
- Document namespace naming rules, creation, endpoint usage, and rejection of bare namespace paths.

Tests:
- Add coverage for namespace name validation, legacy path compatibility, and invalid namespace path extraction.