### PR TITLE
Fix #1849: set mcp.id metadata in MCP filter to avoid re-parsing body

### DIFF
--- a/apis/src/lib.rs
+++ b/apis/src/lib.rs
@@ -13,6 +13,6 @@ pub mod metrics;
 pub mod persistence;
 pub mod registry;
 
-pub use metadata::{MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
+pub use metadata::{MCP_ID_KEY, MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
 
 pub const WANAKU_BODY_ARG: &str = "wanaku_body";

--- a/apis/src/metadata.rs
+++ b/apis/src/metadata.rs
@@ -1,3 +1,4 @@
 pub const MCP_METHOD_KEY: &str = "mcp.method";
 pub const MCP_NAME_KEY: &str = "mcp.name";
+pub const MCP_ID_KEY: &str = "mcp.id";
 pub const NAMESPACE_METADATA_KEY: &str = "wanaku.namespace";

--- a/features/evaluator/src/filter.rs
+++ b/features/evaluator/src/filter.rs
@@ -140,11 +140,16 @@ impl EvaluatorFilter {
             }
             return match evaluator.on_error {
                 ErrorPolicy::Continue => Ok(FilterAction::Continue),
-                ErrorPolicy::Block => Ok(wanaku_filters::response::json_rpc_error(
-                    &wanaku_filters::response::extract_json_rpc_id(body),
-                    -32603,
-                    "evaluator processor module not available",
-                )),
+                ErrorPolicy::Block => {
+                    let json_rpc_id = wanaku_filters::response::json_rpc_id_from_metadata(
+                        ctx.get_metadata(wanaku_filters::MCP_ID_KEY),
+                    );
+                    Ok(wanaku_filters::response::json_rpc_error(
+                        &json_rpc_id,
+                        -32603,
+                        "evaluator processor module not available",
+                    ))
+                }
             };
         };
 
@@ -209,12 +214,14 @@ fn record_trigger(metrics: &Option<MetricsStore>, matched: bool) {
 #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "action dispatch with multiple variants")]
 fn dispatch_action(
     ctx: &mut HttpFilterContext<'_>,
-    body: &mut Option<Bytes>,
+    _body: &mut Option<Bytes>,
     result: ActionResult,
     method: &str,
     evaluator_name: &str,
 ) -> Result<FilterAction, FilterError> {
-    let json_rpc_id = wanaku_filters::response::extract_json_rpc_id(body);
+    let json_rpc_id = wanaku_filters::response::json_rpc_id_from_metadata(
+        ctx.get_metadata(wanaku_filters::MCP_ID_KEY),
+    );
 
     match result {
         ActionResult::Pass => Ok(FilterAction::Continue),

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-pub use wanaku_apis::metadata::{MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
+pub use wanaku_apis::metadata::{MCP_ID_KEY, MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};
 
 #[macro_export]
 macro_rules! body_filter_boilerplate {
@@ -72,6 +72,7 @@ macro_rules! body_filter_boilerplate {
     };
 }
 
+pub mod mcp_id;
 pub mod mcp_init;
 pub mod namespace;
 pub mod prompt_get;
@@ -82,6 +83,7 @@ pub mod response;
 pub mod tool_call;
 pub mod tool_list;
 
+pub use mcp_id::McpIdFilter;
 pub use mcp_init::McpInitFilter;
 pub use namespace::NamespaceFilter;
 pub use prompt_get::PromptGetFilter;

--- a/filters/src/mcp_id.rs
+++ b/filters/src/mcp_id.rs
@@ -1,0 +1,17 @@
+use bytes::Bytes;
+use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
+
+crate::body_filter_boilerplate!(McpIdFilter, "wanaku_mcp_id");
+
+impl McpIdFilter {
+    async fn handle_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+    ) -> Result<FilterAction, FilterError> {
+        let id = crate::response::extract_json_rpc_id(body);
+        let id_json = id.to_string();
+        ctx.set_metadata(crate::MCP_ID_KEY, &id_json);
+        Ok(FilterAction::Continue)
+    }
+}

--- a/filters/src/mcp_init.rs
+++ b/filters/src/mcp_init.rs
@@ -8,25 +8,26 @@ impl McpInitFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &mut Option<Bytes>,
+        _body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
             return Ok(FilterAction::Continue);
         };
 
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+
         match method {
-            "initialize" => self.handle_initialize(body),
+            "initialize" => self.handle_initialize(&json_rpc_id),
             "notifications/initialized" => Self::handle_notification(),
-            "ping" => Self::handle_ping(body),
+            "ping" => Self::handle_ping(&json_rpc_id),
             _ => Ok(FilterAction::Continue),
         }
     }
 
     #[expect(clippy::unused_self, reason = "consistent signature across filter handler methods")]
-    fn handle_initialize(&self, body: &Option<Bytes>) -> Result<FilterAction, FilterError> {
+    fn handle_initialize(&self, json_rpc_id: &serde_json::Value) -> Result<FilterAction, FilterError> {
         trace!("handling MCP initialize");
 
-        let json_rpc_id = crate::response::extract_json_rpc_id(body);
         let response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": json_rpc_id,
@@ -59,10 +60,9 @@ impl McpInitFilter {
         Ok(FilterAction::Reject(crate::response::empty_accepted()))
     }
 
-    fn handle_ping(body: &Option<Bytes>) -> Result<FilterAction, FilterError> {
+    fn handle_ping(json_rpc_id: &serde_json::Value) -> Result<FilterAction, FilterError> {
         trace!("handling MCP ping");
 
-        let json_rpc_id = crate::response::extract_json_rpc_id(body);
         let response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": json_rpc_id,

--- a/filters/src/namespace.rs
+++ b/filters/src/namespace.rs
@@ -24,7 +24,7 @@ impl NamespaceFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &mut Option<Bytes>,
+        _body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let path = ctx.request.uri.path();
 
@@ -37,7 +37,7 @@ impl NamespaceFilter {
             None => {
                 if ctx.get_metadata(crate::MCP_METHOD_KEY).is_some() {
                     tracing::warn!(path = %path, "rejected MCP request on invalid path");
-                    let id = crate::response::extract_json_rpc_id(body);
+                    let id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
                     Ok(crate::response::json_rpc_error(
                         &id,
                         crate::response::JSONRPC_INVALID_REQUEST,

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -11,10 +11,10 @@ struct ParsedBody {
     arguments: serde_json::Map<String, serde_json::Value>,
 }
 
-fn parse_body(body: &Option<Bytes>) -> ParsedBody {
+fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
     let Some(body_bytes) = body else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             name: None,
             arguments: serde_json::Map::new(),
         };
@@ -22,16 +22,11 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
 
     let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             name: None,
             arguments: serde_json::Map::new(),
         };
     };
-
-    let id = parsed
-        .get("id")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
 
     let params = parsed.get("params");
 
@@ -46,7 +41,7 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
         .cloned()
         .unwrap_or_default();
 
-    ParsedBody { id, name, arguments }
+    ParsedBody { id: json_rpc_id, name, arguments }
 }
 
 impl PromptGetFilter {
@@ -68,7 +63,8 @@ impl PromptGetFilter {
             .get_metadata(crate::namespace::NAMESPACE_METADATA_KEY)
             .unwrap_or(wanaku_apis::registry::DEFAULT_NAMESPACE);
 
-        let parsed = parse_body(body);
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+        let parsed = parse_body(body, json_rpc_id);
 
         let prompt_name = match &parsed.name {
             Some(n) => n.clone(),
@@ -185,7 +181,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"summarize","arguments":{"topic":"rust"}}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(1));
         assert_eq!(parsed.id, serde_json::Value::from(1));
         assert_eq!(parsed.name.as_deref(), Some("summarize"));
         assert_eq!(parsed.arguments.len(), 1);
@@ -200,7 +196,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":2,"params":{"name":"greet"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(2));
         assert_eq!(parsed.id, serde_json::Value::from(2));
         assert_eq!(parsed.name.as_deref(), Some("greet"));
         assert!(parsed.arguments.is_empty());
@@ -211,7 +207,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":3,"params":{"arguments":{"key":"val"}}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(3));
         assert_eq!(parsed.id, serde_json::Value::from(3));
         assert!(parsed.name.is_none());
         assert_eq!(parsed.arguments.len(), 1);
@@ -220,7 +216,7 @@ mod tests {
     #[test]
     fn parse_body_missing_params() {
         let body = Some(Bytes::from(r#"{"id":4}"#));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(4));
         assert_eq!(parsed.id, serde_json::Value::from(4));
         assert!(parsed.name.is_none());
         assert!(parsed.arguments.is_empty());
@@ -228,7 +224,7 @@ mod tests {
 
     #[test]
     fn parse_body_none() {
-        let parsed = parse_body(&None);
+        let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.name.is_none());
         assert!(parsed.arguments.is_empty());
@@ -237,7 +233,7 @@ mod tests {
     #[test]
     fn parse_body_malformed_json() {
         let body = Some(Bytes::from("<<<"));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.name.is_none());
         assert!(parsed.arguments.is_empty());
@@ -246,7 +242,7 @@ mod tests {
     #[test]
     fn parse_body_empty_bytes() {
         let body = Some(Bytes::new());
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.name.is_none());
         assert!(parsed.arguments.is_empty());
@@ -257,7 +253,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"params":{"name":"test-prompt"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert_eq!(parsed.name.as_deref(), Some("test-prompt"));
     }
@@ -267,7 +263,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":5,"params":{"name":"p","arguments":"not-a-map"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(5));
         assert_eq!(parsed.id, serde_json::Value::from(5));
         assert_eq!(parsed.name.as_deref(), Some("p"));
         assert!(parsed.arguments.is_empty());
@@ -278,7 +274,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":6,"params":{"name":99}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(6));
         assert_eq!(parsed.id, serde_json::Value::from(6));
         assert!(parsed.name.is_none());
     }

--- a/filters/src/prompt_list.rs
+++ b/filters/src/prompt_list.rs
@@ -10,7 +10,7 @@ impl PromptListFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &mut Option<Bytes>,
+        _body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
             return Ok(FilterAction::Continue);
@@ -26,9 +26,10 @@ impl PromptListFilter {
 
         trace!(namespace = %namespace, "handling MCP prompts/list request");
 
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+
         let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
             tracing::error!("InMemoryRegistry not found in request extensions");
-            let json_rpc_id = crate::response::extract_json_rpc_id(body);
             return Ok(crate::response::json_rpc_error(
                 &json_rpc_id,
                 crate::response::JSONRPC_INTERNAL_ERROR,
@@ -59,8 +60,6 @@ impl PromptListFilter {
                 })
             })
             .collect();
-
-        let json_rpc_id = crate::response::extract_json_rpc_id(body);
 
         let response = serde_json::json!({
             "jsonrpc": "2.0",

--- a/filters/src/resource_list.rs
+++ b/filters/src/resource_list.rs
@@ -10,7 +10,7 @@ impl ResourceListFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &mut Option<Bytes>,
+        _body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
             return Ok(FilterAction::Continue);
@@ -28,9 +28,10 @@ impl ResourceListFilter {
 
         trace!(namespace = %namespace, "handling MCP resources/list request");
 
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+
         let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
             tracing::error!("InMemoryRegistry not found in request extensions");
-            let json_rpc_id = crate::response::extract_json_rpc_id(body);
             return Ok(crate::response::json_rpc_error(
                 &json_rpc_id,
                 crate::response::JSONRPC_INTERNAL_ERROR,
@@ -39,7 +40,6 @@ impl ResourceListFilter {
         };
 
         let all_resources = registry.list_resources_in_namespace(namespace);
-        let json_rpc_id = crate::response::extract_json_rpc_id(body);
 
         let response = if is_template_list {
             let templates: Vec<serde_json::Value> = all_resources

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -50,25 +50,20 @@ struct ParsedBody {
     uri: Option<String>,
 }
 
-fn parse_body(body: &Option<Bytes>) -> ParsedBody {
+fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
     let Some(body_bytes) = body else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             uri: None,
         };
     };
 
     let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             uri: None,
         };
     };
-
-    let id = parsed
-        .get("id")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
 
     let uri = parsed
         .get("params")
@@ -76,11 +71,11 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
         .and_then(|u| u.as_str())
         .map(str::to_owned);
 
-    ParsedBody { id, uri }
+    ParsedBody { id: json_rpc_id, uri }
 }
 
 impl ResourceReadFilter {
-    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP protocol handler with JSON-RPC response construction")]
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -94,7 +89,8 @@ impl ResourceReadFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let parsed = parse_body(body);
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+        let parsed = parse_body(body, json_rpc_id);
 
         let resource_uri = match &parsed.uri {
             Some(u) => u.clone(),
@@ -191,7 +187,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///data/report.csv"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(1));
         assert_eq!(parsed.id, serde_json::Value::from(1));
         assert_eq!(parsed.uri.as_deref(), Some("file:///data/report.csv"));
     }
@@ -201,7 +197,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":2,"params":{}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(2));
         assert_eq!(parsed.id, serde_json::Value::from(2));
         assert!(parsed.uri.is_none());
     }
@@ -209,14 +205,14 @@ mod tests {
     #[test]
     fn parse_body_missing_params() {
         let body = Some(Bytes::from(r#"{"id":3}"#));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(3));
         assert_eq!(parsed.id, serde_json::Value::from(3));
         assert!(parsed.uri.is_none());
     }
 
     #[test]
     fn parse_body_none() {
-        let parsed = parse_body(&None);
+        let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.uri.is_none());
     }
@@ -224,7 +220,7 @@ mod tests {
     #[test]
     fn parse_body_malformed_json() {
         let body = Some(Bytes::from("{broken"));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.uri.is_none());
     }
@@ -232,7 +228,7 @@ mod tests {
     #[test]
     fn parse_body_empty_bytes() {
         let body = Some(Bytes::new());
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.uri.is_none());
     }
@@ -242,7 +238,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"params":{"uri":"s3://bucket/key"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert_eq!(parsed.uri.as_deref(), Some("s3://bucket/key"));
     }
@@ -252,7 +248,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":4,"params":{"uri":123}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(4));
         assert_eq!(parsed.id, serde_json::Value::from(4));
         assert!(parsed.uri.is_none());
     }

--- a/filters/src/response.rs
+++ b/filters/src/response.rs
@@ -39,6 +39,15 @@ pub fn extract_json_rpc_id(body: &Option<Bytes>) -> serde_json::Value {
         .unwrap_or(serde_json::Value::Null)
 }
 
+/// Reads the JSON-RPC request ID from its serialized metadata representation.
+///
+/// The `mcp.id` metadata is set by the `McpIdFilter` early in the filter chain
+/// so that downstream filters can retrieve the id without re-parsing the body.
+pub fn json_rpc_id_from_metadata(raw: Option<&str>) -> serde_json::Value {
+    raw.and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +85,37 @@ mod tests {
     fn extract_id_null_when_body_is_empty() {
         let body = Some(Bytes::new());
         assert_eq!(extract_json_rpc_id(&body), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn metadata_round_trip_numeric_id() {
+        let id = serde_json::Value::from(42);
+        let serialized = id.to_string();
+        assert_eq!(json_rpc_id_from_metadata(Some(&serialized)), serde_json::Value::from(42));
+    }
+
+    #[test]
+    fn metadata_round_trip_string_id() {
+        let id = serde_json::Value::from("req-1");
+        let serialized = id.to_string();
+        assert_eq!(json_rpc_id_from_metadata(Some(&serialized)), serde_json::Value::from("req-1"));
+    }
+
+    #[test]
+    fn metadata_round_trip_null_id() {
+        let id = serde_json::Value::Null;
+        let serialized = id.to_string();
+        assert_eq!(json_rpc_id_from_metadata(Some(&serialized)), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn metadata_none_returns_null() {
+        assert_eq!(json_rpc_id_from_metadata(None), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn metadata_malformed_returns_null() {
+        assert_eq!(json_rpc_id_from_metadata(Some("not valid json {")), serde_json::Value::Null);
     }
 
     #[test]

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -14,25 +14,20 @@ struct ParsedBody {
     arguments: HashMap<String, serde_json::Value>,
 }
 
-fn parse_body(body: &Option<Bytes>) -> ParsedBody {
+fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
     let Some(body_bytes) = body else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             arguments: HashMap::new(),
         };
     };
 
     let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
         return ParsedBody {
-            id: serde_json::Value::Null,
+            id: json_rpc_id,
             arguments: HashMap::new(),
         };
     };
-
-    let id = parsed
-        .get("id")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
 
     let arguments = parsed
         .get("params")
@@ -45,11 +40,11 @@ fn parse_body(body: &Option<Bytes>) -> ParsedBody {
         })
         .unwrap_or_default();
 
-    ParsedBody { id, arguments }
+    ParsedBody { id: json_rpc_id, arguments }
 }
 
 impl ToolCallFilter {
-    #[expect(clippy::too_many_lines, clippy::cognitive_complexity, reason = "MCP protocol handler with JSON-RPC response construction")]
+    #[expect(clippy::too_many_lines, reason = "MCP protocol handler with JSON-RPC response construction")]
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -63,7 +58,8 @@ impl ToolCallFilter {
             return Ok(FilterAction::Continue);
         }
 
-        let mut parsed = parse_body(body);
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+        let mut parsed = parse_body(body, json_rpc_id);
 
         let tool_name = match ctx.get_metadata(crate::MCP_NAME_KEY) {
             Some(n) => n.to_owned(),
@@ -303,7 +299,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(1));
         assert_eq!(parsed.id, serde_json::Value::from(1));
         assert_eq!(parsed.arguments.len(), 1);
         assert_eq!(parsed.arguments.get("message"), Some(&serde_json::Value::String("hello".to_owned())));
@@ -314,7 +310,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":2,"params":{"arguments":{"count":42,"flag":true,"nested":{"a":1}}}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(2));
         assert_eq!(parsed.id, serde_json::Value::from(2));
         assert_eq!(parsed.arguments.get("count"), Some(&serde_json::json!(42)));
         assert_eq!(parsed.arguments.get("flag"), Some(&serde_json::json!(true)));
@@ -326,7 +322,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":3,"params":{"name":"echo"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(3));
         assert_eq!(parsed.id, serde_json::Value::from(3));
         assert!(parsed.arguments.is_empty());
     }
@@ -334,14 +330,14 @@ mod tests {
     #[test]
     fn parse_body_missing_params() {
         let body = Some(Bytes::from(r#"{"id":4}"#));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(4));
         assert_eq!(parsed.id, serde_json::Value::from(4));
         assert!(parsed.arguments.is_empty());
     }
 
     #[test]
     fn parse_body_none() {
-        let parsed = parse_body(&None);
+        let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.arguments.is_empty());
     }
@@ -349,7 +345,7 @@ mod tests {
     #[test]
     fn parse_body_malformed_json() {
         let body = Some(Bytes::from("not json"));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.arguments.is_empty());
     }
@@ -357,7 +353,7 @@ mod tests {
     #[test]
     fn parse_body_empty_bytes() {
         let body = Some(Bytes::new());
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert!(parsed.arguments.is_empty());
     }
@@ -367,7 +363,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"params":{"arguments":{"key":"val"}}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::Null);
         assert!(parsed.id.is_null());
         assert_eq!(parsed.arguments.get("key"), Some(&serde_json::Value::String("val".to_owned())));
     }
@@ -377,7 +373,7 @@ mod tests {
         let body = Some(Bytes::from(
             r#"{"id":5,"params":{"arguments":"not-an-object"}}"#,
         ));
-        let parsed = parse_body(&body);
+        let parsed = parse_body(&body, serde_json::Value::from(5));
         assert_eq!(parsed.id, serde_json::Value::from(5));
         assert!(parsed.arguments.is_empty());
     }

--- a/filters/src/tool_list.rs
+++ b/filters/src/tool_list.rs
@@ -9,7 +9,7 @@ impl ToolListFilter {
     async fn handle_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
-        body: &mut Option<Bytes>,
+        _body: &mut Option<Bytes>,
     ) -> Result<FilterAction, FilterError> {
         let Some(method) = ctx.get_metadata(crate::MCP_METHOD_KEY) else {
             return Ok(FilterAction::Continue);
@@ -25,9 +25,10 @@ impl ToolListFilter {
 
         tracing::debug!(namespace = %namespace, "handling MCP tools/list request");
 
+        let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
+
         let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
             tracing::error!("InMemoryRegistry not found in request extensions");
-            let json_rpc_id = crate::response::extract_json_rpc_id(body);
             return Ok(crate::response::json_rpc_error(
                 &json_rpc_id,
                 crate::response::JSONRPC_INTERNAL_ERROR,
@@ -48,8 +49,6 @@ impl ToolListFilter {
                 })
             })
             .collect();
-
-        let json_rpc_id = crate::response::extract_json_rpc_id(body);
 
         let response = serde_json::json!({
             "jsonrpc": "2.0",

--- a/server/src/default.yaml
+++ b/server/src/default.yaml
@@ -15,6 +15,7 @@ filter_chains:
         allow_headers: ["Content-Type", "Accept", "Mcp-Session-Id", "Mcp-Protocol-Version", "Authorization"]
       - filter: mcp
         on_invalid: continue
+      - filter: wanaku_mcp_id
       - filter: wanaku_namespace
       - filter: wanaku_well_known
       - filter: wanaku_mcp_init

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -120,6 +120,10 @@ fn register_wanaku_filters(registry: &mut praxis_filter::FilterRegistry) {
     );
     praxis_filter::register_filters!(
         @register registry,
+        http "wanaku_mcp_id" => wanaku_filters::McpIdFilter::from_config
+    );
+    praxis_filter::register_filters!(
+        @register registry,
         http "wanaku_namespace" => wanaku_filters::NamespaceFilter::from_config
     );
     praxis_filter::register_filters!(


### PR DESCRIPTION
Fixes #1849

## Summary

Adds a new `McpIdFilter` (`wanaku_mcp_id`) that runs early in the filter chain, right after the `mcp` filter. It extracts the JSON-RPC request `id` from the body once and stores it as `mcp.id` metadata. All downstream filters now read the id from metadata via `json_rpc_id_from_metadata()` instead of repeatedly calling `extract_json_rpc_id(body)` which re-parses the entire body each time.

## Changes

- **apis/src/metadata.rs**: Add `MCP_ID_KEY` constant (`"mcp.id"`)
- **filters/src/mcp_id.rs** (new): `McpIdFilter` that extracts id and sets metadata
- **filters/src/response.rs**: Add `json_rpc_id_from_metadata()` helper with tests
- **filters/src/tool_list.rs, resource_list.rs, prompt_list.rs, mcp_init.rs, namespace.rs**: Replace `extract_json_rpc_id(body)` with metadata read (these no longer need body access for id)
- **filters/src/tool_call.rs, resource_read.rs, prompt_get.rs**: Modified `parse_body()` to accept id from metadata parameter instead of extracting from body
- **features/evaluator/src/filter.rs**: Replace `extract_json_rpc_id(body)` with metadata read in error and dispatch paths
- **server/src/lib.rs**: Register `McpIdFilter`
- **server/src/default.yaml**: Add `wanaku_mcp_id` to filter chain after `mcp`

## Impact

Eliminates redundant body deserialization across the filter chain. The body is parsed for the id exactly once (in `McpIdFilter`) instead of once per downstream filter that needs it.

## Summary by Sourcery

Cache MCP request IDs in metadata and reuse them throughout the filter chain.

New Features:
- Add an early MCP filter that captures the JSON-RPC request ID as metadata for downstream processing.

Enhancements:
- Use stored MCP request ID metadata across filters and evaluator paths to avoid repeated request-body parsing.

Tests:
- Add coverage for JSON-RPC ID metadata serialization and fallback handling.