### PR TITLE
fix #1852: extract management API dispatch into testable function

### DIFF
--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -90,10 +90,12 @@ impl ServeHttp for WanakuManagementService {
         }
 
         let body = match method.as_str() {
-            "POST" | "PUT" | "PATCH" => match read_body(http_session).await {
-                Ok(b) => Some(b),
-                Err(resp) => return resp,
-            },
+            "POST" | "PUT" | "PATCH" if path.starts_with("/api/") => {
+                match read_body(http_session).await {
+                    Ok(b) => Some(b),
+                    Err(resp) => return resp,
+                }
+            }
             _ => None,
         };
 

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -70,7 +70,6 @@ impl WanakuManagementService {
 
 #[async_trait]
 impl ServeHttp for WanakuManagementService {
-    #[expect(clippy::too_many_lines, clippy::large_stack_frames, reason = "route dispatch requires sequential matching")]
     async fn response(&self, http_session: &mut ServerSession) -> Response<Vec<u8>> {
         let req = http_session.req_header();
         let uri = &req.uri;
@@ -78,15 +77,6 @@ impl ServeHttp for WanakuManagementService {
         let query = uri.query().map(std::borrow::ToOwned::to_owned);
         let method = req.method.as_str().to_owned();
         let headers = req.headers.clone();
-
-        if path == "/healthz" || path == "/health" {
-            return json_ok(&serde_json::json!({"status": "ok"}));
-        }
-
-        if path == "/openapi.json" {
-            let body = crate::openapi::openapi_json();
-            return raw_json_response(body);
-        }
 
         #[cfg(feature = "ui")]
         {
@@ -99,89 +89,7 @@ impl ServeHttp for WanakuManagementService {
             }
         }
 
-        let mgmt_route = resolve_management_route(&method, &path);
-        if mgmt_route != ManagementRoute::NotFound {
-            return match mgmt_route {
-                ManagementRoute::Statistics => handle_statistics(&self.registry),
-                ManagementRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        tracing::debug!(%method, %path, "management API request");
-
-        let tool_route = resolve_tool_route(&method, &path);
-        if tool_route != ToolRoute::NotFound {
-            return match tool_route {
-                ToolRoute::List => handle_tool_list(&self.registry),
-                ToolRoute::GetByName(name) => handle_tool_get(&self.registry, &name),
-                ToolRoute::Update(name) => match read_body(http_session).await {
-                    Ok(body) => handle_tool_update(&self.registry, &name, &body),
-                    Err(resp) => resp,
-                },
-                ToolRoute::Delete(name) => handle_tool_delete(&self.registry, &name),
-                ToolRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        let resource_route = resolve_resource_route(&method, &path);
-        if resource_route != ResourceRoute::NotFound {
-            return match resource_route {
-                ResourceRoute::List => handle_resource_list(&self.registry),
-                ResourceRoute::GetByName(name) => handle_resource_get(&self.registry, &name),
-                ResourceRoute::Update(name) => match read_body(http_session).await {
-                    Ok(body) => handle_resource_update(&self.registry, &name, &body),
-                    Err(resp) => resp,
-                },
-                ResourceRoute::Delete(name) => handle_resource_delete(&self.registry, &name),
-                ResourceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        let prompt_route = resolve_prompt_route(&method, &path);
-        if prompt_route != PromptRoute::NotFound {
-            return match prompt_route {
-                PromptRoute::List => handle_prompt_list(&self.registry),
-                PromptRoute::GetByName(name) => handle_prompt_get(&self.registry, &name),
-                PromptRoute::Delete(name) => handle_prompt_delete(&self.registry, &name),
-                PromptRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        let ns_route = resolve_namespace_route(&method, &path);
-        if ns_route != NamespaceRoute::NotFound {
-            return match ns_route {
-                NamespaceRoute::List => handle_namespace_list(&self.registry),
-                NamespaceRoute::GetByName(name) => handle_namespace_get(&self.registry, &name),
-                NamespaceRoute::Create => match read_body(http_session).await {
-                    Ok(body) => handle_namespace_create(&self.registry, &body),
-                    Err(resp) => resp,
-                },
-                NamespaceRoute::Update(id) => match read_body(http_session).await {
-                    Ok(body) => handle_namespace_update(&self.registry, &id, &body),
-                    Err(resp) => resp,
-                },
-                NamespaceRoute::Delete(name) => handle_namespace_delete(&self.registry, &name),
-                NamespaceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        let forward_route = resolve_forward_route(&method, &path);
-        if forward_route != ForwardRoute::NotFound {
-            return match forward_route {
-                ForwardRoute::List => handle_forward_list(&self.registry),
-                ForwardRoute::GetByName(name) => handle_forward_get(&self.registry, &name),
-                ForwardRoute::Create => match read_body(http_session).await {
-                    Ok(body) => handle_forward_create(&self.registry, &body).await,
-                    Err(resp) => resp,
-                },
-                ForwardRoute::Delete(name) => handle_forward_delete(&self.registry, &name),
-                ForwardRoute::Refresh(name) => handle_forward_refresh(&self.registry, &name).await,
-                ForwardRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-            };
-        }
-
-        // Feature dispatch — read body once for POST/PUT, then try each feature
-        let feature_body = match method.as_str() {
+        let body = match method.as_str() {
             "POST" | "PUT" | "PATCH" => match read_body(http_session).await {
                 Ok(b) => Some(b),
                 Err(resp) => return resp,
@@ -189,20 +97,195 @@ impl ServeHttp for WanakuManagementService {
             _ => None,
         };
 
-        let http_ctx = HttpContext::new(
-            &method,
-            &path,
-            query.as_deref(),
-            feature_body.as_deref(),
-            &headers,
-        );
+        let ctx = HttpContext::new(&method, &path, query.as_deref(), body.as_deref(), &headers);
+        dispatch(&ctx, &self.registry, &self.features).await
+    }
+}
 
-        for feature in &self.features {
-            if let Some(response) = feature.handle_route(&http_ctx).await {
-                return response;
-            }
+#[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "route dispatch requires sequential matching")]
+pub(crate) async fn dispatch(
+    ctx: &HttpContext<'_>,
+    registry: &InMemoryRegistry,
+    features: &[Box<dyn Feature>],
+) -> Response<Vec<u8>> {
+    if ctx.path == "/healthz" || ctx.path == "/health" {
+        return json_ok(&serde_json::json!({"status": "ok"}));
+    }
+
+    if ctx.path == "/openapi.json" {
+        let openapi_body = crate::openapi::openapi_json();
+        return raw_json_response(openapi_body);
+    }
+
+    let mgmt_route = resolve_management_route(ctx.method, ctx.path);
+    if mgmt_route != ManagementRoute::NotFound {
+        return match mgmt_route {
+            ManagementRoute::Statistics => handle_statistics(registry),
+            ManagementRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    tracing::debug!(method = %ctx.method, path = %ctx.path, "management API request");
+
+    let tool_route = resolve_tool_route(ctx.method, ctx.path);
+    if tool_route != ToolRoute::NotFound {
+        return match tool_route {
+            ToolRoute::List => handle_tool_list(registry),
+            ToolRoute::GetByName(name) => handle_tool_get(registry, &name),
+            ToolRoute::Update(name) => match ctx.body {
+                Some(b) => handle_tool_update(registry, &name, b),
+                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+            },
+            ToolRoute::Delete(name) => handle_tool_delete(registry, &name),
+            ToolRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    let resource_route = resolve_resource_route(ctx.method, ctx.path);
+    if resource_route != ResourceRoute::NotFound {
+        return match resource_route {
+            ResourceRoute::List => handle_resource_list(registry),
+            ResourceRoute::GetByName(name) => handle_resource_get(registry, &name),
+            ResourceRoute::Update(name) => match ctx.body {
+                Some(b) => handle_resource_update(registry, &name, b),
+                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+            },
+            ResourceRoute::Delete(name) => handle_resource_delete(registry, &name),
+            ResourceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    let prompt_route = resolve_prompt_route(ctx.method, ctx.path);
+    if prompt_route != PromptRoute::NotFound {
+        return match prompt_route {
+            PromptRoute::List => handle_prompt_list(registry),
+            PromptRoute::GetByName(name) => handle_prompt_get(registry, &name),
+            PromptRoute::Delete(name) => handle_prompt_delete(registry, &name),
+            PromptRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    let ns_route = resolve_namespace_route(ctx.method, ctx.path);
+    if ns_route != NamespaceRoute::NotFound {
+        return match ns_route {
+            NamespaceRoute::List => handle_namespace_list(registry),
+            NamespaceRoute::GetByName(name) => handle_namespace_get(registry, &name),
+            NamespaceRoute::Create => match ctx.body {
+                Some(b) => handle_namespace_create(registry, b),
+                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+            },
+            NamespaceRoute::Update(id) => match ctx.body {
+                Some(b) => handle_namespace_update(registry, &id, b),
+                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+            },
+            NamespaceRoute::Delete(name) => handle_namespace_delete(registry, &name),
+            NamespaceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    let forward_route = resolve_forward_route(ctx.method, ctx.path);
+    if forward_route != ForwardRoute::NotFound {
+        return match forward_route {
+            ForwardRoute::List => handle_forward_list(registry),
+            ForwardRoute::GetByName(name) => handle_forward_get(registry, &name),
+            ForwardRoute::Create => match ctx.body {
+                Some(b) => handle_forward_create(registry, b).await,
+                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+            },
+            ForwardRoute::Delete(name) => handle_forward_delete(registry, &name),
+            ForwardRoute::Refresh(name) => handle_forward_refresh(registry, &name).await,
+            ForwardRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
+        };
+    }
+
+    for feature in features {
+        if let Some(response) = feature.handle_route(ctx).await {
+            return response;
         }
+    }
 
-        json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default())
+    json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default())
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+    use wanaku_apis::feature::{Feature, HttpContext};
+    use wanaku_apis::registry::InMemoryRegistry;
+
+    fn parse_body(resp: &http::Response<Vec<u8>>) -> serde_json::Value {
+        serde_json::from_slice(resp.body()).unwrap_or_default()
+    }
+
+    fn data_field(resp: &http::Response<Vec<u8>>) -> serde_json::Value {
+        let body = parse_body(resp);
+        body.get("data").cloned().unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_tools_returns_empty_list() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let ctx = HttpContext::new("GET", "/api/v1/tools", None, None, &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(data_field(&resp).as_array().map(|a| a.len()), Some(0));
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_path_returns_404() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let ctx = HttpContext::new("GET", "/no/such/path", None, None, &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_namespace_create() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let body = r#"{"name":"test-ns"}"#;
+        let ctx = HttpContext::new("POST", "/api/v1/namespaces", None, Some(body), &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 200);
+        let data = data_field(&resp);
+        assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("test-ns"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_health_returns_ok() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let ctx = HttpContext::new("GET", "/healthz", None, None, &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 200);
+        let body = parse_body(&resp);
+        let data = body.get("data").cloned().unwrap_or_default();
+        assert_eq!(data.get("status").and_then(|v| v.as_str()), Some("ok"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_post_without_body_returns_400() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let ctx = HttpContext::new("POST", "/api/v1/namespaces", None, None, &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 400);
     }
 }

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -119,85 +119,67 @@ pub(crate) async fn dispatch(
         return raw_json_response(openapi_body);
     }
 
-    let mgmt_route = resolve_management_route(ctx.method, ctx.path);
-    if mgmt_route != ManagementRoute::NotFound {
-        return match mgmt_route {
-            ManagementRoute::Statistics => handle_statistics(registry),
-            ManagementRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_management_route(ctx.method, ctx.path) {
+        ManagementRoute::Statistics => return handle_statistics(registry),
+        ManagementRoute::NotFound => {}
     }
 
     tracing::debug!(method = %ctx.method, path = %ctx.path, "management API request");
 
-    let tool_route = resolve_tool_route(ctx.method, ctx.path);
-    if tool_route != ToolRoute::NotFound {
-        return match tool_route {
-            ToolRoute::List => handle_tool_list(registry),
-            ToolRoute::GetByName(name) => handle_tool_get(registry, &name),
-            ToolRoute::Update(name) => match ctx.body {
-                Some(b) => handle_tool_update(registry, &name, b),
-                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
-            },
-            ToolRoute::Delete(name) => handle_tool_delete(registry, &name),
-            ToolRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_tool_route(ctx.method, ctx.path) {
+        ToolRoute::List => return handle_tool_list(registry),
+        ToolRoute::GetByName(name) => return handle_tool_get(registry, &name),
+        ToolRoute::Update(name) => return match ctx.body {
+            Some(b) => handle_tool_update(registry, &name, b),
+            None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+        },
+        ToolRoute::Delete(name) => return handle_tool_delete(registry, &name),
+        ToolRoute::NotFound => {}
     }
 
-    let resource_route = resolve_resource_route(ctx.method, ctx.path);
-    if resource_route != ResourceRoute::NotFound {
-        return match resource_route {
-            ResourceRoute::List => handle_resource_list(registry),
-            ResourceRoute::GetByName(name) => handle_resource_get(registry, &name),
-            ResourceRoute::Update(name) => match ctx.body {
-                Some(b) => handle_resource_update(registry, &name, b),
-                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
-            },
-            ResourceRoute::Delete(name) => handle_resource_delete(registry, &name),
-            ResourceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_resource_route(ctx.method, ctx.path) {
+        ResourceRoute::List => return handle_resource_list(registry),
+        ResourceRoute::GetByName(name) => return handle_resource_get(registry, &name),
+        ResourceRoute::Update(name) => return match ctx.body {
+            Some(b) => handle_resource_update(registry, &name, b),
+            None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+        },
+        ResourceRoute::Delete(name) => return handle_resource_delete(registry, &name),
+        ResourceRoute::NotFound => {}
     }
 
-    let prompt_route = resolve_prompt_route(ctx.method, ctx.path);
-    if prompt_route != PromptRoute::NotFound {
-        return match prompt_route {
-            PromptRoute::List => handle_prompt_list(registry),
-            PromptRoute::GetByName(name) => handle_prompt_get(registry, &name),
-            PromptRoute::Delete(name) => handle_prompt_delete(registry, &name),
-            PromptRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_prompt_route(ctx.method, ctx.path) {
+        PromptRoute::List => return handle_prompt_list(registry),
+        PromptRoute::GetByName(name) => return handle_prompt_get(registry, &name),
+        PromptRoute::Delete(name) => return handle_prompt_delete(registry, &name),
+        PromptRoute::NotFound => {}
     }
 
-    let ns_route = resolve_namespace_route(ctx.method, ctx.path);
-    if ns_route != NamespaceRoute::NotFound {
-        return match ns_route {
-            NamespaceRoute::List => handle_namespace_list(registry),
-            NamespaceRoute::GetByName(name) => handle_namespace_get(registry, &name),
-            NamespaceRoute::Create => match ctx.body {
-                Some(b) => handle_namespace_create(registry, b),
-                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
-            },
-            NamespaceRoute::Update(id) => match ctx.body {
-                Some(b) => handle_namespace_update(registry, &id, b),
-                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
-            },
-            NamespaceRoute::Delete(name) => handle_namespace_delete(registry, &name),
-            NamespaceRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_namespace_route(ctx.method, ctx.path) {
+        NamespaceRoute::List => return handle_namespace_list(registry),
+        NamespaceRoute::GetByName(name) => return handle_namespace_get(registry, &name),
+        NamespaceRoute::Create => return match ctx.body {
+            Some(b) => handle_namespace_create(registry, b),
+            None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+        },
+        NamespaceRoute::Update(id) => return match ctx.body {
+            Some(b) => handle_namespace_update(registry, &id, b),
+            None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+        },
+        NamespaceRoute::Delete(name) => return handle_namespace_delete(registry, &name),
+        NamespaceRoute::NotFound => {}
     }
 
-    let forward_route = resolve_forward_route(ctx.method, ctx.path);
-    if forward_route != ForwardRoute::NotFound {
-        return match forward_route {
-            ForwardRoute::List => handle_forward_list(registry),
-            ForwardRoute::GetByName(name) => handle_forward_get(registry, &name),
-            ForwardRoute::Create => match ctx.body {
-                Some(b) => handle_forward_create(registry, b).await,
-                None => json_err(StatusCode::BAD_REQUEST, "request body required"),
-            },
-            ForwardRoute::Delete(name) => handle_forward_delete(registry, &name),
-            ForwardRoute::Refresh(name) => handle_forward_refresh(registry, &name).await,
-            ForwardRoute::NotFound => json_err(StatusCode::NOT_FOUND, StatusCode::NOT_FOUND.canonical_reason().unwrap_or_default()),
-        };
+    match resolve_forward_route(ctx.method, ctx.path) {
+        ForwardRoute::List => return handle_forward_list(registry),
+        ForwardRoute::GetByName(name) => return handle_forward_get(registry, &name),
+        ForwardRoute::Create => return match ctx.body {
+            Some(b) => handle_forward_create(registry, b).await,
+            None => json_err(StatusCode::BAD_REQUEST, "request body required"),
+        },
+        ForwardRoute::Delete(name) => return handle_forward_delete(registry, &name),
+        ForwardRoute::Refresh(name) => return handle_forward_refresh(registry, &name).await,
+        ForwardRoute::NotFound => {}
     }
 
     for feature in features {


### PR DESCRIPTION
## Summary

- Extracts core dispatch logic from `ServeHttp::response` into a standalone `pub(crate) async fn dispatch()` function
- `ServeHttp` adapter becomes a thin wrapper that extracts method/path/body from `ServerSession` and delegates
- Uses the project's `HttpContext` struct to keep the dispatch function signature clean (3 params)
- Adds 5 new tests covering GET tools, unknown path 404, POST namespace, health endpoint, and POST without body

## Integration test

Ran [Full Integration Test (From Source)](https://github.com/orpiske/wanaku-tests/actions/runs/32407949953). Results pending.

## Test plan

- [x] `cargo test -p wanaku-server` — all 63 tests pass (58 existing + 5 new)
- [x] `cargo clippy -p wanaku-server` — no new warnings
- [ ] CI (clippy + tests) via PR Build workflow

## Summary by Sourcery

Extract management API dispatch into a testable function while preserving endpoint behavior and improving request validation.

Enhancements:
- Extract management API routing and response generation into a standalone dispatch function, leaving the HTTP session adapter focused on request extraction and delegation.
- Use a shared HTTP context to support direct, isolated management dispatch and return clear bad-request responses for missing bodies.

Tests:
- Add focused dispatch coverage for tool listing, namespace creation, health checks, unknown routes, and body-less POST requests.