### PR TITLE
fix #1856: remove unnecessary json_ok/json_err wrapper indirection

### DIFF
--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -6,7 +6,7 @@ use wanaku_apis::registry::{
     PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry,
     ToolEntry, ToolRegistry, MCP_FORWARD_TYPE,
 };
-use super::response::{json_ok, json_err};
+use crate::http_response::{json_ok, json_err};
 
 pub(super) fn handle_tool_list(registry: &InMemoryRegistry) -> Response<Vec<u8>> {
     let tools = registry.list_tools();

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -28,7 +28,8 @@ use self::handlers::{
     handle_statistics,
     handle_tool_delete, handle_tool_get, handle_tool_list, handle_tool_update,
 };
-use self::response::{json_err, json_ok, raw_json_response, read_body};
+use crate::http_response::{json_err, json_ok};
+use self::response::{raw_json_response, read_body};
 #[cfg(feature = "ui")]
 use self::response::redirect_response;
 use self::routes::{

--- a/server/src/management/response.rs
+++ b/server/src/management/response.rs
@@ -2,6 +2,8 @@ use http::{Response, StatusCode};
 use pingora_core::protocols::http::ServerSession;
 use tracing::warn;
 
+use crate::http_response::json_err;
+
 pub(super) const MAX_BODY_BYTES: usize = 1_048_576;
 
 #[cfg(feature = "ui")]
@@ -23,14 +25,6 @@ pub(super) fn raw_json_response(body: Vec<u8>) -> Response<Vec<u8>> {
         .header("Access-Control-Allow-Origin", wanaku_apis::config::ENV.cors_origin.as_str())
         .body(body)
         .expect("valid json response")
-}
-
-pub(super) fn json_ok(data: &serde_json::Value) -> Response<Vec<u8>> {
-    crate::http_response::json_ok(data)
-}
-
-pub(super) fn json_err(status: StatusCode, message: &str) -> Response<Vec<u8>> {
-    crate::http_response::json_err(status, message)
 }
 
 pub(super) async fn read_body(session: &mut ServerSession) -> Result<String, Response<Vec<u8>>> {

--- a/server/src/management/ui.rs
+++ b/server/src/management/ui.rs
@@ -1,7 +1,7 @@
 use http::{Response, StatusCode};
 use rust_embed::Embed;
 
-use super::response::json_err;
+use crate::http_response::json_err;
 
 #[derive(Embed)]
 #[folder = "../ui/admin/dist/"]


### PR DESCRIPTION
## Summary

- Removes thin wrapper functions `json_ok` and `json_err` from `server/src/management/response.rs` that just forwarded to `crate::http_response`
- Updates all callers (`handlers.rs`, `mod.rs`, `ui.rs`) to import directly from `crate::http_response`
- `response.rs` is kept because it still contains real logic: `MAX_BODY_BYTES`, `redirect_response`, `raw_json_response`, and `read_body`

## Test plan

- [x] `cargo test -p wanaku-server` — all 58 tests pass
- [x] `cargo clippy -p wanaku-server` — no warnings
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Enhancements:
- Remove redundant management-layer JSON response wrappers and have callers use the shared HTTP response helpers directly.