### PR TITLE
chore: replace too_many_arguments suppressions with context structs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,12 @@ Default configs: `server/src/default.yaml` (embedded, pipeline), `wanaku.yaml` (
 
 ## Architecture
 
-**Workspace:** `apis/` (shared types, Feature trait, LLM, registry, config), `filters/` (core MCP filters), `features/` (self-contained feature crates: mcp-metadata, evaluator, intercept, chat), `server/` (binary, pipeline, mgmt API), `ui/admin/` (React embedded UI).
+**Workspace:** `apis/` (shared types, Feature trait, context structs, LLM, registry, config), `filters/` (core MCP filters), `features/` (self-contained feature crates: mcp-metadata, evaluator, intercept, chat), `server/` (binary, pipeline, mgmt API), `ui/admin/` (React embedded UI).
+
+**Context structs** (`apis/src/`): group related parameters to keep function signatures under the clippy `too-many-arguments-threshold` (5). Use `Type::new(...)` to construct:
+- `HttpContext` (`feature.rs`) — HTTP method, path, query, body, headers. Passed to `Feature::handle_route`.
+- `McpContext` (`mcp.rs`) — MCP method, tool name, arguments, tool list, conversation history. Used by evaluator LLM operations.
+- `PipelineDeps` (`server/src/pipelines.rs`) — filter registry, health, KV, wanaku registry, features. Used by `resolve_pipelines`.
 
 **Dependencies:** praxis-proxy (crates.io), praxis-ai (git dep — NOT on crates.io), rmcp (upstream MCP calls).
 
@@ -259,14 +264,14 @@ The distinction between `block` and `reject-malformed` matters: `block` means th
 
 **Add feature:**
 1. `mkdir features/myfeature` + `Cargo.toml` — depend on `wanaku-apis` (Feature, registry, llm), `wanaku-filters` (boilerplate, response helpers), `praxis-filter` (HttpFilter)
-2. Implement `Feature` trait: `register_filters`, `pipeline_extensions`, `handle_route`, `load_yaml_config`, `load_env_config`
+2. Implement `Feature` trait: `register_filters`, `pipeline_extensions`, `handle_route` (receives `&HttpContext`), `load_yaml_config`, `load_env_config`
 3. Add to workspace `Cargo.toml` (members + deps)
 4. Add dep in `server/Cargo.toml`, `Box::new(MyFeature::new())` in `main.rs`
 5. Add filter to `server/src/default.yaml` if applicable
 
 Reference: `features/evaluator/` (filter + mgmt + WASM), `features/chat/` (mgmt only).
 
-Key patterns: `body_filter_boilerplate!`, `json_rpc_error`, `NAMESPACE_METADATA_KEY`, `llm::{LlmClient, HotSwap}`.
+Key patterns: `body_filter_boilerplate!`, `json_rpc_error`, `NAMESPACE_METADATA_KEY`, `llm::{LlmClient, HotSwap}`, `HttpContext`, `McpContext`.
 
 **Add core filter:**
 1. `filters/src/<method>.rs` — use `body_filter_boilerplate!`
@@ -309,6 +314,7 @@ Pin to a specific `rev` — HEAD may break.
 - Filter logic in `on_request_body` + `end_of_stream` guard
 - `match` over `if let` chains
 - `#[expect(..., reason = "...")]` for allowed lints
+- Group related parameters into context structs (`HttpContext`, `McpContext`, `PipelineDeps`) — never suppress `clippy::too_many_arguments`
 
 ## Debugging
 

--- a/apis/src/feature.rs
+++ b/apis/src/feature.rs
@@ -1,6 +1,39 @@
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension};
 
