### PR TITLE
fix #1827: show forward availability status in UI

### DIFF
--- a/ui/admin/src/Pages/Forwards/ForwardDetailModal.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardDetailModal.tsx
@@ -20,6 +20,23 @@ export const ForwardDetailModal: React.FC<ForwardDetailModalProps> = ({
       <ModalBody>
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
           <div>
+            <strong>Status:</strong>{" "}
+            <Tag
+              type={forward.available === true ? "green" : "red"}
+              size="sm"
+            >
+              {forward.available === true ? "Available" : "Unavailable"}
+            </Tag>
+          </div>
+          {forward.statusMessage && (
+            <div>
+              <strong>Status Detail:</strong>{" "}
+              <span style={{ color: "var(--cds-text-error, #da1e28)" }}>
+                {forward.statusMessage}
+              </span>
+            </div>
+          )}
+          <div>
             <strong>Address:</strong> {forward.address}
           </div>
           <div>

--- a/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardsTable.tsx
@@ -9,7 +9,8 @@ import {
   TableHeader,
   TableRow,
   TableToolbar,
-  TableToolbarContent
+  TableToolbarContent,
+  Tag
 } from "@carbon/react"
 import {Add, Edit, Information, Renew, TrashCan} from "@carbon/icons-react"
 import {ForwardEntry} from "../../models"
@@ -39,7 +40,8 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
     {key: "name", header: "Name"},
     {key: "address", header: "Address"},
     {key: "namespace", header: "Namespace"},
-    {key: "server", header: "Server"}
+    {key: "server", header: "Server"},
+    {key: "status", header: "Status"}
   ]
 
   function forwardsToRows() {
@@ -54,7 +56,8 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
           name: forward.name,
           address: forward.address,
           namespace: getNamespacePathById(forward.namespace ?? undefined),
-          server
+          server,
+          status: forward.available === true ? "available" : "unavailable"
         }
       })
   }
@@ -94,9 +97,21 @@ export const ForwardsTable: React.FC<ForwardsTableProps> = ({
               if (forward) {
                 return (
                   <TableRow {...getRowProps({row})}>
-                    {row.cells.map((cell) => (
-                      <TableCell key={cell.id}>{cell.value}</TableCell>
-                    ))}
+                    {row.cells.map((cell) => {
+                      if (cell.info.header === "status") {
+                        return (
+                          <TableCell key={cell.id}>
+                            <Tag
+                              type={cell.value === "available" ? "green" : "red"}
+                              size="sm"
+                            >
+                              {cell.value === "available" ? "Available" : "Unavailable"}
+                            </Tag>
+                          </TableCell>
+                        )
+                      }
+                      return <TableCell key={cell.id}>{cell.value}</TableCell>
+                    })}
                     <TableCell>
                       <Button
                         kind="ghost"


### PR DESCRIPTION
## Summary
- Add a Status column to the forwards table with green/red tags showing whether the upstream MCP server was reachable during discovery
- Show availability status and error details in the forward detail modal

Backend availability tracking (`available` and `statusMessage` fields on `ForwardEntry`, handler logic) was merged in #1831.

## Test plan
- [x] All 12 Playwright E2E tests pass
- [ ] Register a forward with a reachable upstream — verify green "Available" tag
- [ ] Register a forward with unreachable address — verify red "Unavailable" tag with error message
- [ ] Click detail on an unavailable forward — verify status and error message shown

## Summary by Sourcery

Expose upstream forward availability and failure details throughout the admin UI.

New Features:
- Display forward availability as color-coded Available or Unavailable status tags in the forwards table.
- Show availability status and any associated error details in the forward detail modal.