### PR TITLE
fix #1845: use configurable CORS origin in MCP filter responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ cd ../safety-warn && cargo component build --release && cp target/wasm32-wasip1/
 | `WANAKU_PERSIST_BACKEND` | `"file"` | Persistence backend; `"none"` disables |
 | `WANAKU_PERSIST_PATH` | `$HOME/.wanaku/server` | `registry.json` dir |
 | `WANAKU_UI_PATH` | unset | FS path to UI override |
+| `WANAKU_CORS_ORIGIN` | `"*"` | `Access-Control-Allow-Origin` for all HTTP responses |
 | `WANAKU_AUTH_ISSUER` | unset | OIDC issuer (RFC 9728) |
 | `WANAKU_INFERENCE_API_KEY` | unset | Bearer token for upstream |
 

--- a/apis/src/config.rs
+++ b/apis/src/config.rs
@@ -31,7 +31,8 @@ const WANAKU_PERSIST_PATH: &str = "WANAKU_PERSIST_PATH";
 /// Unset uses the compiled-in [`rust_embed`] bundle.
 const WANAKU_UI_PATH: &str = "WANAKU_UI_PATH";
 
-/// Value for the `Access-Control-Allow-Origin` header on management API responses.
+/// Value for the `Access-Control-Allow-Origin` header on all HTTP responses
+/// (management API, MCP endpoint, and CORS preflight).
 /// Defaults to `"*"`. Set to a specific origin (e.g. `http://localhost:3000`) in production.
 const WANAKU_CORS_ORIGIN: &str = "WANAKU_CORS_ORIGIN";
 
@@ -60,7 +61,7 @@ pub struct WanakuEnv {
     pub persist: Option<PersistEnv>,
     /// Override path for serving the admin UI from the filesystem.
     pub ui_path: Option<PathBuf>,
-    /// Value for the `Access-Control-Allow-Origin` header on management API responses.
+    /// Value for the `Access-Control-Allow-Origin` header on all HTTP responses.
     pub cors_origin: String,
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ These control core server behavior:
 | `WANAKU_PERSIST_BACKEND` | _(unset = disabled)_ | Set to `"file"` to enable file-based registry persistence |
 | `WANAKU_PERSIST_PATH` | `/data/registry` | Directory where `registry.json` is read/written |
 | `WANAKU_UI_PATH` | _(unset = embedded)_ | Filesystem path to admin UI override (use for local dev) |
-| `WANAKU_CORS_ORIGIN` | `*` | Value for `Access-Control-Allow-Origin` on management API responses |
+| `WANAKU_CORS_ORIGIN` | `*` | Value for `Access-Control-Allow-Origin` on all HTTP responses (management API, MCP endpoint, and CORS preflight) |
 | `WANAKU_AUTH_ISSUER` | _(unset = disabled)_ | OIDC issuer URL for RFC 9728 metadata endpoint |
 | `WANAKU_INFERENCE_API_KEY` | _(unset = no auth)_ | Bearer token API key for the inference upstream. Empty means no auth. |
 

--- a/features/mcp-metadata/src/filter.rs
+++ b/features/mcp-metadata/src/filter.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use http::StatusCode;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext, Rejection};
+use wanaku_apis::config::ENV;
 
 use crate::IssuerConfig;
 
