### PR TITLE
fix #1853: consolidate metadata key constants into a single module

### DIFF
--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -8,9 +8,11 @@ pub mod interactions;
 pub mod llm;
 pub mod mcp;
 pub mod mcp_client;
+pub mod metadata;
 pub mod metrics;
 pub mod persistence;
 pub mod registry;
 
+pub use metadata::{MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
+
 pub const WANAKU_BODY_ARG: &str = "wanaku_body";
-pub const NAMESPACE_METADATA_KEY: &str = "wanaku.namespace";

--- a/apis/src/metadata.rs
+++ b/apis/src/metadata.rs
@@ -1,0 +1,3 @@
+pub const MCP_METHOD_KEY: &str = "mcp.method";
+pub const MCP_NAME_KEY: &str = "mcp.name";
+pub const NAMESPACE_METADATA_KEY: &str = "wanaku.namespace";

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-pub const MCP_METHOD_KEY: &str = "mcp.method";
-pub const MCP_NAME_KEY: &str = "mcp.name";
+pub use wanaku_apis::metadata::{MCP_METHOD_KEY, MCP_NAME_KEY};
 
 #[macro_export]
 macro_rules! body_filter_boilerplate {

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-pub use wanaku_apis::metadata::{MCP_METHOD_KEY, MCP_NAME_KEY};
+pub use wanaku_apis::metadata::{MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
 
 #[macro_export]
 macro_rules! body_filter_boilerplate {

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 
-pub use wanaku_apis::NAMESPACE_METADATA_KEY;
+pub use wanaku_apis::metadata::NAMESPACE_METADATA_KEY;
 
 crate::body_filter_boilerplate!(NamespaceFilter, "wanaku_namespace");
 


### PR DESCRIPTION
## Summary

- Creates `apis/src/metadata.rs` as the single source of truth for all filter metadata key constants: `MCP_METHOD_KEY`, `MCP_NAME_KEY`, `NAMESPACE_METADATA_KEY`
- Re-exports from `apis/src/lib.rs` so `wanaku_apis::NAMESPACE_METADATA_KEY` still works
- Changes `filters/src/lib.rs` from defining `MCP_METHOD_KEY`/`MCP_NAME_KEY` directly to re-exporting from `wanaku_apis::metadata`, so `crate::MCP_METHOD_KEY` and `wanaku_filters::MCP_METHOD_KEY` still work
- Zero changes needed in any filter or feature files — all existing import paths continue to resolve

## Test plan

- [x] `cargo test -p wanaku-apis -p wanaku-filters` — all 123 tests pass
- [x] `cargo check -p wanaku-feature-evaluator` — compiles (uses `wanaku_filters::MCP_METHOD_KEY`)
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Enhancements:
- Consolidate MCP and namespace metadata key constants into the `wanaku_apis::metadata` module while preserving existing public import paths.