### PR TITLE
Fix #1515: support roots/list for forwarded MCP servers

### DIFF
--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -13,13 +13,63 @@ use rmcp::{
 };
 use serde_json::Value;
 
-use crate::registry::McpServerInfo;
+use crate::registry::{McpServerInfo, RootEntry};
 
 const TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_TOOLS: usize = 500;
 const MAX_RESOURCES: usize = 500;
 const MAX_RESOURCE_TEMPLATES: usize = 500;
 const MAX_PROMPTS: usize = 500;
+
+/// A [`ClientHandler`](rmcp::ClientHandler) that responds to `roots/list`
+/// with a configured set of root directories.
+///
+/// Upstream MCP servers that require file-system roots (e.g. the MCP
+/// filesystem server) send a `roots/list` request during initialization.
+/// The default handler (`()`) returns an empty list, which causes those
+/// servers to reject the connection.  `RootsHandler` lets callers supply
+/// the roots that the upstream server expects.
+#[allow(deprecated)] // Root / ListRootsResult deprecated by SEP-2577 but still functional
+struct RootsHandler {
+    roots: Vec<rmcp::model::Root>,
+}
+
+#[allow(deprecated)]
+impl RootsHandler {
+    fn from_entries(entries: &[RootEntry]) -> Self {
+        let roots = entries
+            .iter()
+            .map(|e| {
+                let root = rmcp::model::Root::new(e.uri.clone());
+                match &e.name {
+                    Some(name) => root.with_name(name.clone()),
+                    None => root,
+                }
+            })
+            .collect();
+        Self { roots }
+    }
+}
+
+#[allow(deprecated)]
+impl rmcp::ClientHandler for RootsHandler {
+    fn list_roots(
+        &self,
+        _context: rmcp::service::RequestContext<rmcp::RoleClient>,
+    ) -> impl std::future::Future<Output = Result<rmcp::model::ListRootsResult, rmcp::model::ErrorData>>
+           + rmcp::service::MaybeSendFuture
+           + '_ {
+        if self.roots.is_empty() {
+            tracing::warn!(
+                "upstream MCP server requested roots/list but no roots are configured \
+                 for this forward -- the server may reject the connection"
+            );
+        } else {
+            tracing::debug!(root_count = self.roots.len(), "responding to roots/list");
+        }
+        std::future::ready(Ok(rmcp::model::ListRootsResult::new(self.roots.clone())))
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpClientError {
@@ -69,11 +119,12 @@ fn build_transport(url: &str) -> impl rmcp::transport::Transport<rmcp::RoleClien
 }
 
 #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
-pub async fn list_tools(url: &str) -> Result<Vec<Value>, McpClientError> {
+pub async fn list_tools(url: &str, roots: &[RootEntry]) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout {
             url: url.clone(),
@@ -138,11 +189,13 @@ pub async fn call_tool(
     url: &str,
     tool_name: &str,
     arguments: Value,
+    roots: &[RootEntry],
 ) -> Result<CallToolResponse, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout {
             url: url.clone(),
@@ -184,11 +237,12 @@ pub async fn call_tool(
 }
 
 #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
-pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
+pub async fn list_resources(url: &str, roots: &[RootEntry]) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
@@ -242,11 +296,13 @@ pub async fn list_resources(url: &str) -> Result<Vec<Value>, McpClientError> {
 pub async fn read_resource(
     url: &str,
     resource_uri: &str,
+    roots: &[RootEntry],
 ) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
@@ -277,11 +333,12 @@ pub async fn read_resource(
 }
 
 #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
-pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientError> {
+pub async fn list_resource_templates(url: &str, roots: &[RootEntry]) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
@@ -332,11 +389,12 @@ pub async fn list_resource_templates(url: &str) -> Result<Vec<Value>, McpClientE
 }
 
 #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP paginated client call")]
-pub async fn list_prompts(url: &str) -> Result<Vec<Value>, McpClientError> {
+pub async fn list_prompts(url: &str, roots: &[RootEntry]) -> Result<Vec<Value>, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
@@ -391,11 +449,13 @@ pub async fn get_prompt(
     url: &str,
     prompt_name: &str,
     arguments: Option<serde_json::Map<String, Value>>,
+    roots: &[RootEntry],
 ) -> Result<Value, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {
@@ -434,11 +494,12 @@ pub struct ForwardDiscovery {
 }
 
 #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "MCP forward discovery aggregating multiple calls")]
-pub async fn discover_forward(url: &str) -> Result<ForwardDiscovery, McpClientError> {
+pub async fn discover_forward(url: &str, roots: &[RootEntry]) -> Result<ForwardDiscovery, McpClientError> {
     let url = url.to_owned();
     let transport = build_transport(&url);
+    let handler = RootsHandler::from_entries(roots);
 
-    let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
+    let client = tokio::time::timeout(TIMEOUT, Box::pin(handler.serve(transport)))
         .await
         .map_err(|_| McpClientError::Timeout { url: url.clone() })?
         .map_err(|e| McpClientError::Connection {

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -111,6 +111,18 @@ pub struct McpServerInfo {
     pub instructions: Option<String>,
 }
 
+/// A root directory entry for MCP servers that require `roots/list`.
+///
+/// Some upstream MCP servers (e.g. the filesystem server) need the client to
+/// provide one or more root directories during initialization.  Entries here
+/// are returned when the server sends a `roots/list` request.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct RootEntry {
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ForwardEntry {
     pub name: String,
@@ -125,6 +137,10 @@ pub struct ForwardEntry {
     pub available: bool,
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "statusMessage", alias = "status_message")]
     pub status_message: Option<String>,
+    /// Root directories to provide to the upstream MCP server when it sends a
+    /// `roots/list` request.  Optional -- most servers do not require roots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub roots: Option<Vec<RootEntry>>,
 }
 
 fn default_available() -> bool {
@@ -364,6 +380,17 @@ impl InMemoryRegistry {
         }
 
         tracing::info!("loaded registry from persistence backend");
+    }
+
+    /// Find the root entries configured for a forward with the given address.
+    /// Returns an empty slice when no forward matches or the forward has no roots.
+    pub fn roots_for_address(&self, address: &str) -> Vec<RootEntry> {
+        for entry in self.forwards.iter() {
+            if entry.value().address == address {
+                return entry.value().roots.clone().unwrap_or_default();
+            }
+        }
+        Vec::new()
     }
 
     fn snapshot(&self) -> RegistrySnapshot {
@@ -947,6 +974,79 @@ mod tests {
         assert_eq!(entry.name, "legacy");
         assert!(entry.server_info.is_none());
         assert!(entry.labels.is_empty());
+        assert!(entry.roots.is_none());
+    }
+
+    #[test]
+    fn forward_entry_with_roots_round_trip() {
+        let json = r#"{
+            "name": "fs-server",
+            "address": "http://localhost:9000/mcp",
+            "roots": [
+                {"uri": "file:///data/project", "name": "project-root"},
+                {"uri": "file:///tmp"}
+            ]
+        }"#;
+
+        let entry: ForwardEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(entry.name, "fs-server");
+        let roots = entry.roots.as_ref().expect("roots should be Some");
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0].uri, "file:///data/project");
+        assert_eq!(roots[0].name.as_deref(), Some("project-root"));
+        assert_eq!(roots[1].uri, "file:///tmp");
+        assert!(roots[1].name.is_none());
+
+        let serialized = serde_json::to_string(&entry).expect("serialize");
+        let reparsed: ForwardEntry = serde_json::from_str(&serialized).expect("re-deserialize");
+        assert_eq!(reparsed.roots.as_ref().map(|r| r.len()), Some(2));
+    }
+
+    #[test]
+    fn roots_for_address_returns_matching_roots() {
+        let registry = InMemoryRegistry::new();
+        registry.register_forward(ForwardEntry {
+            name: "fs".to_owned(),
+            address: "http://fs:9000/mcp".to_owned(),
+            namespace: None,
+            server_info: None,
+            labels: HashMap::new(),
+            available: true,
+            status_message: None,
+            roots: Some(vec![RootEntry {
+                uri: "file:///data".to_owned(),
+                name: Some("data".to_owned()),
+            }]),
+        });
+
+        let roots = registry.roots_for_address("http://fs:9000/mcp");
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].uri, "file:///data");
+    }
+
+    #[test]
+    fn roots_for_address_returns_empty_when_no_roots() {
+        let registry = InMemoryRegistry::new();
+        registry.register_forward(ForwardEntry {
+            name: "plain".to_owned(),
+            address: "http://plain:8080/mcp".to_owned(),
+            namespace: None,
+            server_info: None,
+            labels: HashMap::new(),
+            available: true,
+            status_message: None,
+            roots: None,
+        });
+
+        let roots = registry.roots_for_address("http://plain:8080/mcp");
+        assert!(roots.is_empty());
+    }
+
+    #[test]
+    fn roots_for_address_returns_empty_when_no_match() {
+        let registry = InMemoryRegistry::new();
+        let roots = registry.roots_for_address("http://unknown:1234/mcp");
+        assert!(roots.is_empty());
     }
 
     #[test]

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -95,7 +95,7 @@ impl PromptGetFilter {
 
         if prompt.messages.is_empty()
             && let Some(ref uri) = prompt.configuration_uri {
-                return self.handle_forwarded_get(uri, &prompt_name, &parsed).await;
+                return self.handle_forwarded_get(registry, uri, &prompt_name, &parsed).await;
             }
 
         let messages: Vec<serde_json::Value> = prompt
@@ -141,10 +141,13 @@ impl PromptGetFilter {
 
     async fn handle_forwarded_get(
         &self,
+        registry: &InMemoryRegistry,
         forward_address: &str,
         prompt_name: &str,
         parsed: &ParsedBody,
     ) -> Result<FilterAction, FilterError> {
+        let roots = registry.roots_for_address(forward_address);
+
         trace!(prompt = %prompt_name, forward = %forward_address, "forwarding prompts/get to remote MCP server");
 
         let arguments = if parsed.arguments.is_empty() {
@@ -153,7 +156,7 @@ impl PromptGetFilter {
             Some(parsed.arguments.clone())
         };
 
-        match wanaku_apis::mcp_client::get_prompt(forward_address, prompt_name, arguments).await {
+        match wanaku_apis::mcp_client::get_prompt(forward_address, prompt_name, arguments, &roots).await {
             Ok(result) => {
                 let response = serde_json::json!({
                     "jsonrpc": "2.0",

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -131,7 +131,7 @@ impl ResourceReadFilter {
         };
 
         if resource.is_mcp_forward() {
-            return self.handle_forwarded_read(&resource, &resource_uri, &parsed).await;
+            return self.handle_forwarded_read(registry, &resource, &resource_uri, &parsed).await;
         }
 
         warn!(uri = %resource_uri, resource_type = %resource.type_, "unsupported resource type — only MCP-forwarded resources are supported");
@@ -142,8 +142,10 @@ impl ResourceReadFilter {
         ))
     }
 
+    #[expect(clippy::too_many_lines, reason = "MCP forwarding handler with roots lookup")]
     async fn handle_forwarded_read(
         &self,
+        registry: &InMemoryRegistry,
         resource: &wanaku_apis::registry::ResourceEntry,
         resource_uri: &str,
         parsed: &ParsedBody,
@@ -157,9 +159,11 @@ impl ResourceReadFilter {
             ));
         };
 
+        let roots = registry.roots_for_address(forward_address);
+
         trace!(uri = %resource_uri, forward = %forward_address, "forwarding resources/read to remote MCP server");
 
-        match wanaku_apis::mcp_client::read_resource(forward_address, resource_uri).await {
+        match wanaku_apis::mcp_client::read_resource(forward_address, resource_uri, &roots).await {
             Ok(contents) => {
                 let response = serde_json::json!({
                     "jsonrpc": "2.0",

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -130,7 +130,7 @@ impl ToolCallFilter {
         };
 
         if tool.is_mcp_forward() {
-            return self.handle_forwarded_call(&tool, &tool_name, &parsed).await;
+            return self.handle_forwarded_call(registry, &tool, &tool_name, &parsed).await;
         }
 
         warn!(tool = %tool_name, tool_type = %tool.type_, "unsupported tool type — only MCP-forwarded tools are supported");
@@ -144,11 +144,14 @@ impl ToolCallFilter {
     #[expect(clippy::too_many_lines, reason = "MCP forwarding handler with error paths")]
     async fn handle_forwarded_call(
         &self,
+        registry: &InMemoryRegistry,
         tool: &ToolEntry,
         tool_name: &str,
         parsed: &ParsedBody,
     ) -> Result<FilterAction, FilterError> {
         trace!(tool = %tool_name, uri = %tool.uri, "forwarding tools/call to remote MCP server");
+
+        let roots = registry.roots_for_address(&tool.uri);
 
         let arguments = serde_json::Value::Object(
             parsed
@@ -158,7 +161,7 @@ impl ToolCallFilter {
                 .collect(),
         );
 
-        match wanaku_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments).await {
+        match wanaku_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments, &roots).await {
             Ok(call_result) => {
                 let mcp_content: Vec<serde_json::Value> = call_result.content
                     .iter()

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -224,7 +224,8 @@ pub(super) async fn handle_forward_create(registry: &InMemoryRegistry, body: &st
         }
     };
 
-    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address, roots).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "forward discovery failed");
@@ -284,7 +285,8 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
     remove_forwarded_resources(registry, &forward.address);
     remove_forwarded_prompts(registry, &forward.address);
 
-    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address, roots).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %name, error = %e, "forward refresh discovery failed");
@@ -309,7 +311,8 @@ pub(super) async fn handle_forward_refresh(registry: &InMemoryRegistry, name: &s
 }
 
 pub async fn discover_and_update_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) {
-    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let discovery = match wanaku_apis::mcp_client::discover_forward(&forward.address, roots).await {
         Ok(d) => d,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "forward discovery failed at startup");
@@ -341,7 +344,8 @@ pub async fn discover_and_update_forward(registry: &InMemoryRegistry, forward: &
 }
 
 pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let tools = match wanaku_apis::mcp_client::list_tools(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let tools = match wanaku_apis::mcp_client::list_tools(&forward.address, roots).await {
         Ok(t) => t,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover tools from forward");
@@ -396,7 +400,8 @@ fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry
 }
 
 pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let resources = match wanaku_apis::mcp_client::list_resources(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let resources = match wanaku_apis::mcp_client::list_resources(&forward.address, roots).await {
         Ok(r) => r,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover resources from forward");
@@ -404,7 +409,7 @@ pub async fn discover_resources_from_forward(registry: &InMemoryRegistry, forwar
         }
     };
 
-    let templates = match wanaku_apis::mcp_client::list_resource_templates(&forward.address).await {
+    let templates = match wanaku_apis::mcp_client::list_resource_templates(&forward.address, roots).await {
         Ok(t) => t,
         Err(e) => {
             tracing::debug!(forward = %forward.name, error = %e, "no resource templates from forward (may not be supported)");
@@ -551,7 +556,8 @@ fn remove_forwarded_tools(registry: &InMemoryRegistry, address: &str) {
 }
 
 pub async fn discover_prompts_from_forward(registry: &InMemoryRegistry, forward: &ForwardEntry) -> usize {
-    let prompts = match wanaku_apis::mcp_client::list_prompts(&forward.address).await {
+    let roots = forward.roots.as_deref().unwrap_or_default();
+    let prompts = match wanaku_apis::mcp_client::list_prompts(&forward.address, roots).await {
         Ok(p) => p,
         Err(e) => {
             warn!(forward = %forward.name, error = %e, "failed to discover prompts from forward");
@@ -1211,6 +1217,7 @@ mod tests {
             labels: HashMap::new(),
             available: true,
             status_message: None,
+            roots: None,
         });
 
         let list_resp = handle_forward_list(&registry);
@@ -1247,6 +1254,7 @@ mod tests {
             labels: HashMap::new(),
             available: true,
             status_message: None,
+            roots: None,
         });
         assert_eq!(handle_forward_delete(&registry, "del-fwd").status(), 200);
         assert_eq!(handle_forward_get(&registry, "del-fwd").status(), 404);
@@ -1298,6 +1306,7 @@ mod tests {
             labels: HashMap::new(),
             available: true,
             status_message: None,
+            roots: None,
         });
 
         let data = data_field(&handle_statistics(&registry));

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -9,7 +9,7 @@ use wanaku_apis::metrics::{
 };
 use wanaku_apis::registry::{
     ForwardEntry, McpServerInfo, NamespaceEntry, PromptArgument, PromptEntry, PromptMessage,
-    ResourceEntry, ToolEntry,
+    ResourceEntry, RootEntry, ToolEntry,
 };
 
 #[derive(serde::Serialize, utoipa::ToSchema)]
@@ -222,7 +222,7 @@ const fn get_statistics() {}
     ),
     components(schemas(
         ToolEntry, ResourceEntry, PromptEntry, PromptArgument, PromptMessage,
-        ForwardEntry, McpServerInfo, NamespaceEntry, Interaction,
+        ForwardEntry, McpServerInfo, RootEntry, NamespaceEntry, Interaction,
         MetricsSnapshot, FilterSnapshot, DurationSnapshot, EvaluatorSnapshot,
         DecisionSnapshot, LlmSnapshot, SchemaSnapshot, WasmSnapshot,
         PipelineSnapshot, GaugeSnapshot,

--- a/wanaku.yaml
+++ b/wanaku.yaml
@@ -2,3 +2,6 @@ forwards:
   - name: "mock-mcp"
     address: "http://localhost:8180/mcp"
     namespace: "test-ns"
+    # roots:
+    #   - uri: "file:///path/to/allowed/directory"
+    #     name: "project-root"


### PR DESCRIPTION
Fixes #1515

## Summary

- Adds a `roots` field to `ForwardEntry` so users can configure root directories for upstream MCP servers that require `roots/list` (e.g. the MCP filesystem server)
- Introduces `RootsHandler`, a custom `ClientHandler` that returns configured roots when the upstream server sends a `roots/list` request
- Logs a warning when a server requests roots but none are configured, helping diagnose connection failures
- Threads roots through all MCP client functions and their callers (management handlers, filter chains)

## Changes

- `apis/src/registry.rs` -- Added `RootEntry` struct and `roots` field on `ForwardEntry`; added `roots_for_address()` helper on `InMemoryRegistry`
- `apis/src/mcp_client.rs` -- Added `RootsHandler` implementing `ClientHandler`; all 8 public functions now accept a `roots` parameter
- `server/src/management/handlers.rs` -- Threads `forward.roots` to all MCP client calls (create, refresh, discovery)
- `filters/src/tool_call.rs`, `filters/src/resource_read.rs`, `filters/src/prompt_get.rs` -- Looks up roots from registry by forward address before forwarding
- `server/src/openapi.rs` -- Added `RootEntry` to OpenAPI schema
- `wanaku.yaml` -- Added commented example of roots configuration

## Summary by Sourcery

Support configured filesystem roots for forwarded MCP servers that use `roots/list`.

New Features:
- Allow forwarded MCP servers to be configured with named root directories for `roots/list` requests.

Bug Fixes:
- Enable upstream MCP servers that require filesystem roots during initialization and forwarding operations.

Enhancements:
- Propagate configured roots through MCP discovery and interaction paths, with diagnostics when roots are requested but unavailable.
- Expose root configuration in the registry model and OpenAPI schema.

Documentation:
- Add a commented roots configuration example to the sample Wanaku configuration.

Tests:
- Add coverage for root configuration serialization and registry lookup behavior.