### PR TITLE
fix #1850: log warning when HotSwap encounters poisoned lock

### DIFF
--- a/apis/src/llm.rs
+++ b/apis/src/llm.rs
@@ -147,14 +147,14 @@ impl<T: Clone> HotSwap<T> {
     pub fn set(&self, value: T) {
         match self.inner.write() {
             Ok(mut guard) => *guard = Some(value),
-            Err(e) => tracing::warn!("HotSwap write lock poisoned, dropping set: {e}"),
+            Err(e) => tracing::warn!(error = %e, "HotSwap write lock poisoned, dropping set"),
         }
     }
 
     pub fn clear(&self) {
         match self.inner.write() {
             Ok(mut guard) => *guard = None,
-            Err(e) => tracing::warn!("HotSwap write lock poisoned, cannot clear: {e}"),
+            Err(e) => tracing::warn!(error = %e, "HotSwap write lock poisoned, cannot clear"),
         }
     }
 
@@ -163,7 +163,7 @@ impl<T: Clone> HotSwap<T> {
         match self.inner.read() {
             Ok(guard) => guard.clone(),
             Err(e) => {
-                tracing::warn!("HotSwap read lock poisoned: {e}");
+                tracing::warn!(error = %e, "HotSwap read lock poisoned");
                 None
             }
         }

--- a/apis/src/llm.rs
+++ b/apis/src/llm.rs
@@ -145,20 +145,28 @@ impl<T: Clone> HotSwap<T> {
     }
 
     pub fn set(&self, value: T) {
-        if let Ok(mut guard) = self.inner.write() {
-            *guard = Some(value);
+        match self.inner.write() {
+            Ok(mut guard) => *guard = Some(value),
+            Err(e) => tracing::warn!("HotSwap write lock poisoned, dropping set: {e}"),
         }
     }
 
     pub fn clear(&self) {
-        if let Ok(mut guard) = self.inner.write() {
-            *guard = None;
+        match self.inner.write() {
+            Ok(mut guard) => *guard = None,
+            Err(e) => tracing::warn!("HotSwap write lock poisoned, cannot clear: {e}"),
         }
     }
 
     #[must_use]
     pub fn get(&self) -> Option<T> {
-        self.inner.read().ok().and_then(|guard| guard.clone())
+        match self.inner.read() {
+            Ok(guard) => guard.clone(),
+            Err(e) => {
+                tracing::warn!("HotSwap read lock poisoned: {e}");
+                None
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Changes `HotSwap::set()`, `clear()`, and `get()` from silently swallowing poisoned `RwLock` errors to logging `tracing::warn!` when a poisoned lock is encountered
- Follows the established pattern used by `InMemoryInteractionStore` in `apis/src/interactions.rs`
- Behavior is unchanged: `set`/`clear` are still no-ops on poison, `get` still returns `None` — but now these failures are visible in logs

## Test plan

- [x] `cargo test -p wanaku-apis` — all 63 tests pass
- [x] `cargo clippy -p wanaku-apis` — no warnings
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Bug Fixes:
- Log warnings when HotSwap encounters poisoned read or write locks while preserving its existing fallback behavior.