### PR TITLE
docs: align documentation with governed action proxy positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Wanaku
 
-Rust MCP server built on the Praxis proxy framework. Routes MCP requests through a filter pipeline for namespace isolation, tool/resource/prompt management, and MCP-to-MCP forwarding.
+Governed action proxy for AI agents, built in Rust on the Praxis proxy framework. Sits between agents and backend systems, intercepting tool calls, agent-to-agent messages, and inference traffic. Policy, identity, data controls, and audit are enforced in the proxy layer — agents never touch backends directly.
 
 ## Core Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# Wanaku - An MCP Router that connects everything
+# Wanaku — A Governed Action Proxy for AI Agents
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Build](https://img.shields.io/github/actions/workflow/status/wanaku-ai/wanaku/main-build.yml?branch=main)](https://github.com/wanaku-ai/wanaku/actions)
 [![Release](https://img.shields.io/github/v/release/wanaku-ai/wanaku)](https://github.com/wanaku-ai/wanaku/releases)
 
-The Wanaku MCP Router is a router for AI-enabled applications powered by the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
-It sits between AI clients and your backend services, routing requests through a filter pipeline to provide namespace isolation, tool management, and MCP-to-MCP tool forwarding.
+Wanaku is a governed action proxy for AI agents. It sits between agents and the systems they act on, intercepting tool calls, agent-to-agent messages, and inference traffic. Integration developers build [Apache Camel](https://camel.apache.org/) routes and publish them as tools; agents call those tools with parameters, but Wanaku runs the actual work — the agent never touches backend systems directly. Policy, identity, data controls, and audit happen in the proxy, not in the agent.
 
 The project name comes from the origins of the word [Guanaco](https://en.wikipedia.org/wiki/Guanaco), a camelid native to
 South America.
 
 ## Key Features
 
-- **Unified MCP Routing** - Centralized routing and resource management for AI agents
-- **MCP-to-MCP Bridge** - Act as a gateway or proxy for other MCP servers, with auto-discovery of remote tools
-- **Multi-Namespace Support** - Organize tools and resources across isolated namespaces
-- **Secure by Default** - Authentication and authorization via oauth2-proxy and Keycloak (optional — can run without auth)
-- **Extensible Architecture** - Plugin system via feature crates and a composable filter pipeline
-- **Admin Dashboard** - Web UI for managing tools, resources, prompts, and forwards
-- **Container-Ready** - Multi-arch images (x86_64, aarch64) published automatically
+- **Agent Isolation** — Agents call tools through Wanaku; they never reach backend systems directly
+- **Policy Enforcement** — LLM-powered evaluators + WASM action scripts classify, filter, and block tool calls in the proxy layer
+- **Identity & Auth** — Authentication and authorization via oauth2-proxy and Keycloak, enforced before actions reach backends
+- **Tool Discovery** — Auto-discover tools from upstream MCP servers; integration developers publish Camel routes as tools
+- **Namespace Isolation** — Organize tools and resources across isolated namespaces per team, tenant, or environment
+- **Extensible Architecture** — Plugin system via feature crates and a composable filter pipeline
+- **Admin Dashboard** — Web UI for managing tools, resources, prompts, and forwards
+- **Container-Ready** — Multi-arch images (x86_64, aarch64) published automatically
 
 ## Quick Start
 
@@ -140,8 +140,8 @@ Contributors working on the project may want to refer to the development documen
 
 ## Related Projects
 
-- [Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability/) - Apache Camel-based capability services
-- [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/) - SDK for building capability services in Java
+- [Camel Integration Capability](https://github.com/wanaku-ai/camel-integration-capability/) — Build Apache Camel routes and publish them as tools that agents can call through Wanaku
+- [Java SDK](https://github.com/wanaku-ai/wanaku-capabilities-java-sdk/) — SDK for building capability services in Java
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,7 @@ When deploying Wanaku, please follow these security best practices:
 - Review audit logs regularly
 - Set up alerts for suspicious activity
 
-For more security configuration options, see the [Configuration Guide](docs/configurations.md).
+For more security configuration options, see the [Configuration Guide](docs/configuration.md).
 
 ## Acknowledgments
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-Wanaku is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. At its core, it's a sophisticated HTTP filter pipeline that routes AI agent requests to the right tools, enforces security policies, and manages namespaces.
+Wanaku is a governed action proxy for AI agents, built in Rust on the Praxis proxy framework. It sits between agents and the systems they act on, intercepting every tool call, agent-to-agent message, and inference request. Policy, identity, data controls, and audit are enforced in the proxy — agents never touch backend systems directly.
 
-This isn't your typical REST API. It's a proxy. Requests flow through a chain of filters, each responsible for a specific concern—CORS, protocol parsing, namespace isolation, tool dispatch. Think of it as middleware, but composable and pluggable.
+Under the hood, Wanaku is an HTTP filter pipeline. Actions flow through a chain of filters, each responsible for a specific governance concern — identity, policy evaluation, namespace isolation, tool dispatch. Unlike a gateway that just passes traffic, the proxy does the work: it resolves tools, forwards actions to backends, and returns results to the agent.
 
 ## High-Level Architecture
 
@@ -13,9 +13,9 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
                  │ MCP (JSON-RPC over HTTP)
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              Wanaku Server (Port 8081)                      │
+│         Wanaku — Governed Action Proxy (Port 8081)          │
 │  ┌────────────────────────────────────────────────────────┐ │
-│  │              Filter Pipeline (Praxis)                  │ │
+│  │           Governance Pipeline (Praxis)                 │ │
 │  │  CORS → MCP Parse → Namespace → Evaluator →            │ │
 │  │  Tool List/Call → Resource → Prompt → Static Response  │ │
 │  └────────────────────────────────────────────────────────┘ │
@@ -25,20 +25,21 @@ This isn't your typical REST API. It's a proxy. Requests flow through a chain of
 │  └────────────────────────────────────────────────────────┘ │
 └────────────────────────────────┬────────────────────────────┘
                                  │
-                        MCP Forward (HTTP)
+                        Action Forward (HTTP)
                                  │
                                  ▼
                    ┌───────────────────────┐
-                   │ Upstream MCP Servers  │
+                   │   Backend Systems     │
+                   │  (Upstream MCP/Camel) │
                    └───────────────────────┘
 ```
 
-**Request flow:**
+**Action flow:**
 
-1. LLM sends MCP request to `/mcp` or `/{namespace}/mcp`
-2. Praxis filter pipeline processes the request
+1. Agent sends an MCP action (tool call, resource read, prompt get) to `/mcp` or `/{namespace}/mcp`
+2. Governance pipeline intercepts: identity, policy, namespace isolation
 3. Filters query the in-memory registry for tools/resources/prompts
-4. For tool calls: the filter forwards the request to the upstream MCP server registered as the tool's forward address via HTTP
+4. For tool calls: the proxy forwards the action to the backend system registered as the tool's forward address — the agent never reaches the backend directly
 5. Response flows back through filters, wrapped in JSON-RPC
 
 ## The Filter Pipeline
@@ -368,7 +369,7 @@ See [Contributing: Admin UI](./contributing-admin-ui.md) for development details
 
 ### Standalone
 
-Run Wanaku as the only MCP server. Tools are registered via the management API or `wanaku.yaml`, and execute via MCP forwarding to upstream servers.
+Run Wanaku as a standalone proxy. Tools are registered via the management API or `wanaku.yaml`, and actions are forwarded to upstream servers.
 
 **Pros:** Simple, no dependencies
 **Cons:** No persistence beyond file snapshots

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to Wanaku
 
-Thank you for your interest in contributing to the Wanaku MCP Router project!
+Thank you for your interest in contributing to the Wanaku project!
 
 ## Getting Started
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -63,7 +63,7 @@ For deployment details, see `deploy/auth/README.md` and [Configuration](./config
 
 ### Chat Feature (`features/chat/`)
 
-Proxies LLM chat completion requests to an inference backend (any OpenAI-compatible endpoint). This lets you use Wanaku as a unified API gateway for both MCP tools and raw LLM chat.
+Proxies LLM chat completion requests to an inference backend (any OpenAI-compatible endpoint). This lets you proxy LLM chat completions alongside MCP tool actions through a single Wanaku deployment.
 
 **How it works:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,8 @@
 # Getting Started with Wanaku
 
-Wanaku is a Rust-based MCP (Model Context Protocol) server that routes AI agent requests through a sophisticated filter pipeline. Think of it as the bouncer at the club: it checks IDs, enforces the rules, and makes sure everyone gets to the right place.
+Wanaku is a governed action proxy for AI agents. It sits between agents and the systems they act on, intercepting tool calls and enforcing policy, identity, and data controls before actions reach backend systems. The agent never touches backends directly — Wanaku runs the work on its behalf.
 
-This guide gets you from zero to running MCP server in under 10 minutes.
+This guide gets you from zero to a running Wanaku proxy in under 10 minutes.
 
 ## Prerequisites
 
@@ -210,4 +210,4 @@ See [Configuration](./configuration.md) for the full list.
 - **[Management API](./management-api.md)** — full REST API reference
 - **[FAQ](./faq.md)** — common issues and troubleshooting
 
-You now have a running MCP server. The rest is about configuring it to match your environment.
+You now have a running Wanaku proxy. The rest is about configuring it to match your environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,23 @@
 # Wanaku Documentation
 
-Wanaku is a Rust-based MCP (Model Context Protocol) server built on the Praxis proxy framework. It routes AI agent requests through a filter pipeline to provide namespace isolation, tool/resource/prompt management, and MCP-to-MCP tool forwarding.
+Wanaku is a governed action proxy for AI agents. It sits between agents and the systems they act on, intercepting tool calls, agent-to-agent messages, and inference traffic. Integration developers build Apache Camel routes and publish them as tools; agents call those tools with parameters, but Wanaku runs the actual work — the agent never touches backend systems directly. Policy, identity, data controls, and audit happen in the proxy, not in the agent.
 
 ## Why Rust?
 
-The classic Wanaku MCP Router (Java + Quarkus) is a fully-featured MCP server with service catalogs, Camel routes, Infinispan persistence, and OIDC integration. Wanaku expands on that foundation with a composable filter pipeline architecture built on the Praxis proxy framework — enabling pluggable feature crates that would be difficult to express in the classic architecture.
+The classic Wanaku (Java + Quarkus) is a fully-featured implementation with service catalogs, Camel routes, Infinispan persistence, and OIDC integration. Wanaku expands on that foundation with a composable filter pipeline architecture built on the Praxis proxy framework — enabling pluggable governance features (evaluators, policy gates, interaction tracking) that would be difficult to express in the classic architecture.
 
 Wanaku shares the same MCP protocol and management API as classic Wanaku.
 
 ## What You Get
 
+- **Agent isolation** — agents call tools through the proxy; they never reach backend systems directly
+- **Policy enforcement** — LLM-powered evaluators + WASM action scripts classify, filter, and block tool calls
+- **Identity & auth** — oauth2-proxy + Keycloak, enforced before actions reach backends
 - **MCP endpoint** (port 8081) — JSON-RPC over HTTP, compatible with any MCP client
 - **Management API** (port 8080) — REST API for tools, resources, prompts, namespaces
 - **Admin UI** — React-based web interface embedded in the binary
-- **Namespace isolation** — different tools visible to different namespaces
-- **Tool routing** — MCP-to-MCP forwarding to upstream servers with auto-discovery
+- **Namespace isolation** — different tools visible to different namespaces per team, tenant, or environment
+- **Tool discovery** — auto-discover tools from upstream MCP servers; integration developers publish Camel routes as tools
 - **Feature system** — pluggable filters for evaluation, LLM chat, interaction tracking
 - **File persistence** — optional registry snapshots to survive restarts
 
@@ -24,7 +27,7 @@ All in a single binary with no runtime dependencies (except libc).
 
 ### Getting Started
 
-- **[Getting Started](./getting-started.md)** — download, install, and run your first MCP server
+- **[Getting Started](./getting-started.md)** — download, install, and run your first Wanaku proxy
 - **[Configuration](./configuration.md)** — all environment variables and YAML config options
 - **[Authentication](./auth.md)** — set up oauth2-proxy with Keycloak
 - **[Management API](./management-api.md)** — REST API reference for tools, resources, etc.
@@ -41,9 +44,10 @@ All in a single binary with no runtime dependencies (except libc).
 
 ## Who This Is For
 
-- **You want a composable filter pipeline** for MCP request processing
-- **You want namespace isolation** without multi-tenancy complexity
-- **You need pluggable features** for custom request processing
+- **You need governed agent actions** — policy, identity, and audit enforced in the proxy, not in the agent or the LLM
+- **You want agent isolation** — agents call tools but never touch backends directly
+- **You want namespace isolation** — different tool catalogs per team, tenant, or environment without multi-tenancy complexity
+- **You need pluggable governance** — evaluators, safety gates, and custom filters in the action path
 
 ## Who This Isn't For (Yet)
 
@@ -61,21 +65,21 @@ These are solvable, but they're not in scope for the initial release.
                │ MCP (JSON-RPC over HTTP)
                ▼
 ┌────────────────────────────────────────────┐
-│       Praxis Filter Pipeline                │
-│  CORS → MCP Parse → Namespace →             │
+│     Wanaku — Governed Action Proxy          │
+│  Identity → Policy → Namespace →            │
 │  Evaluator → Tool/Resource/Prompt          │
 └──────────────┬─────────────────────────────┘
                │
-          MCP Forward
+          Action forwarding
                │
                ▼
         ┌──────────┐
-        │ Upstream │
-        │   MCP    │
+        │ Backend  │
+        │ Systems  │
         └──────────┘
 ```
 
-Requests flow through a chain of filters. Each filter reads metadata (method, namespace, tool name) and decides whether to continue, reject, or synthesize a response. The in-memory registry tracks tools, resources, prompts, forwards, and namespaces. Tool calls are forwarded to upstream MCP servers.
+Agents send tool calls through Wanaku. The proxy intercepts every action, enforces identity and policy, resolves the target namespace, and forwards the action to the appropriate backend system. The agent never reaches backends directly — governance is enforced in the proxy layer.
 
 See [Architecture](./architecture.md) for the full story.
 
@@ -176,7 +180,7 @@ See [Configuration](./configuration.md) for details.
 
 ### Standalone
 
-Run Wanaku as the only MCP server. Tools are discovered from forwarded MCP servers registered via the management API or `wanaku.yaml`, executing via MCP forwarding to those upstream servers.
+Run Wanaku as a standalone proxy. Tools are discovered from upstream MCP servers registered as forwards via the management API or `wanaku.yaml`.
 
 **Pros:** Simple, no dependencies
 **Cons:** No persistence beyond file snapshots
@@ -190,16 +194,16 @@ Deploy Wanaku as a `Deployment` with a `PersistentVolume` for the registry. Use 
 
 ## What's Different from Classic Wanaku?
 
-| Feature | Classic (Java) | Wanaku (Rust) |
+| Capability | Classic (Java) | Wanaku (Rust) |
 |---|---|---|
 | **MCP protocol** | ✅ Full support | ✅ Full support |
 | **Namespace isolation** | ✅ Yes | ✅ Yes |
-| **MCP forwarding** | ✅ Yes | ✅ Yes (with auto-discovery) |
-| **Filter pipeline** | — | ✅ Composable filter chain |
+| **Action forwarding** | ✅ Yes | ✅ Yes (with auto-discovery) |
+| **Governance pipeline** | — | ✅ Composable filter chain with policy enforcement |
+| **WASM evaluators** | — | ✅ LLM + WASM action scripts for policy gates |
 | **Feature crates** | — | ✅ Pluggable Rust crates |
-| **WASM evaluators** | — | ✅ LLM + WASM action scripts |
 | **Service catalogs** | ✅ Yes | ❌ Not yet |
-| **Camel routes** | ✅ Yes | ⚠️ Delegate via MCP forward |
+| **Camel routes as tools** | ✅ Direct | ⚠️ Via MCP forward to Camel-based upstream |
 | **OIDC/OAuth** | ✅ Keycloak | ✅ oauth2-proxy + Keycloak |
 | **Persistence** | ✅ Infinispan | ⚠️ File snapshots only |
 | **Admin UI** | ✅ React + Orval | ✅ React + Orval |

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -341,7 +341,7 @@ Both instances share a cookie secret for SSO.
 
 **For production deployments without auth:**
 
-1. Run Praxis standalone on ports 8081/8080 without oauth2-proxy
+1. Run Wanaku standalone on ports 8081/8080 without oauth2-proxy
 2. Bind to localhost only (`WANAKU_MGMT_LISTEN=127.0.0.1:8080`)
 3. Use a reverse proxy with API key auth (nginx `auth_request`, Envoy `ext_authz`)
 

--- a/index.md
+++ b/index.md
@@ -2,9 +2,9 @@
 layout: home
 
 hero:
-  name: "Wanaku MCP Router"
-  text: "Documentation"
-  tagline: Documentation guides to help you learn and use the Wanaku MCP Router.
+  name: "Wanaku"
+  text: "A Governed Action Proxy for AI Agents"
+  tagline: Documentation guides to help you learn and use Wanaku.
   actions:
     - theme: brand
       text: Getting Started


### PR DESCRIPTION
## Summary

- Reframe Wanaku's identity from "MCP Router" / "MCP server" to "governed action proxy for AI agents" across all user-facing documentation
- Update titles, opening paragraphs, feature lists, architecture diagrams, and comparison tables to reflect the new positioning
- Replace "gateway" terminology with proxy-specific language
- Fix `SECURITY.md` link typo (`configurations.md` → `configuration.md`)

## Files changed (10)

**Identity/branding:** README.md, CLAUDE.md, AGENTS.md, docs/index.md
**Architecture framing:** docs/architecture.md, docs/getting-started.md, index.md (VitePress)
**Terminology cleanup:** docs/contributing.md, docs/features.md, docs/management-api.md
**Bugfix:** SECURITY.md

## Test plan

- [ ] Verify VitePress site renders correctly with updated hero section
- [ ] Confirm CLAUDE.md/AGENTS.md sync hook propagated correctly
- [ ] Spot-check that upstream MCP server references (technically correct) were not inadvertently changed

## Summary by Sourcery

Align documentation with Wanaku's governed action proxy identity for AI agents.

Bug Fixes:
- Correct the broken security documentation link to the singular configuration guide filename.

Enhancements:
- Reposition Wanaku throughout user-facing and contributor documentation as a governed action proxy for AI agents, emphasizing agent isolation, policy enforcement, identity, and backend governance.
- Update architecture descriptions, diagrams, feature lists, comparison tables, and terminology to consistently describe proxy-based action forwarding and governance.

Documentation:
- Align the README, VitePress landing page, architecture, getting-started, features, management API, contributing, and project guidance documentation with Wanaku's governed action proxy positioning.