### PR TITLE
Fix #1847: consolidate duplicated JSON-RPC params parsing across filters

### DIFF
--- a/filters/src/json_rpc.rs
+++ b/filters/src/json_rpc.rs
@@ -1,0 +1,121 @@
+use bytes::Bytes;
+
+/// Method-specific fields parsed from a JSON-RPC request's `params` object.
+///
+/// The request `id` is deliberately not part of this struct: it is read once
+/// from `mcp.id` metadata (set by `McpIdFilter`) rather than re-parsed here.
+#[derive(Default)]
+pub(crate) struct JsonRpcParams {
+    pub(crate) name: Option<String>,
+    pub(crate) uri: Option<String>,
+    pub(crate) arguments: serde_json::Map<String, serde_json::Value>,
+}
+
+impl JsonRpcParams {
+    pub(crate) fn parse(body: &Option<Bytes>) -> Self {
+        let Some(body_bytes) = body else {
+            return Self::default();
+        };
+
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
+            return Self::default();
+        };
+
+        let Some(params) = value.get("params") else {
+            return Self::default();
+        };
+
+        let name = params.get("name").and_then(|n| n.as_str()).map(str::to_owned);
+        let uri = params.get("uri").and_then(|u| u.as_str()).map(str::to_owned);
+        let arguments = params
+            .get("arguments")
+            .and_then(|a| a.as_object())
+            .cloned()
+            .unwrap_or_default();
+
+        Self { name, uri, arguments }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_all_fields_present() {
+        let body = Some(Bytes::from(
+            r#"{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"summarize","uri":"file:///x","arguments":{"topic":"rust"}}}"#,
+        ));
+        let params = JsonRpcParams::parse(&body);
+        assert_eq!(params.name.as_deref(), Some("summarize"));
+        assert_eq!(params.uri.as_deref(), Some("file:///x"));
+        assert_eq!(params.arguments.get("topic"), Some(&serde_json::json!("rust")));
+    }
+
+    #[test]
+    fn parse_arguments_with_non_string_values() {
+        let body = Some(Bytes::from(
+            r#"{"params":{"arguments":{"count":42,"flag":true,"nested":{"a":1}}}}"#,
+        ));
+        let params = JsonRpcParams::parse(&body);
+        assert_eq!(params.arguments.get("count"), Some(&serde_json::json!(42)));
+        assert_eq!(params.arguments.get("flag"), Some(&serde_json::json!(true)));
+        assert_eq!(params.arguments.get("nested"), Some(&serde_json::json!({"a": 1})));
+    }
+
+    #[test]
+    fn parse_missing_params() {
+        let body = Some(Bytes::from(r#"{"id":1}"#));
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.name.is_none());
+        assert!(params.uri.is_none());
+        assert!(params.arguments.is_empty());
+    }
+
+    #[test]
+    fn parse_none_body() {
+        let params = JsonRpcParams::parse(&None);
+        assert!(params.name.is_none());
+        assert!(params.uri.is_none());
+        assert!(params.arguments.is_empty());
+    }
+
+    #[test]
+    fn parse_malformed_json() {
+        let body = Some(Bytes::from("not json"));
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.name.is_none());
+        assert!(params.uri.is_none());
+        assert!(params.arguments.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_bytes() {
+        let body = Some(Bytes::new());
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.name.is_none());
+        assert!(params.uri.is_none());
+        assert!(params.arguments.is_empty());
+    }
+
+    #[test]
+    fn parse_arguments_is_not_object() {
+        let body = Some(Bytes::from(r#"{"params":{"arguments":"not-an-object"}}"#));
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.arguments.is_empty());
+    }
+
+    #[test]
+    fn parse_uri_is_not_string() {
+        let body = Some(Bytes::from(r#"{"params":{"uri":123}}"#));
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.uri.is_none());
+    }
+
+    #[test]
+    fn parse_name_is_not_string() {
+        let body = Some(Bytes::from(r#"{"params":{"name":99}}"#));
+        let params = JsonRpcParams::parse(&body);
+        assert!(params.name.is_none());
+    }
+}

--- a/filters/src/lib.rs
+++ b/filters/src/lib.rs
@@ -72,6 +72,7 @@ macro_rules! body_filter_boilerplate {
     };
 }
 
+pub mod json_rpc;
 pub mod mcp_id;
 pub mod mcp_init;
 pub mod namespace;

--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -12,36 +12,8 @@ struct ParsedBody {
 }
 
 fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
-    let Some(body_bytes) = body else {
-        return ParsedBody {
-            id: json_rpc_id,
-            name: None,
-            arguments: serde_json::Map::new(),
-        };
-    };
-
-    let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
-        return ParsedBody {
-            id: json_rpc_id,
-            name: None,
-            arguments: serde_json::Map::new(),
-        };
-    };
-
-    let params = parsed.get("params");
-
-    let name = params
-        .and_then(|p| p.get("name"))
-        .and_then(|n| n.as_str())
-        .map(str::to_owned);
-
-    let arguments = params
-        .and_then(|p| p.get("arguments"))
-        .and_then(|a| a.as_object())
-        .cloned()
-        .unwrap_or_default();
-
-    ParsedBody { id: json_rpc_id, name, arguments }
+    let params = crate::json_rpc::JsonRpcParams::parse(body);
+    ParsedBody { id: json_rpc_id, name: params.name, arguments: params.arguments }
 }
 
 impl PromptGetFilter {
@@ -203,26 +175,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_missing_name() {
-        let body = Some(Bytes::from(
-            r#"{"id":3,"params":{"arguments":{"key":"val"}}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(3));
-        assert_eq!(parsed.id, serde_json::Value::from(3));
-        assert!(parsed.name.is_none());
-        assert_eq!(parsed.arguments.len(), 1);
-    }
-
-    #[test]
-    fn parse_body_missing_params() {
-        let body = Some(Bytes::from(r#"{"id":4}"#));
-        let parsed = parse_body(&body, serde_json::Value::from(4));
-        assert_eq!(parsed.id, serde_json::Value::from(4));
-        assert!(parsed.name.is_none());
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
     fn parse_body_none() {
         let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
@@ -231,51 +183,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_malformed_json() {
-        let body = Some(Bytes::from("<<<"));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.name.is_none());
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_empty_bytes() {
-        let body = Some(Bytes::new());
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.name.is_none());
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_no_id_field() {
+    fn parse_body_id_comes_from_parameter_not_body() {
         let body = Some(Bytes::from(
-            r#"{"params":{"name":"test-prompt"}}"#,
+            r#"{"jsonrpc":"2.0","id":999,"params":{"name":"greet"}}"#,
         ));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert_eq!(parsed.name.as_deref(), Some("test-prompt"));
-    }
-
-    #[test]
-    fn parse_body_arguments_is_not_object() {
-        let body = Some(Bytes::from(
-            r#"{"id":5,"params":{"name":"p","arguments":"not-a-map"}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(5));
-        assert_eq!(parsed.id, serde_json::Value::from(5));
-        assert_eq!(parsed.name.as_deref(), Some("p"));
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_name_is_not_string() {
-        let body = Some(Bytes::from(
-            r#"{"id":6,"params":{"name":99}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(6));
-        assert_eq!(parsed.id, serde_json::Value::from(6));
-        assert!(parsed.name.is_none());
+        let parsed = parse_body(&body, serde_json::Value::from(1));
+        assert_eq!(parsed.id, serde_json::Value::from(1));
     }
 }

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -51,26 +51,7 @@ struct ParsedBody {
 }
 
 fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
-    let Some(body_bytes) = body else {
-        return ParsedBody {
-            id: json_rpc_id,
-            uri: None,
-        };
-    };
-
-    let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
-        return ParsedBody {
-            id: json_rpc_id,
-            uri: None,
-        };
-    };
-
-    let uri = parsed
-        .get("params")
-        .and_then(|p| p.get("uri"))
-        .and_then(|u| u.as_str())
-        .map(str::to_owned);
-
+    let uri = crate::json_rpc::JsonRpcParams::parse(body).uri;
     ParsedBody { id: json_rpc_id, uri }
 }
 
@@ -193,24 +174,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_missing_uri() {
-        let body = Some(Bytes::from(
-            r#"{"id":2,"params":{}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(2));
-        assert_eq!(parsed.id, serde_json::Value::from(2));
-        assert!(parsed.uri.is_none());
-    }
-
-    #[test]
-    fn parse_body_missing_params() {
-        let body = Some(Bytes::from(r#"{"id":3}"#));
-        let parsed = parse_body(&body, serde_json::Value::from(3));
-        assert_eq!(parsed.id, serde_json::Value::from(3));
-        assert!(parsed.uri.is_none());
-    }
-
-    #[test]
     fn parse_body_none() {
         let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
@@ -218,39 +181,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_malformed_json() {
-        let body = Some(Bytes::from("{broken"));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.uri.is_none());
-    }
-
-    #[test]
-    fn parse_body_empty_bytes() {
-        let body = Some(Bytes::new());
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.uri.is_none());
-    }
-
-    #[test]
-    fn parse_body_no_id_field() {
+    fn parse_body_id_comes_from_parameter_not_body() {
         let body = Some(Bytes::from(
-            r#"{"params":{"uri":"s3://bucket/key"}}"#,
+            r#"{"jsonrpc":"2.0","id":999,"params":{"uri":"file:///x"}}"#,
         ));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert_eq!(parsed.uri.as_deref(), Some("s3://bucket/key"));
-    }
-
-    #[test]
-    fn parse_body_uri_is_not_string() {
-        let body = Some(Bytes::from(
-            r#"{"id":4,"params":{"uri":123}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(4));
-        assert_eq!(parsed.id, serde_json::Value::from(4));
-        assert!(parsed.uri.is_none());
+        let parsed = parse_body(&body, serde_json::Value::from(1));
+        assert_eq!(parsed.id, serde_json::Value::from(1));
     }
 
     #[test]

--- a/filters/src/tool_call.rs
+++ b/filters/src/tool_call.rs
@@ -15,31 +15,7 @@ struct ParsedBody {
 }
 
 fn parse_body(body: &Option<Bytes>, json_rpc_id: serde_json::Value) -> ParsedBody {
-    let Some(body_bytes) = body else {
-        return ParsedBody {
-            id: json_rpc_id,
-            arguments: HashMap::new(),
-        };
-    };
-
-    let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
-        return ParsedBody {
-            id: json_rpc_id,
-            arguments: HashMap::new(),
-        };
-    };
-
-    let arguments = parsed
-        .get("params")
-        .and_then(|p| p.get("arguments"))
-        .and_then(|a| a.as_object())
-        .map(|args| {
-            args.iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect()
-        })
-        .unwrap_or_default();
-
+    let arguments = crate::json_rpc::JsonRpcParams::parse(body).arguments.into_iter().collect();
     ParsedBody { id: json_rpc_id, arguments }
 }
 
@@ -309,36 +285,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_arguments_with_non_string_values() {
-        let body = Some(Bytes::from(
-            r#"{"id":2,"params":{"arguments":{"count":42,"flag":true,"nested":{"a":1}}}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(2));
-        assert_eq!(parsed.id, serde_json::Value::from(2));
-        assert_eq!(parsed.arguments.get("count"), Some(&serde_json::json!(42)));
-        assert_eq!(parsed.arguments.get("flag"), Some(&serde_json::json!(true)));
-        assert_eq!(parsed.arguments.get("nested"), Some(&serde_json::json!({"a": 1})));
-    }
-
-    #[test]
-    fn parse_body_missing_arguments() {
-        let body = Some(Bytes::from(
-            r#"{"id":3,"params":{"name":"echo"}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(3));
-        assert_eq!(parsed.id, serde_json::Value::from(3));
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_missing_params() {
-        let body = Some(Bytes::from(r#"{"id":4}"#));
-        let parsed = parse_body(&body, serde_json::Value::from(4));
-        assert_eq!(parsed.id, serde_json::Value::from(4));
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
     fn parse_body_none() {
         let parsed = parse_body(&None, serde_json::Value::Null);
         assert!(parsed.id.is_null());
@@ -346,39 +292,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_body_malformed_json() {
-        let body = Some(Bytes::from("not json"));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_empty_bytes() {
-        let body = Some(Bytes::new());
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert!(parsed.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_body_no_id_field() {
+    fn parse_body_id_comes_from_parameter_not_body() {
         let body = Some(Bytes::from(
-            r#"{"params":{"arguments":{"key":"val"}}}"#,
+            r#"{"jsonrpc":"2.0","id":999,"params":{"arguments":{}}}"#,
         ));
-        let parsed = parse_body(&body, serde_json::Value::Null);
-        assert!(parsed.id.is_null());
-        assert_eq!(parsed.arguments.get("key"), Some(&serde_json::Value::String("val".to_owned())));
-    }
-
-    #[test]
-    fn parse_body_arguments_is_not_object() {
-        let body = Some(Bytes::from(
-            r#"{"id":5,"params":{"arguments":"not-an-object"}}"#,
-        ));
-        let parsed = parse_body(&body, serde_json::Value::from(5));
-        assert_eq!(parsed.id, serde_json::Value::from(5));
-        assert!(parsed.arguments.is_empty());
+        let parsed = parse_body(&body, serde_json::Value::from(1));
+        assert_eq!(parsed.id, serde_json::Value::from(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `tool_call.rs`, `resource_read.rs`, and `prompt_get.rs` each hand-rolled the same body-parsing bootstrap (default on missing/malformed body, then extract fields from `params`) to pull out their own method-specific fields (`arguments`, `uri`, or `name`+`arguments`).
- Factors that into a shared `JsonRpcParams::parse()` in a new `filters/src/json_rpc.rs`, which borrows fields off a single parsed `Value` so only the `arguments` map is cloned.
- The request `id` is intentionally **not** part of the shared struct — it already flows from `mcp.id` metadata (set once by `McpIdFilter`, #1849) rather than being re-parsed from the body, and this change does not touch that path. Each filter's test suite gained a regression test asserting `id` still comes from that parameter and not from a same-named field in the body.
- Consolidated the three files' near-identical edge-case tests (malformed JSON, empty bytes, missing params, wrong-typed fields) into `json_rpc.rs`'s own test module, keeping a couple of integration-level tests per filter to confirm the wiring.

Fixes #1847.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all green, including 3 new regression tests for the id/metadata invariant)
- [x] `cargo clippy -p wanaku-filters --all-targets` (no new warnings vs. main)
- [x] Reviewed by the adversarial-code-reviewer agent; the one finding (a double-clone of the `arguments` payload) was fixed before this PR was opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate duplicated JSON-RPC parameter parsing across the request filters while preserving metadata-based request ID handling.

Enhancements:
- Centralize JSON-RPC parameter parsing for tool calls, resource reads, and prompt requests in a shared parser with consistent handling of invalid or missing input.
- Preserve request IDs from MCP metadata rather than body payloads across all affected filters.

Tests:
- Consolidate shared parser edge-case coverage and add regression tests verifying that body IDs cannot override metadata IDs.