### PR TITLE
fix #873: forward HTTP headers to downstream tool calls

### DIFF
--- a/apis/src/config.rs
+++ b/apis/src/config.rs
@@ -36,6 +36,13 @@ const WANAKU_UI_PATH: &str = "WANAKU_UI_PATH";
 /// Defaults to `"*"`. Set to a specific origin (e.g. `http://localhost:3000`) in production.
 const WANAKU_CORS_ORIGIN: &str = "WANAKU_CORS_ORIGIN";
 
+/// Comma-separated list of HTTP header names to forward from incoming MCP
+/// requests to downstream tool invocations (e.g. `Authorization,DPoP`).
+/// Empty by default — no headers are forwarded unless explicitly configured.
+/// Per-tool overrides are configured via the `wanaku.forward_headers` label
+/// on individual `ToolEntry` records.
+const WANAKU_FORWARD_HEADERS: &str = "WANAKU_FORWARD_HEADERS";
+
 /// File-persistence settings, present only when enabled.
 #[derive(Debug, Clone)]
 pub struct PersistEnv {
@@ -63,6 +70,8 @@ pub struct WanakuEnv {
     pub ui_path: Option<PathBuf>,
     /// Value for the `Access-Control-Allow-Origin` header on all HTTP responses.
     pub cors_origin: String,
+    /// Global allowlist of HTTP header names forwarded to downstream tool calls.
+    pub forward_headers: Vec<String>,
 }
 
 /// Global configuration, initialized lazily on first access.
@@ -105,6 +114,12 @@ impl WanakuEnv {
             ui_path: std::env::var(WANAKU_UI_PATH).ok().map(PathBuf::from),
             cors_origin: std::env::var(WANAKU_CORS_ORIGIN)
                 .unwrap_or_else(|_| "*".to_owned()),
+            forward_headers: std::env::var(WANAKU_FORWARD_HEADERS)
+                .unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
     }
 }

