### PR TITLE
fix #1854: move env var read from InterceptFeature::new() to load_env_config()

### DIFF
--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -80,7 +80,10 @@ impl Feature for InterceptFeature {
             Ok(guard) => guard.clone(),
             Err(e) => {
                 tracing::warn!(error = %e, "interaction store lock poisoned");
-                return None;
+                return Some(wanaku_apis::http_response::json_err(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "interaction store unavailable",
+                ));
             }
         };
         Some(match route {

--- a/features/intercept/src/lib.rs
+++ b/features/intercept/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod filter;
 mod routes;
 
+use std::sync::RwLock;
+
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 
@@ -17,18 +19,14 @@ use crate::routes::{
 const DEFAULT_CAPACITY: usize = 1000;
 
 pub struct InterceptFeature {
-    store: InMemoryInteractionStore,
+    store: RwLock<InMemoryInteractionStore>,
 }
 
 impl InterceptFeature {
     #[must_use]
     pub fn new() -> Self {
-        let capacity = std::env::var("WANAKU_INTERACTION_CAPACITY")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(DEFAULT_CAPACITY);
         Self {
-            store: InMemoryInteractionStore::new(capacity),
+            store: RwLock::new(InMemoryInteractionStore::new(DEFAULT_CAPACITY)),
         }
     }
 }
@@ -63,9 +61,14 @@ impl Feature for InterceptFeature {
     }
 
     fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>> {
-        vec![Box::new(InteractionStoreExtension {
-            store: self.store.clone(),
-        })]
+        let store = match self.store.read() {
+            Ok(guard) => guard.clone(),
+            Err(e) => {
+                tracing::warn!(error = %e, "interaction store lock poisoned, using default");
+                InMemoryInteractionStore::new(DEFAULT_CAPACITY)
+            }
+        };
+        vec![Box::new(InteractionStoreExtension { store })]
     }
 
     async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
@@ -73,14 +76,36 @@ impl Feature for InterceptFeature {
         if route == InteractionRoute::NotFound {
             return None;
         }
+        let store = match self.store.read() {
+            Ok(guard) => guard.clone(),
+            Err(e) => {
+                tracing::warn!(error = %e, "interaction store lock poisoned");
+                return None;
+            }
+        };
         Some(match route {
-            InteractionRoute::List => handle_interaction_list(&self.store),
-            InteractionRoute::Clear => handle_interaction_clear(&self.store),
+            InteractionRoute::List => handle_interaction_list(&store),
+            InteractionRoute::Clear => handle_interaction_clear(&store),
             InteractionRoute::NotFound => return None,
         })
     }
 
     fn load_yaml_config(&self, _root: &serde_yaml::Value) {}
 
-    fn load_env_config(&self) {}
+    fn load_env_config(&self) {
+        if let Some(capacity) = std::env::var("WANAKU_INTERACTION_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            match self.store.write() {
+                Ok(mut guard) => {
+                    *guard = InMemoryInteractionStore::new(capacity);
+                    tracing::info!(capacity, "interaction store capacity configured from env");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to update interaction store capacity");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Moves `WANAKU_INTERACTION_CAPACITY` env var reading from `InterceptFeature::new()` to `load_env_config()`, consistent with the Feature trait lifecycle
- Wraps `store` field in `RwLock<InMemoryInteractionStore>` since `load_env_config(&self)` takes a shared reference
- Server lifecycle guarantees `load_env_config()` runs before `pipeline_extensions()` and `handle_route()`, so there's no concurrent write contention at runtime
- Poisoned lock handling follows codebase patterns: `pipeline_extensions` falls back to default-capacity store, `handle_route` returns `None`
- `InMemoryInteractionStore` clone is cheap (Arc clone)

## Test plan

- [x] `cargo build` — full project compiles
- [x] `cargo clippy -p wanaku-feature-intercept` — no warnings
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Move interaction store environment configuration into the feature configuration phase while preserving reliable request handling.

Bug Fixes:
- Apply the interaction-capacity environment setting during feature configuration rather than construction, aligning it with the feature lifecycle.

Enhancements:
- Make the interaction store safely replaceable and readable through the feature lifecycle while handling poisoned locks gracefully.