+/// Bundles the HTTP request components dispatched to [`Feature::handle_route`].
+///
+/// Built once per management API request and shared across all features
+/// during route dispatch. Fields map directly to the incoming Pingora
+/// `ServerSession` request.
+#[derive(Debug)]
+pub struct HttpContext<'a> {
+    /// HTTP method (`"GET"`, `"POST"`, …).
+    pub method: &'a str,
+    /// Request path, e.g. `"/api/v1/chat/completions"`.
+    pub path: &'a str,
+    /// Raw query string, if present.
+    pub query: Option<&'a str>,
+    /// Request body (read once for POST/PUT/PATCH, `None` otherwise).
+    pub body: Option<&'a str>,
+    /// HTTP headers forwarded from the client.
+    pub headers: &'a http::HeaderMap,
+}
+
+impl<'a> HttpContext<'a> {
+    /// Creates a new HTTP context from the request components.
+    #[must_use]
+    pub fn new(
+        method: &'a str,
+        path: &'a str,
+        query: Option<&'a str>,
+        body: Option<&'a str>,
+        headers: &'a http::HeaderMap,
+    ) -> Self {
+        Self { method, path, query, body, headers }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait Feature: Send + Sync {
     fn name(&self) -> &'static str;
@@ -9,15 +42,7 @@ pub trait Feature: Send + Sync {
 
     fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>>;
 
-    #[expect(clippy::too_many_arguments, reason = "trait method requires all context parameters")]
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        query: Option<&str>,
-        body: Option<&str>,
-        headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>>;
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>>;
 
     fn load_yaml_config(&self, root: &serde_yaml::Value);
 

--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -6,6 +6,7 @@ pub mod feature;
 pub mod http_response;
 pub mod interactions;
 pub mod llm;
+pub mod mcp;
 pub mod mcp_client;
 pub mod metrics;
 pub mod persistence;

--- a/apis/src/mcp.rs
+++ b/apis/src/mcp.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+use crate::interactions::Interaction;
+use crate::registry::ToolEntry;
+
+/// Bundles the MCP request state needed by the evaluator pipeline.
+///
+/// Assembled once per evaluator invocation from filter metadata and
+/// registry lookups, then threaded through LLM operations, schema
+/// validation, and retry logic.
+#[derive(Debug)]
+pub struct McpContext<'a> {
+    /// JSON-RPC method, e.g. `"tools/call"` or `"tools/list"`.
+    pub method: &'a str,
+    /// Tool name extracted from `params.name` (set by the MCP filter).
+    pub tool_name: Option<&'a str>,
+    /// Tool-call arguments from `params.arguments`.
+    pub arguments: &'a HashMap<String, String>,
+    /// Tools visible in the current namespace (populated for `LlmOperation::Filter`).
+    pub tools: &'a [ToolEntry],
+    /// Recent conversation history for the active conversation ID.
+    pub history: &'a [Interaction],
+}
+
+impl<'a> McpContext<'a> {
+    /// Creates a new MCP context from the parsed request state.
+    #[must_use]
+    pub fn new(
+        method: &'a str,
+        tool_name: Option<&'a str>,
+        arguments: &'a HashMap<String, String>,
+        tools: &'a [ToolEntry],
+        history: &'a [Interaction],
+    ) -> Self {
+        Self { method, tool_name, arguments, tools, history }
+    }
+}

--- a/features/chat/src/lib.rs
+++ b/features/chat/src/lib.rs
@@ -6,7 +6,7 @@ mod routes;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension};
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 
 use crate::routes::{
     ChatRoute, handle_chat_completions, handle_chat_list_llms, handle_chat_list_models,
@@ -48,15 +48,8 @@ impl Feature for ChatFeature {
         vec![]
     }
 
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        _query: Option<&str>,
-        body: Option<&str>,
-        _headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
-        let route = resolve_chat_route(method, path);
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        let route = resolve_chat_route(ctx.method, ctx.path);
         if route == ChatRoute::NotFound {
             return None;
         }
@@ -77,7 +70,7 @@ impl Feature for ChatFeature {
                     &self.inference_base_url,
                     self.upstream_host.as_deref(),
                     &self.api_key,
-                    body.unwrap_or(""),
+                    ctx.body.unwrap_or(""),
                 )
                 .await
             }

--- a/features/evaluator/src/filter.rs
+++ b/features/evaluator/src/filter.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use wanaku_apis::interactions::{InMemoryInteractionStore, InteractionStore};
+use wanaku_apis::mcp::McpContext;
 use wanaku_apis::metrics::{MetricsStore, SkipReason};
 use wanaku_apis::registry::{InMemoryRegistry, ToolRegistry};
 
@@ -94,14 +95,18 @@ impl EvaluatorFilter {
             _ => Vec::new(),
         };
 
-        let raw_llm_result = crate::llm_op::run_llm_operation(
-            &evaluator.name,
-            &evaluator.llm,
+        let mcp_ctx = McpContext::new(
             &method,
             tool_name.as_deref(),
             &arguments,
             &tools,
             &history,
+        );
+
+        let raw_llm_result = crate::llm_op::run_llm_operation(
+            &evaluator.name,
+            &evaluator.llm,
+            &mcp_ctx,
             metrics.as_ref(),
         )
         .await
@@ -113,11 +118,7 @@ impl EvaluatorFilter {
             &raw_llm_result,
             &evaluator,
             compiled_schema.as_ref(),
-            &method,
-            tool_name.as_deref(),
-            &arguments,
-            &tools,
-            &history,
+            &mcp_ctx,
             metrics.as_ref(),
         )
         .await;
@@ -277,17 +278,12 @@ fn dispatch_action(
     }
 }
 
-#[expect(clippy::too_many_arguments, reason = "retry requires original request context")]
 #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "schema validation with retry logic")]
 async fn validate_and_retry_if_needed(
     raw_result: &str,
     evaluator: &EvaluatorDef,
     compiled_schema: Option<&std::sync::Arc<crate::schema::CompiledSchema>>,
-    method: &str,
-    tool_name: Option<&str>,
-    arguments: &HashMap<String, String>,
-    tools: &[wanaku_apis::registry::ToolEntry],
-    history: &[wanaku_apis::interactions::Interaction],
+    mcp: &McpContext<'_>,
     metrics: Option<&MetricsStore>,
 ) -> String {
     let Some(schema) = compiled_schema else {
@@ -319,11 +315,7 @@ async fn validate_and_retry_if_needed(
     let retry_result = if let Some(raw_schema) = raw_schema {
         crate::llm_op::retry_with_schema_correction(
             &evaluator.llm,
-            method,
-            tool_name,
-            arguments,
-            tools,
-            history,
+            mcp,
             raw_result,
             raw_schema,
             &validation_error,

--- a/features/evaluator/src/lib.rs
+++ b/features/evaluator/src/lib.rs
@@ -15,7 +15,7 @@ pub mod state;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 
 use crate::config::EvaluatorsConfig;
 use crate::routes::{
@@ -78,26 +78,19 @@ impl Feature for EvaluatorFeature {
         })]
     }
 
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        _query: Option<&str>,
-        body: Option<&str>,
-        _headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
-        let route = resolve_evaluator_route(method, path);
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        let route = resolve_evaluator_route(ctx.method, ctx.path);
         if route == EvaluatorRoute::NotFound {
             return None;
         }
         Some(match route {
             EvaluatorRoute::ListEvaluators => handle_list_evaluators(&self.state),
             EvaluatorRoute::UpdateEvaluators => {
-                handle_update_evaluators(&self.state, body.unwrap_or(""))
+                handle_update_evaluators(&self.state, ctx.body.unwrap_or(""))
             }
             EvaluatorRoute::ListBindings => handle_list_bindings(&self.state),
             EvaluatorRoute::BindNamespace(ns) => {
-                handle_bind_namespace(&self.state, &ns, body.unwrap_or(""))
+                handle_bind_namespace(&self.state, &ns, ctx.body.unwrap_or(""))
             }
             EvaluatorRoute::UnbindNamespace(ns) => handle_unbind_namespace(&self.state, &ns),
             EvaluatorRoute::NotFound => return None,

--- a/features/evaluator/src/llm_op.rs
+++ b/features/evaluator/src/llm_op.rs
@@ -1,28 +1,20 @@
-use std::collections::HashMap;
-
-use wanaku_apis::interactions::Interaction;
 use wanaku_apis::llm::{self, LlmClient};
+use wanaku_apis::mcp::McpContext;
 use wanaku_apis::metrics::MetricsStore;
-use wanaku_apis::registry::ToolEntry;
 
 use crate::config::LlmDef;
 
 /// Execute the LLM operation and return the raw result string.
 /// The processor WASM module is responsible for parsing and acting on this.
-#[expect(clippy::too_many_arguments, reason = "LLM operation requires full request context")]
 pub async fn run_llm_operation(
     evaluator_name: &str,
     llm_def: &LlmDef,
-    method: &str,
-    tool_name: Option<&str>,
-    arguments: &HashMap<String, String>,
-    tools: &[ToolEntry],
-    history: &[Interaction],
+    mcp: &McpContext<'_>,
     metrics: Option<&MetricsStore>,
 ) -> Option<String> {
     let client = LlmClient::new(&llm_def.url, &llm_def.model, &llm_def.api_key)?;
 
-    let user_prompt = build_context_prompt(method, tool_name, arguments, tools, history);
+    let user_prompt = build_context_prompt(mcp);
 
     let start = std::time::Instant::now();
     let result = client.chat(&llm_def.prompt, &user_prompt).await;
@@ -38,21 +30,15 @@ pub async fn run_llm_operation(
 }
 
 #[expect(clippy::too_many_lines, reason = "prompt assembly with multiple optional sections")]
-fn build_context_prompt(
-    method: &str,
-    tool_name: Option<&str>,
-    arguments: &HashMap<String, String>,
-    tools: &[ToolEntry],
-    history: &[Interaction],
-) -> String {
+fn build_context_prompt(mcp: &McpContext<'_>) -> String {
     let mut prompt = String::with_capacity(4096);
 
-    if !history.is_empty() {
+    if !mcp.history.is_empty() {
         prompt.push_str("## Conversation Context\n\n");
-        let capped = if history.len() > 10 {
-            &history[history.len() - 10..]
+        let capped = if mcp.history.len() > 10 {
+            &mcp.history[mcp.history.len() - 10..]
         } else {
-            history
+            mcp.history
         };
         for interaction in capped {
             if let Some(messages) = interaction.request_body.get("messages")
@@ -78,15 +64,15 @@ fn build_context_prompt(
         }
     }
 
-    prompt.push_str(&format!("## Request: {method}\n\n"));
+    prompt.push_str(&format!("## Request: {}\n\n", mcp.method));
 
-    if let Some(name) = tool_name {
+    if let Some(name) = mcp.tool_name {
         prompt.push_str(&format!("Tool: {name}\n"));
     }
 
-    if !arguments.is_empty() {
+    if !mcp.arguments.is_empty() {
         prompt.push_str("Arguments:\n");
-        for (key, value) in arguments {
+        for (key, value) in mcp.arguments {
             prompt.push_str(&format!(
                 "  {}: {}\n",
                 llm::sanitize(key, 500),
@@ -95,9 +81,9 @@ fn build_context_prompt(
         }
     }
 
-    if !tools.is_empty() {
+    if !mcp.tools.is_empty() {
         prompt.push_str("\n## Available Tools\n\n");
-        for tool in tools {
+        for tool in mcp.tools {
             prompt.push_str(&format!(
                 "- {}: {}\n",
                 tool.name,
@@ -111,21 +97,16 @@ fn build_context_prompt(
 
 /// Retry an LLM operation with a correction prompt that includes
 /// the schema and the previous (invalid) response.
-#[expect(clippy::too_many_arguments, reason = "retry requires original context plus correction data")]
 pub async fn retry_with_schema_correction(
     llm_def: &LlmDef,
-    method: &str,
-    tool_name: Option<&str>,
-    arguments: &HashMap<String, String>,
-    tools: &[ToolEntry],
-    history: &[Interaction],
+    mcp: &McpContext<'_>,
     previous_result: &str,
     schema: &serde_json::Value,
     validation_error: &str,
 ) -> Option<String> {
     let client = LlmClient::new(&llm_def.url, &llm_def.model, &llm_def.api_key)?;
 
-    let base_prompt = build_context_prompt(method, tool_name, arguments, tools, history);
+    let base_prompt = build_context_prompt(mcp);
     let correction = format!(
         "{base_prompt}\n\n## Correction\n\n\
          Your previous response did not match the expected JSON schema.\n\

--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -6,7 +6,7 @@ mod routes;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 use wanaku_apis::interactions::InMemoryInteractionStore;
 
 use crate::routes::{
@@ -68,15 +68,8 @@ impl Feature for InterceptFeature {
         })]
     }
 
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        _query: Option<&str>,
-        _body: Option<&str>,
-        _headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
-        let route = resolve_interaction_route(method, path);
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        let route = resolve_interaction_route(ctx.method, ctx.path);
         if route == InteractionRoute::NotFound {
             return None;
         }

--- a/features/mcp-metadata/src/lib.rs
+++ b/features/mcp-metadata/src/lib.rs
@@ -5,7 +5,7 @@ pub mod filter;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 
 const WANAKU_AUTH_ISSUER: &str = "WANAKU_AUTH_ISSUER";
 
@@ -59,14 +59,7 @@ impl Feature for McpMetadataFeature {
         })]
     }
 
-    async fn handle_route(
-        &self,
-        _method: &str,
-        _path: &str,
-        _query: Option<&str>,
-        _body: Option<&str>,
-        _headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
+    async fn handle_route(&self, _ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
         None
     }
 

--- a/features/metrics/src/lib.rs
+++ b/features/metrics/src/lib.rs
@@ -4,7 +4,7 @@
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 use wanaku_apis::metrics::MetricsStore;
 
 pub struct MetricsFeature {
@@ -42,15 +42,8 @@ impl Feature for MetricsFeature {
         })]
     }
 
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        _query: Option<&str>,
-        _body: Option<&str>,
-        _headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
-        if method != "GET" || path != "/api/v1/metrics" {
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        if ctx.method != "GET" || ctx.path != "/api/v1/metrics" {
             return None;
         }
         let snapshot = self.store.snapshot();

--- a/features/plugins/src/lib.rs
+++ b/features/plugins/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::RwLock;
 
 use http::{Response, StatusCode};
 use praxis_filter::{FilterRegistry, PipelineExtension};
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 use wanaku_apis::http_response::json_err;
 
 use crate::manifest::PluginManifest;
@@ -117,15 +117,8 @@ impl Feature for PluginsFeature {
     }
 
     #[expect(clippy::too_many_lines, reason = "route dispatch with plugin proxy logic")]
-    async fn handle_route(
-        &self,
-        method: &str,
-        path: &str,
-        query: Option<&str>,
-        body: Option<&str>,
-        headers: &http::HeaderMap,
-    ) -> Option<Response<Vec<u8>>> {
-        let route = resolve_plugin_route(method, path);
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        let route = resolve_plugin_route(ctx.method, ctx.path);
         if route == PluginRoute::NotFound {
             return None;
         }
@@ -151,10 +144,10 @@ impl Feature for PluginsFeature {
                             &self.client,
                             &target_url,
                             &proxy_path,
-                            query,
-                            method,
-                            body,
-                            headers,
+                            ctx.query,
+                            ctx.method,
+                            ctx.body,
+                            ctx.headers,
                         )
                         .await
                     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -84,15 +84,15 @@ fn main() {
     let mgmt_registry = wanaku_registry.clone();
 
     info!("building wanaku pipelines");
-    let pipelines = wanaku_server::pipelines::resolve_pipelines(
-        &config,
+    let pipeline_deps = wanaku_server::pipelines::PipelineDeps::new(
         &filter_registry,
         &health_registry,
         &kv_stores,
         &wanaku_registry,
         &features,
-    )
-    .unwrap_or_else(|e| fatal(&e));
+    );
+    let pipelines = wanaku_server::pipelines::resolve_pipelines(&config, &pipeline_deps)
+        .unwrap_or_else(|e| fatal(&e));
 
     info!("initializing server");
     let mut server = PingoraServerRuntime::new(&config);

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -14,7 +14,7 @@ use http::{Response, StatusCode};
 use pingora_core::apps::http_app::ServeHttp;
 use pingora_core::protocols::http::ServerSession;
 
-use wanaku_apis::feature::Feature;
+use wanaku_apis::feature::{Feature, HttpContext};
 use wanaku_apis::registry::InMemoryRegistry;
 
 use self::handlers::{
@@ -189,11 +189,16 @@ impl ServeHttp for WanakuManagementService {
             _ => None,
         };
 
+        let http_ctx = HttpContext::new(
+            &method,
+            &path,
+            query.as_deref(),
+            feature_body.as_deref(),
+            &headers,
+        );
+
         for feature in &self.features {
-            if let Some(response) = feature
-                .handle_route(&method, &path, query.as_deref(), feature_body.as_deref(), &headers)
-                .await
-            {
+            if let Some(response) = feature.handle_route(&http_ctx).await {
                 return response;
             }
         }

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -9,6 +9,38 @@ use tracing::info;
 use wanaku_apis::feature::Feature;
 use wanaku_apis::registry::InMemoryRegistry;
 
+/// Dependencies needed to build filter pipelines for all listeners.
+///
+/// Groups the Praxis infrastructure registries and Wanaku-specific
+/// extensions so that [`resolve_pipelines`] receives a single context
+/// instead of many individual references.
+pub struct PipelineDeps<'a> {
+    /// Praxis filter registry (all registered HTTP filters).
+    pub filter_registry: &'a FilterRegistry,
+    /// Health-check registry for liveness/readiness probes.
+    pub health_registry: &'a praxis_core::health::HealthRegistry,
+    /// Key-value store registry for filter state.
+    pub kv_stores: &'a praxis_core::kv::KvStoreRegistry,
+    /// Wanaku in-memory registry (tools, resources, prompts, namespaces, forwards).
+    pub wanaku_registry: &'a InMemoryRegistry,
+    /// Wanaku feature crates that provide pipeline extensions and filters.
+    pub features: &'a [Box<dyn Feature>],
+}
+
+impl<'a> PipelineDeps<'a> {
+    /// Creates pipeline dependencies from all required registries and features.
+    #[must_use]
+    pub fn new(
+        filter_registry: &'a FilterRegistry,
+        health_registry: &'a praxis_core::health::HealthRegistry,
+        kv_stores: &'a praxis_core::kv::KvStoreRegistry,
+        wanaku_registry: &'a InMemoryRegistry,
+        features: &'a [Box<dyn Feature>],
+    ) -> Self {
+        Self { filter_registry, health_registry, kv_stores, wanaku_registry, features }
+    }
+}
+
 struct RegistryExtension {
     registry: InMemoryRegistry,
 }
@@ -24,14 +56,10 @@ impl PipelineExtension for RegistryExtension {
 /// # Errors
 ///
 /// Returns an error if pipeline construction fails.
-#[expect(clippy::too_many_arguments, clippy::too_many_lines, reason = "pipeline construction requires all dependencies")]
+#[expect(clippy::too_many_lines, reason = "pipeline construction requires all dependencies")]
 pub fn resolve_pipelines(
     config: &Config,
-    registry: &FilterRegistry,
-    health_registry: &praxis_core::health::HealthRegistry,
-    kv_stores: &praxis_core::kv::KvStoreRegistry,
-    wanaku_registry: &InMemoryRegistry,
-    features: &[Box<dyn Feature>],
+    deps: &PipelineDeps<'_>,
 ) -> Result<ListenerPipelines, Box<dyn std::error::Error + Send + Sync>> {
     let chains: HashMap<&str, &[_]> = config
         .filter_chains
@@ -53,7 +81,7 @@ pub fn resolve_pipelines(
             entries.extend_from_slice(chain_filters);
         }
 
-        let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains)?;
+        let mut pipeline = FilterPipeline::build_with_chains(&mut entries, deps.filter_registry, &chains)?;
 
         pipeline.apply_body_limits(
             config.body_limits.max_request_bytes,
@@ -61,19 +89,19 @@ pub fn resolve_pipelines(
             config.insecure_options.allow_unbounded_body,
         )?;
 
-        if !health_registry.is_empty() {
-            pipeline.set_health_registry(Arc::clone(health_registry));
+        if !deps.health_registry.is_empty() {
+            pipeline.set_health_registry(Arc::clone(deps.health_registry));
         }
 
-        if !kv_stores.is_empty() {
-            pipeline.set_kv_stores(kv_stores.clone());
+        if !deps.kv_stores.is_empty() {
+            pipeline.set_kv_stores(deps.kv_stores.clone());
         }
 
         pipeline.add_pipeline_extension(Box::new(RegistryExtension {
-            registry: wanaku_registry.clone(),
+            registry: deps.wanaku_registry.clone(),
         }));
 
-        for feature in features {
+        for feature in deps.features {
             for ext in feature.pipeline_extensions() {
                 pipeline.add_pipeline_extension(ext);
             }


### PR DESCRIPTION
Introduce HttpContext, McpContext, and PipelineDeps to group related
parameters, removing all clippy::too_many_arguments exceptions.

## Summary by Sourcery

Replace scattered multi-argument interfaces with shared context structs across HTTP routing, MCP evaluation, and pipeline construction.

New Features:
- Add shared HTTP, MCP, and pipeline dependency context types for passing grouped request and service state.

Enhancements:
- Refactor feature routing, evaluator LLM operations, and pipeline resolution to use context structs instead of long argument lists.
- Remove clippy too-many-arguments suppressions and document the context-struct conventions for contributors.

Documentation:
- Update architecture and feature-development guidance to describe and require the new context structs.