--- a/apis/src/mcp_client.rs
+++ b/apis/src/mcp_client.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
+use http::{HeaderName, HeaderValue};
 use rmcp::{
     ServiceExt as _,
     model::{
@@ -64,7 +66,17 @@ pub enum McpClientError {
 }
 
 fn build_transport(url: &str) -> impl rmcp::transport::Transport<rmcp::RoleClient> + use<> {
-    let config = StreamableHttpClientTransportConfig::with_uri(url);
+    build_transport_with_headers(url, HashMap::new())
+}
+
+fn build_transport_with_headers(
+    url: &str,
+    headers: HashMap<HeaderName, HeaderValue>,
+) -> impl rmcp::transport::Transport<rmcp::RoleClient> + use<> {
+    let mut config = StreamableHttpClientTransportConfig::with_uri(url);
+    if !headers.is_empty() {
+        config = config.custom_headers(headers);
+    }
     StreamableHttpClientTransport::from_config(config)
 }
 
@@ -138,9 +150,10 @@ pub async fn call_tool(
     url: &str,
     tool_name: &str,
     arguments: Value,
+    forward_headers: HashMap<HeaderName, HeaderValue>,
 ) -> Result<CallToolResponse, McpClientError> {
     let url = url.to_owned();
-    let transport = build_transport(&url);
+    let transport = build_transport_with_headers(&url, forward_headers);
 
     let client = tokio::time::timeout(TIMEOUT, Box::pin(().serve(transport)))
         .await

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -178,6 +178,7 @@ pub const MCP_FORWARD_TYPE: &str = "mcp-forward";
 pub const FORWARD_ADDRESS_LABEL: &str = "wanaku.forward_address";
 pub const IS_TEMPLATE_LABEL: &str = "wanaku.is_template";
 pub const FORWARD_HEADERS_LABEL: &str = "wanaku.forward_headers";
+pub const INJECT_HEADER_ARGS_LABEL: &str = "wanaku.inject_header_args";
 
 impl ToolEntry {
     pub fn is_mcp_forward(&self) -> bool {
@@ -194,6 +195,12 @@ impl ToolEntry {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    pub fn inject_header_args(&self) -> bool {
+        self.labels
+            .get(INJECT_HEADER_ARGS_LABEL)
+            .map_or(true, |v| v != "false")
     }
 }
 
@@ -841,6 +848,26 @@ mod tests {
         assert_eq!(headers.len(), 2);
         assert!(headers.contains(&"authorization".to_owned()));
         assert!(headers.contains(&"dpop".to_owned()));
+    }
+
+    #[test]
+    fn tool_inject_header_args_default_true() {
+        let tool = sample_tool();
+        assert!(tool.inject_header_args());
+    }
+
+    #[test]
+    fn tool_inject_header_args_explicit_false() {
+        let mut tool = sample_tool();
+        tool.labels.insert(INJECT_HEADER_ARGS_LABEL.to_owned(), "false".to_owned());
+        assert!(!tool.inject_header_args());
+    }
+
+    #[test]
+    fn tool_inject_header_args_explicit_true() {
+        let mut tool = sample_tool();
+        tool.labels.insert(INJECT_HEADER_ARGS_LABEL.to_owned(), "true".to_owned());
+        assert!(tool.inject_header_args());
     }
 
     #[test]

--- a/apis/src/registry.rs
+++ b/apis/src/registry.rs
@@ -177,10 +177,23 @@ pub const MCP_FORWARD_TYPE: &str = "mcp-forward";
 
 pub const FORWARD_ADDRESS_LABEL: &str = "wanaku.forward_address";
 pub const IS_TEMPLATE_LABEL: &str = "wanaku.is_template";
+pub const FORWARD_HEADERS_LABEL: &str = "wanaku.forward_headers";
 
 impl ToolEntry {
     pub fn is_mcp_forward(&self) -> bool {
         self.type_ == MCP_FORWARD_TYPE
+    }
+
+    pub fn forward_headers(&self) -> Vec<String> {
+        self.labels
+            .get(FORWARD_HEADERS_LABEL)
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_lowercase())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -813,6 +826,28 @@ mod tests {
         assert!(registry.get_resource("r1").is_none());
         assert!(registry.get_resource("r2").is_some());
         assert!(registry.get_resource("r3").is_none());
+    }
+
+    #[test]
+    fn tool_forward_headers_from_label() {
+        let mut tool = sample_tool();
+        assert!(tool.forward_headers().is_empty());
+
+        tool.labels.insert(
+            FORWARD_HEADERS_LABEL.to_owned(),
+            "Authorization, DPoP".to_owned(),
+        );
+        let headers = tool.forward_headers();
+        assert_eq!(headers.len(), 2);
+        assert!(headers.contains(&"authorization".to_owned()));
+        assert!(headers.contains(&"dpop".to_owned()));
+    }
+
+    #[test]
+    fn tool_forward_headers_empty_value() {
+        let mut tool = sample_tool();
+        tool.labels.insert(FORWARD_HEADERS_LABEL.to_owned(), String::new());
+        assert!(tool.forward_headers().is_empty());
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ These control core server behavior:
 | `WANAKU_CORS_ORIGIN` | `*` | Value for `Access-Control-Allow-Origin` on all HTTP responses (management API, MCP endpoint, and CORS preflight) |
 | `WANAKU_AUTH_ISSUER` | _(unset = disabled)_ | OIDC issuer URL for RFC 9728 metadata endpoint |
 | `WANAKU_INFERENCE_API_KEY` | _(unset = no auth)_ | Bearer token API key for the inference upstream. Empty means no auth. |
+| `WANAKU_FORWARD_HEADERS` | _(unset = none)_ | Comma-separated list of HTTP header names to forward from incoming MCP requests to downstream tool invocations (e.g., `Authorization,DPoP`). Per-tool overrides via the `wanaku.forward_headers` label. |
 
 **Example:**
 
@@ -93,6 +94,38 @@ wanaku-server
 The server serves files from the specified directory instead of the embedded bundle.
 
 **Warning:** Relative paths don't work. Use an absolute path.
+
+### Header Forwarding
+
+By default, Wanaku does not forward any HTTP headers from incoming MCP requests to downstream tool invocations. To enable header forwarding (e.g., for gateway-mediated token exchange), configure an allowlist of header names.
+
+**Global allowlist** — applies to all tool calls:
+
+```bash
+export WANAKU_FORWARD_HEADERS=Authorization,DPoP
+```
+
+**Per-tool override** — set the `wanaku.forward_headers` label on a `ToolEntry`:
+
+```json
+{
+  "name": "github-api",
+  "uri": "http://mcp-gateway:8080/mcp",
+  "type": "mcp-forward",
+  "labels": {
+    "wanaku.forward_headers": "Authorization,X-Third-Party-Token"
+  }
+}
+```
+
+Both lists are merged at runtime — a header is forwarded if it appears in either the global allowlist or the per-tool label. Header names are case-insensitive.
+
+**Use case:** A gateway (Envoy ExtProc, IBM ContextForge) sits between Wanaku and a protected downstream API. The gateway performs token exchange (e.g., Keycloak STS) using the `Authorization` header from the original request. Wanaku forwards the header so the gateway has a `subject_token` to exchange.
+
+**Security considerations:**
+
+- Headers that would corrupt the downstream HTTP request (`host`, `content-type`, `content-length`, `transfer-encoding`, `connection`) and rmcp-reserved headers (`accept`, `mcp-session-id`, `last-event-id`) are always blocked, even if they appear in the allowlist.
+- When `Authorization` forwarding is enabled, anyone with management API access can register a tool pointing to an arbitrary URL — the caller's bearer token would then be forwarded to that URL. Secure the management API (authentication, network isolation) before enabling credential forwarding in production.
 
 ## Feature-Specific Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,19 @@ export WANAKU_FORWARD_HEADERS=Authorization,DPoP
 
 Both lists are merged at runtime — a header is forwarded if it appears in either the global allowlist or the per-tool label. Header names are case-insensitive.
 
+**SEP-2243 argument injection** — When a tool's input schema has properties annotated with `x-mcp-header` (SEP-2243), Wanaku automatically injects matching forwarded header values as tool arguments before forwarding. This ensures downstream MCP servers using `@McpParamHeader` receive the value correctly. This behavior is enabled by default and can be disabled per-tool:
+
+```json
+{
+  "labels": {
+    "wanaku.forward_headers": "Authorization",
+    "wanaku.inject_header_args": "false"
+  }
+}
+```
+
+When disabled, headers are forwarded only as raw HTTP headers on the downstream connection — suitable for gateway scenarios where the gateway reads headers directly.
+
 **Use case:** A gateway (Envoy ExtProc, IBM ContextForge) sits between Wanaku and a protected downstream API. The gateway performs token exchange (e.g., Keycloak STS) using the `Authorization` header from the original request. Wanaku forwards the header so the gateway has a `subject_token` to exchange.
 
 **Security considerations:**

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -132,7 +132,13 @@ impl ToolCallFilter {
 
         if tool.is_mcp_forward() {
             let forward_headers = collect_forward_headers(&ctx.request.headers, &tool);
-            inject_header_arguments(&mut parsed.arguments, &tool.input_schema, &forward_headers);
+            if tool.inject_header_args() {
+                inject_header_arguments(
+                    &mut parsed.arguments,
+                    &tool.input_schema,
+                    &forward_headers,
+                );
+            }
             return self
                 .handle_forwarded_call(&tool, &tool_name, &parsed, forward_headers)
                 .await;

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
+use http::{HeaderName, HeaderValue};
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use tracing::{trace, warn};
+use wanaku_apis::config::ENV;
 use wanaku_apis::registry::{InMemoryRegistry, ToolEntry, ToolRegistry};
 
 crate::body_filter_boilerplate!(ToolCallFilter, "wanaku_tool_call");
@@ -129,7 +131,10 @@ impl ToolCallFilter {
         };
 
         if tool.is_mcp_forward() {
-            return self.handle_forwarded_call(&tool, &tool_name, &parsed).await;
+            let forward_headers = collect_forward_headers(&ctx.request.headers, &tool);
+            return self
+                .handle_forwarded_call(&tool, &tool_name, &parsed, forward_headers)
+                .await;
         }
 
         warn!(tool = %tool_name, tool_type = %tool.type_, "unsupported tool type — only MCP-forwarded tools are supported");
@@ -146,8 +151,14 @@ impl ToolCallFilter {
         tool: &ToolEntry,
         tool_name: &str,
         parsed: &ParsedBody,
+        forward_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<FilterAction, FilterError> {
-        trace!(tool = %tool_name, uri = %tool.uri, "forwarding tools/call to remote MCP server");
+        trace!(
+            tool = %tool_name,
+            uri = %tool.uri,
+            forwarded_header_count = forward_headers.len(),
+            "forwarding tools/call to remote MCP server"
+        );
 
         let arguments = serde_json::Value::Object(
             parsed
@@ -157,7 +168,9 @@ impl ToolCallFilter {
                 .collect(),
         );
 
-        match wanaku_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments).await {
+        match wanaku_apis::mcp_client::call_tool(&tool.uri, tool_name, arguments, forward_headers)
+            .await
+        {
             Ok(call_result) => {
                 let mcp_content: Vec<serde_json::Value> = call_result.content
                     .iter()
@@ -183,6 +196,59 @@ impl ToolCallFilter {
             }
         }
     }
+}
+
+fn collect_forward_headers(
+    request_headers: &http::HeaderMap,
+    tool: &ToolEntry,
+) -> HashMap<HeaderName, HeaderValue> {
+    let global = &ENV.forward_headers;
+    let per_tool = tool.forward_headers();
+    extract_allowed_headers(request_headers, global, &per_tool)
+}
+
+const DENIED_HEADERS: &[&str] = &[
+    "accept",
+    "mcp-session-id",
+    "last-event-id",
+    "host",
+    "content-type",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+];
+
+fn extract_allowed_headers(
+    request_headers: &http::HeaderMap,
+    global_allowlist: &[String],
+    tool_allowlist: &[String],
+) -> HashMap<HeaderName, HeaderValue> {
+    if global_allowlist.is_empty() && tool_allowlist.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut result = HashMap::new();
+
+    for (name, value) in request_headers {
+        let name_lower = name.as_str().to_lowercase();
+
+        if DENIED_HEADERS.contains(&name_lower.as_str()) {
+            if global_allowlist.contains(&name_lower) || tool_allowlist.contains(&name_lower) {
+                warn!(header = %name, "header is in the denylist and cannot be forwarded");
+            }
+            continue;
+        }
+
+        if global_allowlist.contains(&name_lower) || tool_allowlist.contains(&name_lower) {
+            if result.contains_key(name) {
+                trace!(header = %name, "duplicate header value overwritten");
+            }
+            trace!(header = %name, "forwarding header to downstream MCP server");
+            result.insert(name.clone(), value.clone());
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -299,5 +365,103 @@ mod tests {
         });
         let result = response.get("result").expect("result missing");
         assert_eq!(result.get("isError"), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn extract_allowed_headers_empty_allowlists() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("authorization", "Bearer tok".parse().unwrap());
+        let result = extract_allowed_headers(&headers, &[], &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn extract_allowed_headers_global_match() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("authorization", "Bearer tok".parse().unwrap());
+        headers.insert("x-custom", "val".parse().unwrap());
+
+        let global = vec!["authorization".to_owned()];
+        let result = extract_allowed_headers(&headers, &global, &[]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&HeaderName::from_static("authorization")).unwrap(), "Bearer tok");
+    }
+
+    #[test]
+    fn extract_allowed_headers_per_tool_match() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("dpop", "proof-jwt".parse().unwrap());
+        headers.insert("x-unrelated", "val".parse().unwrap());
+
+        let per_tool = vec!["dpop".to_owned()];
+        let result = extract_allowed_headers(&headers, &[], &per_tool);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&HeaderName::from_static("dpop")).unwrap(), "proof-jwt");
+    }
+
+    #[test]
+    fn extract_allowed_headers_combined_global_and_per_tool() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("authorization", "Bearer tok".parse().unwrap());
+        headers.insert("dpop", "proof-jwt".parse().unwrap());
+        headers.insert("x-unrelated", "val".parse().unwrap());
+
+        let global = vec!["authorization".to_owned()];
+        let per_tool = vec!["dpop".to_owned()];
+        let result = extract_allowed_headers(&headers, &global, &per_tool);
+
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&HeaderName::from_static("authorization")));
+        assert!(result.contains_key(&HeaderName::from_static("dpop")));
+    }
+
+    #[test]
+    fn extract_allowed_headers_no_matching_headers() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-other", "val".parse().unwrap());
+
+        let global = vec!["authorization".to_owned()];
+        let result = extract_allowed_headers(&headers, &global, &[]);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn extract_allowed_headers_denied_header_blocked() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-type", "text/plain".parse().unwrap());
+        headers.insert("authorization", "Bearer tok".parse().unwrap());
+
+        let global = vec!["content-type".to_owned(), "authorization".to_owned()];
+        let result = extract_allowed_headers(&headers, &global, &[]);
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&HeaderName::from_static("authorization")));
+        assert!(!result.contains_key(&HeaderName::from_static("content-type")));
+    }
+
+    #[test]
+    fn extract_allowed_headers_all_rmcp_reserved_blocked() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("accept", "application/json".parse().unwrap());
+        headers.insert("mcp-session-id", "abc".parse().unwrap());
+        headers.insert("host", "evil.com".parse().unwrap());
+        headers.insert("transfer-encoding", "chunked".parse().unwrap());
+        headers.insert("connection", "keep-alive".parse().unwrap());
+        headers.insert("content-length", "42".parse().unwrap());
+
+        let global = vec![
+            "accept".to_owned(),
+            "mcp-session-id".to_owned(),
+            "host".to_owned(),
+            "transfer-encoding".to_owned(),
+            "connection".to_owned(),
+            "content-length".to_owned(),
+        ];
+        let result = extract_allowed_headers(&headers, &global, &[]);
+
+        assert!(result.is_empty());
     }
 }

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -132,6 +132,7 @@ impl ToolCallFilter {
 
         if tool.is_mcp_forward() {
             let forward_headers = collect_forward_headers(&ctx.request.headers, &tool);
+            inject_header_arguments(&mut parsed.arguments, &tool.input_schema, &forward_headers);
             return self
                 .handle_forwarded_call(&tool, &tool_name, &parsed, forward_headers)
                 .await;
@@ -194,6 +195,42 @@ impl ToolCallFilter {
                     &format!("forwarded tool call failed: {e}"),
                 ))
             }
+        }
+    }
+}
+
+fn inject_header_arguments(
+    arguments: &mut HashMap<String, serde_json::Value>,
+    input_schema: &serde_json::Value,
+    forward_headers: &HashMap<HeaderName, HeaderValue>,
+) {
+    if forward_headers.is_empty() {
+        return;
+    }
+
+    let Some(properties) = input_schema.get("properties").and_then(|p| p.as_object()) else {
+        return;
+    };
+
+    for (prop_name, prop_schema) in properties {
+        let Some(header_name) = prop_schema.get("x-mcp-header").and_then(|h| h.as_str()) else {
+            continue;
+        };
+
+        if arguments.contains_key(prop_name) {
+            continue;
+        }
+
+        let header_key = HeaderName::from_bytes(header_name.as_bytes()).ok();
+        let value = header_key.and_then(|k| forward_headers.get(&k));
+
+        if let Some(val) = value.and_then(|v| v.to_str().ok()) {
+            trace!(
+                property = %prop_name,
+                header = %header_name,
+                "injecting forwarded header as tool argument (x-mcp-header)"
+            );
+            arguments.insert(prop_name.clone(), serde_json::Value::String(val.to_owned()));
         }
     }
 }
