### PR TITLE
Require praxis-ai 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ praxis-filter = { version = "0.5.1", package = "praxis-proxy-filter" }
 praxis-protocol = { version = "0.5.1", package = "praxis-proxy-protocol" }
 praxis-proxy = { version = "0.5.1", package = "praxis-proxy" }
 
-praxis-ai-apis = { git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
-praxis-ai-filters = { git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
+praxis-ai-apis = { version = "0.2.0", git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
+praxis-ai-filters = { version = "0.2.0", git = "https://github.com/praxis-proxy/ai", rev = "b2baf287d27ffce7cba9638014f96ef66bf009fc", default-features = false }
 
 wanaku-apis = { version = "0.3.0", path = "apis" }
 wanaku-filters = { version = "0.3.0", path = "filters" }


### PR DESCRIPTION
## Summary

- add explicit `0.2.0` version requirements for `praxis-ai-apis` and `praxis-ai-filters`
- retain the required Git revision pins because these crates are not published on crates.io
- make Cargo validate that the pinned sources match the requested release

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `cargo test` (279 passed; 7 environment-dependent tests ignored)
- `git diff --check`

## Existing local check failures

- `cargo fmt --check` reports formatting differences throughout unrelated Rust files with rustfmt 1.98
- `cargo clippy --all-targets --all-features -- -D warnings` reports existing Rust 1.98 lint failures in unrelated files