### PR TITLE
chore: add features/metrics crate to Containerfile cache-build stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,10 +45,11 @@ COPY features/chat/Cargo.toml features/chat/Cargo.toml
 COPY features/evaluator/Cargo.toml features/evaluator/Cargo.toml
 COPY features/intercept/Cargo.toml features/intercept/Cargo.toml
 COPY features/mcp-metadata/Cargo.toml features/mcp-metadata/Cargo.toml
+COPY features/metrics/Cargo.toml features/metrics/Cargo.toml
 COPY features/plugins/Cargo.toml features/plugins/Cargo.toml
 
 RUN mkdir -p apis/src filters/src server/src \
-    features/chat/src features/evaluator/src features/intercept/src features/mcp-metadata/src features/plugins/src \
+    features/chat/src features/evaluator/src features/intercept/src features/mcp-metadata/src features/metrics/src features/plugins/src \
     ui/admin/dist \
     && echo '//! stub' > apis/src/lib.rs \
     && echo '//! stub' > filters/src/lib.rs \
@@ -57,6 +58,7 @@ RUN mkdir -p apis/src filters/src server/src \
     && echo '//! stub' > features/evaluator/src/lib.rs \
     && echo '//! stub' > features/intercept/src/lib.rs \
     && echo '//! stub' > features/mcp-metadata/src/lib.rs \
+    && echo '//! stub' > features/metrics/src/lib.rs \
     && echo '//! stub' > features/plugins/src/lib.rs \
     && printf '//! stub\nfn main() {}\n' > server/src/main.rs
 


### PR DESCRIPTION
## Summary
- The `features/metrics` workspace crate was added in #1830 but the Containerfile was not updated
- Container builds fail because the cache-build stage cannot resolve the `features/metrics` workspace member
- Adds the `COPY`, `mkdir`, and stub `lib.rs` entries matching all other feature crates

## Test plan
- [ ] CI "Build Main" workflow passes on both `ubuntu-latest` and `ubuntu-24.04-arm`

## Summary by Sourcery

Include the metrics workspace crate in the Containerfile cache-build stage so container builds resolve all workspace members.

Bug Fixes:
- Fix Containerfile cache-build failures by including the features/metrics workspace crate in the container build context.

Build:
- Update the cache-build stage to prepare the metrics crate alongside the other workspace feature crates.