### PR TITLE
feat: add GET /api/v1/management/info endpoint

### DIFF
--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -37,6 +37,7 @@ The `data` value can be an object, an array, or `null`. This envelope keeps the 
 | `GET` | `/health` | Get the server health. |
 | `GET` | `/healthz` | Get the server health. |
 | `GET` | `/openapi.json` | Get the OpenAPI document. |
+| `GET` | `/api/v1/management/info` | Get the server name and version. |
 | `GET` | `/api/v1/management/statistics` | Get registry counts. |
 | `GET` | `/api/v1/tools` | List tools. |
 | `GET` | `/api/v1/tools/{name}` | Get a tool. |

--- a/server/src/management/handlers.rs
+++ b/server/src/management/handlers.rs
@@ -788,6 +788,13 @@ pub(super) fn handle_statistics(registry: &InMemoryRegistry) -> Response<Vec<u8>
     }))
 }
 
+pub(super) fn handle_info() -> Response<Vec<u8>> {
+    json_ok(&serde_json::json!({
+        "name": env!("CARGO_PKG_NAME"),
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -801,6 +808,7 @@ mod tests {
 
     use super::{
         handle_forward_delete, handle_forward_get, handle_forward_list,
+        handle_info,
         handle_namespace_create, handle_namespace_delete, handle_namespace_get,
         handle_namespace_list, handle_namespace_update,
         handle_prompt_delete, handle_prompt_get, handle_prompt_list,
@@ -1384,6 +1392,15 @@ mod tests {
         assert!(body.get("data").is_some());
         assert!(body["data"].is_null());
         assert!(body.get("error").and_then(|v| v.as_str()).is_some());
+    }
+
+    #[test]
+    fn info_returns_name_and_version() {
+        let resp = handle_info();
+        assert_eq!(resp.status(), 200);
+        let data = data_field(&resp);
+        assert!(data.get("name").and_then(|v| v.as_str()).is_some());
+        assert!(data.get("version").and_then(|v| v.as_str()).is_some());
     }
 }
 

--- a/server/src/management/mod.rs
+++ b/server/src/management/mod.rs
@@ -25,6 +25,7 @@ use self::handlers::{
     handle_prompt_delete, handle_prompt_get, handle_prompt_list,
     handle_resource_delete, handle_resource_get, handle_resource_list,
     handle_resource_update,
+    handle_info,
     handle_statistics,
     handle_tool_delete, handle_tool_get, handle_tool_list, handle_tool_update,
 };
@@ -121,6 +122,7 @@ pub(crate) async fn dispatch(
     }
 
     match resolve_management_route(ctx.method, ctx.path) {
+        ManagementRoute::Info => return handle_info(),
         ManagementRoute::Statistics => return handle_statistics(registry),
         ManagementRoute::NotFound => {}
     }
@@ -260,6 +262,21 @@ mod dispatch_tests {
         let body = parse_body(&resp);
         let data = body.get("data").cloned().unwrap_or_default();
         assert_eq!(data.get("status").and_then(|v| v.as_str()), Some("ok"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_info_returns_name_and_version() {
+        let registry = InMemoryRegistry::new();
+        let headers = http::HeaderMap::new();
+        let features: &[Box<dyn Feature>] = &[];
+        let ctx = HttpContext::new("GET", "/api/v1/management/info", None, None, &headers);
+
+        let resp = dispatch(&ctx, &registry, features).await;
+
+        assert_eq!(resp.status(), 200);
+        let data = data_field(&resp);
+        assert!(data.get("name").and_then(|v| v.as_str()).is_some());
+        assert!(data.get("version").and_then(|v| v.as_str()).is_some());
     }
 
     #[tokio::test]

--- a/server/src/management/routes.rs
+++ b/server/src/management/routes.rs
@@ -79,6 +79,7 @@ pub(super) fn resolve_prompt_route(method: &str, path: &str) -> PromptRoute {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum ManagementRoute {
+    Info,
     Statistics,
     NotFound,
 }
@@ -89,6 +90,7 @@ pub(super) fn resolve_management_route(method: &str, path: &str) -> ManagementRo
     };
 
     match (method, suffix) {
+        ("GET", "/info") => ManagementRoute::Info,
         ("GET", "/statistics") => ManagementRoute::Statistics,
         _ => ManagementRoute::NotFound,
     }
@@ -263,6 +265,22 @@ mod tests {
         assert_eq!(
             resolve_forward_route("DELETE", "/api/v1/forwards/a/b"),
             ForwardRoute::NotFound
+        );
+    }
+
+    #[test]
+    fn management_route_info() {
+        assert_eq!(
+            resolve_management_route("GET", "/api/v1/management/info"),
+            ManagementRoute::Info
+        );
+    }
+
+    #[test]
+    fn management_route_info_rejects_post() {
+        assert_eq!(
+            resolve_management_route("POST", "/api/v1/management/info"),
+            ManagementRoute::NotFound
         );
     }
 }

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -193,6 +193,13 @@ const fn clear_interactions() {}
 )]
 const fn get_metrics() {}
 
+// -- Info ---------------------------------------------------------------------
+
+#[utoipa::path(get, path = "/api/v1/management/info", tag = "Management",
+    responses((status = 200, description = "Server name and version", body = serde_json::Value))
+)]
+const fn get_info() {}
+
 // -- Statistics ---------------------------------------------------------------
 
 #[utoipa::path(get, path = "/api/v1/management/statistics", tag = "Management",
@@ -218,7 +225,7 @@ const fn get_statistics() {}
         list_forwards, get_forward, create_forward, delete_forward, refresh_forward,
         list_interactions, clear_interactions,
         get_metrics,
-        get_statistics,
+        get_info, get_statistics,
     ),
     components(schemas(
         ToolEntry, ResourceEntry, PromptEntry, PromptArgument, PromptMessage,


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/management/info` endpoint returning server name and version
- Uses compile-time `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")` so the response stays in sync with `Cargo.toml`
- Follows existing route/handler/dispatch pattern with OpenAPI stub and documentation

## Test plan

- [x] Route resolution tests (info resolves, POST rejected)
- [x] Handler unit test (returns name + version)
- [x] Dispatch integration test (end-to-end through `dispatch()`)
- [x] All 67 server tests pass

## Summary by Sourcery

Add a GET management info endpoint that reports the server identity and version.

New Features:
- Add a management endpoint that returns the server name and version.

Enhancements:
- Expose the new endpoint in the OpenAPI specification and management API documentation.

Tests:
- Add route, handler, and dispatch coverage for the management info endpoint, including rejecting unsupported methods.