### PR TITLE
fix #1851: hoist parse_body to avoid double parsing in tool_call filter

### DIFF
--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -61,10 +61,11 @@ impl ToolCallFilter {
             return Ok(FilterAction::Continue);
         }
 
+        let mut parsed = parse_body(body);
+
         let tool_name = match ctx.get_metadata(crate::MCP_NAME_KEY) {
             Some(n) => n.to_owned(),
             None => {
-                let parsed = parse_body(body);
                 return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INVALID_PARAMS, "missing tool name in tools/call"));
             }
         };
@@ -72,8 +73,6 @@ impl ToolCallFilter {
         let namespace = ctx
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
             .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
-
-        let mut parsed = parse_body(body);
 
         let conversation_id = parsed.arguments
             .remove(wanaku_apis::correlation::REQUEST_ID_ARG)


### PR DESCRIPTION
## Summary

- Hoists `parse_body(body)` call to the top of `handle_body` in `ToolCallFilter`, so the body is parsed once instead of twice (previously parsed in both the error path at line 67 and the main path at line 76)
- No behavior change — same parse result, just computed earlier

## Test plan

- [x] `cargo test -p wanaku-filters` — all 60 tests pass
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Parse tool-call request bodies once to eliminate redundant work while preserving existing behavior.

Bug Fixes:
- Avoid parsing tool-call request bodies twice when handling missing tool-name errors.

Enhancements:
- Hoist request-body parsing so the parsed result is shared across all handling paths without changing behavior.