@@ -160,7 +161,7 @@ async fn proxy_token_endpoint(issuer: &str, body: &Option<Bytes>) -> Rejection {
                 Ok(resp_body) => {
                     Rejection::status(status)
                         .with_header("content-type", "application/json")
-                        .with_header("access-control-allow-origin", "*")
+                        .with_header("access-control-allow-origin", ENV.cors_origin.as_str())
                         .with_body(resp_body)
                 }
                 Err(e) => {
@@ -184,13 +185,13 @@ fn redirect_to(url: &str, query: Option<&str>) -> Rejection {
     tracing::debug!(target = %target, "redirecting to issuer");
     Rejection::status(StatusCode::FOUND.as_u16())
         .with_header("location", &target)
-        .with_header("access-control-allow-origin", "*")
+        .with_header("access-control-allow-origin", ENV.cors_origin.as_str())
 }
 
 fn json_response(status: StatusCode, value: &serde_json::Value) -> Rejection {
     let body = Bytes::from(value.to_string());
     Rejection::status(status.as_u16())
         .with_header("content-type", "application/json")
-        .with_header("access-control-allow-origin", "*")
+        .with_header("access-control-allow-origin", ENV.cors_origin.as_str())
         .with_body(body)
 }

--- a/filters/src/response.rs
+++ b/filters/src/response.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use http::StatusCode;
 use praxis_filter::Rejection;
+use wanaku_apis::config::ENV;
 
 pub const JSONRPC_INVALID_REQUEST: i32 = -32600;
 pub const JSONRPC_INVALID_PARAMS: i32 = -32602;
@@ -9,13 +10,13 @@ pub const JSONRPC_INTERNAL_ERROR: i32 = -32603;
 pub fn json_response(body: Bytes) -> Rejection {
     Rejection::status(StatusCode::OK.as_u16())
         .with_header("content-type", "application/json")
-        .with_header("access-control-allow-origin", "*")
+        .with_header("access-control-allow-origin", ENV.cors_origin.as_str())
         .with_body(body)
 }
 
 pub fn empty_accepted() -> Rejection {
     Rejection::status(StatusCode::ACCEPTED.as_u16())
-        .with_header("access-control-allow-origin", "*")
+        .with_header("access-control-allow-origin", ENV.cors_origin.as_str())
 }
 
 pub fn json_rpc_error(id: &serde_json::Value, code: i32, message: &str) -> praxis_filter::FilterAction {
@@ -136,7 +137,7 @@ mod tests {
         let r = json_response(Bytes::from("{}"));
         assert_eq!(r.status, 200);
         assert!(r.headers.iter().any(|(k, v)| k == "content-type" && v == "application/json"));
-        assert!(r.headers.iter().any(|(k, v)| k == "access-control-allow-origin" && v == "*"));
+        assert!(r.headers.iter().any(|(k, v)| k == "access-control-allow-origin" && v == ENV.cors_origin.as_str()));
     }
 
     #[test]

--- a/server/src/default.yaml
+++ b/server/src/default.yaml
@@ -10,7 +10,7 @@ filter_chains:
   - name: mcp_router
     filters:
       - filter: cors
-        allow_origins: ["*"]
+        allow_origins: ["__WANAKU_CORS_ORIGIN__"]
         allow_methods: ["GET", "POST", "OPTIONS"]
         allow_headers: ["Content-Type", "Accept", "Mcp-Session-Id", "Mcp-Protocol-Version", "Authorization"]
       - filter: mcp

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,7 +15,9 @@ pub fn load_config(
     explicit_path: Option<&str>,
 ) -> Result<praxis_core::config::Config, praxis_core::errors::ProxyError> {
     let env = &wanaku_apis::config::ENV;
-    let mut config = DEFAULT_CONFIG.replace("127.0.0.1:11434", &env.inference_upstream);
+    let mut config = DEFAULT_CONFIG
+        .replace("127.0.0.1:11434", &env.inference_upstream)
+        .replace("__WANAKU_CORS_ORIGIN__", &env.cors_origin);
     if let Some(sni) = &env.inference_tls_sni {
         config = config.replace(
             "- name: inference\n            endpoints:",


### PR DESCRIPTION
## Summary

- Replaces hardcoded `"*"` CORS origin values with `ENV.cors_origin.as_str()` in:
  - `filters/src/response.rs` — `json_response()` and `empty_accepted()`
  - `features/mcp-metadata/src/filter.rs` — `proxy_token_endpoint()`, `redirect_to()`, and local `json_response()`
  - `server/src/default.yaml` — CORS preflight filter now uses `__WANAKU_CORS_ORIGIN__` placeholder, replaced at startup
- The management API already respected `WANAKU_CORS_ORIGIN` — this makes all endpoints consistent
- Default value is `"*"` (unchanged behavior unless `WANAKU_CORS_ORIGIN` is explicitly set)
- Updates config docstrings in `apis/src/config.rs` to reflect expanded scope
- Updates user documentation in `docs/configuration.md` and developer docs in `CLAUDE.md`

## Test plan

- [x] `cargo test -p wanaku-filters` — all 60 tests pass (test assertion updated)
- [x] `cargo clippy -p wanaku-filters -p wanaku-feature-mcp-metadata` — no warnings
- [x] Full Integration Test (From Source) — all actual tests passed; skip-threshold guard (unrelated)
- [ ] CI (clippy + tests) via PR Build workflow