### PR TITLE
Fix #1813: correct HTTP status code and unify proxy error messages

### DIFF
--- a/features/chat/src/routes.rs
+++ b/features/chat/src/routes.rs
@@ -65,7 +65,7 @@ pub(crate) async fn handle_chat_list_models(
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "failed to fetch models from inference backend");
-            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to reach inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, "upstream request failed");
         }
     };
 
@@ -74,7 +74,7 @@ pub(crate) async fn handle_chat_list_models(
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, status = %status, "failed to read inference backend models response");
-            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to read inference backend response: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, "upstream response read failed");
         }
     };
 
@@ -174,7 +174,7 @@ pub(crate) async fn handle_chat_completions(
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "chat completions request to inference backend failed");
-            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to reach inference backend: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, "upstream request failed");
         }
     };
 
@@ -183,7 +183,7 @@ pub(crate) async fn handle_chat_completions(
         Ok(t) => t,
         Err(e) => {
             warn!(error = %e, status = %status, "failed to read inference backend completions response");
-            return json_err(StatusCode::BAD_GATEWAY, &format!("failed to read inference backend response: {e}"));
+            return json_err(StatusCode::BAD_GATEWAY, "upstream response read failed");
         }
     };
 

--- a/server/src/management/response.rs
+++ b/server/src/management/response.rs
@@ -47,7 +47,7 @@ pub(super) async fn read_body(session: &mut ServerSession) -> Result<String, Res
             Ok(None) => break,
             Err(e) => {
                 warn!(error = %e, "management request body read failed");
-                return Err(json_err(StatusCode::BAD_GATEWAY, "request body read failed"));
+                return Err(json_err(StatusCode::INTERNAL_SERVER_ERROR, "request body read failed"));
             }
         }
     }


### PR DESCRIPTION
Fixes #1813

## Summary

- Changed `BAD_GATEWAY` to `INTERNAL_SERVER_ERROR` in `server/src/management/response.rs` for client body read failures (reading the client's request body is not an upstream operation)
- Unified chat proxy error messages in `features/chat/src/routes.rs` to use the same "upstream request failed" / "upstream response read failed" wording used by the plugin proxy in `features/plugins/src/handlers.rs`
- Error details remain available in the `warn!` log statements

## Summary by Sourcery

Correct management request body failure status codes and align chat proxy error responses with the shared upstream error wording.

Bug Fixes:
- Return HTTP 500 instead of 502 when management request body reads fail.
- Standardize chat proxy error messages for upstream request and response read failures.