### PR TITLE
fix #1855: replace YAML string manipulation with programmatic config modification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Default configs: `server/src/default.yaml` (embedded, pipeline), `wanaku.yaml` (
 
 **Critical:** Changes to `server/src/default.yaml` don't trigger rebuilds (`include_str!`). Touch `server/src/lib.rs` to force recompile.
 
+**Config modification at startup:** `load_config` in `server/src/lib.rs` parses the embedded `default.yaml` into `serde_yaml::Value` and applies env var overrides programmatically (inference upstream, TLS SNI, CORS origin) before passing to praxis. Helper functions `find_named_entry_mut`, `find_inference_cluster`, `apply_inference_config`, and `apply_cors_config` navigate the YAML tree. Falls back to raw defaults with error logging if parsing or serialization fails.
+
 ## Build Info
 
 - Rust 2024, MSRV 1.96

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,8 @@ listeners:
   allow_headers: ["Content-Type", "Authorization"]
 ```
 
+**Note:** The `WANAKU_CORS_ORIGIN` env var overrides `allow_origins` in the embedded default pipeline config at startup. If you provide a custom pipeline config via `--pipeline-config`, `allow_origins` in that file is used as-is — the env var only applies to the embedded default.
+
 **MCP filter (praxis-ai):**
 
 ```yaml

--- a/server/src/default.yaml
+++ b/server/src/default.yaml
@@ -10,7 +10,7 @@ filter_chains:
   - name: mcp_router
     filters:
       - filter: cors
-        allow_origins: ["__WANAKU_CORS_ORIGIN__"]
+        allow_origins: ["*"]
         allow_methods: ["GET", "POST", "OPTIONS"]
         allow_headers: ["Content-Type", "Accept", "Mcp-Session-Id", "Mcp-Protocol-Version", "Authorization"]
       - filter: mcp

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,7 +4,74 @@ pub mod management;
 pub mod openapi;
 pub mod pipelines;
 
+use serde_yaml::Value;
+
 const DEFAULT_CONFIG: &str = include_str!("default.yaml");
+
+fn find_named_entry_mut<'a>(
+    sequence: &'a mut [Value],
+    key: &str,
+    name: &str,
+) -> Option<&'a mut Value> {
+    sequence.iter_mut().find(|entry| {
+        entry
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|n| n == name)
+    })
+}
+
+fn find_inference_cluster(yaml: &mut Value) -> Option<&mut Value> {
+    let chains = yaml.get_mut("filter_chains").and_then(Value::as_sequence_mut)?;
+    let chain = find_named_entry_mut(chains, "name", "inference_proxy")?;
+    let filters = chain.get_mut("filters").and_then(Value::as_sequence_mut)?;
+    let lb = find_named_entry_mut(filters, "filter", "load_balancer")?;
+    let clusters = lb.get_mut("clusters").and_then(Value::as_sequence_mut)?;
+    find_named_entry_mut(clusters, "name", "inference")
+}
+
+fn apply_inference_config(yaml: &mut Value, env: &wanaku_apis::config::WanakuEnv) {
+    let Some(cluster) = find_inference_cluster(yaml) else {
+        tracing::warn!("could not locate inference cluster in pipeline config — env overrides skipped");
+        return;
+    };
+
+    if let Some(endpoint) = cluster
+        .get_mut("endpoints")
+        .and_then(Value::as_sequence_mut)
+        .and_then(|eps| eps.first_mut())
+    {
+        *endpoint = Value::String(env.inference_upstream.clone());
+    }
+
+    if let Some(sni) = &env.inference_tls_sni
+        && let Some(mapping) = cluster.as_mapping_mut()
+    {
+        let mut tls = serde_yaml::Mapping::new();
+        tls.insert(Value::String("sni".into()), Value::String(sni.clone()));
+        mapping.insert(Value::String("tls".into()), Value::Mapping(tls));
+    }
+}
+
+fn apply_cors_config(yaml: &mut Value, env: &wanaku_apis::config::WanakuEnv) {
+    let Some(chains) = yaml.get_mut("filter_chains").and_then(Value::as_sequence_mut) else {
+        return;
+    };
+    let Some(chain) = find_named_entry_mut(chains, "name", "mcp_router") else {
+        return;
+    };
+    let Some(filters) = chain.get_mut("filters").and_then(Value::as_sequence_mut) else {
+        return;
+    };
+    let Some(cors) = find_named_entry_mut(filters, "filter", "cors") else {
+        return;
+    };
+    if let Some(origins) = cors.get_mut("allow_origins").and_then(Value::as_sequence_mut) {
+        if let Some(first) = origins.first_mut() {
+            *first = Value::String(env.cors_origin.clone());
+        }
+    }
+}
 
 /// Load configuration, falling back to the built-in default.
 ///
@@ -15,15 +82,25 @@ pub fn load_config(
     explicit_path: Option<&str>,
 ) -> Result<praxis_core::config::Config, praxis_core::errors::ProxyError> {
     let env = &wanaku_apis::config::ENV;
-    let mut config = DEFAULT_CONFIG
-        .replace("127.0.0.1:11434", &env.inference_upstream)
-        .replace("__WANAKU_CORS_ORIGIN__", &env.cors_origin);
-    if let Some(sni) = &env.inference_tls_sni {
-        config = config.replace(
-            "- name: inference\n            endpoints:",
-            &format!("- name: inference\n            tls:\n              sni: \"{sni}\"\n            endpoints:"),
-        );
-    }
+
+    let config = match serde_yaml::from_str::<Value>(DEFAULT_CONFIG) {
+        Ok(mut yaml) => {
+            apply_inference_config(&mut yaml, env);
+            apply_cors_config(&mut yaml, env);
+            match serde_yaml::to_string(&yaml) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to serialize modified config — using raw defaults");
+                    DEFAULT_CONFIG.to_string()
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to parse embedded config — using raw defaults");
+            DEFAULT_CONFIG.to_string()
+        }
+    };
+
     praxis_core::config::Config::load(explicit_path, &config)
 }
 


### PR DESCRIPTION
## Summary

- Replaces fragile `String::replace` calls in `load_config` with programmatic YAML modification via `serde_yaml::Value`
- Adds `find_named_entry_mut` helper for navigating YAML sequences by name
- `find_inference_cluster` navigates: `filter_chains -> inference_proxy -> filters -> load_balancer -> clusters -> inference`
- `apply_inference_config` modifies the endpoint and optionally adds TLS SNI config
- Fallback to raw defaults with `tracing::error!` if parsing/serialization fails
- Warning logged if inference cluster can't be located

## Integration test

Ran [Full Integration Test (From Source)](https://github.com/orpiske/wanaku-tests/actions/runs/32407711315). Results pending.

## Test plan

- [x] `cargo test -p wanaku-server` — all 58 tests pass
- [x] `cargo clippy -p wanaku-server` — no warnings
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Apply environment-based configuration overrides by modifying the embedded YAML structure programmatically instead of performing string replacements.

Bug Fixes:
- Replace fragile YAML string substitutions with structured configuration updates for inference upstream, optional TLS SNI, and CORS origin overrides.
- Fall back to the embedded raw defaults with error logging when configuration parsing or serialization fails.

Enhancements:
- Add YAML navigation helpers for locating named filter chains, filters, and inference clusters.
- Warn when the inference cluster cannot be found and document the startup behavior of CORS environment overrides.

Documentation:
- Document that WANAKU_CORS_ORIGIN applies only to the embedded default pipeline configuration.