### PR TITLE
chore: add forward status verification to UI E2E tests

### DIFF
--- a/tests/e2e/ui/pages/forwards.page.ts
+++ b/tests/e2e/ui/pages/forwards.page.ts
@@ -67,4 +67,11 @@ export class ForwardsPage extends BasePage {
     await this.detailModal().locator('button[aria-label="Close"]').click();
     await this.detailModal().waitFor({ state: 'hidden', timeout: 5_000 });
   }
+
+  async getRowStatusText(name: string): Promise<string> {
+    const row = this.rowWithText(name);
+    const tag = row.locator('.cds--tag');
+    await tag.waitFor({ state: 'visible', timeout: 5_000 });
+    return tag.innerText();
+  }
 }

--- a/tests/e2e/ui/tests/forwards.spec.ts
+++ b/tests/e2e/ui/tests/forwards.spec.ts
@@ -93,4 +93,40 @@ test.describe('Forwards', () => {
     const headerText = await forwards.page.locator('th').allInnerTexts();
     expect(headerText.some(h => h.includes('Server'))).toBeTruthy();
   });
+
+  test('status column appears in table', async () => {
+    await forwards.goto();
+    const headerText = await forwards.page.locator('th').allInnerTexts();
+    expect(headerText.some(h => h.includes('Status'))).toBeTruthy();
+  });
+
+  test('forward shows unavailable status when unreachable', async () => {
+    const data = forwardData();
+    createdForwards.push(data.name);
+    await api.addForward(data);
+
+    await forwards.goto();
+    await forwards.waitForForwardInTable(data.name);
+
+    const status = await forwards.getRowStatusText(data.name);
+    expect(status).toBe('Unavailable');
+  });
+
+  test('detail modal shows status', async () => {
+    const data = forwardData();
+    createdForwards.push(data.name);
+    await api.addForward(data);
+
+    await forwards.goto();
+    await forwards.waitForForwardInTable(data.name);
+    await forwards.clickDetailForward(data.name);
+
+    const hasStatus = await forwards.detailModalHasText('Status:');
+    expect(hasStatus).toBeTruthy();
+
+    const hasUnavailable = await forwards.detailModalHasText('Unavailable');
+    expect(hasUnavailable).toBeTruthy();
+
+    await forwards.closeDetailModal();
+  });
 });


### PR DESCRIPTION
## Summary

- Add E2E test for the Status column header in the forwards table
- Add E2E test verifying unreachable forwards show "Unavailable" status tag
- Add E2E test for status display in the forward detail modal
- Add `getRowStatusText()` page object method with explicit tag visibility wait

## Test plan

- [ ] Run `cd tests/e2e/ui && npx playwright test forwards` against a running wanaku server
- [ ] Verify all three new tests pass alongside existing forward tests

## Summary by Sourcery

Verify forward status presentation throughout the UI with expanded E2E coverage.

Enhancements:
- Expand forwards UI E2E coverage to verify status column headers, unavailable statuses for unreachable forwards, and status details in the forward modal.
- Add page-object support for retrieving and waiting for forward row status tags.

Tests:
- Add end-to-end tests covering forward status visibility in tables and detail modals.