### PR TITLE
chore: add test for handle_chat_list_llms response body

### DIFF
--- a/features/chat/src/routes.rs
+++ b/features/chat/src/routes.rs
@@ -231,6 +231,15 @@ mod tests {
     }
 
     #[test]
+    fn list_llms_returns_non_empty_array() {
+        let response = handle_chat_list_llms();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body: Vec<String> = serde_json::from_slice(response.body()).unwrap();
+        assert!(!body.is_empty(), "LLM list must not be empty");
+    }
+
+    #[test]
     fn list_models_for_llm() {
         assert_eq!(
             resolve_chat_route("GET", "/api/v1/chat/ollama/models"),


### PR DESCRIPTION
## Summary
- Adds a unit test verifying that `handle_chat_list_llms()` returns a 200 OK response with a non-empty JSON array of strings.

## Test plan
- [x] `cargo test -p wanaku-feature-chat` passes (10 tests)

## Summary by Sourcery

Tests:
- Add coverage for the LLM listing endpoint to verify successful status responses and non-empty string-array JSON bodies.