### PR TITLE
docs: add optional Parallel Search MCP forward

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,14 @@ Tools are discovered automatically from upstream MCP servers. Register a forward
 wanaku forwards add --service="http://localhost:8180/mcp" --name my-mcp-server --no-auth
 ```
 
+As an optional alternative, an operator can explicitly register [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp):
+
+```bash
+wanaku forwards add --service="https://search.parallel.ai/mcp" --name parallel-search --no-auth
+```
+
+The Parallel endpoint requires no account or API key. Here, `--no-auth` is the existing local management tutorial flag for connecting the CLI to the local Wanaku server; it does not disable security globally. The forward is used only after an operator runs the command. User-provided search objectives, search queries, and requested URLs are sent to Parallel.
+
 Wanaku connects to the upstream server, discovers all available tools, and registers them automatically.
 
 List the discovered tools:


### PR DESCRIPTION
## Why

Adds an optional Parallel Search MCP forward to the existing getting-started workflow. Operators can explicitly register the endpoint without a Parallel account or API key while keeping the existing localhost example and Wanaku security guidance unchanged.

## Changes

- Add the native `wanaku forwards add` command for the optional Parallel Search MCP endpoint.
- Clarify that `--no-auth` is the existing local management tutorial flag and does not disable security globally.
- User-provided search objectives, search queries, and requested URLs are sent to Parallel.

## Validation

- `git diff --check`: passed.
- Targeted documentation assertions for the sole changed path, exact command, and data-routing disclosure: passed.
- `git status --short`: passed and confirmed only `docs/getting-started.md` is modified.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.

## Summary by Sourcery

Document optional registration of the Parallel Search MCP endpoint in the getting-started workflow.

New Features:
- Document the optional Parallel Search MCP endpoint for getting-started users.

Enhancements:
- Clarify the scope of the local `--no-auth` tutorial flag and disclose the data sent to Parallel.

Documentation:
- Add instructions and security/data-routing guidance for registering Parallel Search MCP.