@@ -365,6 +402,95 @@ mod tests {
         });
         let result = response.get("result").expect("result missing");
         assert_eq!(result.get("isError"), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn inject_header_arguments_from_schema() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "auth": {
+                    "type": "string",
+                    "x-mcp-header": "Authorization"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        });
+        let mut args = HashMap::new();
+        args.insert("message".to_owned(), serde_json::json!("hello"));
+
+        let mut headers = HashMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer tok"),
+        );
+
+        inject_header_arguments(&mut args, &schema, &headers);
+        assert_eq!(args.get("auth"), Some(&serde_json::json!("Bearer tok")));
+        assert_eq!(args.get("message"), Some(&serde_json::json!("hello")));
+    }
+
+    #[test]
+    fn inject_header_arguments_does_not_overwrite_existing() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "auth": {
+                    "type": "string",
+                    "x-mcp-header": "Authorization"
+                }
+            }
+        });
+        let mut args = HashMap::new();
+        args.insert("auth".to_owned(), serde_json::json!("existing-value"));
+
+        let mut headers = HashMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer tok"),
+        );
+
+        inject_header_arguments(&mut args, &schema, &headers);
+        assert_eq!(args.get("auth"), Some(&serde_json::json!("existing-value")));
+    }
+
+    #[test]
+    fn inject_header_arguments_no_annotation() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"}
+            }
+        });
+        let mut args = HashMap::new();
+        let mut headers = HashMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer tok"),
+        );
+
+        inject_header_arguments(&mut args, &schema, &headers);
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn inject_header_arguments_header_not_forwarded() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "auth": {
+                    "type": "string",
+                    "x-mcp-header": "Authorization"
+                }
+            }
+        });
+        let mut args = HashMap::new();
+        let headers = HashMap::new();
+
+        inject_header_arguments(&mut args, &schema, &headers);
+        assert!(args.is_empty());
     }
 
     #[test]

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -381,7 +381,7 @@ fn register_discovered_tools(registry: &InMemoryRegistry, forward: &ForwardEntry
             uri: forward.address.clone(),
             type_: MCP_FORWARD_TYPE.to_owned(),
             input_schema,
-            labels: std::collections::HashMap::new(),
+            labels: forward.labels.clone(),
             id: None,
             namespace: Some(namespace.to_owned()),
             configuration_uri: None,


### PR DESCRIPTION
## Summary

- Add configurable HTTP header forwarding from incoming MCP requests to downstream tool invocations via MCP forwarding
- Enables gateway-mediated token exchange (Scenario B-2) where a gateway (Envoy ExtProc, IBM ContextForge) performs STS token exchange using the `Authorization` header from the original request
- Global allowlist via `WANAKU_FORWARD_HEADERS` env var; per-tool override via `wanaku.forward_headers` label
- Default-deny: no headers forwarded unless explicitly configured
- Structural/reserved headers (`host`, `content-type`, `content-length`, `transfer-encoding`, `connection`, `accept`, `mcp-session-id`, `last-event-id`) are always blocked

## Test plan

- [x] Unit tests for `extract_allowed_headers` (empty allowlists, global match, per-tool match, combined, no match, denylist blocking, all reserved headers blocked)
- [x] Unit tests for `ToolEntry::forward_headers` (from label, empty value)
- [x] All 315 existing + new tests pass
- [ ] Integration test: set `WANAKU_FORWARD_HEADERS=Authorization`, send a tools/call with an Authorization header, verify the downstream MCP server receives it
- [ ] Integration test: verify denied headers (content-type, host) are NOT forwarded even when in the allowlist

Closes #873

## Summary by Sourcery

Enable secure, opt-in HTTP header forwarding for downstream MCP calls, including gateway token-exchange scenarios.

New Features:
- Support configurable forwarding of selected incoming HTTP headers to downstream MCP tool calls through global configuration or per-tool labels.
- Automatically inject forwarded header values into SEP-2243-annotated tool arguments, with per-tool control over this behavior.

Enhancements:
- Block structural and MCP-reserved headers from forwarding regardless of allowlist configuration.
- Preserve forwarding labels when registering discovered tools.

Documentation:
- Document global and per-tool header forwarding, SEP-2243 argument injection, and associated security considerations.

Tests:
- Add coverage for header allowlist matching, denylist enforcement, and annotated argument injection.