### PR TITLE
fix #1844: add batch registration methods to avoid per-item persistence

### DIFF
--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -443,6 +443,9 @@ impl ToolRegistry for InMemoryRegistry {
     }
 
     fn register_tools_batch(&self, tools: Vec<ToolEntry>) {
+        if tools.is_empty() {
+            return;
+        }
         let inject = self.inject_request_id.load(Ordering::Relaxed);
         for mut tool in tools {
             if tool.namespace.is_none() {
@@ -515,6 +518,9 @@ impl ResourceRegistry for InMemoryRegistry {
     }
 
     fn register_resources_batch(&self, resources: Vec<ResourceEntry>) {
+        if resources.is_empty() {
+            return;
+        }
         for mut resource in resources {
             if resource.namespace.is_none() {
                 resource.namespace = Some(DEFAULT_NAMESPACE.to_owned());
@@ -583,6 +589,9 @@ impl PromptRegistry for InMemoryRegistry {
     }
 
     fn register_prompts_batch(&self, prompts: Vec<PromptEntry>) {
+        if prompts.is_empty() {
+            return;
+        }
         for mut prompt in prompts {
             if prompt.namespace.is_none() {
                 prompt.namespace = Some(DEFAULT_NAMESPACE.to_owned());

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -232,6 +232,7 @@ pub trait ToolRegistry: Send + Sync {
     fn get_tool(&self, name: &str) -> Option<ToolEntry>;
     fn get_tool_in_namespace(&self, namespace: &str, name: &str) -> Option<ToolEntry>;
     fn register_tool(&self, tool: ToolEntry);
+    fn register_tools_batch(&self, tools: Vec<ToolEntry>);
     fn remove_tool(&self, name: &str) -> bool;
     fn remove_tools_batch(&self, names: &[String]) -> usize;
     fn tool_count(&self) -> usize;
@@ -243,6 +244,7 @@ pub trait ResourceRegistry: Send + Sync {
     fn get_resource(&self, name: &str) -> Option<ResourceEntry>;
     fn get_resource_in_namespace(&self, namespace: &str, name: &str) -> Option<ResourceEntry>;
     fn register_resource(&self, resource: ResourceEntry);
+    fn register_resources_batch(&self, resources: Vec<ResourceEntry>);
     fn remove_resource(&self, name: &str) -> bool;
     fn remove_resources_batch(&self, names: &[String]) -> usize;
     fn resource_count(&self) -> usize;
@@ -254,6 +256,7 @@ pub trait PromptRegistry: Send + Sync {
     fn get_prompt(&self, name: &str) -> Option<PromptEntry>;
     fn get_prompt_in_namespace(&self, namespace: &str, name: &str) -> Option<PromptEntry>;
     fn register_prompt(&self, prompt: PromptEntry);
+    fn register_prompts_batch(&self, prompts: Vec<PromptEntry>);
     fn remove_prompt(&self, name: &str) -> bool;
     fn remove_prompts_batch(&self, names: &[String]) -> usize;
     fn prompt_count(&self) -> usize;
@@ -439,6 +442,20 @@ impl ToolRegistry for InMemoryRegistry {
         self.persist();
     }
 
+    fn register_tools_batch(&self, tools: Vec<ToolEntry>) {
+        let inject = self.inject_request_id.load(Ordering::Relaxed);
+        for mut tool in tools {
+            if tool.namespace.is_none() {
+                tool.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+            }
+            if inject {
+                inject_request_id_arg(&mut tool.input_schema);
+            }
+            self.tools.insert(tool.name.clone(), tool);
+        }
+        self.persist();
+    }
+
     fn remove_tool(&self, name: &str) -> bool {
         let removed = self.tools.remove(name).is_some();
         if removed {
@@ -497,6 +514,16 @@ impl ResourceRegistry for InMemoryRegistry {
         self.persist();
     }
 
+    fn register_resources_batch(&self, resources: Vec<ResourceEntry>) {
+        for mut resource in resources {
+            if resource.namespace.is_none() {
+                resource.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+            }
+            self.resources.insert(resource.name.clone(), resource);
+        }
+        self.persist();
+    }
+
     fn remove_resource(&self, name: &str) -> bool {
         let removed = self.resources.remove(name).is_some();
         if removed {
@@ -552,6 +579,16 @@ impl PromptRegistry for InMemoryRegistry {
             prompt.namespace = Some(DEFAULT_NAMESPACE.to_owned());
         }
         self.prompts.insert(prompt.name.clone(), prompt);
+        self.persist();
+    }
+
+    fn register_prompts_batch(&self, prompts: Vec<PromptEntry>) {
+        for mut prompt in prompts {
+            if prompt.namespace.is_none() {
+                prompt.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+            }
+            self.prompts.insert(prompt.name.clone(), prompt);
+        }
         self.persist();
     }
 

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -447,9 +447,10 @@ impl ToolRegistry for InMemoryRegistry {
             return;
         }
         let inject = self.inject_request_id.load(Ordering::Relaxed);
+        let default_ns = DEFAULT_NAMESPACE.to_owned();
         for mut tool in tools {
             if tool.namespace.is_none() {
-                tool.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+                tool.namespace = Some(default_ns.clone());
             }
             if inject {
                 inject_request_id_arg(&mut tool.input_schema);
@@ -521,9 +522,10 @@ impl ResourceRegistry for InMemoryRegistry {
         if resources.is_empty() {
             return;
         }
+        let default_ns = DEFAULT_NAMESPACE.to_owned();
         for mut resource in resources {
             if resource.namespace.is_none() {
-                resource.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+                resource.namespace = Some(default_ns.clone());
             }
             self.resources.insert(resource.name.clone(), resource);
         }
@@ -592,9 +594,10 @@ impl PromptRegistry for InMemoryRegistry {
         if prompts.is_empty() {
             return;
         }
+        let default_ns = DEFAULT_NAMESPACE.to_owned();
         for mut prompt in prompts {
             if prompt.namespace.is_none() {
-                prompt.namespace = Some(DEFAULT_NAMESPACE.to_owned());
+                prompt.namespace = Some(default_ns.clone());
             }
             self.prompts.insert(prompt.name.clone(), prompt);
         }

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -355,7 +355,7 @@ pub async fn discover_tools_from_forward(registry: &InMemoryRegistry, forward: &
 #[expect(clippy::too_many_lines, reason = "sequential tool registration")]
 fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry, tools: &[serde_json::Value]) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
-    let mut count = 0;
+    let mut batch = Vec::with_capacity(tools.len());
 
     for tool_json in tools {
         let name = match tool_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
@@ -374,7 +374,8 @@ fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry
             .cloned()
             .unwrap_or(serde_json::json!({"type": "object"}));
 
-        let tool = ToolEntry {
+        info!(tool = %name, forward = %forward.name, "discovered forwarded tool");
+        batch.push(ToolEntry {
             name: name.to_owned(),
             description: description.to_owned(),
             uri: forward.address.clone(),
@@ -385,13 +386,11 @@ fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry
             namespace: Some(namespace.to_owned()),
             configuration_uri: None,
             secrets_uri: None,
-        };
-
-        info!(tool = %name, forward = %forward.name, "discovered forwarded tool");
-        registry.register_tool(tool);
-        count += 1;
+        });
     }
 
+    let count = batch.len();
+    registry.register_tools_batch(batch);
     count
 }
 
@@ -423,7 +422,7 @@ fn register_discovered_resources(
     templates: &[serde_json::Value],
 ) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
-    let mut count = 0;
+    let mut batch = Vec::with_capacity(resources.len() + templates.len());
 
     for res_json in resources {
         let name = match res_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
@@ -455,7 +454,8 @@ fn register_discovered_resources(
             forward.address.clone(),
         );
 
-        let resource = ResourceEntry {
+        info!(resource = %name, forward = %forward.name, "discovered forwarded resource");
+        batch.push(ResourceEntry {
             name: name.to_owned(),
             description: description.to_owned(),
             location: uri.to_owned(),
@@ -466,11 +466,7 @@ fn register_discovered_resources(
             namespace: Some(namespace.to_owned()),
             configuration_uri: None,
             secrets_uri: None,
-        };
-
-        info!(resource = %name, forward = %forward.name, "discovered forwarded resource");
-        registry.register_resource(resource);
-        count += 1;
+        });
     }
 
     for tmpl_json in templates {
@@ -507,7 +503,8 @@ fn register_discovered_resources(
             "true".to_owned(),
         );
 
-        let resource = ResourceEntry {
+        info!(template = %name, uri_template = %uri_template, forward = %forward.name, "discovered forwarded resource template");
+        batch.push(ResourceEntry {
             name: name.to_owned(),
             description: description.to_owned(),
             location: uri_template.to_owned(),
@@ -518,13 +515,11 @@ fn register_discovered_resources(
             namespace: Some(namespace.to_owned()),
             configuration_uri: None,
             secrets_uri: None,
-        };
-
-        info!(template = %name, uri_template = %uri_template, forward = %forward.name, "discovered forwarded resource template");
-        registry.register_resource(resource);
-        count += 1;
+        });
     }
 
+    let count = batch.len();
+    registry.register_resources_batch(batch);
     count
 }
 
@@ -569,7 +564,7 @@ fn register_discovered_prompts(
     prompts: &[serde_json::Value],
 ) -> usize {
     let namespace = forward.namespace.as_deref().unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
-    let mut count = 0;
+    let mut batch = Vec::with_capacity(prompts.len());
 
     for prompt_json in prompts {
         let name = match prompt_json.get("name").and_then(|n| n.as_str()).map(str::trim) {
@@ -619,10 +614,11 @@ fn register_discovered_prompts(
         };
 
         info!(prompt = %name, forward = %forward.name, "discovered forwarded prompt");
-        registry.register_prompt(prompt);
-        count += 1;
+        batch.push(prompt);
     }
 
+    let count = batch.len();
+    registry.register_prompts_batch(batch);
     count
 }
 


### PR DESCRIPTION
## Summary

- Adds `register_tools_batch`, `register_resources_batch`, `register_prompts_batch` to registry traits and `InMemoryRegistry` implementation
- Updates `register_discovered_tools/resources/prompts` in handlers to collect entries into a Vec and call batch methods
- Reduces N persist calls to 1 per discovery operation (where N = number of discovered tools/resources/prompts)
- Empty batches skip persistence entirely (consistent with existing `remove_*_batch` pattern)

## Integration test

Ran [Full Integration Test (From Source)](https://github.com/orpiske/wanaku-tests/actions/runs/32407539562). All actual tests passed; run marked as failure due to pre-existing skip-threshold guard (`33% > 30%` in router-tests) — unrelated to this change.

## Test plan

- [x] `cargo test` — all tests pass (63 apis + 58 server + 60 filters)
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Batch registry discovery entries before registration to avoid per-item persistence overhead.

New Features:
- Add batch registration APIs for tools, resources, and prompts across registry interfaces and the in-memory implementation.

Enhancements:
- Batch discovered registry entries in management handlers to reduce persistence operations to one per discovery type and skip persistence for empty batches.