### PR TITLE
Fix #1870: add deterministic action policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5090,6 +5090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wanaku-feature-action-policy"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "wanaku-feature-evaluator"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5093,9 +5093,18 @@ dependencies = [
 name = "wanaku-feature-action-policy"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "praxis-proxy-filter",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "tracing",
+ "wanaku-filters",
+ "wanaku-infra",
+ "wanaku-types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -5233,6 +5242,7 @@ dependencies = [
  "tokio",
  "tracing",
  "utoipa",
+ "wanaku-feature-action-policy",
  "wanaku-feature-evaluator",
  "wanaku-feature-intercept",
  "wanaku-feature-mcp-metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,6 +5100,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
  "wanaku-filters",
  "wanaku-infra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "features/action-policy",
     "features/evaluator",
     "features/intercept",
     "features/mcp-metadata",
@@ -48,6 +49,7 @@ wanaku-infra = { version = "0.3.0", path = "infra" }
 wanaku-types = { version = "0.3.0", path = "types" }
 wanaku-filters = { version = "0.3.0", path = "filters" }
 wanaku-feature-evaluator = { version = "0.3.0", path = "features/evaluator" }
+wanaku-feature-action-policy = { version = "0.3.0", path = "features/action-policy" }
 wanaku-feature-intercept = { version = "0.3.0", path = "features/intercept" }
 wanaku-feature-mcp-metadata = { version = "0.3.0", path = "features/mcp-metadata" }
 wanaku-feature-metrics = { version = "0.3.0", path = "features/metrics" }

--- a/Containerfile
+++ b/Containerfile
@@ -42,6 +42,7 @@ COPY types/Cargo.toml types/Cargo.toml
 COPY infra/Cargo.toml infra/Cargo.toml
 COPY filters/Cargo.toml filters/Cargo.toml
 COPY server/Cargo.toml server/Cargo.toml
+COPY features/action-policy/Cargo.toml features/action-policy/Cargo.toml
 COPY features/evaluator/Cargo.toml features/evaluator/Cargo.toml
 COPY features/intercept/Cargo.toml features/intercept/Cargo.toml
 COPY features/mcp-metadata/Cargo.toml features/mcp-metadata/Cargo.toml
@@ -49,12 +50,13 @@ COPY features/metrics/Cargo.toml features/metrics/Cargo.toml
 COPY features/plugins/Cargo.toml features/plugins/Cargo.toml
 
 RUN mkdir -p types/src infra/src filters/src server/src \
-    features/evaluator/src features/intercept/src features/mcp-metadata/src features/metrics/src features/plugins/src \
+    features/action-policy/src features/evaluator/src features/intercept/src features/mcp-metadata/src features/metrics/src features/plugins/src \
     ui/admin/dist \
     && echo '//! stub' > types/src/lib.rs \
     && echo '//! stub' > infra/src/lib.rs \
     && echo '//! stub' > filters/src/lib.rs \
     && echo '//! stub' > server/src/lib.rs \
+    && echo '//! stub' > features/action-policy/src/lib.rs \
     && echo '//! stub' > features/evaluator/src/lib.rs \
     && echo '//! stub' > features/intercept/src/lib.rs \
     && echo '//! stub' > features/mcp-metadata/src/lib.rs \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Contributors working on the project may want to refer to the development documen
 - [Features / Plugins](docs/features.md) - Feature crate system
 - [Plugin Development](docs/plugin-development-guide.md) - Guide for writing new feature crates
 - [Evaluator Engine](docs/evaluator-engine.md) - WASM-based evaluator
+- [Action Policies](docs/action-policies.md) - Deterministic MCP action rules
 - [Contributing](CONTRIBUTING.md) - Contribution guidelines
 - [Security](SECURITY.md) - Security policy
 

--- a/docs/action-policies.md
+++ b/docs/action-policies.md
@@ -1,0 +1,215 @@
+# Action Policies
+
+Action policies give Wanaku a deterministic authorization layer for MCP actions. They complement the evaluator. Use action policies for rules that depend on known names, labels, URIs, and structured request values. Use evaluators for contextual or semantic decisions.
+
+## Configure a policy
+
+Add one `action_policy` object to `wanaku.yaml`:
+
+```yaml
+action_policy:
+  rules:
+    - id: deny-production-delete
+      description: Prevent destructive production calls
+      effect: deny
+      selectors:
+        namespace: production
+        operation: tools/call
+        target_type: tool
+        target_name:
+          matcher: glob
+          value: "delete-*"
+        labels:
+          risk: high
+      predicates:
+        - operator: equals
+          pointer: /arguments/force
+          value: true
+      reason_code: destructive_action_denied
+      message: This action is not permitted.
+      metadata:
+        owner: platform-security
+
+    - id: allow-public-reports
+      effect: allow
+      selectors:
+        operation: resources/read
+        target_type: resource
+        uri:
+          matcher: prefix
+          value: "https://reports.example/public/"
+```
+
+Wanaku validates and compiles the complete policy before activation. Wanaku rejects the revision if a rule is invalid. An invalid revision does not replace the last active revision.
+
+Each rule uses these fields:
+
+| Field | Required | Value |
+| --- | --- | --- |
+| `id` | Yes | A stable identifier. Start with a letter or digit. Then use letters, digits, `_`, `-`, `.`, `/`, or `:`. |
+| `description` | No | Text for operators. |
+| `effect` | Yes | `allow` or `deny`. |
+| `selectors` | Yes | One or more action selectors. |
+| `predicates` | No | A list of typed JSON Pointer predicates. |
+| `reason_code` | No | A stable identifier for a denied action. |
+| `message` | No | A safe message that Wanaku can return to the caller. |
+| `metadata` | No | Operator metadata. Metadata keys use the identifier syntax. Values are JSON values. |
+
+Unknown fields cause validation to fail. Rule IDs must be unique in one policy.
+
+## Select actions
+
+A rule can use these selectors:
+
+| Selector | Value |
+| --- | --- |
+| `namespace` | The Wanaku namespace. |
+| `operation` | `tools/call`, `resources/read`, or `prompts/get`. |
+| `target_type` | `tool`, `resource`, or `prompt`. |
+| `target_name` | An `exact` or `glob` match expression. |
+| `labels` | Required registry label key-value pairs. |
+| `uri` | An `exact` or `prefix` match expression for a resource URI. |
+
+All selectors and all predicates in one rule use AND semantics. The rule matches only when every configured condition matches.
+
+For `labels`, the configured labels must be a subset of the registry entry labels. Extra labels on the registry entry do not prevent a match. Prompt entries do not currently supply registry labels to the policy adapter.
+
+### Match target names
+
+Use `exact` to compare the complete target name:
+
+```yaml
+target_name: { matcher: exact, value: delete-account }
+```
+
+Use `glob` for target names. `*` matches zero or more characters. `?` matches one character. A backslash escapes the next character. For example, `report-\*` matches the literal name `report-*`. A trailing backslash is invalid.
+
+URI selectors do not support glob matching. They support `exact` and literal `prefix` matching only.
+
+### Match resource URIs
+
+Wanaku compares the exact URI string from `resources/read`. Wanaku does not decode, resolve, or normalize the URI. Case, escaping, separators, and trailing slashes remain significant.
+
+```yaml
+uri:
+  matcher: prefix
+  value: "s3://company-private/"
+```
+
+A URI selector applies only to a resource read. Tool registry transport URIs are not policy resource URIs.
+
+## Match structured request values
+
+Each predicate reads the MCP `params` object with an RFC 6901 JSON Pointer. JSON types remain distinct. The string `"1"` does not equal the number `1`.
+
+| Operator | Operand | Match condition |
+| --- | --- | --- |
+| `exists` | `value: true` or `false` | The pointer is present or absent. |
+| `equals` | `value` | The present value equals the operand. |
+| `not_equals` | `value` | The present value does not equal the operand. |
+| `one_of` | Non-empty `values` | The present value equals one list value. |
+| `not_one_of` | Non-empty `values` | The present value equals no list value. |
+
+Example:
+
+```yaml
+predicates:
+  - operator: exists
+    pointer: /arguments/approved
+    value: true
+  - operator: one_of
+    pointer: /arguments/environment
+    values: [production, staging]
+```
+
+Missing is different from JSON `null`:
+
+| Input at the pointer | `exists: true` | `exists: false` | `equals: null` | `not_equals: null` | `one_of: [null]` | `not_one_of: [null]` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Missing | No | Yes | No | No | No | No |
+| `null` | Yes | No | Yes | No | Yes | No |
+| `false` | Yes | No | No | Yes | No | Yes |
+| `0` | Yes | No | No | Yes | No | Yes |
+| `""` | Yes | No | No | Yes | No | Yes |
+
+A missing value never matches a comparison operator. Use `exists: false` to match an omitted value.
+
+## Decision behavior
+
+Wanaku evaluates all rules. The declaration order does not change the result.
+
+1. If any matching rule has `effect: deny`, Wanaku denies the action.
+2. If no deny matches and an allow matches, Wanaku records an explicit allow and continues the pipeline.
+3. If no rule matches, Wanaku continues the pipeline. The baseline behavior belongs to [#1872](https://github.com/wanaku-ai/wanaku/issues/1872).
+
+A static allow does not skip the evaluator or another downstream filter. A static deny returns a JSON-RPC error before the evaluator and upstream action handler run.
+
+The caller receives one deterministic safe denial reason. Wanaku selects the matching deny rule with the lexicographically lowest rule ID. A configured `reason_code` and `message` take precedence. Otherwise, Wanaku uses `action_policy_denied` and `The requested action is not allowed.` The decision model retains all matching rule IDs and configured reason codes for authorized internal consumers.
+
+An unconfigured policy continues governed requests. If no active last-known-good policy exists, an invalid configured policy rejects governed requests with `action_policy_invalid`. If an active policy exists, an invalid update or startup policy does not replace it. Wanaku continues to enforce the active last-known-good policy. These are temporary failure semantics. [#1872](https://github.com/wanaku-ai/wanaku/issues/1872) owns the final baseline and failure modes.
+
+Wanaku governs `tools/call`, `resources/read`, and `prompts/get`. Wanaku does not filter `tools/list`, `resources/list`, or `prompts/list`. Discovery does not grant authorization.
+
+## Pipeline position
+
+Place `wanaku_action_policy` after MCP metadata, namespace resolution, and `wanaku_mcp_init`. Place it before `wanaku_evaluator`:
+
+```yaml
+- filter: mcp
+- filter: wanaku_namespace
+- filter: wanaku_mcp_init
+- filter: wanaku_action_policy
+- filter: wanaku_evaluator
+```
+
+The default pipeline already uses this order.
+
+## Manage policy revisions
+
+The management API uses a dedicated policy resource:
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/api/v1/action-policies` | Get the effective policy and active revision metadata. |
+| `PUT` | `/api/v1/action-policies` | Validate and activate a policy. |
+| `GET` | `/api/v1/action-policies/revisions` | List revision metadata, newest first. |
+| `GET` | `/api/v1/action-policies/revisions/active` | Get the active revision and policy. |
+| `GET` | `/api/v1/action-policies/revisions/{id}` | Get one revision and policy. |
+| `POST` | `/api/v1/action-policies/revisions/{id}/activate` | Validate the selected policy and create a new active revision. |
+
+Activate a policy:
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/action-policies \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "policy": {
+      "rules": [{
+        "id": "deny-delete",
+        "effect": "deny",
+        "selectors": {"operation": "tools/call"}
+      }]
+    },
+    "expected_revision": 4
+  }'
+```
+
+`expected_revision` is optional. If it does not equal the active revision, Wanaku returns HTTP `409 Conflict`. A validation failure returns HTTP `422 Unprocessable Entity`. Wanaku records the invalid revision as rejected. It does not replace the active revision.
+
+Rollback creates a new revision. It does not change historical data:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/action-policies/revisions/2/activate \
+  -H 'Content-Type: application/json' \
+  -d '{"expected_revision": 4}'
+```
+
+Wanaku stores policy revisions in `action-policy-revisions.json` under `WANAKU_PERSIST_PATH` when file persistence is enabled. It writes the file after each revision change. The history contains at most 50 revisions. The policy revision stream is independent from `evaluator-revisions.json`.
+
+At startup, Wanaku immediately validates and installs the persisted active policy. If `wanaku.yaml` contains a different valid policy, Wanaku activates a new startup revision. If the policy is unchanged, Wanaku does not create a duplicate revision. An invalid startup policy does not replace a persisted last-known-good policy.
+
+## Deferred work
+
+Governance audit events and external decision evidence belong to [#1869](https://github.com/wanaku-ai/wanaku/issues/1869). Action-policy decisions already retain rule IDs and reason codes for that integration. Wanaku does not copy structured request values into management responses.
+
+Agent-to-agent action adapters belong to [#383](https://github.com/wanaku-ai/wanaku/issues/383). The engine and action context are transport-neutral so that work can reuse the current rule semantics.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,7 @@ filter_chains:
       - filter: wanaku_namespace        # Extract namespace from path
       - filter: wanaku_well_known       # RFC 9728 OAuth metadata (feature)
       - filter: wanaku_mcp_init         # Initialize MCP context
+      - filter: wanaku_action_policy    # Deterministic static action policy
       - filter: wanaku_evaluator        # Evaluator engine (feature)
       - filter: wanaku_tool_list        # Handle tools/list
       - filter: wanaku_tool_call        # Handle tools/call
@@ -289,8 +290,9 @@ pub trait Feature: Send + Sync {
 1. **Metrics** (`features/metrics/`) — exposes an in-memory metrics snapshot
 2. **Intercept** (`features/intercept/`) — records request/response interactions for conversation history
 3. **MCP Metadata** (`features/mcp-metadata/`) — RFC 9728 OAuth Protected Resource Metadata and well-known endpoints
-4. **Evaluator** (`features/evaluator/`) — WASM-based LLM evaluation engine for trigger→evaluate→act pipelines
-5. **Plugins** (`features/plugins/`) — loads external UI plugins from a filesystem directory
+4. **Action policy** (`features/action-policy/`) — deterministic allow and deny rules for MCP actions
+5. **Evaluator** (`features/evaluator/`) — WASM-based LLM evaluation engine for trigger→evaluate→act pipelines
+6. **Plugins** (`features/plugins/`) — loads external UI plugins from a filesystem directory
 
 See [Features](./features.md) for how to create your own.
 
@@ -447,6 +449,7 @@ These are all solvable (implement traits, add filters), but they're not in scope
 ## Related Docs
 
 - [Configuration](./configuration.md) — all env vars and YAML options
+- [Action Policies](./action-policies.md) — schema, matching, decisions, and revisions
 - [Features](./features.md) — enable evaluators, create custom features
 - [Management API](./management-api.md) — REST API reference
 - [Contributing: Admin UI](./contributing-admin-ui.md) — customize the embedded UI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,12 @@ If the startup `wanaku.yaml` evaluator configuration is identical to the persist
 
 **Limitation:** File persistence supports one writer. Use a shared external persistence implementation before you run multiple replicas.
 
+### Action Policy Revision Persistence
+
+Action-policy revision history uses the same persistence settings. Wanaku writes `action-policy-revisions.json` in `WANAKU_PERSIST_PATH`. The action-policy stream is independent from the evaluator stream.
+
+Wanaku writes the file after each revision change. Wanaku validates and installs the persisted active policy during startup. See [Action Policies](./action-policies.md) for the policy schema and lifecycle.
+
 ### Admin UI Override
 
 The admin UI is embedded in the binary. To serve UI files from a directory on disk instead of the embedded bundle:
@@ -259,6 +265,7 @@ filter_chains:
       - filter: wanaku_namespace
       - filter: wanaku_well_known
       - filter: wanaku_mcp_init
+      - filter: wanaku_action_policy
       - filter: wanaku_evaluator
       - filter: wanaku_tool_list
       - filter: wanaku_tool_call
@@ -369,6 +376,7 @@ Wanaku loads these top-level sections from `wanaku.yaml`:
 - `forwards` — core forward bootstrap configuration
 - `llm_connections` — named LLM connections (model/url/api_key) for evaluators; config-only, never exposed via the management API
 - `evaluators` — evaluator feature configuration
+- `action_policy` — declarative action-policy rules
 - `plugins` — plugin service mappings owned by the plugins feature
 
 Wanaku discovers tools, resources, and prompts from the configured forwards.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ All in a single binary with no runtime dependencies (except libc).
 - **[Configuration](./configuration.md)** — all environment variables and YAML config options
 - **[Authentication](./auth.md)** — set up oauth2-proxy with Keycloak
 - **[Management API](./management-api.md)** — REST API reference for tools, resources, etc.
+- **[Action Policies](./action-policies.md)** — deterministic rules for MCP actions
 - **[FAQ](./faq.md)** — common issues and troubleshooting
 
 ### Understanding the System

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -129,6 +129,19 @@ Use this body to bind a namespace:
 
 See [Evaluator Engine](evaluator-engine.md) for the evaluator configuration schema.
 
+### Action Policies
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/action-policies` | Get the effective policy. |
+| `PUT` | `/api/v1/action-policies` | Validate and activate a policy. |
+| `GET` | `/api/v1/action-policies/revisions` | List policy revision metadata. |
+| `GET` | `/api/v1/action-policies/revisions/active` | Get the active policy revision. |
+| `GET` | `/api/v1/action-policies/revisions/{id}` | Get one policy revision. |
+| `POST` | `/api/v1/action-policies/revisions/{id}/activate` | Activate a prior policy as a new revision. |
+
+The update and activation requests accept an optional `expected_revision`. Wanaku returns `409 Conflict` if the value does not equal the active revision. See [Action Policies](action-policies.md) for request examples and validation behavior.
+
 ### Inference Proxy (not part of this API)
 
 Chat completions do not go through the management API. Wanaku exposes a

--- a/features/action-policy/Cargo.toml
+++ b/features/action-policy/Cargo.toml
@@ -24,3 +24,6 @@ tracing = { workspace = true }
 wanaku-filters = { workspace = true }
 wanaku-infra = { workspace = true }
 wanaku-types = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/features/action-policy/Cargo.toml
+++ b/features/action-policy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wanaku-feature-action-policy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lib]
+name = "wanaku_feature_action_policy"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/features/action-policy/Cargo.toml
+++ b/features/action-policy/Cargo.toml
@@ -12,6 +12,15 @@ name = "wanaku_feature_action_policy"
 workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+praxis-filter = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+wanaku-filters = { workspace = true }
+wanaku-infra = { workspace = true }
+wanaku-types = { workspace = true }

--- a/features/action-policy/src/engine.rs
+++ b/features/action-policy/src/engine.rs
@@ -1,0 +1,354 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{CompiledPolicy, CompiledRule, Effect, TargetType};
+
+/// The safe message used when a deny rule does not configure one.
+pub const DEFAULT_DENY_MESSAGE: &str = "The requested action is not allowed.";
+/// The stable reason code used when a deny rule does not configure one.
+pub const DEFAULT_DENY_REASON_CODE: &str = "action_policy_denied";
+
+/// Trusted identity data for future actor selectors.
+///
+/// Only a trusted proxy identity component must construct this value. Action
+/// request headers and parameters must not populate it directly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActorContext {
+    principal_id: String,
+    issuer: String,
+    attributes: BTreeMap<String, Value>,
+}
+
+impl ActorContext {
+    #[must_use]
+    pub fn new(
+        principal_id: impl Into<String>,
+        issuer: impl Into<String>,
+        attributes: BTreeMap<String, Value>,
+    ) -> Self {
+        Self {
+            principal_id: principal_id.into(),
+            issuer: issuer.into(),
+            attributes,
+        }
+    }
+
+    #[must_use]
+    pub fn principal_id(&self) -> &str {
+        &self.principal_id
+    }
+
+    #[must_use]
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    #[must_use]
+    pub const fn attributes(&self) -> &BTreeMap<String, Value> {
+        &self.attributes
+    }
+}
+
+/// A transport-neutral action presented to the policy engine.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ActionContext {
+    namespace: String,
+    operation: String,
+    target_type: TargetType,
+    target_name: Option<String>,
+    labels: BTreeMap<String, String>,
+    uri: Option<String>,
+    input: Value,
+    actor: Option<ActorContext>,
+}
+
+impl ActionContext {
+    #[must_use]
+    pub fn new(
+        namespace: impl Into<String>,
+        operation: impl Into<String>,
+        target_type: TargetType,
+        input: Value,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            operation: operation.into(),
+            target_type,
+            target_name: None,
+            labels: BTreeMap::new(),
+            uri: None,
+            input,
+            actor: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_target_name(mut self, target_name: impl Into<String>) -> Self {
+        self.target_name = Some(target_name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
+        self
+    }
+
+    #[must_use]
+    pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_actor(mut self, actor: ActorContext) -> Self {
+        self.actor = Some(actor);
+        self
+    }
+
+    #[must_use]
+    pub const fn actor(&self) -> Option<&ActorContext> {
+        self.actor.as_ref()
+    }
+}
+
+/// Availability of a compiled policy snapshot.
+#[derive(Clone, Copy)]
+pub enum PolicyState<'a> {
+    Available(&'a CompiledPolicy),
+    Unavailable,
+    Invalid,
+}
+
+/// A matching rule retained for audit and authorized inspection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedRule {
+    rule_id: String,
+    effect: Effect,
+    reason_code: Option<String>,
+}
+
+impl MatchedRule {
+    #[must_use]
+    pub fn rule_id(&self) -> &str {
+        &self.rule_id
+    }
+
+    #[must_use]
+    pub const fn effect(&self) -> Effect {
+        self.effect
+    }
+
+    #[must_use]
+    pub fn reason_code(&self) -> Option<&str> {
+        self.reason_code.as_deref()
+    }
+}
+
+/// Internal rule evidence for an explicit decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecisionDetails {
+    matched_rules: Vec<MatchedRule>,
+    contributing_rules: Vec<MatchedRule>,
+}
+
+/// The single caller-safe reason selected for an explicit denial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimaryDenyReason {
+    reason_code: String,
+    message: String,
+}
+
+impl PrimaryDenyReason {
+    #[must_use]
+    pub fn reason_code(&self) -> &str {
+        &self.reason_code
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl DecisionDetails {
+    #[must_use]
+    pub fn matched_rules(&self) -> &[MatchedRule] {
+        &self.matched_rules
+    }
+
+    #[must_use]
+    pub fn contributing_rules(&self) -> &[MatchedRule] {
+        &self.contributing_rules
+    }
+}
+
+/// A policy result. Baseline behavior is deliberately not applied here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyDecision {
+    /// One or more allow rules matched and no deny rule matched. The caller
+    /// must continue through downstream governance filters.
+    ExplicitAllow {
+        details: DecisionDetails,
+    },
+    /// At least one deny rule matched.
+    ExplicitDeny {
+        reason: PrimaryDenyReason,
+        details: DecisionDetails,
+    },
+    NoMatch,
+    PolicyUnavailable,
+    PolicyInvalid,
+}
+
+impl PolicyDecision {
+    #[must_use]
+    pub const fn details(&self) -> Option<&DecisionDetails> {
+        match self {
+            Self::ExplicitAllow { details } | Self::ExplicitDeny { details, .. } => Some(details),
+            Self::NoMatch | Self::PolicyUnavailable | Self::PolicyInvalid => None,
+        }
+    }
+
+    #[must_use]
+    pub fn deny_message(&self) -> Option<&str> {
+        match self {
+            Self::ExplicitDeny { reason, .. } => Some(reason.message()),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn deny_reason_code(&self) -> Option<&str> {
+        match self {
+            Self::ExplicitDeny { reason, .. } => Some(reason.reason_code()),
+            _ => None,
+        }
+    }
+}
+
+pub struct PolicyEngine;
+
+impl PolicyEngine {
+    /// Evaluate every rule in one immutable policy snapshot.
+    #[must_use]
+    pub fn evaluate(state: PolicyState<'_>, context: &ActionContext) -> PolicyDecision {
+        let policy = match state {
+            PolicyState::Available(policy) => policy,
+            PolicyState::Unavailable => return PolicyDecision::PolicyUnavailable,
+            PolicyState::Invalid => return PolicyDecision::PolicyInvalid,
+        };
+
+        evaluate_policy(policy, context)
+    }
+}
+
+fn evaluate_policy(policy: &CompiledPolicy, context: &ActionContext) -> PolicyDecision {
+    let mut matches: Vec<&CompiledRule> = policy
+        .rules()
+        .iter()
+        .filter(|rule| rule_matches(rule, context))
+        .collect();
+    matches.sort_by(|left, right| left.rule().id.cmp(&right.rule().id));
+
+    if matches.is_empty() {
+        return PolicyDecision::NoMatch;
+    }
+
+    let deny_rules: Vec<&CompiledRule> = matches
+        .iter()
+        .copied()
+        .filter(|rule| rule.rule().effect == Effect::Deny)
+        .collect();
+    if let Some(primary) = deny_rules.first() {
+        return PolicyDecision::ExplicitDeny {
+            reason: primary_deny_reason(primary),
+            details: decision_details(&matches, &deny_rules),
+        };
+    }
+
+    PolicyDecision::ExplicitAllow {
+        details: decision_details(&matches, &matches),
+    }
+}
+
+fn primary_deny_reason(rule: &CompiledRule) -> PrimaryDenyReason {
+    PrimaryDenyReason {
+        reason_code: rule
+            .rule()
+            .reason_code
+            .clone()
+            .unwrap_or_else(|| DEFAULT_DENY_REASON_CODE.to_owned()),
+        message: rule
+            .rule()
+            .message
+            .clone()
+            .unwrap_or_else(|| DEFAULT_DENY_MESSAGE.to_owned()),
+    }
+}
+
+fn decision_details(matches: &[&CompiledRule], contributors: &[&CompiledRule]) -> DecisionDetails {
+    DecisionDetails {
+        matched_rules: matches.iter().map(|rule| rule_evidence(rule)).collect(),
+        contributing_rules: contributors
+            .iter()
+            .map(|rule| rule_evidence(rule))
+            .collect(),
+    }
+}
+
+fn rule_evidence(rule: &CompiledRule) -> MatchedRule {
+    MatchedRule {
+        rule_id: rule.rule().id.clone(),
+        effect: rule.rule().effect,
+        reason_code: rule.rule().reason_code.clone(),
+    }
+}
+
+fn rule_matches(rule: &CompiledRule, context: &ActionContext) -> bool {
+    basic_selectors_match(rule, context)
+        && target_selectors_match(rule, context)
+        && labels_match(rule, context)
+        && rule
+            .predicates()
+            .iter()
+            .all(|predicate| predicate.matches(&context.input))
+}
+
+fn basic_selectors_match(rule: &CompiledRule, context: &ActionContext) -> bool {
+    let selectors = &rule.rule().selectors;
+    selectors
+        .namespace
+        .as_ref()
+        .is_none_or(|namespace| namespace == &context.namespace)
+        && selectors
+            .operation
+            .as_ref()
+            .is_none_or(|operation| operation == &context.operation)
+        && selectors
+            .target_type
+            .is_none_or(|target_type| target_type == context.target_type)
+}
+
+fn target_selectors_match(rule: &CompiledRule, context: &ActionContext) -> bool {
+    rule.target_name().is_none_or(|matcher| {
+        context
+            .target_name
+            .as_deref()
+            .is_some_and(|name| matcher.matches(name))
+    }) && rule.uri().is_none_or(|matcher| {
+        context
+            .uri
+            .as_deref()
+            .is_some_and(|uri| matcher.matches(uri))
+    })
+}
+
+fn labels_match(rule: &CompiledRule, context: &ActionContext) -> bool {
+    rule.rule()
+        .selectors
+        .labels
+        .iter()
+        .all(|(key, value)| context.labels.get(key) == Some(value))
+}

--- a/features/action-policy/src/filter.rs
+++ b/features/action-policy/src/filter.rs
@@ -1,0 +1,484 @@
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
+use wanaku_filters::json_rpc::{McpRequestView, RequestViewError};
+use wanaku_infra::registry::InMemoryRegistry;
+use wanaku_types::registry::{DEFAULT_NAMESPACE, ToolRegistry};
+
+use crate::{
+    ActionContext, ActionPolicyState, PolicyDecision, PolicyEngine, PolicySnapshot, PolicyState,
+    TargetType,
+};
+
+const POLICY_DENIED_JSON_RPC_CODE: i32 = -32003;
+const INVALID_ACTION_REASON_CODE: &str = "invalid_action_request";
+const INVALID_ACTION_MESSAGE: &str = "The action request is invalid.";
+const INVALID_POLICY_REASON_CODE: &str = "action_policy_invalid";
+const INVALID_POLICY_MESSAGE: &str = "The action policy is unavailable.";
+
+wanaku_filters::body_filter_boilerplate!(ActionPolicyFilter, "wanaku_action_policy");
+
+impl ActionPolicyFilter {
+    async fn handle_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+    ) -> Result<FilterAction, FilterError> {
+        let Some(method) = ctx.get_metadata(wanaku_filters::MCP_METHOD_KEY) else {
+            return Ok(FilterAction::Continue);
+        };
+        if !is_governed_method(method) {
+            return Ok(FilterAction::Continue);
+        }
+
+        let id = wanaku_filters::response::json_rpc_id_from_metadata(
+            ctx.get_metadata(wanaku_filters::MCP_ID_KEY),
+        );
+        let Some(state) = ctx.extensions.get::<ActionPolicyState>() else {
+            return Ok(policy_error(
+                &id,
+                INVALID_POLICY_REASON_CODE,
+                INVALID_POLICY_MESSAGE,
+            ));
+        };
+        let snapshot = state.snapshot();
+        Ok(evaluate_snapshot(ctx, body.as_ref(), snapshot, &id))
+    }
+}
+
+fn evaluate_snapshot(
+    ctx: &HttpFilterContext<'_>,
+    body: Option<&Bytes>,
+    snapshot: PolicySnapshot,
+    id: &serde_json::Value,
+) -> FilterAction {
+    let policy = match snapshot {
+        PolicySnapshot::Valid(policy) => policy,
+        PolicySnapshot::Unconfigured => return FilterAction::Continue,
+        PolicySnapshot::Invalid => {
+            return policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE);
+        }
+    };
+    let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
+        return policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE);
+    };
+    evaluate_request(RequestEvaluation {
+        method: ctx
+            .get_metadata(wanaku_filters::MCP_METHOD_KEY)
+            .unwrap_or_default(),
+        namespace: ctx
+            .get_metadata(wanaku_types::NAMESPACE_METADATA_KEY)
+            .unwrap_or(DEFAULT_NAMESPACE),
+        body,
+        policy: &policy,
+        registry,
+        id,
+    })
+}
+
+fn is_governed_method(method: &str) -> bool {
+    matches!(method, "tools/call" | "resources/read" | "prompts/get")
+}
+
+#[derive(Clone, Copy)]
+struct RequestEvaluation<'a> {
+    method: &'a str,
+    namespace: &'a str,
+    body: Option<&'a Bytes>,
+    policy: &'a crate::CompiledPolicy,
+    registry: &'a InMemoryRegistry,
+    id: &'a serde_json::Value,
+}
+
+fn evaluate_request(input: RequestEvaluation<'_>) -> FilterAction {
+    let RequestEvaluation {
+        method,
+        namespace,
+        body,
+        policy,
+        registry,
+        id,
+    } = input;
+    let Ok(view) = McpRequestView::parse(body) else {
+        return policy_error(id, INVALID_ACTION_REASON_CODE, INVALID_ACTION_MESSAGE);
+    };
+    let Ok(context) = action_context(method, namespace, &view, registry) else {
+        return policy_error(id, INVALID_ACTION_REASON_CODE, INVALID_ACTION_MESSAGE);
+    };
+    let decision = PolicyEngine::evaluate(PolicyState::Available(policy), &context);
+    match &decision {
+        PolicyDecision::ExplicitDeny { .. } => policy_error(
+            id,
+            decision
+                .deny_reason_code()
+                .unwrap_or(crate::DEFAULT_DENY_REASON_CODE),
+            decision
+                .deny_message()
+                .unwrap_or(crate::DEFAULT_DENY_MESSAGE),
+        ),
+        PolicyDecision::ExplicitAllow { .. } | PolicyDecision::NoMatch => FilterAction::Continue,
+        PolicyDecision::PolicyUnavailable | PolicyDecision::PolicyInvalid => {
+            policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE)
+        }
+    }
+}
+
+fn action_context(
+    method: &str,
+    namespace: &str,
+    view: &McpRequestView,
+    registry: &InMemoryRegistry,
+) -> Result<ActionContext, RequestViewError> {
+    let input = serde_json::Value::Object(view.params()?.clone());
+    match method {
+        "tools/call" => tool_context(namespace, view, registry, input),
+        "resources/read" => resource_context(namespace, view, registry, input),
+        "prompts/get" => prompt_context(namespace, view, input),
+        _ => Err(RequestViewError::UnexpectedMethod {
+            expected: "governed MCP method",
+            actual: method.to_owned(),
+        }),
+    }
+}
+
+fn tool_context(
+    namespace: &str,
+    view: &McpRequestView,
+    registry: &InMemoryRegistry,
+    input: serde_json::Value,
+) -> Result<ActionContext, RequestViewError> {
+    let request = view.tool_call()?;
+    let tool = registry.get_tool_in_namespace(namespace, request.name());
+    let context = ActionContext::new(namespace, "tools/call", TargetType::Tool, input)
+        .with_target_name(request.name());
+    Ok(match tool {
+        Some(tool) => context.with_labels(to_labels(&tool.labels)),
+        None => context,
+    })
+}
+
+fn resource_context(
+    namespace: &str,
+    view: &McpRequestView,
+    registry: &InMemoryRegistry,
+    input: serde_json::Value,
+) -> Result<ActionContext, RequestViewError> {
+    let request = view.resource_read()?;
+    let resource = wanaku_filters::resource_read::find_resource_in_namespace(
+        registry,
+        namespace,
+        request.uri(),
+    );
+    let context = ActionContext::new(namespace, "resources/read", TargetType::Resource, input)
+        .with_uri(request.uri());
+    Ok(match resource {
+        Some(resource) => context
+            .with_target_name(resource.name)
+            .with_labels(to_labels(&resource.labels)),
+        None => context,
+    })
+}
+
+fn prompt_context(
+    namespace: &str,
+    view: &McpRequestView,
+    input: serde_json::Value,
+) -> Result<ActionContext, RequestViewError> {
+    let request = view.prompt_get()?;
+    Ok(
+        ActionContext::new(namespace, "prompts/get", TargetType::Prompt, input)
+            .with_target_name(request.name()),
+    )
+}
+
+fn to_labels(labels: &std::collections::HashMap<String, String>) -> BTreeMap<String, String> {
+    labels
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn policy_error(id: &serde_json::Value, reason_code: &str, message: &str) -> FilterAction {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": POLICY_DENIED_JSON_RPC_CODE,
+            "message": message,
+            "data": { "reason_code": reason_code }
+        }
+    });
+    FilterAction::Reject(wanaku_filters::response::json_response(Bytes::from(
+        response.to_string(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DEFAULT_DENY_REASON_CODE;
+    use wanaku_types::registry::{
+        PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry, ToolEntry,
+    };
+
+    fn compile_policy(rule: &serde_json::Value) -> crate::CompiledPolicy {
+        let policy: crate::ActionPolicy = serde_json::from_value(serde_json::json!({
+            "rules": [rule.clone()]
+        }))
+        .expect("valid test policy");
+        policy.compile().expect("compilable test policy")
+    }
+
+    fn request(method: &str, params: &serde_json::Value) -> Bytes {
+        Bytes::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": method,
+                "params": params.clone()
+            })
+            .to_string(),
+        )
+    }
+
+    fn assert_denied(action: FilterAction, expected_reason: &str) {
+        assert!(matches!(action, FilterAction::Reject(_)));
+        if let FilterAction::Reject(rejection) = action {
+            assert!(rejection.body.is_some());
+            if let Some(body) = rejection.body {
+                let response = serde_json::from_slice::<serde_json::Value>(&body);
+                assert!(response.is_ok());
+                if let Ok(response) = response {
+                    assert_eq!(response["id"], 7);
+                    assert_eq!(response["error"]["data"]["reason_code"], expected_reason);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "three governed MCP method fixtures")]
+    fn denies_tool_resource_and_prompt_actions() {
+        let registry = InMemoryRegistry::new();
+        registry.register_tool(ToolEntry {
+            name: "delete".to_owned(),
+            description: String::new(),
+            uri: "tool://delete".to_owned(),
+            type_: "mcp-forward".to_owned(),
+            input_schema: serde_json::json!({}),
+            labels: std::collections::HashMap::from([("risk".to_owned(), "high".to_owned())]),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+        registry.register_resource(ResourceEntry {
+            name: "secrets".to_owned(),
+            description: String::new(),
+            location: "file:///secrets".to_owned(),
+            type_: "mcp-forward".to_owned(),
+            mime_type: String::new(),
+            labels: std::collections::HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+        registry.register_prompt(PromptEntry {
+            name: "admin".to_owned(),
+            description: String::new(),
+            arguments: Vec::new(),
+            messages: Vec::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+        });
+
+        let cases = [
+            (
+                "tools/call",
+                serde_json::json!({"name": "delete", "arguments": {}}),
+                serde_json::json!({
+                    "id": "deny-tool", "effect": "deny", "reason_code": "tool_denied",
+                    "selectors": {"operation": "tools/call", "target_name": {"matcher": "exact", "value": "delete"}, "labels": {"risk": "high"}}
+                }),
+                "tool_denied",
+            ),
+            (
+                "resources/read",
+                serde_json::json!({"uri": "file:///secrets"}),
+                serde_json::json!({
+                    "id": "deny-resource", "effect": "deny", "reason_code": "resource_denied",
+                    "selectors": {"operation": "resources/read", "uri": {"matcher": "exact", "value": "file:///secrets"}}
+                }),
+                "resource_denied",
+            ),
+            (
+                "prompts/get",
+                serde_json::json!({"name": "admin"}),
+                serde_json::json!({
+                    "id": "deny-prompt", "effect": "deny", "reason_code": "prompt_denied",
+                    "selectors": {"operation": "prompts/get", "target_name": {"matcher": "exact", "value": "admin"}}
+                }),
+                "prompt_denied",
+            ),
+        ];
+
+        for (method, params, rule, reason) in cases {
+            let policy = compile_policy(&rule);
+            let body = request(method, &params);
+            let id = serde_json::json!(7);
+            let action = evaluate_request(RequestEvaluation {
+                method,
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&body),
+                policy: &policy,
+                registry: &registry,
+                id: &id,
+            });
+            assert_denied(action, reason);
+        }
+    }
+
+    #[test]
+    fn explicit_allow_and_no_match_continue() {
+        let registry = InMemoryRegistry::new();
+        let policy = compile_policy(&serde_json::json!({
+            "id": "allow", "effect": "allow",
+            "selectors": {"operation": "tools/call"}
+        }));
+        let body = request("tools/call", &serde_json::json!({"name": "safe"}));
+        let id = serde_json::json!(7);
+        assert!(matches!(
+            evaluate_request(RequestEvaluation {
+                method: "tools/call",
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&body),
+                policy: &policy,
+                registry: &registry,
+                id: &id,
+            }),
+            FilterAction::Continue
+        ));
+
+        let body = request("prompts/get", &serde_json::json!({"name": "safe"}));
+        assert!(matches!(
+            evaluate_request(RequestEvaluation {
+                method: "prompts/get",
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&body),
+                policy: &policy,
+                registry: &registry,
+                id: &id,
+            }),
+            FilterAction::Continue
+        ));
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "resource and tool registry fixtures verify URI isolation"
+    )]
+    fn resource_name_comes_from_registry_and_tool_uri_is_not_exposed() {
+        let registry = InMemoryRegistry::new();
+        registry.register_resource(ResourceEntry {
+            name: "registered-name".to_owned(),
+            description: String::new(),
+            location: "file:///requested-resource".to_owned(),
+            type_: "mcp-forward".to_owned(),
+            mime_type: String::new(),
+            labels: std::collections::HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+        registry.register_tool(ToolEntry {
+            name: "tool-with-uri".to_owned(),
+            description: String::new(),
+            uri: "file:///tool-location".to_owned(),
+            type_: "mcp-forward".to_owned(),
+            input_schema: serde_json::json!({}),
+            labels: std::collections::HashMap::new(),
+            id: None,
+            namespace: None,
+            configuration_uri: None,
+            secrets_uri: None,
+        });
+        let id = serde_json::json!(7);
+
+        let resource_policy = compile_policy(&serde_json::json!({
+            "id": "deny-resource-name", "effect": "deny",
+            "selectors": {
+                "operation": "resources/read",
+                "target_name": {"matcher": "exact", "value": "registered-name"}
+            }
+        }));
+        let resource_body = request(
+            "resources/read",
+            &serde_json::json!({"uri": "file:///requested-resource"}),
+        );
+        assert_denied(
+            evaluate_request(RequestEvaluation {
+                method: "resources/read",
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&resource_body),
+                policy: &resource_policy,
+                registry: &registry,
+                id: &id,
+            }),
+            DEFAULT_DENY_REASON_CODE,
+        );
+
+        let tool_uri_policy = compile_policy(&serde_json::json!({
+            "id": "deny-tool-uri", "effect": "deny",
+            "selectors": {
+                "operation": "tools/call",
+                "uri": {"matcher": "exact", "value": "file:///tool-location"}
+            }
+        }));
+        let tool_body = request(
+            "tools/call",
+            &serde_json::json!({"name": "tool-with-uri", "arguments": {}}),
+        );
+        assert!(matches!(
+            evaluate_request(RequestEvaluation {
+                method: "tools/call",
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&tool_body),
+                policy: &tool_uri_policy,
+                registry: &registry,
+                id: &id,
+            }),
+            FilterAction::Continue
+        ));
+    }
+
+    #[test]
+    fn malformed_governed_request_is_safely_rejected() {
+        let registry = InMemoryRegistry::new();
+        let policy = compile_policy(&serde_json::json!({
+            "id": "deny", "effect": "deny", "selectors": {"operation": "tools/call"}
+        }));
+        let malformed = Bytes::from("not JSON");
+        let id = serde_json::json!(7);
+        let action = evaluate_request(RequestEvaluation {
+            method: "tools/call",
+            namespace: DEFAULT_NAMESPACE,
+            body: Some(&malformed),
+            policy: &policy,
+            registry: &registry,
+            id: &id,
+        });
+        assert_denied(action, INVALID_ACTION_REASON_CODE);
+    }
+
+    #[test]
+    fn list_and_unrelated_methods_are_not_governed() {
+        for method in ["tools/list", "resources/list", "prompts/list", "initialize"] {
+            assert!(!is_governed_method(method));
+        }
+    }
+}

--- a/features/action-policy/src/handlers.rs
+++ b/features/action-policy/src/handlers.rs
@@ -1,0 +1,172 @@
+use http::{Response, StatusCode};
+use wanaku_types::http_response::{json_err, json_ok};
+
+use crate::revision::{ActionPolicyRevision, RevisionError, RevisionOrigin};
+use crate::state::ActivatePolicyParams;
+use crate::{ActionPolicy, ActionPolicyState};
+
+pub(crate) fn handle_effective(state: &ActionPolicyState) -> Response<Vec<u8>> {
+    revision_response(state.revision_store().active_revision())
+}
+
+#[derive(serde::Deserialize)]
+struct UpdateRequest {
+    policy: ActionPolicy,
+    #[serde(default)]
+    expected_revision: Option<u64>,
+}
+
+pub(crate) fn handle_update(state: &ActionPolicyState, body: &str) -> Response<Vec<u8>> {
+    let request = match parse_update_request(body) {
+        Ok(request) => request,
+        Err(error) => {
+            return json_err(
+                StatusCode::BAD_REQUEST,
+                &format!("invalid action policy request: {error}"),
+            );
+        }
+    };
+    match state.try_activate(
+        request.policy,
+        ActivatePolicyParams {
+            origin: RevisionOrigin::Api,
+            actor: None,
+            expected_revision: request.expected_revision,
+        },
+    ) {
+        Ok(revision) => revision_ok(&revision),
+        Err(error) => revision_error(error),
+    }
+}
+
+fn parse_update_request(body: &str) -> Result<UpdateRequest, serde_json::Error> {
+    match serde_json::from_str(body) {
+        Ok(request) => Ok(request),
+        Err(wrapper_error) => match serde_json::from_str(body) {
+            Ok(policy) => Ok(UpdateRequest {
+                policy,
+                expected_revision: None,
+            }),
+            Err(_) => Err(wrapper_error),
+        },
+    }
+}
+
+pub(crate) fn handle_list_revisions(state: &ActionPolicyState) -> Response<Vec<u8>> {
+    json_ok(&serde_json::json!(state.revision_store().list_revisions()))
+}
+
+pub(crate) fn handle_active_revision(state: &ActionPolicyState) -> Response<Vec<u8>> {
+    revision_response(state.revision_store().active_revision())
+}
+
+pub(crate) fn handle_get_revision(state: &ActionPolicyState, id: u64) -> Response<Vec<u8>> {
+    revision_response(state.revision_store().get_revision(id))
+}
+
+pub(crate) fn handle_activate_revision(
+    state: &ActionPolicyState,
+    id: u64,
+    body: &str,
+) -> Response<Vec<u8>> {
+    #[derive(serde::Deserialize, Default)]
+    struct ActivateRequest {
+        #[serde(default)]
+        expected_revision: Option<u64>,
+    }
+    let request = if body.is_empty() {
+        ActivateRequest::default()
+    } else {
+        match serde_json::from_str(body) {
+            Ok(request) => request,
+            Err(error) => {
+                return json_err(
+                    StatusCode::BAD_REQUEST,
+                    &format!("invalid activate request: {error}"),
+                );
+            }
+        }
+    };
+    match state.rollback(id, request.expected_revision) {
+        Ok(revision) => revision_ok(&revision),
+        Err(error) => revision_error(error),
+    }
+}
+
+fn revision_response(revision: Option<ActionPolicyRevision>) -> Response<Vec<u8>> {
+    match revision {
+        Some(revision) => revision_ok(&revision),
+        None => json_err(StatusCode::NOT_FOUND, "no action policy revision found"),
+    }
+}
+
+fn revision_ok(revision: &ActionPolicyRevision) -> Response<Vec<u8>> {
+    json_ok(&serde_json::json!({"revision": revision.metadata, "policy": revision.policy}))
+}
+
+fn revision_error(error: RevisionError) -> Response<Vec<u8>> {
+    match error {
+        RevisionError::NotFound(id) => {
+            json_err(StatusCode::NOT_FOUND, &format!("revision {id} not found"))
+        }
+        RevisionError::Conflict { expected, actual } => json_err(
+            StatusCode::CONFLICT,
+            &format!("expected active revision {expected}, but current is {actual}"),
+        ),
+        RevisionError::ValidationFailed(reason) => json_err(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &format!("configuration rejected: {reason}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(id: &str) -> String {
+        serde_json::json!({"policy": {"rules": [{"id": id, "effect": "deny", "selectors": {"operation": "tools/call"}}]}}).to_string()
+    }
+
+    #[test]
+    fn update_query_conflict_and_rollback() {
+        let state = ActionPolicyState::new();
+        assert_eq!(
+            handle_update(&state, &request("first")).status(),
+            StatusCode::OK
+        );
+        assert_eq!(handle_effective(&state).status(), StatusCode::OK);
+        assert_eq!(handle_list_revisions(&state).status(), StatusCode::OK);
+        assert_eq!(handle_get_revision(&state, 1).status(), StatusCode::OK);
+        assert_eq!(
+            handle_get_revision(&state, 99).status(),
+            StatusCode::NOT_FOUND
+        );
+        let conflict = serde_json::json!({"policy": {"rules": [{"id": "second", "effect": "allow", "selectors": {"operation": "prompts/get"}}]}, "expected_revision": 99}).to_string();
+        assert_eq!(
+            handle_update(&state, &conflict).status(),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            handle_activate_revision(&state, 1, r#"{"expected_revision":1}"#).status(),
+            StatusCode::OK
+        );
+        assert_eq!(state.revision_store().active_revision_id(), Some(2));
+    }
+
+    #[test]
+    fn invalid_candidate_is_rejected_without_replacing_active() {
+        let state = ActionPolicyState::new();
+        assert_eq!(
+            handle_update(&state, &request("valid")).status(),
+            StatusCode::OK
+        );
+        let invalid = serde_json::json!({"policy": {"rules": [{"id": "invalid", "effect": "deny", "selectors": {}}]}}).to_string();
+        assert_eq!(
+            handle_update(&state, &invalid).status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(state.revision_store().active_revision_id(), Some(1));
+        assert_eq!(state.revision_store().list_revisions().len(), 2);
+    }
+}

--- a/features/action-policy/src/lib.rs
+++ b/features/action-policy/src/lib.rs
@@ -3,11 +3,16 @@
 
 //! Transport-neutral action-policy schema and matcher compilation.
 
+mod engine;
 mod matcher;
 mod predicate;
 mod schema;
 mod validation;
 
+pub use engine::{
+    ActionContext, ActorContext, DEFAULT_DENY_MESSAGE, DEFAULT_DENY_REASON_CODE, DecisionDetails,
+    MatchedRule, PolicyDecision, PolicyEngine, PolicyState, PrimaryDenyReason,
+};
 pub use matcher::{CompiledMatcher, Matcher, MatcherCompileError};
 pub use predicate::CompiledPredicate;
 pub use schema::{

--- a/features/action-policy/src/lib.rs
+++ b/features/action-policy/src/lib.rs
@@ -4,10 +4,16 @@
 //! Transport-neutral action-policy schema and matcher compilation.
 
 mod engine;
+pub mod filter;
 mod matcher;
 mod predicate;
 mod schema;
+mod state;
 mod validation;
+
+use http::Response;
+use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
+use wanaku_types::feature::{Feature, HttpContext};
 
 pub use engine::{
     ActionContext, ActorContext, DEFAULT_DENY_MESSAGE, DEFAULT_DENY_REASON_CODE, DecisionDetails,
@@ -19,3 +25,65 @@ pub use schema::{
     ActionPolicy, Effect, MatchExpression, MatchKind, Predicate, Rule, Selectors, TargetType,
 };
 pub use validation::{CompiledPolicy, CompiledRule, ValidationError};
+
+pub use state::{ActionPolicyState, PolicySnapshot};
+
+/// Startup-configured action-policy feature.
+pub struct ActionPolicyFeature {
+    state: ActionPolicyState,
+}
+
+impl ActionPolicyFeature {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: ActionPolicyState::new(),
+        }
+    }
+}
+
+impl Default for ActionPolicyFeature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct ActionPolicyExtension {
+    state: ActionPolicyState,
+}
+
+impl PipelineExtension for ActionPolicyExtension {
+    fn prepare(&self, extensions: &mut RequestExtensions) {
+        extensions.insert(self.state.clone());
+    }
+}
+
+#[async_trait::async_trait]
+impl Feature for ActionPolicyFeature {
+    fn name(&self) -> &'static str {
+        "action-policy"
+    }
+
+    fn register_filters(&self, registry: &mut FilterRegistry) {
+        praxis_filter::register_filters!(
+            @register registry,
+            http "wanaku_action_policy" => crate::filter::ActionPolicyFilter::from_config
+        );
+    }
+
+    fn pipeline_extensions(&self) -> Vec<Box<dyn PipelineExtension>> {
+        vec![Box::new(ActionPolicyExtension {
+            state: self.state.clone(),
+        })]
+    }
+
+    async fn handle_route(&self, _ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        None
+    }
+
+    fn load_yaml_config(&self, root: &serde_yaml::Value) {
+        self.state.load_yaml(root.get("action_policy"));
+    }
+
+    fn load_env_config(&self) {}
+}

--- a/features/action-policy/src/lib.rs
+++ b/features/action-policy/src/lib.rs
@@ -1,0 +1,16 @@
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! Transport-neutral action-policy schema and matcher compilation.
+
+mod matcher;
+mod predicate;
+mod schema;
+mod validation;
+
+pub use matcher::{CompiledMatcher, Matcher, MatcherCompileError};
+pub use predicate::CompiledPredicate;
+pub use schema::{
+    ActionPolicy, Effect, MatchExpression, MatchKind, Predicate, Rule, Selectors, TargetType,
+};
+pub use validation::{CompiledPolicy, CompiledRule, ValidationError};

--- a/features/action-policy/src/lib.rs
+++ b/features/action-policy/src/lib.rs
@@ -5,12 +5,17 @@
 
 mod engine;
 pub mod filter;
+mod handlers;
 mod matcher;
 mod predicate;
+pub mod revision;
+pub mod revision_persistence;
+mod routes;
 mod schema;
 mod state;
 mod validation;
 
+use crate::routes::ActionPolicyRoute;
 use http::Response;
 use praxis_filter::{FilterRegistry, PipelineExtension, RequestExtensions};
 use wanaku_types::feature::{Feature, HttpContext};
@@ -39,6 +44,15 @@ impl ActionPolicyFeature {
         Self {
             state: ActionPolicyState::new(),
         }
+    }
+
+    #[must_use]
+    pub fn with_revision_persistence(
+        mut self,
+        persistence: std::sync::Arc<dyn revision_persistence::RevisionPersistence>,
+    ) -> Self {
+        self.state = self.state.with_revision_persistence(persistence);
+        self
     }
 }
 
@@ -77,12 +91,28 @@ impl Feature for ActionPolicyFeature {
         })]
     }
 
-    async fn handle_route(&self, _ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
-        None
+    async fn handle_route(&self, ctx: &HttpContext<'_>) -> Option<Response<Vec<u8>>> {
+        use handlers::{
+            handle_activate_revision, handle_active_revision, handle_effective,
+            handle_get_revision, handle_list_revisions, handle_update,
+        };
+        Some(
+            match routes::resolve_action_policy_route(ctx.method, ctx.path) {
+                ActionPolicyRoute::Effective => handle_effective(&self.state),
+                ActionPolicyRoute::Update => handle_update(&self.state, ctx.body.unwrap_or("")),
+                ActionPolicyRoute::ListRevisions => handle_list_revisions(&self.state),
+                ActionPolicyRoute::ActiveRevision => handle_active_revision(&self.state),
+                ActionPolicyRoute::GetRevision(id) => handle_get_revision(&self.state, id),
+                ActionPolicyRoute::ActivateRevision(id) => {
+                    handle_activate_revision(&self.state, id, ctx.body.unwrap_or(""))
+                }
+                ActionPolicyRoute::NotFound => return None,
+            },
+        )
     }
 
     fn load_yaml_config(&self, root: &serde_yaml::Value) {
-        self.state.load_yaml(root.get("action_policy"));
+        self.state.reconcile_startup(root.get("action_policy"));
     }
 
     fn load_env_config(&self) {}

--- a/features/action-policy/src/matcher.rs
+++ b/features/action-policy/src/matcher.rs
@@ -1,0 +1,113 @@
+use thiserror::Error;
+
+use crate::{MatchExpression, MatchKind};
+
+/// Interface for compiled string matching strategies.
+pub trait Matcher: Send + Sync {
+    fn matches(&self, candidate: &str) -> bool;
+}
+
+/// A compiled matcher. Later strategies can implement [`Matcher`] without
+/// changing policy evaluation.
+pub struct CompiledMatcher {
+    matcher: Box<dyn Matcher>,
+}
+
+impl CompiledMatcher {
+    /// Wrap a custom matching strategy.
+    #[must_use]
+    pub fn new(matcher: impl Matcher + 'static) -> Self {
+        Self {
+            matcher: Box::new(matcher),
+        }
+    }
+
+    pub(crate) fn compile(expression: &MatchExpression) -> Result<Self, MatcherCompileError> {
+        let matcher: Box<dyn Matcher> = match expression.matcher {
+            MatchKind::Exact => Box::new(ExactMatcher(expression.value.clone())),
+            MatchKind::Prefix => Box::new(PrefixMatcher(expression.value.clone())),
+            MatchKind::Glob => Box::new(GlobMatcher::compile(&expression.value)?),
+        };
+        Ok(Self { matcher })
+    }
+
+    #[must_use]
+    pub fn matches(&self, candidate: &str) -> bool {
+        self.matcher.matches(candidate)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MatcherCompileError {
+    #[error("glob pattern has a trailing escape")]
+    TrailingEscape,
+}
+
+struct ExactMatcher(String);
+
+impl Matcher for ExactMatcher {
+    fn matches(&self, candidate: &str) -> bool {
+        candidate == self.0
+    }
+}
+
+struct PrefixMatcher(String);
+
+impl Matcher for PrefixMatcher {
+    fn matches(&self, candidate: &str) -> bool {
+        candidate.starts_with(&self.0)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GlobToken {
+    AnySequence,
+    AnyCharacter,
+    Literal(char),
+}
+
+struct GlobMatcher(Vec<GlobToken>);
+
+impl GlobMatcher {
+    fn compile(pattern: &str) -> Result<Self, MatcherCompileError> {
+        let mut tokens = Vec::new();
+        let mut chars = pattern.chars();
+        while let Some(character) = chars.next() {
+            match character {
+                '*' => tokens.push(GlobToken::AnySequence),
+                '?' => tokens.push(GlobToken::AnyCharacter),
+                '\\' => match chars.next() {
+                    Some(literal) => tokens.push(GlobToken::Literal(literal)),
+                    None => return Err(MatcherCompileError::TrailingEscape),
+                },
+                literal => tokens.push(GlobToken::Literal(literal)),
+            }
+        }
+        Ok(Self(tokens))
+    }
+}
+
+impl Matcher for GlobMatcher {
+    fn matches(&self, candidate: &str) -> bool {
+        let characters: Vec<char> = candidate.chars().collect();
+        let mut previous = vec![false; characters.len() + 1];
+        previous[0] = true;
+
+        for token in &self.0 {
+            let mut current = vec![false; characters.len() + 1];
+            if matches!(token, GlobToken::AnySequence) {
+                current[0] = previous[0];
+            }
+            for (index, character) in characters.iter().enumerate() {
+                current[index + 1] = match token {
+                    GlobToken::AnySequence => previous[index + 1] || current[index],
+                    GlobToken::AnyCharacter => previous[index],
+                    GlobToken::Literal(literal) => previous[index] && literal == character,
+                };
+            }
+            previous = current;
+        }
+
+        previous[characters.len()]
+    }
+}

--- a/features/action-policy/src/predicate.rs
+++ b/features/action-policy/src/predicate.rs
@@ -1,0 +1,39 @@
+use serde_json::Value;
+
+use crate::Predicate;
+
+/// A validated JSON Pointer predicate.
+#[derive(Debug, Clone)]
+pub struct CompiledPredicate(Predicate);
+
+impl CompiledPredicate {
+    pub(crate) const fn new(predicate: Predicate) -> Self {
+        Self(predicate)
+    }
+
+    /// Test a predicate against a JSON document.
+    ///
+    /// Missing values never match comparison operators. They only match
+    /// `exists: false`. JSON `null` is a present, typed value.
+    #[must_use]
+    pub fn matches(&self, document: &Value) -> bool {
+        let value = document.pointer(self.0.pointer());
+        match &self.0 {
+            Predicate::Exists {
+                value: expected, ..
+            } => value.is_some() == *expected,
+            Predicate::Equals {
+                value: expected, ..
+            } => value.is_some_and(|actual| actual == expected),
+            Predicate::NotEquals {
+                value: expected, ..
+            } => value.is_some_and(|actual| actual != expected),
+            Predicate::OneOf { values, .. } => {
+                value.is_some_and(|actual| values.iter().any(|expected| actual == expected))
+            }
+            Predicate::NotOneOf { values, .. } => {
+                value.is_some_and(|actual| values.iter().all(|expected| actual != expected))
+            }
+        }
+    }
+}

--- a/features/action-policy/src/revision.rs
+++ b/features/action-policy/src/revision.rs
@@ -1,0 +1,213 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use wanaku_types::revision::{RevisionHistory, RevisionHistoryError, RevisionRecord};
+use wanaku_types::time::iso_now;
+
+pub use wanaku_types::revision::{ActivationStatus, RevisionId, RevisionMetadata, RevisionOrigin};
+
+use crate::ActionPolicy;
+use crate::revision_persistence::RevisionPersistence;
+
+const DEFAULT_MAX_HISTORY: usize = 50;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionPolicyRevision {
+    pub metadata: RevisionMetadata,
+    pub policy: ActionPolicy,
+}
+
+impl RevisionRecord for ActionPolicyRevision {
+    fn metadata(&self) -> &RevisionMetadata {
+        &self.metadata
+    }
+    fn metadata_mut(&mut self) -> &mut RevisionMetadata {
+        &mut self.metadata
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevisionError {
+    Conflict {
+        expected: RevisionId,
+        actual: RevisionId,
+    },
+    NotFound(RevisionId),
+    ValidationFailed(String),
+}
+
+impl std::fmt::Display for RevisionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conflict { expected, actual } => write!(
+                f,
+                "conflict: expected active revision {expected}, but current is {actual}"
+            ),
+            Self::NotFound(id) => write!(f, "revision {id} not found"),
+            Self::ValidationFailed(reason) => write!(f, "validation failed: {reason}"),
+        }
+    }
+}
+
+pub struct RecordRevisionParams {
+    pub policy: ActionPolicy,
+    pub origin: RevisionOrigin,
+    pub actor: Option<String>,
+    pub expected_revision: Option<RevisionId>,
+    pub activate: bool,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct RevisionStore {
+    history: RevisionHistory<ActionPolicyRevision>,
+    persistence: Option<Arc<dyn RevisionPersistence>>,
+}
+
+impl RevisionStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            history: RevisionHistory::new(DEFAULT_MAX_HISTORY),
+            persistence: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_persistence(persistence: Arc<dyn RevisionPersistence>) -> Self {
+        let store = Self {
+            history: RevisionHistory::new(DEFAULT_MAX_HISTORY),
+            persistence: Some(persistence),
+        };
+        store.load();
+        store
+    }
+
+    fn load(&self) {
+        let Some(persistence) = &self.persistence else {
+            return;
+        };
+        match persistence.load() {
+            Ok(snapshot) => {
+                if self.history.restore(snapshot).is_err() {
+                    tracing::error!("action policy revision history lock is unavailable");
+                }
+            }
+            Err(error) => tracing::error!(error = %error, "failed to load action policy revisions"),
+        }
+    }
+
+    pub(crate) fn persist(&self) {
+        let Some(persistence) = &self.persistence else {
+            return;
+        };
+        let Ok(snapshot) = self.history.snapshot() else {
+            tracing::error!("action policy revision history lock is unavailable");
+            return;
+        };
+        if let Err(error) = persistence.save(&snapshot) {
+            tracing::error!(error = %error, "failed to persist action policy revisions");
+        }
+    }
+
+    pub fn active_revision(&self) -> Option<ActionPolicyRevision> {
+        self.history.active_revision()
+    }
+    pub fn active_revision_id(&self) -> Option<RevisionId> {
+        self.history.active_revision_id()
+    }
+    pub fn list_revisions(&self) -> Vec<RevisionMetadata> {
+        self.history.list_metadata()
+    }
+    pub fn get_revision(&self, id: RevisionId) -> Option<ActionPolicyRevision> {
+        self.history.get(id)
+    }
+
+    pub(crate) fn commit(
+        &self,
+        params: &RecordRevisionParams,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        self.history
+            .commit(params.expected_revision, params.activate, |id| {
+                build_revision(id, params)
+            })
+            .map_err(map_error)
+    }
+
+    pub fn restore_policy(
+        &self,
+        id: RevisionId,
+        expected: Option<RevisionId>,
+    ) -> Result<ActionPolicy, RevisionError> {
+        let policy = self
+            .get_revision(id)
+            .ok_or(RevisionError::NotFound(id))?
+            .policy;
+        self.history
+            .check_concurrency(expected)
+            .map_err(|error| map_unit_error(&error))?;
+        Ok(policy)
+    }
+}
+
+impl Default for RevisionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_revision(
+    id: RevisionId,
+    params: &RecordRevisionParams,
+) -> Result<ActionPolicyRevision, RevisionError> {
+    let now = iso_now();
+    let checksum = wanaku_types::revision::checksum(&params.policy).map_err(|error| {
+        RevisionError::ValidationFailed(format!("failed to serialize policy: {error}"))
+    })?;
+    Ok(ActionPolicyRevision {
+        metadata: RevisionMetadata {
+            id,
+            created_at: now.clone(),
+            activated_at: params.activate.then_some(now),
+            status: if params.activate {
+                ActivationStatus::Active
+            } else {
+                ActivationStatus::Rejected
+            },
+            checksum,
+            origin: params.origin.clone(),
+            actor: params.actor.clone(),
+            failure_reason: params.failure_reason.clone(),
+        },
+        policy: params.policy.clone(),
+    })
+}
+
+fn map_error(error: RevisionHistoryError<RevisionError>) -> RevisionError {
+    match error {
+        RevisionHistoryError::Conflict { expected, actual } => {
+            RevisionError::Conflict { expected, actual }
+        }
+        RevisionHistoryError::Build(error) => error,
+        RevisionHistoryError::Lock => {
+            RevisionError::ValidationFailed("internal lock error".to_owned())
+        }
+    }
+}
+
+fn map_unit_error(error: &RevisionHistoryError<()>) -> RevisionError {
+    match error {
+        RevisionHistoryError::Conflict { expected, actual } => RevisionError::Conflict {
+            expected: *expected,
+            actual: *actual,
+        },
+        RevisionHistoryError::Build(()) | RevisionHistoryError::Lock => {
+            RevisionError::ValidationFailed("internal lock error".to_owned())
+        }
+    }
+}
+
+#[must_use]
+pub fn policy_checksum(policy: &ActionPolicy) -> Option<String> {
+    wanaku_types::revision::checksum(policy).ok()
+}

--- a/features/action-policy/src/revision_persistence.rs
+++ b/features/action-policy/src/revision_persistence.rs
@@ -1,0 +1,83 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use wanaku_types::persistence::PersistenceError;
+
+use crate::revision::ActionPolicyRevision;
+
+pub type RevisionsSnapshot = wanaku_types::revision::RevisionSnapshot<ActionPolicyRevision>;
+
+pub trait RevisionPersistence: Send + Sync {
+    fn load(&self) -> Result<RevisionsSnapshot, PersistenceError>;
+    fn save(&self, snapshot: &RevisionsSnapshot) -> Result<(), PersistenceError>;
+}
+
+pub struct FileRevisionPersistence {
+    path: PathBuf,
+}
+
+impl FileRevisionPersistence {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn from_config() -> Option<Arc<dyn RevisionPersistence>> {
+        let persist = wanaku_types::config::ENV.persist.as_ref()?;
+        Some(Arc::new(Self::new(
+            persist.dir.join("action-policy-revisions.json"),
+        )))
+    }
+}
+
+impl RevisionPersistence for FileRevisionPersistence {
+    fn load(&self) -> Result<RevisionsSnapshot, PersistenceError> {
+        if !self.path.exists() {
+            return Ok(RevisionsSnapshot::default());
+        }
+        Ok(serde_json::from_str(&std::fs::read_to_string(&self.path)?)?)
+    }
+
+    fn save(&self, snapshot: &RevisionsSnapshot) -> Result<(), PersistenceError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(snapshot)?;
+        let temporary = self.path.with_extension("json.tmp");
+        {
+            let mut file = std::fs::File::create(&temporary)?;
+            file.write_all(content.as_bytes())?;
+            file.sync_all()?;
+        }
+        std::fs::rename(temporary, &self.path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_is_empty_and_snapshot_round_trips() {
+        let directory = std::env::temp_dir().join(format!(
+            "wanaku-action-policy-revisions-{}",
+            std::process::id()
+        ));
+        let path = directory.join("action-policy-revisions.json");
+        let backend = FileRevisionPersistence::new(&path);
+        let empty = backend.load().expect("missing file");
+        assert!(empty.revisions.is_empty());
+
+        let snapshot = RevisionsSnapshot {
+            revisions: Vec::new(),
+            active_id: Some(7),
+            next_id: 8,
+        };
+        backend.save(&snapshot).expect("save");
+        let loaded = backend.load().expect("load");
+        assert_eq!(loaded.active_id, Some(7));
+        assert_eq!(loaded.next_id, 8);
+        let _ = std::fs::remove_dir_all(directory);
+    }
+}

--- a/features/action-policy/src/routes.rs
+++ b/features/action-policy/src/routes.rs
@@ -1,0 +1,81 @@
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ActionPolicyRoute {
+    Effective,
+    Update,
+    ListRevisions,
+    ActiveRevision,
+    GetRevision(u64),
+    ActivateRevision(u64),
+    NotFound,
+}
+
+pub(crate) fn resolve_action_policy_route(method: &str, path: &str) -> ActionPolicyRoute {
+    let Some(suffix) = path.strip_prefix("/api/v1/action-policies") else {
+        return ActionPolicyRoute::NotFound;
+    };
+    if suffix.is_empty() || suffix == "/" {
+        return match method {
+            "GET" => ActionPolicyRoute::Effective,
+            "PUT" => ActionPolicyRoute::Update,
+            _ => ActionPolicyRoute::NotFound,
+        };
+    }
+    let Some(suffix) = suffix.strip_prefix("/revisions") else {
+        return ActionPolicyRoute::NotFound;
+    };
+    resolve_revision_route(method, suffix)
+}
+
+fn resolve_revision_route(method: &str, suffix: &str) -> ActionPolicyRoute {
+    if suffix.is_empty() || suffix == "/" {
+        return if method == "GET" {
+            ActionPolicyRoute::ListRevisions
+        } else {
+            ActionPolicyRoute::NotFound
+        };
+    }
+    let segment = suffix.strip_prefix('/').unwrap_or(suffix);
+    if segment == "active" && method == "GET" {
+        return ActionPolicyRoute::ActiveRevision;
+    }
+    let (id, action) = segment
+        .split_once('/')
+        .map_or((segment, None), |(id, action)| (id, Some(action)));
+    let Ok(id) = id.parse() else {
+        return ActionPolicyRoute::NotFound;
+    };
+    match (method, action) {
+        ("GET", None) => ActionPolicyRoute::GetRevision(id),
+        ("POST", Some("activate")) => ActionPolicyRoute::ActivateRevision(id),
+        _ => ActionPolicyRoute::NotFound,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_resource_family() {
+        assert_eq!(
+            resolve_action_policy_route("GET", "/api/v1/action-policies"),
+            ActionPolicyRoute::Effective
+        );
+        assert_eq!(
+            resolve_action_policy_route("PUT", "/api/v1/action-policies"),
+            ActionPolicyRoute::Update
+        );
+        assert_eq!(
+            resolve_action_policy_route("GET", "/api/v1/action-policies/revisions/7"),
+            ActionPolicyRoute::GetRevision(7)
+        );
+        assert_eq!(
+            resolve_action_policy_route("POST", "/api/v1/action-policies/revisions/7/activate"),
+            ActionPolicyRoute::ActivateRevision(7)
+        );
+        assert_eq!(
+            resolve_action_policy_route("GET", "/api/v1/action-policies/revisions/active"),
+            ActionPolicyRoute::ActiveRevision
+        );
+    }
+}

--- a/features/action-policy/src/schema.rs
+++ b/features/action-policy/src/schema.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A complete action-policy document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionPolicy {
+    #[serde(default)]
+    pub rules: Vec<Rule>,
+}
+
+/// One stable, independently auditable policy rule.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Rule {
+    pub id: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub effect: Effect,
+    #[serde(default)]
+    pub selectors: Selectors,
+    #[serde(default)]
+    pub predicates: Vec<Predicate>,
+    #[serde(default)]
+    pub reason_code: Option<String>,
+    /// A safe message that can be returned to an action caller.
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Effect {
+    Allow,
+    Deny,
+}
+
+/// Transport-neutral action selectors.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Selectors {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// The action operation. MCP adapters use values such as `tools/call`.
+    #[serde(default)]
+    pub operation: Option<String>,
+    #[serde(default)]
+    pub target_type: Option<TargetType>,
+    #[serde(default)]
+    pub target_name: Option<MatchExpression>,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+    #[serde(default)]
+    pub uri: Option<MatchExpression>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TargetType {
+    Tool,
+    Resource,
+    Prompt,
+}
+
+/// A named matcher and its literal pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MatchExpression {
+    pub matcher: MatchKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchKind {
+    Exact,
+    Glob,
+    Prefix,
+}
+
+/// A typed comparison against a JSON Pointer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "operator", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Predicate {
+    Exists { pointer: String, value: bool },
+    Equals { pointer: String, value: Value },
+    NotEquals { pointer: String, value: Value },
+    OneOf { pointer: String, values: Vec<Value> },
+    NotOneOf { pointer: String, values: Vec<Value> },
+}
+
+impl Predicate {
+    #[must_use]
+    pub fn pointer(&self) -> &str {
+        match self {
+            Self::Exists { pointer, .. }
+            | Self::Equals { pointer, .. }
+            | Self::NotEquals { pointer, .. }
+            | Self::OneOf { pointer, .. }
+            | Self::NotOneOf { pointer, .. } => pointer,
+        }
+    }
+}

--- a/features/action-policy/src/state.rs
+++ b/features/action-policy/src/state.rs
@@ -1,5 +1,9 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
+use crate::revision::{
+    ActionPolicyRevision, RecordRevisionParams, RevisionError, RevisionOrigin, RevisionStore,
+    policy_checksum,
+};
 use crate::{ActionPolicy, CompiledPolicy};
 
 #[derive(Clone)]
@@ -12,6 +16,14 @@ pub enum PolicySnapshot {
 #[derive(Clone)]
 pub struct ActionPolicyState {
     snapshot: Arc<RwLock<PolicySnapshot>>,
+    revisions: RevisionStore,
+    activation: Arc<Mutex<()>>,
+}
+
+pub struct ActivatePolicyParams {
+    pub origin: RevisionOrigin,
+    pub actor: Option<String>,
+    pub expected_revision: Option<u64>,
 }
 
 impl ActionPolicyState {
@@ -19,43 +31,187 @@ impl ActionPolicyState {
     pub fn new() -> Self {
         Self {
             snapshot: Arc::new(RwLock::new(PolicySnapshot::Unconfigured)),
+            revisions: RevisionStore::new(),
+            activation: Arc::new(Mutex::new(())),
         }
     }
 
     #[must_use]
-    pub fn snapshot(&self) -> PolicySnapshot {
-        match self.snapshot.read() {
-            Ok(snapshot) => snapshot.clone(),
-            Err(_) => PolicySnapshot::Invalid,
+    pub fn with_revision_persistence(
+        mut self,
+        persistence: Arc<dyn crate::revision_persistence::RevisionPersistence>,
+    ) -> Self {
+        self.revisions = RevisionStore::with_persistence(persistence);
+        if self.revisions.active_revision().is_some() {
+            self.reinstall_active_or_invalid();
         }
+        self
     }
 
-    pub(crate) fn load_yaml(&self, value: Option<&serde_yaml::Value>) {
-        let snapshot = match value {
-            None => PolicySnapshot::Unconfigured,
-            Some(value) => match serde_yaml::from_value::<ActionPolicy>(value.clone()) {
-                Ok(policy) => match policy.compile() {
-                    Ok(compiled) => PolicySnapshot::Valid(Arc::new(compiled)),
-                    Err(error) => {
-                        tracing::error!(error = %error, "action policy validation failed");
-                        PolicySnapshot::Invalid
-                    }
-                },
-                Err(error) => {
-                    tracing::error!(error = %error, "action policy configuration is invalid");
-                    PolicySnapshot::Invalid
-                }
-            },
+    #[must_use]
+    pub fn snapshot(&self) -> PolicySnapshot {
+        self.snapshot
+            .read()
+            .map_or(PolicySnapshot::Invalid, |snapshot| snapshot.clone())
+    }
+
+    #[must_use]
+    pub const fn revision_store(&self) -> &RevisionStore {
+        &self.revisions
+    }
+
+    pub fn try_activate(
+        &self,
+        policy: ActionPolicy,
+        params: ActivatePolicyParams,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        let compiled = match policy.clone().compile() {
+            Ok(compiled) => compiled,
+            Err(error) => return self.reject(policy, params, error.to_string()),
         };
-        match self.snapshot.write() {
-            Ok(mut active) => *active = snapshot,
+        self.activate_compiled(policy, compiled, params)
+    }
+
+    fn activate_compiled(
+        &self,
+        policy: ActionPolicy,
+        compiled: CompiledPolicy,
+        params: ActivatePolicyParams,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        let _guard = self.activation.lock().map_err(|_| lock_error())?;
+        let revision = self.revisions.commit(&RecordRevisionParams {
+            policy,
+            origin: params.origin,
+            actor: params.actor,
+            expected_revision: params.expected_revision,
+            activate: true,
+            failure_reason: None,
+        })?;
+        self.install(PolicySnapshot::Valid(Arc::new(compiled)))?;
+        self.revisions.persist();
+        Ok(revision)
+    }
+
+    fn reject(
+        &self,
+        policy: ActionPolicy,
+        params: ActivatePolicyParams,
+        reason: String,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        let _guard = self.activation.lock().map_err(|_| lock_error())?;
+        self.revisions.commit(&RecordRevisionParams {
+            policy,
+            origin: params.origin,
+            actor: params.actor,
+            expected_revision: params.expected_revision,
+            activate: false,
+            failure_reason: Some(reason.clone()),
+        })?;
+        self.revisions.persist();
+        if self.revisions.active_revision().is_none() {
+            self.install(PolicySnapshot::Invalid)?;
+        }
+        Err(RevisionError::ValidationFailed(reason))
+    }
+
+    pub fn rollback(
+        &self,
+        source_id: u64,
+        expected_revision: Option<u64>,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        let policy = self
+            .revisions
+            .restore_policy(source_id, expected_revision)?;
+        self.try_activate(
+            policy,
+            ActivatePolicyParams {
+                origin: RevisionOrigin::Api,
+                actor: None,
+                expected_revision,
+            },
+        )
+    }
+
+    pub(crate) fn reconcile_startup(&self, value: Option<&serde_yaml::Value>) {
+        let startup = match parse_startup(value) {
+            Ok(startup) => startup,
             Err(error) => {
-                tracing::error!(error = %error, "action policy state lock is unavailable");
+                tracing::error!(error = %error, "action policy configuration is invalid");
+                self.reinstall_active_or_invalid();
+                return;
+            }
+        };
+        match startup {
+            Some(policy) if self.matches_active(&policy) => self.reinstall_active_or_invalid(),
+            Some(policy) => self.activate_startup(policy),
+            None if self.revisions.active_revision().is_some() => {
+                self.reinstall_active_or_invalid();
+            }
+            None => {
+                let _ = self.install(PolicySnapshot::Unconfigured);
             }
         }
     }
+
+    fn activate_startup(&self, policy: ActionPolicy) {
+        let result = self.try_activate(
+            policy,
+            ActivatePolicyParams {
+                origin: RevisionOrigin::Startup,
+                actor: None,
+                expected_revision: None,
+            },
+        );
+        if let Err(error) = result {
+            tracing::error!(error = %error, "startup action policy rejected");
+            if self.revisions.active_revision().is_none() {
+                let _ = self.install(PolicySnapshot::Invalid);
+            } else {
+                self.reinstall_active_or_invalid();
+            }
+        }
+    }
+
+    fn matches_active(&self, policy: &ActionPolicy) -> bool {
+        self.revisions.active_revision().is_some_and(|revision| {
+            policy_checksum(policy).is_some_and(|checksum| checksum == revision.metadata.checksum)
+        })
+    }
+
+    fn reinstall_active_or_invalid(&self) {
+        let Some(revision) = self.revisions.active_revision() else {
+            let _ = self.install(PolicySnapshot::Invalid);
+            return;
+        };
+        match revision.policy.compile() {
+            Ok(compiled) => {
+                let _ = self.install(PolicySnapshot::Valid(Arc::new(compiled)));
+            }
+            Err(error) => {
+                tracing::error!(revision_id = revision.metadata.id, error = %error, "persisted action policy revision is invalid");
+                let _ = self.install(PolicySnapshot::Invalid);
+            }
+        }
+    }
+
+    fn install(&self, snapshot: PolicySnapshot) -> Result<(), RevisionError> {
+        let mut active = self.snapshot.write().map_err(|_| lock_error())?;
+        *active = snapshot;
+        Ok(())
+    }
 }
 
+fn lock_error() -> RevisionError {
+    RevisionError::ValidationFailed("internal lock error".to_owned())
+}
+
+fn parse_startup(
+    value: Option<&serde_yaml::Value>,
+) -> Result<Option<ActionPolicy>, serde_yaml::Error> {
+    value
+        .map(|value| serde_yaml::from_value(value.clone()))
+        .transpose()
+}
 impl Default for ActionPolicyState {
     fn default() -> Self {
         Self::new()
@@ -65,37 +221,142 @@ impl Default for ActionPolicyState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn policy(id: &str) -> ActionPolicy {
+        serde_json::from_value(serde_json::json!({"rules": [{"id": id, "effect": "deny", "selectors": {"operation": "tools/call"}}]})).expect("valid policy")
+    }
+
+    fn activate(
+        state: &ActionPolicyState,
+        policy: ActionPolicy,
+        expected_revision: Option<u64>,
+    ) -> Result<ActionPolicyRevision, RevisionError> {
+        state.try_activate(
+            policy,
+            ActivatePolicyParams {
+                origin: RevisionOrigin::Api,
+                actor: None,
+                expected_revision,
+            },
+        )
+    }
 
     #[test]
-    fn loads_valid_missing_and_invalid_yaml_states() {
+    fn rejection_and_conflict_preserve_active_revision() {
         let state = ActionPolicyState::new();
-        assert!(matches!(state.snapshot(), PolicySnapshot::Unconfigured));
-
-        let valid: serde_yaml::Value = serde_yaml::from_str(
-            r#"
-rules:
-  - id: deny-delete
-    effect: deny
-    selectors:
-      operation: tools/call
-"#,
+        let first = activate(&state, policy("first"), None).expect("activate");
+        assert!(matches!(
+            activate(&state, policy("second"), Some(99)),
+            Err(RevisionError::Conflict { .. })
+        ));
+        let invalid: ActionPolicy = serde_json::from_value(
+            serde_json::json!({"rules": [{"id": "bad", "effect": "deny", "selectors": {}}]}),
         )
-        .expect("valid YAML");
-        state.load_yaml(Some(&valid));
+        .expect("schema");
+        assert!(matches!(
+            activate(&state, invalid, Some(first.metadata.id)),
+            Err(RevisionError::ValidationFailed(_))
+        ));
+        assert_eq!(
+            state.revision_store().active_revision_id(),
+            Some(first.metadata.id)
+        );
+        assert_eq!(state.revision_store().list_revisions().len(), 2);
+    }
+
+    #[test]
+    fn rollback_creates_a_new_active_revision() {
+        let state = ActionPolicyState::new();
+        let first = activate(&state, policy("first"), None).expect("first");
+        let second = activate(&state, policy("second"), Some(first.metadata.id)).expect("second");
+        let restored = state
+            .rollback(first.metadata.id, Some(second.metadata.id))
+            .expect("rollback");
+        assert!(restored.metadata.id > second.metadata.id);
+        assert_eq!(restored.policy.rules[0].id, "first");
+    }
+
+    #[test]
+    fn startup_reconciliation_preserves_active_policy() {
+        let state = ActionPolicyState::new();
+        activate(&state, policy("first"), None).expect("activate");
+        let invalid = serde_yaml::from_str::<serde_yaml::Value>("rules: invalid").expect("yaml");
+        state.reconcile_startup(Some(&invalid));
         assert!(matches!(state.snapshot(), PolicySnapshot::Valid(_)));
-
-        let invalid: serde_yaml::Value = serde_yaml::from_str(
-            r#"
-rules:
-  - id: no-selectors
-    effect: deny
-"#,
+        let rejected = serde_yaml::from_str::<serde_yaml::Value>(
+            "rules:\n  - id: rejected\n    effect: deny\n    selectors: {}",
         )
-        .expect("valid YAML shape");
-        state.load_yaml(Some(&invalid));
-        assert!(matches!(state.snapshot(), PolicySnapshot::Invalid));
+        .expect("yaml");
+        state.reconcile_startup(Some(&rejected));
+        assert!(matches!(state.snapshot(), PolicySnapshot::Valid(_)));
+        assert_eq!(state.revision_store().list_revisions().len(), 2);
+        state.reconcile_startup(None);
+        assert!(matches!(state.snapshot(), PolicySnapshot::Valid(_)));
+    }
 
-        state.load_yaml(None);
-        assert!(matches!(state.snapshot(), PolicySnapshot::Unconfigured));
+    #[test]
+    fn persistence_restart_restores_an_independent_active_stream() {
+        let directory =
+            std::env::temp_dir().join(format!("wanaku-action-policy-state-{}", std::process::id()));
+        let path = directory.join("action-policy-revisions.json");
+        let persistence: Arc<dyn crate::revision_persistence::RevisionPersistence> = Arc::new(
+            crate::revision_persistence::FileRevisionPersistence::new(&path),
+        );
+        let state = ActionPolicyState::new().with_revision_persistence(persistence.clone());
+        let revision = activate(&state, policy("persisted"), None).expect("activate");
+
+        let restored = ActionPolicyState::new().with_revision_persistence(persistence);
+        assert_eq!(
+            restored.revision_store().active_revision_id(),
+            Some(revision.metadata.id)
+        );
+        assert!(matches!(restored.snapshot(), PolicySnapshot::Valid(_)));
+        restored.reconcile_startup(None);
+        assert!(matches!(restored.snapshot(), PolicySnapshot::Valid(_)));
+        let next = activate(&restored, policy("next"), Some(revision.metadata.id)).expect("next");
+        assert!(next.metadata.id > revision.metadata.id);
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn first_invalid_policy_sets_invalid_snapshot() {
+        let state = ActionPolicyState::new();
+        let invalid: ActionPolicy = serde_json::from_value(
+            serde_json::json!({"rules": [{"id": "bad", "effect": "deny", "selectors": {}}]}),
+        )
+        .expect("schema");
+        assert!(matches!(
+            activate(&state, invalid, None),
+            Err(RevisionError::ValidationFailed(_))
+        ));
+        assert!(matches!(state.snapshot(), PolicySnapshot::Invalid));
+        assert!(state.revision_store().active_revision().is_none());
+        assert_eq!(state.revision_store().list_revisions().len(), 1);
+    }
+
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "synchronous test needs OS threads to verify activation locking"
+    )]
+    fn concurrent_updates_with_one_expected_revision_do_not_both_activate() {
+        let state = ActionPolicyState::new();
+        let first = activate(&state, policy("first"), None).expect("first");
+        let left = state.clone();
+        let right = state.clone();
+        let expected = first.metadata.id;
+        let left = std::thread::spawn(move || activate(&left, policy("left"), Some(expected)));
+        let right = std::thread::spawn(move || activate(&right, policy("right"), Some(expected)));
+        let results = [
+            left.join().expect("left thread"),
+            right.join().expect("right thread"),
+        ];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(RevisionError::Conflict { .. })))
+                .count(),
+            1
+        );
     }
 }

--- a/features/action-policy/src/state.rs
+++ b/features/action-policy/src/state.rs
@@ -1,0 +1,101 @@
+use std::sync::{Arc, RwLock};
+
+use crate::{ActionPolicy, CompiledPolicy};
+
+#[derive(Clone)]
+pub enum PolicySnapshot {
+    Unconfigured,
+    Valid(Arc<CompiledPolicy>),
+    Invalid,
+}
+
+#[derive(Clone)]
+pub struct ActionPolicyState {
+    snapshot: Arc<RwLock<PolicySnapshot>>,
+}
+
+impl ActionPolicyState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            snapshot: Arc::new(RwLock::new(PolicySnapshot::Unconfigured)),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> PolicySnapshot {
+        match self.snapshot.read() {
+            Ok(snapshot) => snapshot.clone(),
+            Err(_) => PolicySnapshot::Invalid,
+        }
+    }
+
+    pub(crate) fn load_yaml(&self, value: Option<&serde_yaml::Value>) {
+        let snapshot = match value {
+            None => PolicySnapshot::Unconfigured,
+            Some(value) => match serde_yaml::from_value::<ActionPolicy>(value.clone()) {
+                Ok(policy) => match policy.compile() {
+                    Ok(compiled) => PolicySnapshot::Valid(Arc::new(compiled)),
+                    Err(error) => {
+                        tracing::error!(error = %error, "action policy validation failed");
+                        PolicySnapshot::Invalid
+                    }
+                },
+                Err(error) => {
+                    tracing::error!(error = %error, "action policy configuration is invalid");
+                    PolicySnapshot::Invalid
+                }
+            },
+        };
+        match self.snapshot.write() {
+            Ok(mut active) => *active = snapshot,
+            Err(error) => {
+                tracing::error!(error = %error, "action policy state lock is unavailable");
+            }
+        }
+    }
+}
+
+impl Default for ActionPolicyState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_valid_missing_and_invalid_yaml_states() {
+        let state = ActionPolicyState::new();
+        assert!(matches!(state.snapshot(), PolicySnapshot::Unconfigured));
+
+        let valid: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+rules:
+  - id: deny-delete
+    effect: deny
+    selectors:
+      operation: tools/call
+"#,
+        )
+        .expect("valid YAML");
+        state.load_yaml(Some(&valid));
+        assert!(matches!(state.snapshot(), PolicySnapshot::Valid(_)));
+
+        let invalid: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+rules:
+  - id: no-selectors
+    effect: deny
+"#,
+        )
+        .expect("valid YAML shape");
+        state.load_yaml(Some(&invalid));
+        assert!(matches!(state.snapshot(), PolicySnapshot::Invalid));
+
+        state.load_yaml(None);
+        assert!(matches!(state.snapshot(), PolicySnapshot::Unconfigured));
+    }
+}

--- a/features/action-policy/src/validation.rs
+++ b/features/action-policy/src/validation.rs
@@ -1,0 +1,267 @@
+use std::collections::HashSet;
+
+use thiserror::Error;
+
+use crate::{
+    ActionPolicy, CompiledMatcher, CompiledPredicate, MatchKind, MatcherCompileError, Rule,
+};
+
+/// A validated and compiled policy document.
+pub struct CompiledPolicy {
+    rules: Vec<CompiledRule>,
+}
+
+/// The compiled selectors and predicates for one rule.
+pub struct CompiledRule {
+    rule: Rule,
+    target_name: Option<CompiledMatcher>,
+    uri: Option<CompiledMatcher>,
+    predicates: Vec<CompiledPredicate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ValidationError {
+    #[error("rule ID '{0}' is not a valid identifier")]
+    InvalidRuleId(String),
+    #[error("rule ID '{0}' is duplicated")]
+    DuplicateRuleId(String),
+    #[error("rule '{rule_id}' has an invalid {field} identifier: '{value}'")]
+    InvalidIdentifier {
+        rule_id: String,
+        field: &'static str,
+        value: String,
+    },
+    #[error("rule '{0}' must have at least one action selector")]
+    MissingSelector(String),
+    #[error("rule '{rule_id}' has an empty matcher value for {field}")]
+    EmptyMatcher {
+        rule_id: String,
+        field: &'static str,
+    },
+    #[error("rule '{0}' can use only exact or prefix URI matching")]
+    InvalidUriMatcher(String),
+    #[error("rule '{0}' can use only exact or glob target-name matching")]
+    InvalidTargetNameMatcher(String),
+    #[error("rule '{rule_id}' has an invalid {field}: {source}")]
+    InvalidMatcher {
+        rule_id: String,
+        field: &'static str,
+        source: MatcherCompileError,
+    },
+    #[error("rule '{rule_id}' has an invalid JSON Pointer: '{pointer}'")]
+    InvalidJsonPointer { rule_id: String, pointer: String },
+    #[error("rule '{rule_id}' has an empty operand for operator '{operator}'")]
+    EmptyOperand {
+        rule_id: String,
+        operator: &'static str,
+    },
+}
+
+impl ActionPolicy {
+    /// Validate and compile all matchers before policy activation.
+    pub fn compile(self) -> Result<CompiledPolicy, ValidationError> {
+        let mut ids = HashSet::new();
+        let mut rules = Vec::with_capacity(self.rules.len());
+        for rule in self.rules {
+            validate_identifier(&rule.id)
+                .map_err(|()| ValidationError::InvalidRuleId(rule.id.clone()))?;
+            if !ids.insert(rule.id.clone()) {
+                return Err(ValidationError::DuplicateRuleId(rule.id));
+            }
+            rules.push(CompiledRule::compile(rule)?);
+        }
+        Ok(CompiledPolicy { rules })
+    }
+}
+
+impl CompiledPolicy {
+    #[must_use]
+    pub fn rules(&self) -> &[CompiledRule] {
+        &self.rules
+    }
+}
+
+impl CompiledRule {
+    #[must_use]
+    pub const fn rule(&self) -> &Rule {
+        &self.rule
+    }
+
+    #[must_use]
+    pub const fn target_name(&self) -> Option<&CompiledMatcher> {
+        self.target_name.as_ref()
+    }
+
+    #[must_use]
+    pub const fn uri(&self) -> Option<&CompiledMatcher> {
+        self.uri.as_ref()
+    }
+
+    #[must_use]
+    pub fn predicates(&self) -> &[CompiledPredicate] {
+        &self.predicates
+    }
+
+    fn compile(rule: Rule) -> Result<Self, ValidationError> {
+        if !has_selector(&rule) {
+            return Err(ValidationError::MissingSelector(rule.id.clone()));
+        }
+        validate_rule_identifiers(&rule)?;
+
+        let target_name = match rule.selectors.target_name.as_ref() {
+            Some(expression)
+                if !matches!(expression.matcher, MatchKind::Exact | MatchKind::Glob) =>
+            {
+                return Err(ValidationError::InvalidTargetNameMatcher(rule.id.clone()));
+            }
+            expression => compile_matcher(&rule, "target_name", expression)?,
+        };
+        let uri = match rule.selectors.uri.as_ref() {
+            Some(expression)
+                if !matches!(expression.matcher, MatchKind::Exact | MatchKind::Prefix) =>
+            {
+                return Err(ValidationError::InvalidUriMatcher(rule.id.clone()));
+            }
+            expression => compile_matcher(&rule, "uri", expression)?,
+        };
+
+        let predicates = compile_predicates(&rule)?;
+
+        Ok(Self {
+            rule,
+            target_name,
+            uri,
+            predicates,
+        })
+    }
+}
+
+fn validate_rule_identifiers(rule: &Rule) -> Result<(), ValidationError> {
+    validate_optional_identifier(rule, "namespace", rule.selectors.namespace.as_deref())?;
+    validate_optional_identifier(rule, "operation", rule.selectors.operation.as_deref())?;
+    validate_optional_identifier(rule, "reason_code", rule.reason_code.as_deref())?;
+    for label in rule.selectors.labels.keys() {
+        validate_named_identifier(&rule.id, "label", label)?;
+    }
+    for key in rule.metadata.keys() {
+        validate_named_identifier(&rule.id, "metadata", key)?;
+    }
+    Ok(())
+}
+
+fn has_selector(rule: &Rule) -> bool {
+    let selectors = &rule.selectors;
+    selectors.namespace.is_some()
+        || selectors.operation.is_some()
+        || selectors.target_type.is_some()
+        || selectors.target_name.is_some()
+        || !selectors.labels.is_empty()
+        || selectors.uri.is_some()
+}
+
+fn compile_predicates(rule: &Rule) -> Result<Vec<CompiledPredicate>, ValidationError> {
+    let mut predicates = Vec::with_capacity(rule.predicates.len());
+    for predicate in &rule.predicates {
+        if !valid_json_pointer(predicate.pointer()) {
+            return Err(ValidationError::InvalidJsonPointer {
+                rule_id: rule.id.clone(),
+                pointer: predicate.pointer().to_owned(),
+            });
+        }
+        match predicate {
+            crate::Predicate::OneOf { values, .. } if values.is_empty() => {
+                return empty_operand(&rule.id, "one_of");
+            }
+            crate::Predicate::NotOneOf { values, .. } if values.is_empty() => {
+                return empty_operand(&rule.id, "not_one_of");
+            }
+            _ => {}
+        }
+        predicates.push(CompiledPredicate::new(predicate.clone()));
+    }
+    Ok(predicates)
+}
+
+fn empty_operand<T>(rule_id: &str, operator: &'static str) -> Result<T, ValidationError> {
+    Err(ValidationError::EmptyOperand {
+        rule_id: rule_id.to_owned(),
+        operator,
+    })
+}
+
+fn compile_matcher(
+    rule: &Rule,
+    field: &'static str,
+    expression: Option<&crate::MatchExpression>,
+) -> Result<Option<CompiledMatcher>, ValidationError> {
+    let Some(expression) = expression else {
+        return Ok(None);
+    };
+    if expression.value.is_empty() {
+        return Err(ValidationError::EmptyMatcher {
+            rule_id: rule.id.clone(),
+            field,
+        });
+    }
+    CompiledMatcher::compile(expression)
+        .map(Some)
+        .map_err(|source| ValidationError::InvalidMatcher {
+            rule_id: rule.id.clone(),
+            field,
+            source,
+        })
+}
+
+fn validate_optional_identifier(
+    rule: &Rule,
+    field: &'static str,
+    value: Option<&str>,
+) -> Result<(), ValidationError> {
+    match value {
+        Some(value) => validate_named_identifier(&rule.id, field, value),
+        None => Ok(()),
+    }
+}
+
+fn validate_named_identifier(
+    rule_id: &str,
+    field: &'static str,
+    value: &str,
+) -> Result<(), ValidationError> {
+    validate_identifier(value).map_err(|()| ValidationError::InvalidIdentifier {
+        rule_id: rule_id.to_owned(),
+        field,
+        value: value.to_owned(),
+    })
+}
+
+fn validate_identifier(value: &str) -> Result<(), ()> {
+    let mut characters = value.chars();
+    match characters.next() {
+        Some(first) if first.is_ascii_alphanumeric() => {}
+        _ => return Err(()),
+    }
+    if characters.all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | '/' | ':')
+    }) {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+fn valid_json_pointer(pointer: &str) -> bool {
+    if pointer.is_empty() {
+        return true;
+    }
+    if !pointer.starts_with('/') {
+        return false;
+    }
+    let mut characters = pointer.chars();
+    while let Some(character) = characters.next() {
+        if character == '~' && !matches!(characters.next(), Some('0' | '1')) {
+            return false;
+        }
+    }
+    true
+}

--- a/features/action-policy/tests/engine.rs
+++ b/features/action-policy/tests/engine.rs
@@ -1,0 +1,281 @@
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use wanaku_feature_action_policy::{
+    ActionContext, ActionPolicy, ActorContext, DEFAULT_DENY_MESSAGE, DEFAULT_DENY_REASON_CODE,
+    Effect, MatchExpression, MatchKind, MatchedRule, PolicyDecision, PolicyEngine, PolicyState,
+    Predicate, Rule, Selectors, TargetType,
+};
+
+fn rule(id: &str, effect: Effect) -> Rule {
+    Rule {
+        id: id.to_owned(),
+        description: None,
+        effect,
+        selectors: Selectors {
+            operation: Some("tools/call".to_owned()),
+            ..Selectors::default()
+        },
+        predicates: Vec::new(),
+        reason_code: None,
+        message: None,
+        metadata: BTreeMap::new(),
+    }
+}
+
+fn context() -> ActionContext {
+    ActionContext::new(
+        "production",
+        "tools/call",
+        TargetType::Tool,
+        json!({ "arguments": { "approved": true } }),
+    )
+    .with_target_name("reports/read")
+    .with_labels(BTreeMap::from([
+        ("owner".to_owned(), "finance".to_owned()),
+        ("tier".to_owned(), "sensitive".to_owned()),
+    ]))
+    .with_uri("tool://reports/read")
+}
+
+#[test]
+fn matches_all_transport_neutral_selectors_and_predicates() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut candidate = rule("complete-match", Effect::Allow);
+    candidate.selectors.namespace = Some("production".to_owned());
+    candidate.selectors.target_type = Some(TargetType::Tool);
+    candidate.selectors.target_name = Some(MatchExpression {
+        matcher: MatchKind::Glob,
+        value: "reports/*".to_owned(),
+    });
+    candidate
+        .selectors
+        .labels
+        .insert("owner".to_owned(), "finance".to_owned());
+    candidate.selectors.uri = Some(MatchExpression {
+        matcher: MatchKind::Prefix,
+        value: "tool://reports/".to_owned(),
+    });
+    candidate.predicates.push(Predicate::Equals {
+        pointer: "/arguments/approved".to_owned(),
+        value: json!(true),
+    });
+    let policy = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+
+    assert!(matches!(
+        PolicyEngine::evaluate(PolicyState::Available(&policy), &context()),
+        PolicyDecision::ExplicitAllow { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn required_labels_are_a_subset_of_context_labels() -> Result<(), Box<dyn std::error::Error>> {
+    let mut candidate = rule("label-subset", Effect::Allow);
+    candidate
+        .selectors
+        .labels
+        .insert("owner".to_owned(), "finance".to_owned());
+    let policy = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+
+    assert!(matches!(
+        PolicyEngine::evaluate(PolicyState::Available(&policy), &context()),
+        PolicyDecision::ExplicitAllow { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "selector mismatch matrix")]
+fn selector_and_predicate_mismatches_produce_no_match() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rules = Vec::new();
+    for (id, selectors) in [
+        (
+            "namespace",
+            Selectors {
+                namespace: Some("development".to_owned()),
+                ..Selectors::default()
+            },
+        ),
+        (
+            "operation",
+            Selectors {
+                operation: Some("resources/read".to_owned()),
+                ..Selectors::default()
+            },
+        ),
+        (
+            "type",
+            Selectors {
+                target_type: Some(TargetType::Resource),
+                ..Selectors::default()
+            },
+        ),
+        (
+            "name",
+            Selectors {
+                target_name: Some(MatchExpression {
+                    matcher: MatchKind::Exact,
+                    value: "reports/write".to_owned(),
+                }),
+                ..Selectors::default()
+            },
+        ),
+        (
+            "uri",
+            Selectors {
+                uri: Some(MatchExpression {
+                    matcher: MatchKind::Exact,
+                    value: "tool://other".to_owned(),
+                }),
+                ..Selectors::default()
+            },
+        ),
+    ] {
+        let mut candidate = rule(id, Effect::Deny);
+        candidate.selectors = selectors;
+        rules.push(candidate);
+    }
+    let mut labels = rule("labels", Effect::Deny);
+    labels
+        .selectors
+        .labels
+        .insert("owner".to_owned(), "engineering".to_owned());
+    rules.push(labels);
+    let mut predicate = rule("predicate", Effect::Deny);
+    predicate.predicates.push(Predicate::Equals {
+        pointer: "/arguments/approved".to_owned(),
+        value: json!(false),
+    });
+    rules.push(predicate);
+    let policy = ActionPolicy { rules }.compile()?;
+
+    assert_eq!(
+        PolicyEngine::evaluate(PolicyState::Available(&policy), &context()),
+        PolicyDecision::NoMatch
+    );
+    Ok(())
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "rule order and evidence matrix")]
+fn deny_overrides_allow_and_is_independent_of_declaration_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let allow = rule("a-allow", Effect::Allow);
+    let mut later_deny = rule("z-deny", Effect::Deny);
+    later_deny.reason_code = Some("later_deny".to_owned());
+    later_deny.message = Some("Later deny".to_owned());
+    let mut primary_deny = rule("b-deny", Effect::Deny);
+    primary_deny.reason_code = Some("primary_deny".to_owned());
+    primary_deny.message = Some("Primary deny".to_owned());
+
+    let forward = ActionPolicy {
+        rules: vec![allow.clone(), later_deny.clone(), primary_deny.clone()],
+    }
+    .compile()?;
+    let reverse = ActionPolicy {
+        rules: vec![primary_deny, later_deny, allow],
+    }
+    .compile()?;
+    let forward_decision = PolicyEngine::evaluate(PolicyState::Available(&forward), &context());
+    let reverse_decision = PolicyEngine::evaluate(PolicyState::Available(&reverse), &context());
+
+    assert_eq!(forward_decision, reverse_decision);
+    assert_eq!(forward_decision.deny_reason_code(), Some("primary_deny"));
+    assert_eq!(forward_decision.deny_message(), Some("Primary deny"));
+    let details = forward_decision
+        .details()
+        .ok_or("missing decision details")?;
+    let matched: Vec<&str> = details
+        .matched_rules()
+        .iter()
+        .map(MatchedRule::rule_id)
+        .collect();
+    let contributing: Vec<&str> = details
+        .contributing_rules()
+        .iter()
+        .map(MatchedRule::rule_id)
+        .collect();
+    assert_eq!(matched, vec!["a-allow", "b-deny", "z-deny"]);
+    assert_eq!(contributing, vec!["b-deny", "z-deny"]);
+    Ok(())
+}
+
+#[test]
+fn explicit_allow_remains_a_continue_state() -> Result<(), Box<dyn std::error::Error>> {
+    let policy = ActionPolicy {
+        rules: vec![rule("allow", Effect::Allow)],
+    }
+    .compile()?;
+    let decision = PolicyEngine::evaluate(PolicyState::Available(&policy), &context());
+
+    assert!(matches!(decision, PolicyDecision::ExplicitAllow { .. }));
+    assert!(decision.deny_message().is_none());
+    Ok(())
+}
+
+#[test]
+fn default_deny_message_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let policy = ActionPolicy {
+        rules: vec![rule("deny", Effect::Deny)],
+    }
+    .compile()?;
+    let decision = PolicyEngine::evaluate(PolicyState::Available(&policy), &context());
+    assert_eq!(decision.deny_message(), Some(DEFAULT_DENY_MESSAGE));
+    assert_eq!(decision.deny_reason_code(), Some(DEFAULT_DENY_REASON_CODE));
+    Ok(())
+}
+
+#[test]
+fn distinguishes_no_match_unavailable_and_invalid() -> Result<(), Box<dyn std::error::Error>> {
+    let mut candidate = rule("other-operation", Effect::Allow);
+    candidate.selectors.operation = Some("prompts/get".to_owned());
+    let policy = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+
+    assert_eq!(
+        PolicyEngine::evaluate(PolicyState::Available(&policy), &context()),
+        PolicyDecision::NoMatch
+    );
+    assert_eq!(
+        PolicyEngine::evaluate(PolicyState::Unavailable, &context()),
+        PolicyDecision::PolicyUnavailable
+    );
+    assert_eq!(
+        PolicyEngine::evaluate(PolicyState::Invalid, &context()),
+        PolicyDecision::PolicyInvalid
+    );
+    Ok(())
+}
+
+#[test]
+fn actor_context_is_typed_and_not_used_as_a_selector() -> Result<(), Box<dyn std::error::Error>> {
+    let actor = ActorContext::new(
+        "user-123",
+        "https://identity.example",
+        BTreeMap::from([("admin".to_owned(), json!(false))]),
+    );
+    let action = context().with_actor(actor);
+    let policy = ActionPolicy {
+        rules: vec![rule("allow", Effect::Allow)],
+    }
+    .compile()?;
+
+    let retained = action.actor().ok_or("missing actor")?;
+    assert_eq!(retained.principal_id(), "user-123");
+    assert_eq!(retained.issuer(), "https://identity.example");
+    assert_eq!(retained.attributes().get("admin"), Some(&json!(false)));
+    assert!(matches!(
+        PolicyEngine::evaluate(PolicyState::Available(&policy), &action),
+        PolicyDecision::ExplicitAllow { .. }
+    ));
+    Ok(())
+}

--- a/features/action-policy/tests/integration.rs
+++ b/features/action-policy/tests/integration.rs
@@ -1,0 +1,154 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+
+use http::{HeaderMap, StatusCode};
+use serde_json::json;
+use wanaku_feature_action_policy::revision_persistence::FileRevisionPersistence;
+use wanaku_feature_action_policy::{
+    ActionContext, ActionPolicy, ActionPolicyFeature, PolicyDecision, PolicyEngine, PolicyState,
+    TargetType,
+};
+use wanaku_types::feature::{Feature, HttpContext};
+
+fn yaml_policy() -> ActionPolicy {
+    serde_yaml::from_str(
+        r#"
+rules:
+  - id: deny-tool
+    effect: deny
+    selectors:
+      operation: tools/call
+      target_name: { matcher: exact, value: delete }
+  - id: deny-resource
+    effect: deny
+    selectors:
+      operation: resources/read
+      uri: { matcher: prefix, value: "file:///secret/" }
+  - id: deny-exact-resource
+    effect: deny
+    selectors:
+      operation: resources/read
+      uri: { matcher: exact, value: "file:///locked" }
+  - id: deny-prompt
+    effect: deny
+    selectors:
+      operation: prompts/get
+      target_name: { matcher: exact, value: admin }
+"#,
+    )
+    .expect("valid YAML policy")
+}
+
+#[test]
+fn yaml_compilation_governs_all_three_mcp_action_types() {
+    let policy = yaml_policy().compile().expect("compiled policy");
+    let cases = [
+        ActionContext::new("default", "tools/call", TargetType::Tool, json!({}))
+            .with_target_name("delete"),
+        ActionContext::new("default", "resources/read", TargetType::Resource, json!({}))
+            .with_uri("file:///secret/report"),
+        ActionContext::new("default", "resources/read", TargetType::Resource, json!({}))
+            .with_uri("file:///locked"),
+        ActionContext::new("default", "prompts/get", TargetType::Prompt, json!({}))
+            .with_target_name("admin"),
+    ];
+    for context in cases {
+        assert!(matches!(
+            PolicyEngine::evaluate(PolicyState::Available(&policy), &context),
+            PolicyDecision::ExplicitDeny { .. }
+        ));
+    }
+}
+
+#[test]
+fn static_allow_remains_an_explicit_continue_state_for_the_adapter() {
+    let policy: ActionPolicy = serde_json::from_value(json!({"rules": [
+        {"id": "allow-tool", "effect": "allow", "selectors": {"operation": "tools/call"}},
+        {"id": "allow-resource", "effect": "allow", "selectors": {"operation": "resources/read"}},
+        {"id": "allow-prompt", "effect": "allow", "selectors": {"operation": "prompts/get"}}
+    ]}))
+    .expect("policy");
+    let compiled = policy.compile().expect("compiled policy");
+    let actions = [
+        ActionContext::new("default", "tools/call", TargetType::Tool, json!({})),
+        ActionContext::new("default", "resources/read", TargetType::Resource, json!({})),
+        ActionContext::new("default", "prompts/get", TargetType::Prompt, json!({})),
+    ];
+    for action in actions {
+        assert!(matches!(
+            PolicyEngine::evaluate(PolicyState::Available(&compiled), &action),
+            PolicyDecision::ExplicitAllow { .. }
+        ));
+    }
+}
+
+fn context<'a>(
+    method: &'a str,
+    path: &'a str,
+    body: Option<&'a str>,
+    headers: &'a HeaderMap,
+) -> HttpContext<'a> {
+    HttpContext::new(method, path, None, body, headers)
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one management lifecycle must retain state across all requests"
+)]
+async fn management_activation_conflict_rollback_and_restart_cross_public_boundary() {
+    let directory =
+        std::env::temp_dir().join(format!("wanaku-policy-integration-{}", std::process::id()));
+    let path = directory.join("action-policy-revisions.json");
+    let persistence = Arc::new(FileRevisionPersistence::new(&path));
+    let feature = ActionPolicyFeature::new().with_revision_persistence(persistence.clone());
+    let headers = HeaderMap::new();
+    let body = json!({"policy": yaml_policy()}).to_string();
+    let response = feature
+        .handle_route(&context(
+            "PUT",
+            "/api/v1/action-policies",
+            Some(&body),
+            &headers,
+        ))
+        .await
+        .expect("owned route");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let stale = json!({"policy": yaml_policy(), "expected_revision": 99}).to_string();
+    let response = feature
+        .handle_route(&context(
+            "PUT",
+            "/api/v1/action-policies",
+            Some(&stale),
+            &headers,
+        ))
+        .await
+        .expect("owned route");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    let response = feature
+        .handle_route(&context(
+            "POST",
+            "/api/v1/action-policies/revisions/1/activate",
+            Some(r#"{"expected_revision":1}"#),
+            &headers,
+        ))
+        .await
+        .expect("owned route");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let restarted = ActionPolicyFeature::new().with_revision_persistence(persistence);
+    let response = restarted
+        .handle_route(&context(
+            "GET",
+            "/api/v1/action-policies/revisions/active",
+            None,
+            &headers,
+        ))
+        .await
+        .expect("owned route");
+    assert_eq!(response.status(), StatusCode::OK);
+    let _ = std::fs::remove_dir_all(directory);
+}

--- a/features/action-policy/tests/schema.rs
+++ b/features/action-policy/tests/schema.rs
@@ -1,0 +1,383 @@
+use serde_json::json;
+use wanaku_feature_action_policy::{
+    ActionPolicy, Effect, MatchExpression, MatchKind, Predicate, Rule, Selectors, TargetType,
+    ValidationError,
+};
+
+fn rule(id: &str) -> Rule {
+    Rule {
+        id: id.to_owned(),
+        description: None,
+        effect: Effect::Deny,
+        selectors: Selectors {
+            operation: Some("tools/call".to_owned()),
+            ..Selectors::default()
+        },
+        predicates: Vec::new(),
+        reason_code: None,
+        message: None,
+        metadata: std::collections::BTreeMap::new(),
+    }
+}
+
+#[test]
+fn schema_round_trips_all_selector_and_predicate_types() -> Result<(), Box<dyn std::error::Error>> {
+    let source = json!({
+        "rules": [{
+            "id": "protect.files",
+            "description": "Protect confidential file resources.",
+            "effect": "deny",
+            "selectors": {
+                "namespace": "production",
+                "operation": "resources/read",
+                "target_type": "resource",
+                "target_name": { "matcher": "glob", "value": "documents/*" },
+                "labels": { "classification": "confidential" },
+                "uri": { "matcher": "prefix", "value": "file:///approved/" }
+            },
+            "predicates": [
+                { "operator": "exists", "pointer": "/arguments/path", "value": true },
+                { "operator": "equals", "pointer": "/arguments/mode", "value": "write" },
+                { "operator": "not_equals", "pointer": "/arguments/count", "value": 0 },
+                { "operator": "one_of", "pointer": "/arguments/tier", "values": ["a", "b"] },
+                { "operator": "not_one_of", "pointer": "/arguments/enabled", "values": [false] }
+            ],
+            "reason_code": "restricted_resource",
+            "message": "This resource is not available.",
+            "metadata": { "owner": "security", "ticket": 1870 }
+        }]
+    });
+
+    let policy: ActionPolicy = serde_json::from_value(source.clone())?;
+    assert_eq!(serde_json::to_value(&policy)?, source);
+    assert_eq!(
+        policy.rules[0].selectors.target_type,
+        Some(TargetType::Resource)
+    );
+    assert!(policy.compile().is_ok());
+    Ok(())
+}
+
+#[test]
+fn rejects_duplicate_and_invalid_rule_ids() {
+    let duplicate = ActionPolicy {
+        rules: vec![rule("same-id"), rule("same-id")],
+    };
+    assert_eq!(
+        duplicate.compile().err(),
+        Some(ValidationError::DuplicateRuleId("same-id".to_owned()))
+    );
+
+    let invalid = ActionPolicy {
+        rules: vec![rule("invalid id")],
+    };
+    assert_eq!(
+        invalid.compile().err(),
+        Some(ValidationError::InvalidRuleId("invalid id".to_owned()))
+    );
+}
+
+#[test]
+fn requires_an_action_selector() {
+    let mut candidate = rule("no-selector");
+    candidate.selectors = Selectors::default();
+    assert_eq!(
+        ActionPolicy {
+            rules: vec![candidate]
+        }
+        .compile()
+        .err(),
+        Some(ValidationError::MissingSelector("no-selector".to_owned()))
+    );
+}
+
+#[test]
+fn validates_reason_code_and_metadata_keys() {
+    let mut bad_reason = rule("bad-reason");
+    bad_reason.reason_code = Some("not stable".to_owned());
+    assert!(matches!(
+        ActionPolicy {
+            rules: vec![bad_reason]
+        }
+        .compile(),
+        Err(ValidationError::InvalidIdentifier {
+            field: "reason_code",
+            ..
+        })
+    ));
+
+    let mut bad_metadata = rule("bad-metadata");
+    bad_metadata
+        .metadata
+        .insert("unsafe key".to_owned(), json!(true));
+    assert!(matches!(
+        ActionPolicy {
+            rules: vec![bad_metadata]
+        }
+        .compile(),
+        Err(ValidationError::InvalidIdentifier {
+            field: "metadata",
+            ..
+        })
+    ));
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "matcher behavior matrix")]
+fn compiles_exact_glob_and_literal_uri_prefix_matchers() -> Result<(), Box<dyn std::error::Error>> {
+    let mut first = rule("matchers");
+    first.selectors.target_name = Some(MatchExpression {
+        matcher: MatchKind::Glob,
+        value: "report-??-\\*".to_owned(),
+    });
+    first.selectors.uri = Some(MatchExpression {
+        matcher: MatchKind::Prefix,
+        value: "file:///safe/%2e%2e/".to_owned(),
+    });
+    let compiled = ActionPolicy { rules: vec![first] }.compile()?;
+    let compiled_rule = &compiled.rules()[0];
+
+    assert!(
+        compiled_rule
+            .target_name()
+            .is_some_and(|matcher| matcher.matches("report-ab-*"))
+    );
+    assert!(
+        !compiled_rule
+            .target_name()
+            .is_some_and(|matcher| matcher.matches("report-a-*"))
+    );
+    assert!(
+        compiled_rule
+            .uri()
+            .is_some_and(|matcher| matcher.matches("file:///safe/%2e%2e/item"))
+    );
+    assert!(
+        !compiled_rule
+            .uri()
+            .is_some_and(|matcher| matcher.matches("file:///safe/../item"))
+    );
+    Ok(())
+}
+
+#[test]
+fn compiles_exact_target_name_matcher() -> Result<(), Box<dyn std::error::Error>> {
+    let mut candidate = rule("exact-name");
+    candidate.selectors.target_name = Some(MatchExpression {
+        matcher: MatchKind::Exact,
+        value: "reports/read".to_owned(),
+    });
+    let compiled = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+    let matcher = compiled.rules()[0].target_name();
+    assert!(matcher.is_some_and(|matcher| matcher.matches("reports/read")));
+    assert!(!matcher.is_some_and(|matcher| matcher.matches("reports/read/all")));
+    Ok(())
+}
+
+#[test]
+fn rejects_glob_uri_and_invalid_matcher_values() {
+    let mut glob_uri = rule("glob-uri");
+    glob_uri.selectors.uri = Some(MatchExpression {
+        matcher: MatchKind::Glob,
+        value: "file:///*".to_owned(),
+    });
+    assert_eq!(
+        ActionPolicy {
+            rules: vec![glob_uri]
+        }
+        .compile()
+        .err(),
+        Some(ValidationError::InvalidUriMatcher("glob-uri".to_owned()))
+    );
+
+    let mut bad_glob = rule("bad-glob");
+    bad_glob.selectors.target_name = Some(MatchExpression {
+        matcher: MatchKind::Glob,
+        value: "unfinished\\".to_owned(),
+    });
+    assert!(matches!(
+        ActionPolicy {
+            rules: vec![bad_glob]
+        }
+        .compile(),
+        Err(ValidationError::InvalidMatcher { .. })
+    ));
+}
+
+#[test]
+fn rejects_prefix_target_name() {
+    let mut candidate = rule("prefix-name");
+    candidate.selectors.target_name = Some(MatchExpression {
+        matcher: MatchKind::Prefix,
+        value: "reports/".to_owned(),
+    });
+    assert_eq!(
+        ActionPolicy {
+            rules: vec![candidate]
+        }
+        .compile()
+        .err(),
+        Some(ValidationError::InvalidTargetNameMatcher(
+            "prefix-name".to_owned()
+        ))
+    );
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "missing-value operator matrix")]
+fn missing_values_only_match_exists_false() -> Result<(), Box<dyn std::error::Error>> {
+    let document = json!({});
+    let predicates = vec![
+        Predicate::Exists {
+            pointer: "/missing".to_owned(),
+            value: false,
+        },
+        Predicate::Equals {
+            pointer: "/missing".to_owned(),
+            value: json!(null),
+        },
+        Predicate::NotEquals {
+            pointer: "/missing".to_owned(),
+            value: json!(null),
+        },
+        Predicate::OneOf {
+            pointer: "/missing".to_owned(),
+            values: vec![json!(null)],
+        },
+        Predicate::NotOneOf {
+            pointer: "/missing".to_owned(),
+            values: vec![json!(null)],
+        },
+    ];
+    let mut candidate = rule("missing");
+    candidate.predicates = predicates;
+    let compiled = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+    let results: Vec<bool> = compiled.rules()[0]
+        .predicates()
+        .iter()
+        .map(|predicate| predicate.matches(&document))
+        .collect();
+    assert_eq!(results, vec![true, false, false, false, false]);
+    Ok(())
+}
+
+#[test]
+#[expect(clippy::too_many_lines, reason = "typed JSON value matrix")]
+fn comparisons_preserve_json_types_and_empty_values() -> Result<(), Box<dyn std::error::Error>> {
+    let document = json!({
+        "null": null,
+        "false": false,
+        "zero": 0,
+        "empty_string": "",
+        "empty_array": [],
+        "empty_object": {}
+    });
+    let values = [
+        ("/null", json!(null)),
+        ("/false", json!(false)),
+        ("/zero", json!(0)),
+        ("/empty_string", json!("")),
+        ("/empty_array", json!([])),
+        ("/empty_object", json!({})),
+    ];
+    let mut candidate = rule("typed-values");
+    candidate.predicates = values
+        .into_iter()
+        .map(|(pointer, value)| Predicate::Equals {
+            pointer: pointer.to_owned(),
+            value,
+        })
+        .collect();
+    let compiled = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+    assert!(
+        compiled.rules()[0]
+            .predicates()
+            .iter()
+            .all(|predicate| predicate.matches(&document))
+    );
+
+    let wrong_type = Predicate::Equals {
+        pointer: "/zero".to_owned(),
+        value: json!("0"),
+    };
+    let mut candidate = rule("wrong-type");
+    candidate.predicates.push(wrong_type);
+    let compiled = ActionPolicy {
+        rules: vec![candidate],
+    }
+    .compile()?;
+    assert!(!compiled.rules()[0].predicates()[0].matches(&document));
+    Ok(())
+}
+
+#[test]
+fn validates_json_pointers_and_non_empty_set_operands() {
+    for pointer in ["missing-slash", "/bad~2escape", "/trailing~"] {
+        let mut candidate = rule("bad-pointer");
+        candidate.predicates.push(Predicate::Exists {
+            pointer: pointer.to_owned(),
+            value: true,
+        });
+        assert!(matches!(
+            ActionPolicy {
+                rules: vec![candidate]
+            }
+            .compile(),
+            Err(ValidationError::InvalidJsonPointer { .. })
+        ));
+    }
+
+    let mut candidate = rule("empty-one-of");
+    candidate.predicates.push(Predicate::OneOf {
+        pointer: "/value".to_owned(),
+        values: Vec::new(),
+    });
+    assert!(matches!(
+        ActionPolicy {
+            rules: vec![candidate]
+        }
+        .compile(),
+        Err(ValidationError::EmptyOperand { .. })
+    ));
+}
+
+#[test]
+fn rejects_unknown_matchers_operators_and_malformed_operands() {
+    let unknown_matcher = json!({
+        "rules": [{
+            "id": "bad-matcher",
+            "effect": "deny",
+            "selectors": {
+                "target_name": { "matcher": "regex", "value": ".*" }
+            }
+        }]
+    });
+    assert!(serde_json::from_value::<ActionPolicy>(unknown_matcher).is_err());
+
+    let unknown_operator = json!({
+        "rules": [{
+            "id": "bad-operator",
+            "effect": "deny",
+            "predicates": [{ "operator": "contains", "pointer": "/value", "value": "x" }]
+        }]
+    });
+    assert!(serde_json::from_value::<ActionPolicy>(unknown_operator).is_err());
+
+    let malformed_operand = json!({
+        "rules": [{
+            "id": "bad-operand",
+            "effect": "deny",
+            "predicates": [{ "operator": "one_of", "pointer": "/value", "values": "x" }]
+        }]
+    });
+    assert!(serde_json::from_value::<ActionPolicy>(malformed_operand).is_err());
+}

--- a/features/action-policy/tests/schema.rs
+++ b/features/action-policy/tests/schema.rs
@@ -320,6 +320,98 @@ fn comparisons_preserve_json_types_and_empty_values() -> Result<(), Box<dyn std:
 }
 
 #[test]
+#[expect(clippy::too_many_lines, reason = "present-value predicate truth table")]
+fn present_value_predicate_operators_match_and_reject_as_typed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let document = json!({"value": 7});
+    let cases = [
+        (
+            Predicate::Exists {
+                pointer: "/value".to_owned(),
+                value: true,
+            },
+            true,
+        ),
+        (
+            Predicate::Exists {
+                pointer: "/value".to_owned(),
+                value: false,
+            },
+            false,
+        ),
+        (
+            Predicate::Equals {
+                pointer: "/value".to_owned(),
+                value: json!(7),
+            },
+            true,
+        ),
+        (
+            Predicate::Equals {
+                pointer: "/value".to_owned(),
+                value: json!(8),
+            },
+            false,
+        ),
+        (
+            Predicate::NotEquals {
+                pointer: "/value".to_owned(),
+                value: json!(8),
+            },
+            true,
+        ),
+        (
+            Predicate::NotEquals {
+                pointer: "/value".to_owned(),
+                value: json!(7),
+            },
+            false,
+        ),
+        (
+            Predicate::OneOf {
+                pointer: "/value".to_owned(),
+                values: vec![json!(6), json!(7)],
+            },
+            true,
+        ),
+        (
+            Predicate::OneOf {
+                pointer: "/value".to_owned(),
+                values: vec![json!(6), json!(8)],
+            },
+            false,
+        ),
+        (
+            Predicate::NotOneOf {
+                pointer: "/value".to_owned(),
+                values: vec![json!(6), json!(8)],
+            },
+            true,
+        ),
+        (
+            Predicate::NotOneOf {
+                pointer: "/value".to_owned(),
+                values: vec![json!(6), json!(7)],
+            },
+            false,
+        ),
+    ];
+    for (index, (predicate, expected)) in cases.into_iter().enumerate() {
+        let mut candidate = rule(&format!("predicate-{index}"));
+        candidate.predicates.push(predicate);
+        let compiled = ActionPolicy {
+            rules: vec![candidate],
+        }
+        .compile()?;
+        assert_eq!(
+            compiled.rules()[0].predicates()[0].matches(&document),
+            expected
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn validates_json_pointers_and_non_empty_set_operands() {
     for pointer in ["missing-slash", "/bad~2escape", "/trailing~"] {
         let mut candidate = rule("bad-pointer");

--- a/features/evaluator/src/revision.rs
+++ b/features/evaluator/src/revision.rs
@@ -1,9 +1,10 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use wanaku_types::revision::{RevisionHistory, RevisionHistoryError, RevisionRecord};
 use wanaku_types::time::iso_now;
+
+pub use wanaku_types::revision::{ActivationStatus, RevisionId, RevisionMetadata, RevisionOrigin};
 
 use crate::config::EvaluatorDef;
 use crate::revision_persistence::{RevisionPersistence, RevisionsSnapshot};
@@ -12,49 +13,21 @@ use crate::revision_persistence::{RevisionPersistence, RevisionsSnapshot};
 /// beyond this limit are silently dropped.
 const DEFAULT_MAX_HISTORY: usize = 50;
 
-/// Unique identifier for an evaluator configuration revision.
-pub type RevisionId = u64;
-
-/// Where a configuration revision originated.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RevisionOrigin {
-    /// Loaded from `wanaku.yaml` at server startup.
-    Startup,
-    /// Submitted through the management API.
-    Api,
-}
-
-/// Whether a revision was successfully activated.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ActivationStatus {
-    /// The revision is currently active.
-    Active,
-    /// The revision was once active but has been replaced by a newer one.
-    Superseded,
-    /// Activation was rejected because validation or compilation failed.
-    Rejected,
-}
-
-/// Metadata attached to every configuration revision.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RevisionMetadata {
-    pub id: RevisionId,
-    pub created_at: String,
-    pub activated_at: Option<String>,
-    pub status: ActivationStatus,
-    pub checksum: String,
-    pub origin: RevisionOrigin,
-    pub actor: Option<String>,
-    pub failure_reason: Option<String>,
-}
-
 /// An immutable evaluator configuration revision.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Revision {
     pub metadata: RevisionMetadata,
     pub evaluators: Vec<EvaluatorDef>,
+}
+
+impl RevisionRecord for Revision {
+    fn metadata(&self) -> &RevisionMetadata {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut RevisionMetadata {
+        &mut self.metadata
+    }
 }
 
 /// Errors that can occur during revision operations.
@@ -108,58 +81,21 @@ pub struct RecordRevisionParams {
 /// rollback survive a restart.
 #[derive(Clone)]
 pub struct RevisionStore {
-    inner: Arc<RwLock<RevisionStoreInner>>,
+    history: RevisionHistory<Revision>,
     persistence: Option<Arc<dyn RevisionPersistence>>,
 }
 
-struct RevisionStoreInner {
-    revisions: Vec<Revision>,
-    active_id: Option<RevisionId>,
-    max_history: usize,
-    /// The next revision ID to assign. Instance-scoped (not a process global)
-    /// so it can be seeded from persisted history at startup, keeping IDs
-    /// monotonic across restarts.
-    next_id: RevisionId,
-}
+struct PersistenceAdapter<'a>(&'a dyn RevisionPersistence);
 
-impl RevisionStoreInner {
-    fn check_concurrency(
-        &self,
-        expected: Option<RevisionId>,
-    ) -> Result<(), RevisionError> {
-        if let Some(expected) = expected {
-            let actual = self.active_id.unwrap_or(0);
-            if actual != expected {
-                return Err(RevisionError::Conflict { expected, actual });
-            }
-        }
-        Ok(())
+impl wanaku_types::revision::RevisionPersistence<Revision> for PersistenceAdapter<'_> {
+    type Error = wanaku_types::persistence::PersistenceError;
+
+    fn load(&self) -> Result<RevisionsSnapshot, Self::Error> {
+        self.0.load()
     }
 
-    fn mark_previous_superseded(&mut self) {
-        if let Some(prev_id) = self.active_id
-            && let Some(prev) = self
-                .revisions
-                .iter_mut()
-                .find(|r| r.metadata.id == prev_id)
-        {
-            prev.metadata.status = ActivationStatus::Superseded;
-        }
-    }
-
-    fn trim_history(&mut self) {
-        while self.revisions.len() > self.max_history {
-            let is_active =
-                self.active_id == Some(self.revisions[0].metadata.id);
-            if is_active && self.revisions.len() <= self.max_history + 1 {
-                break;
-            }
-            if is_active {
-                self.revisions.remove(1);
-            } else {
-                self.revisions.remove(0);
-            }
-        }
+    fn save(&self, snapshot: &RevisionsSnapshot) -> Result<(), Self::Error> {
+        self.0.save(snapshot)
     }
 }
 
@@ -174,12 +110,7 @@ impl RevisionStore {
     #[must_use]
     pub fn with_max_history(max_history: usize) -> Self {
         Self {
-            inner: Arc::new(RwLock::new(RevisionStoreInner {
-                revisions: Vec::new(),
-                active_id: None,
-                max_history,
-                next_id: 1,
-            })),
+            history: RevisionHistory::new(max_history),
             persistence: None,
         }
     }
@@ -189,13 +120,15 @@ impl RevisionStore {
     /// the highest persisted ID so IDs stay monotonic across restarts.
     #[must_use]
     pub fn with_persistence(backend: Arc<dyn RevisionPersistence>) -> Self {
+        Self::with_max_history_and_persistence(DEFAULT_MAX_HISTORY, backend)
+    }
+
+    fn with_max_history_and_persistence(
+        max_history: usize,
+        backend: Arc<dyn RevisionPersistence>,
+    ) -> Self {
         let store = Self {
-            inner: Arc::new(RwLock::new(RevisionStoreInner {
-                revisions: Vec::new(),
-                active_id: None,
-                max_history: DEFAULT_MAX_HISTORY,
-                next_id: 1,
-            })),
+            history: RevisionHistory::new(max_history),
             persistence: Some(backend),
         };
         store.load_persisted();
@@ -209,31 +142,25 @@ impl RevisionStore {
         let Some(backend) = self.persistence.as_ref() else {
             return;
         };
-        let snapshot = match backend.load() {
+        let adapter = PersistenceAdapter(backend.as_ref());
+        let snapshot = match wanaku_types::revision::RevisionPersistence::load(&adapter) {
             Ok(s) => s,
             Err(e) => {
                 tracing::error!(error = %e, "failed to load persisted evaluator revisions; starting empty");
                 return;
             }
         };
-        let Ok(mut guard) = self.inner.write() else {
+        let count = snapshot.revisions.len();
+        let active_id = snapshot.active_id;
+        let next_id = snapshot.next_id;
+        if self.history.restore(snapshot).is_err() {
             tracing::warn!("revision store lock poisoned; persisted revisions not loaded");
             return;
-        };
-        let max_id = snapshot
-            .revisions
-            .iter()
-            .map(|r| r.metadata.id)
-            .max()
-            .unwrap_or(0);
-        guard.next_id = snapshot.next_id.max(max_id.saturating_add(1)).max(1);
-        guard.revisions = snapshot.revisions;
-        guard.active_id = snapshot.active_id;
-        guard.trim_history();
+        }
         tracing::info!(
-            count = guard.revisions.len(),
-            active = ?guard.active_id,
-            next_id = guard.next_id,
+            count,
+            active = ?active_id,
+            next_id,
             "loaded persisted evaluator revisions"
         );
     }
@@ -246,18 +173,12 @@ impl RevisionStore {
         let Some(backend) = self.persistence.as_ref() else {
             return;
         };
-        let snapshot = {
-            let Ok(guard) = self.inner.read() else {
-                tracing::warn!("revision store lock poisoned; skipping persist");
-                return;
-            };
-            RevisionsSnapshot {
-                revisions: guard.revisions.clone(),
-                active_id: guard.active_id,
-                next_id: guard.next_id,
-            }
+        let Ok(snapshot) = self.history.snapshot() else {
+            tracing::warn!("revision store lock poisoned; skipping persist");
+            return;
         };
-        if let Err(e) = backend.save(&snapshot) {
+        let adapter = PersistenceAdapter(backend.as_ref());
+        if let Err(e) = wanaku_types::revision::RevisionPersistence::save(&adapter, &snapshot) {
             tracing::error!(error = %e, "failed to persist evaluator revisions");
         }
     }
@@ -271,42 +192,22 @@ impl RevisionStore {
 
     /// Return the currently active revision, if any.
     pub fn active_revision(&self) -> Option<Revision> {
-        let guard = self.inner.read().ok()?;
-        let active_id = guard.active_id?;
-        guard
-            .revisions
-            .iter()
-            .find(|r| r.metadata.id == active_id)
-            .cloned()
+        self.history.active_revision()
     }
 
     /// Return the ID of the currently active revision, if any.
     pub fn active_revision_id(&self) -> Option<RevisionId> {
-        self.inner.read().ok().and_then(|g| g.active_id)
+        self.history.active_revision_id()
     }
 
     /// List all stored revisions, newest first.
     pub fn list_revisions(&self) -> Vec<RevisionMetadata> {
-        self.inner
-            .read()
-            .map(|guard| {
-                let mut metas: Vec<_> =
-                    guard.revisions.iter().map(|r| r.metadata.clone()).collect();
-                metas.sort_by_key(|m| std::cmp::Reverse(m.id));
-                metas
-            })
-            .unwrap_or_default()
+        self.history.list_metadata()
     }
 
     /// Retrieve a specific revision by ID.
     pub fn get_revision(&self, id: RevisionId) -> Option<Revision> {
-        self.inner.read().ok().and_then(|guard| {
-            guard
-                .revisions
-                .iter()
-                .find(|r| r.metadata.id == id)
-                .cloned()
-        })
+        self.history.get(id)
     }
 
     /// Record a new revision with the given evaluator definitions and origin.
@@ -340,28 +241,11 @@ impl RevisionStore {
         &self,
         params: &RecordRevisionParams,
     ) -> Result<Revision, RevisionError> {
-        let Ok(mut guard) = self.inner.write() else {
-            return Err(RevisionError::ValidationFailed(
-                "internal lock error".to_owned(),
-            ));
-        };
-
-        guard.check_concurrency(params.expected_revision)?;
-
-        // Allocate the ID before committing it, so a checksum failure in
-        // build_revision leaves next_id untouched (no gaps).
-        let id = guard.next_id;
-        let revision = build_revision(id, params)?;
-        guard.next_id = id.saturating_add(1);
-
-        if params.activate {
-            guard.mark_previous_superseded();
-            guard.active_id = Some(id);
-        }
-
-        guard.revisions.push(revision.clone());
-        guard.trim_history();
-        Ok(revision)
+        self.history
+            .commit(params.expected_revision, params.activate, |id| {
+                build_revision(id, params)
+            })
+            .map_err(map_history_error)
     }
 
     /// Restore a previous revision by creating a new revision with the same
@@ -382,14 +266,36 @@ impl RevisionStore {
 
         // Verify the optimistic concurrency precondition before the caller
         // tries to activate.
-        if let Some(expected) = expected_revision {
-            let actual = self.active_revision_id().unwrap_or(0);
-            if actual != expected {
-                return Err(RevisionError::Conflict { expected, actual });
-            }
-        }
+        self.history
+            .check_concurrency(expected_revision)
+            .map_err(RevisionError::from)?;
 
         Ok(defs)
+    }
+}
+
+fn map_history_error(error: RevisionHistoryError<RevisionError>) -> RevisionError {
+    match error {
+        RevisionHistoryError::Conflict { expected, actual } => {
+            RevisionError::Conflict { expected, actual }
+        }
+        RevisionHistoryError::Build(error) => error,
+        RevisionHistoryError::Lock => {
+            RevisionError::ValidationFailed("internal lock error".to_owned())
+        }
+    }
+}
+
+impl From<RevisionHistoryError<()>> for RevisionError {
+    fn from(error: RevisionHistoryError<()>) -> Self {
+        match error {
+            RevisionHistoryError::Conflict { expected, actual } => {
+                Self::Conflict { expected, actual }
+            }
+            RevisionHistoryError::Build(()) | RevisionHistoryError::Lock => {
+                Self::ValidationFailed("internal lock error".to_owned())
+            }
+        }
     }
 }
 
@@ -449,12 +355,9 @@ pub fn config_checksum(defs: &[EvaluatorDef]) -> Option<String> {
 /// bounded history absorbs it and checksums are stable again thereafter. A
 /// stronger hash is not worth a new dependency for this use.
 fn compute_checksum(defs: &[EvaluatorDef]) -> Result<String, RevisionError> {
-    let json = serde_json::to_string(defs).map_err(|e| {
+    wanaku_types::revision::checksum(&defs).map_err(|e| {
         RevisionError::ValidationFailed(format!("failed to serialize evaluator config: {e}"))
-    })?;
-    let mut hasher = DefaultHasher::new();
-    json.hash(&mut hasher);
-    Ok(format!("{:016x}", hasher.finish()))
+    })
 }
 
 #[cfg(test)]
@@ -768,13 +671,14 @@ mod tests {
     impl RevisionPersistence for MemoryPersistence {
         fn load(&self) -> Result<RevisionsSnapshot, PersistenceError> {
             let guard = self.saved.lock().unwrap();
-            let snapshot = guard.as_ref().map_or_else(RevisionsSnapshot::default, |s| {
-                RevisionsSnapshot {
-                    revisions: s.revisions.clone(),
-                    active_id: s.active_id,
-                    next_id: s.next_id,
-                }
-            });
+            let snapshot =
+                guard
+                    .as_ref()
+                    .map_or_else(RevisionsSnapshot::default, |s| RevisionsSnapshot {
+                        revisions: s.revisions.clone(),
+                        active_id: s.active_id,
+                        next_id: s.next_id,
+                    });
             Ok(snapshot)
         }
 
@@ -850,14 +754,7 @@ mod tests {
         let backend = Arc::new(MemoryPersistence::default());
 
         // Record more than the history bound so early IDs are trimmed away.
-        let store = {
-            let s = RevisionStore::with_persistence(backend.clone());
-            // Shrink the bound so the test stays small.
-            if let Ok(mut g) = s.inner.write() {
-                g.max_history = 3;
-            }
-            s
-        };
+        let store = RevisionStore::with_max_history_and_persistence(3, backend.clone());
         for i in 0..5 {
             store
                 .record_revision(&active_params(
@@ -866,12 +763,7 @@ mod tests {
                 ))
                 .unwrap();
         }
-        let highest = store
-            .list_revisions()
-            .iter()
-            .map(|m| m.id)
-            .max()
-            .unwrap();
+        let highest = store.list_revisions().iter().map(|m| m.id).max().unwrap();
 
         // Restart and record again: the new ID must exceed the highest ever
         // assigned, not just the highest still in the trimmed history.

--- a/features/evaluator/src/revision_persistence.rs
+++ b/features/evaluator/src/revision_persistence.rs
@@ -14,26 +14,14 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
 use wanaku_types::persistence::PersistenceError;
 
-use crate::revision::{Revision, RevisionId};
+use crate::revision::Revision;
 
 /// The persistent form of a revision store: the full history plus the active
 /// revision ID and the next revision counter needed to resume ID assignment
 /// after a restart.
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct RevisionsSnapshot {
-    #[serde(default)]
-    pub revisions: Vec<Revision>,
-    #[serde(default)]
-    pub active_id: Option<RevisionId>,
-    /// The next revision ID to assign. Persisted so IDs stay monotonic across
-    /// restarts even after history trimming removes the highest-numbered
-    /// revisions from `revisions`.
-    #[serde(default)]
-    pub next_id: RevisionId,
-}
+pub type RevisionsSnapshot = wanaku_types::revision::RevisionSnapshot<Revision>;
 
 /// A backend that loads and stores evaluator revision history.
 pub trait RevisionPersistence: Send + Sync {
@@ -99,8 +87,9 @@ mod tests {
 
     #[test]
     fn load_missing_file_returns_empty() {
-        let backend =
-            FileRevisionPersistence::new("/tmp/wanaku-nonexistent-revisions/evaluator-revisions.json");
+        let backend = FileRevisionPersistence::new(
+            "/tmp/wanaku-nonexistent-revisions/evaluator-revisions.json",
+        );
         let snapshot = backend.load();
         assert!(snapshot.is_ok(), "loading missing file should return Ok");
         if let Ok(s) = snapshot {

--- a/filters/src/json_rpc.rs
+++ b/filters/src/json_rpc.rs
@@ -1,39 +1,234 @@
 use bytes::Bytes;
+use serde_json::{Map, Value};
+use thiserror::Error;
 
-/// Method-specific fields parsed from a JSON-RPC request's `params` object.
+/// A parsed JSON-RPC request with fallible, typed MCP adapters.
 ///
-/// The request `id` is deliberately not part of this struct: it is read once
-/// from `mcp.id` metadata (set by `McpIdFilter`) rather than re-parsed here.
+/// Parsing occurs once. Accessors borrow values from the parsed request and do
+/// not convert missing or malformed fields to empty values.
+pub struct McpRequestView {
+    request: Map<String, Value>,
+}
+
+impl McpRequestView {
+    /// Parse a complete buffered JSON-RPC request body.
+    pub fn parse(body: Option<&Bytes>) -> Result<Self, RequestViewError> {
+        let body = body.ok_or(RequestViewError::MissingBody)?;
+        let value: Value = serde_json::from_slice(body)
+            .map_err(|error| RequestViewError::MalformedJson(error.to_string()))?;
+        let Value::Object(request) = value else {
+            return Err(RequestViewError::RequestNotObject);
+        };
+        Ok(Self { request })
+    }
+
+    pub fn method(&self) -> Result<&str, RequestViewError> {
+        required_string(&self.request, "method")
+    }
+
+    pub fn tool_call(&self) -> Result<ToolCallRequest<'_>, RequestViewError> {
+        self.require_method("tools/call")?;
+        Ok(ToolCallRequest {
+            name: self.required_param_string("name")?,
+            arguments: self.optional_param_object("arguments")?,
+        })
+    }
+
+    pub fn resource_read(&self) -> Result<ResourceReadRequest<'_>, RequestViewError> {
+        self.require_method("resources/read")?;
+        Ok(ResourceReadRequest {
+            uri: self.required_param_string("uri")?,
+        })
+    }
+
+    pub fn prompt_get(&self) -> Result<PromptGetRequest<'_>, RequestViewError> {
+        self.require_method("prompts/get")?;
+        Ok(PromptGetRequest {
+            name: self.required_param_string("name")?,
+            arguments: self.optional_param_object("arguments")?,
+        })
+    }
+
+    fn params(&self) -> Result<&Map<String, Value>, RequestViewError> {
+        match self.request.get("params") {
+            None => Err(RequestViewError::MissingParams),
+            Some(Value::Object(params)) => Ok(params),
+            Some(_) => Err(RequestViewError::ParamsNotObject),
+        }
+    }
+
+    fn require_method(&self, expected: &'static str) -> Result<(), RequestViewError> {
+        let actual = self.method()?;
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(RequestViewError::UnexpectedMethod {
+                expected,
+                actual: actual.to_owned(),
+            })
+        }
+    }
+
+    fn required_param_string(&self, field: &'static str) -> Result<&str, RequestViewError> {
+        required_string(self.params()?, field)
+    }
+
+    fn optional_param_string(&self, field: &'static str) -> Result<Option<&str>, RequestViewError> {
+        optional_string(self.params()?, field)
+    }
+
+    fn optional_param_object(
+        &self,
+        field: &'static str,
+    ) -> Result<Option<&Map<String, Value>>, RequestViewError> {
+        match self.params()?.get(field) {
+            None => Ok(None),
+            Some(Value::Object(value)) => Ok(Some(value)),
+            Some(_) => Err(RequestViewError::InvalidFieldType {
+                field,
+                expected: "object",
+            }),
+        }
+    }
+}
+
+/// A validated `tools/call` request view.
+pub struct ToolCallRequest<'a> {
+    name: &'a str,
+    arguments: Option<&'a Map<String, Value>>,
+}
+
+impl ToolCallRequest<'_> {
+    #[must_use]
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    #[must_use]
+    pub const fn arguments(&self) -> Option<&Map<String, Value>> {
+        self.arguments
+    }
+}
+
+/// A validated `resources/read` request view.
+pub struct ResourceReadRequest<'a> {
+    uri: &'a str,
+}
+
+impl ResourceReadRequest<'_> {
+    #[must_use]
+    pub const fn uri(&self) -> &str {
+        self.uri
+    }
+}
+
+/// A validated `prompts/get` request view.
+pub struct PromptGetRequest<'a> {
+    name: &'a str,
+    arguments: Option<&'a Map<String, Value>>,
+}
+
+impl PromptGetRequest<'_> {
+    #[must_use]
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    #[must_use]
+    pub const fn arguments(&self) -> Option<&Map<String, Value>> {
+        self.arguments
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RequestViewError {
+    #[error("request body is missing")]
+    MissingBody,
+    #[error("request body is not valid JSON: {0}")]
+    MalformedJson(String),
+    #[error("JSON-RPC request must be an object")]
+    RequestNotObject,
+    #[error("JSON-RPC params are missing")]
+    MissingParams,
+    #[error("JSON-RPC params must be an object")]
+    ParamsNotObject,
+    #[error("expected JSON-RPC method '{expected}', got '{actual}'")]
+    UnexpectedMethod {
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("required field '{0}' is missing")]
+    MissingField(&'static str),
+    #[error("field '{field}' must be a {expected}")]
+    InvalidFieldType {
+        field: &'static str,
+        expected: &'static str,
+    },
+}
+
+fn required_string<'a>(
+    object: &'a Map<String, Value>,
+    field: &'static str,
+) -> Result<&'a str, RequestViewError> {
+    match object.get(field) {
+        None => Err(RequestViewError::MissingField(field)),
+        Some(Value::String(value)) => Ok(value),
+        Some(_) => Err(RequestViewError::InvalidFieldType {
+            field,
+            expected: "string",
+        }),
+    }
+}
+
+fn optional_string<'a>(
+    object: &'a Map<String, Value>,
+    field: &'static str,
+) -> Result<Option<&'a str>, RequestViewError> {
+    match object.get(field) {
+        None => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(RequestViewError::InvalidFieldType {
+            field,
+            expected: "string",
+        }),
+    }
+}
+
+/// Compatibility parser for existing filters. New governed filters must use
+/// [`McpRequestView`] so malformed input remains distinguishable.
 #[derive(Default)]
 pub(crate) struct JsonRpcParams {
     pub(crate) name: Option<String>,
     pub(crate) uri: Option<String>,
-    pub(crate) arguments: serde_json::Map<String, serde_json::Value>,
+    pub(crate) arguments: Map<String, Value>,
 }
 
 impl JsonRpcParams {
     pub(crate) fn parse(body: &Option<Bytes>) -> Self {
-        let Some(body_bytes) = body else {
+        let Ok(view) = McpRequestView::parse(body.as_ref()) else {
             return Self::default();
         };
-
-        let Ok(value) = serde_json::from_slice::<serde_json::Value>(body_bytes) else {
-            return Self::default();
-        };
-
-        let Some(params) = value.get("params") else {
-            return Self::default();
-        };
-
-        let name = params.get("name").and_then(serde_json::Value::as_str).map(str::to_owned);
-        let uri = params.get("uri").and_then(serde_json::Value::as_str).map(str::to_owned);
-        let arguments = params
-            .get("arguments")
-            .and_then(serde_json::Value::as_object)
+        let name = view
+            .optional_param_string("name")
+            .ok()
+            .flatten()
+            .map(str::to_owned);
+        let uri = view
+            .optional_param_string("uri")
+            .ok()
+            .flatten()
+            .map(str::to_owned);
+        let arguments = view
+            .optional_param_object("arguments")
+            .ok()
+            .flatten()
             .cloned()
             .unwrap_or_default();
-
-        Self { name, uri, arguments }
+        Self {
+            name,
+            uri,
+            arguments,
+        }
     }
 }
 
@@ -41,81 +236,190 @@ impl JsonRpcParams {
 mod tests {
     use super::*;
 
+    fn body(value: &str) -> Option<Bytes> {
+        Some(Bytes::copy_from_slice(value.as_bytes()))
+    }
+
     #[test]
-    fn parse_all_fields_present() {
-        let body = Some(Bytes::from(
-            r#"{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"summarize","uri":"file:///x","arguments":{"topic":"rust"}}}"#,
+    fn adapters_preserve_typed_arguments() -> Result<(), Box<dyn std::error::Error>> {
+        let request = body(
+            r#"{"method":"tools/call","params":{"name":"lookup","arguments":{"null":null,"false":false,"zero":0,"empty":"","nested":{"a":1}}}}"#,
+        );
+        let view = McpRequestView::parse(request.as_ref())?;
+        let call = view.tool_call()?;
+        let arguments = call.arguments().ok_or("missing arguments")?;
+
+        assert_eq!(view.method()?, "tools/call");
+        assert_eq!(call.name(), "lookup");
+        assert_eq!(arguments.get("null"), Some(&Value::Null));
+        assert_eq!(arguments.get("false"), Some(&serde_json::json!(false)));
+        assert_eq!(arguments.get("zero"), Some(&serde_json::json!(0)));
+        assert_eq!(arguments.get("empty"), Some(&serde_json::json!("")));
+        assert_eq!(arguments.get("nested"), Some(&serde_json::json!({"a": 1})));
+        Ok(())
+    }
+
+    #[test]
+    fn supports_resource_and_prompt_adapters() -> Result<(), Box<dyn std::error::Error>> {
+        let resource = body(r#"{"method":"resources/read","params":{"uri":"file:///safe/item"}}"#);
+        let resource_view = McpRequestView::parse(resource.as_ref())?;
+        assert_eq!(resource_view.resource_read()?.uri(), "file:///safe/item");
+
+        let prompt = body(r#"{"method":"prompts/get","params":{"name":"summary"}}"#);
+        let prompt_view = McpRequestView::parse(prompt.as_ref())?;
+        let prompt = prompt_view.prompt_get()?;
+        assert_eq!(prompt.name(), "summary");
+        assert!(prompt.arguments().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn distinguishes_body_and_request_errors() {
+        assert_eq!(
+            McpRequestView::parse(None).err(),
+            Some(RequestViewError::MissingBody)
+        );
+        assert!(matches!(
+            McpRequestView::parse(body("not json").as_ref()),
+            Err(RequestViewError::MalformedJson(_))
         ));
-        let params = JsonRpcParams::parse(&body);
-        assert_eq!(params.name.as_deref(), Some("summarize"));
+        assert_eq!(
+            McpRequestView::parse(body("[]").as_ref()).err(),
+            Some(RequestViewError::RequestNotObject)
+        );
+    }
+
+    #[test]
+    fn distinguishes_missing_and_non_object_params() -> Result<(), Box<dyn std::error::Error>> {
+        let missing = body(r#"{"method":"tools/call"}"#);
+        let view = McpRequestView::parse(missing.as_ref())?;
+        assert_eq!(
+            view.tool_call().err(),
+            Some(RequestViewError::MissingParams)
+        );
+
+        let invalid = body(r#"{"method":"tools/call","params":null}"#);
+        let view = McpRequestView::parse(invalid.as_ref())?;
+        assert_eq!(
+            view.tool_call().err(),
+            Some(RequestViewError::ParamsNotObject)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn distinguishes_missing_and_wrong_method_types() -> Result<(), Box<dyn std::error::Error>> {
+        let missing = body(r#"{"params":{}}"#);
+        let view = McpRequestView::parse(missing.as_ref())?;
+        assert_eq!(
+            view.method().err(),
+            Some(RequestViewError::MissingField("method"))
+        );
+        assert_eq!(
+            view.tool_call().err(),
+            Some(RequestViewError::MissingField("method"))
+        );
+
+        let invalid = body(r#"{"method":7,"params":{}}"#);
+        let view = McpRequestView::parse(invalid.as_ref())?;
+        assert_eq!(
+            view.method().err(),
+            Some(RequestViewError::InvalidFieldType {
+                field: "method",
+                expected: "string",
+            })
+        );
+        assert_eq!(
+            view.tool_call().err(),
+            Some(RequestViewError::InvalidFieldType {
+                field: "method",
+                expected: "string",
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_request_through_the_wrong_adapter() -> Result<(), Box<dyn std::error::Error>> {
+        let request = body(r#"{"method":"prompts/get","params":{"name":"summary"}}"#);
+        let view = McpRequestView::parse(request.as_ref())?;
+        assert_eq!(
+            view.tool_call().err(),
+            Some(RequestViewError::UnexpectedMethod {
+                expected: "tools/call",
+                actual: "prompts/get".to_owned(),
+            })
+        );
+        assert_eq!(
+            view.resource_read().err(),
+            Some(RequestViewError::UnexpectedMethod {
+                expected: "resources/read",
+                actual: "prompts/get".to_owned(),
+            })
+        );
+        assert!(view.prompt_get().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "field error matrix")]
+    fn distinguishes_missing_and_wrong_field_types() -> Result<(), Box<dyn std::error::Error>> {
+        for (request, expected) in [
+            (
+                r#"{"method":"tools/call","params":{"arguments":{}}}"#,
+                RequestViewError::MissingField("name"),
+            ),
+            (
+                r#"{"method":"tools/call","params":{"name":99}}"#,
+                RequestViewError::InvalidFieldType {
+                    field: "name",
+                    expected: "string",
+                },
+            ),
+            (
+                r#"{"method":"tools/call","params":{"name":"tool","arguments":null}}"#,
+                RequestViewError::InvalidFieldType {
+                    field: "arguments",
+                    expected: "object",
+                },
+            ),
+        ] {
+            let request = body(request);
+            let view = McpRequestView::parse(request.as_ref())?;
+            assert_eq!(view.tool_call().err(), Some(expected));
+        }
+
+        let missing_uri = body(r#"{"method":"resources/read","params":{}}"#);
+        let view = McpRequestView::parse(missing_uri.as_ref())?;
+        assert_eq!(
+            view.resource_read().err(),
+            Some(RequestViewError::MissingField("uri"))
+        );
+        let wrong_uri = body(r#"{"method":"resources/read","params":{"uri":false}}"#);
+        let view = McpRequestView::parse(wrong_uri.as_ref())?;
+        assert_eq!(
+            view.resource_read().err(),
+            Some(RequestViewError::InvalidFieldType {
+                field: "uri",
+                expected: "string",
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn compatibility_parser_keeps_existing_lossy_behavior() {
+        let malformed = body("not json");
+        let params = JsonRpcParams::parse(&malformed);
+        assert!(params.name.is_none());
+        assert!(params.uri.is_none());
+        assert!(params.arguments.is_empty());
+
+        let complete =
+            body(r#"{"params":{"name":"summary","uri":"file:///x","arguments":{"count":42}}}"#);
+        let params = JsonRpcParams::parse(&complete);
+        assert_eq!(params.name.as_deref(), Some("summary"));
         assert_eq!(params.uri.as_deref(), Some("file:///x"));
-        assert_eq!(params.arguments.get("topic"), Some(&serde_json::json!("rust")));
-    }
-
-    #[test]
-    fn parse_arguments_with_non_string_values() {
-        let body = Some(Bytes::from(
-            r#"{"params":{"arguments":{"count":42,"flag":true,"nested":{"a":1}}}}"#,
-        ));
-        let params = JsonRpcParams::parse(&body);
         assert_eq!(params.arguments.get("count"), Some(&serde_json::json!(42)));
-        assert_eq!(params.arguments.get("flag"), Some(&serde_json::json!(true)));
-        assert_eq!(params.arguments.get("nested"), Some(&serde_json::json!({"a": 1})));
-    }
-
-    #[test]
-    fn parse_missing_params() {
-        let body = Some(Bytes::from(r#"{"id":1}"#));
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.name.is_none());
-        assert!(params.uri.is_none());
-        assert!(params.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_none_body() {
-        let params = JsonRpcParams::parse(&None);
-        assert!(params.name.is_none());
-        assert!(params.uri.is_none());
-        assert!(params.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_malformed_json() {
-        let body = Some(Bytes::from("not json"));
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.name.is_none());
-        assert!(params.uri.is_none());
-        assert!(params.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_empty_bytes() {
-        let body = Some(Bytes::new());
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.name.is_none());
-        assert!(params.uri.is_none());
-        assert!(params.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_arguments_is_not_object() {
-        let body = Some(Bytes::from(r#"{"params":{"arguments":"not-an-object"}}"#));
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.arguments.is_empty());
-    }
-
-    #[test]
-    fn parse_uri_is_not_string() {
-        let body = Some(Bytes::from(r#"{"params":{"uri":123}}"#));
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.uri.is_none());
-    }
-
-    #[test]
-    fn parse_name_is_not_string() {
-        let body = Some(Bytes::from(r#"{"params":{"name":99}}"#));
-        let params = JsonRpcParams::parse(&body);
-        assert!(params.name.is_none());
     }
 }

--- a/filters/src/json_rpc.rs
+++ b/filters/src/json_rpc.rs
@@ -49,7 +49,8 @@ impl McpRequestView {
         })
     }
 
-    fn params(&self) -> Result<&Map<String, Value>, RequestViewError> {
+    /// Return the typed JSON-RPC params object.
+    pub fn params(&self) -> Result<&Map<String, Value>, RequestViewError> {
         match self.request.get("params") {
             None => Err(RequestViewError::MissingParams),
             Some(Value::Object(params)) => Ok(params),

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -46,6 +46,24 @@ fn matches_uri_template(template: &str, uri: &str) -> bool {
     pos == uri.len()
 }
 
+/// Resolve the registry resource used for one exact requested URI.
+///
+/// The returned entry can use either an exact location or a URI template.
+#[must_use]
+pub fn find_resource_in_namespace(
+    registry: &InMemoryRegistry,
+    namespace: &str,
+    uri: &str,
+) -> Option<wanaku_types::registry::ResourceEntry> {
+    registry
+        .list_resources_in_namespace(namespace)
+        .into_iter()
+        .find(|resource| {
+            (!resource.is_template() && resource.location == uri)
+                || (resource.is_template() && matches_uri_template(&resource.location, uri))
+        })
+}
+
 struct ParsedBody {
     id: serde_json::Value,
     uri: Option<String>,
@@ -89,20 +107,13 @@ impl ResourceReadFilter {
             return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
         };
 
-        let resources = registry.list_resources_in_namespace(namespace);
-        let resource = resources.iter().find(|r| !r.is_template() && r.location == resource_uri)
-            .or_else(|| resources.iter().find(|r| r.is_template() && matches_uri_template(&r.location, resource_uri)));
-
-        let resource = match resource {
-            Some(r) => r.clone(),
-            None => {
-                warn!(uri = %resource_uri, namespace = %namespace, "resource not found in registry");
-                return Ok(crate::response::json_rpc_error(
-                    &parsed.id,
-                    crate::response::JSONRPC_INVALID_PARAMS,
-                    &format!("resource not found: {resource_uri}"),
-                ));
-            }
+        let Some(resource) = find_resource_in_namespace(registry, namespace, resource_uri) else {
+            warn!(uri = %resource_uri, namespace = %namespace, "resource not found in registry");
+            return Ok(crate::response::json_rpc_error(
+                &parsed.id,
+                crate::response::JSONRPC_INVALID_PARAMS,
+                &format!("resource not found: {resource_uri}"),
+            ));
         };
 
         if resource.is_mcp_forward() {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { workspace = true }
 wanaku-infra = { workspace = true, features = ["openapi"] }
 wanaku-types = { workspace = true, features = ["openapi"] }
 wanaku-filters = { workspace = true }
+wanaku-feature-action-policy = { workspace = true }
 wanaku-feature-evaluator = { workspace = true }
 wanaku-feature-intercept = { workspace = true }
 wanaku-feature-mcp-metadata = { workspace = true }

--- a/server/src/default.yaml
+++ b/server/src/default.yaml
@@ -19,6 +19,7 @@ filter_chains:
       - filter: wanaku_namespace
       - filter: wanaku_well_known
       - filter: wanaku_mcp_init
+      - filter: wanaku_action_policy
       - filter: wanaku_evaluator
       - filter: wanaku_tool_list
       - filter: wanaku_tool_call

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -285,6 +285,38 @@ mod tests {
         assert_eq!(inference_host_header_value(&env), "127.0.0.1:11434");
     }
 
+    #[test]
+    fn action_policy_runs_before_evaluator() {
+        let yaml: Value =
+            serde_yaml::from_str(super::DEFAULT_CONFIG).expect("default.yaml must parse");
+        let chains = yaml["filter_chains"]
+            .as_sequence()
+            .expect("filter chains");
+        let router = chains
+            .iter()
+            .find(|chain| chain["name"].as_str() == Some("mcp_router"))
+            .expect("MCP router");
+        let filters: Vec<&str> = router["filters"]
+            .as_sequence()
+            .expect("filters")
+            .iter()
+            .filter_map(|entry| entry["filter"].as_str())
+            .collect();
+        let policy = filters
+            .iter()
+            .position(|name| *name == "wanaku_action_policy")
+            .expect("action-policy filter");
+        let init = filters
+            .iter()
+            .position(|name| *name == "wanaku_mcp_init")
+            .expect("MCP init filter");
+        let evaluator = filters
+            .iter()
+            .position(|name| *name == "wanaku_evaluator")
+            .expect("evaluator filter");
+        assert!(init < policy && policy < evaluator);
+    }
+
     /// Guards against the `headers`/`request_set`/`Host` lookup silently
     /// drifting out of sync with `default.yaml` (e.g. a filter rename or
     /// reorder) and falling back to the unpatched placeholder value.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -161,6 +161,7 @@ fn build_features(
         Box::new(wanaku_feature_metrics::MetricsFeature::new(metrics_store.clone())),
         Box::new(wanaku_feature_intercept::InterceptFeature::new()),
         Box::new(wanaku_feature_mcp_metadata::McpMetadataFeature::new()),
+        Box::new(wanaku_feature_action_policy::ActionPolicyFeature::new()),
         Box::new(evaluator),
         Box::new(wanaku_feature_plugins::PluginsFeature::new(args.plugins_path.as_deref())),
     ]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -148,6 +148,13 @@ fn build_features(
     args: &ServerArgs,
     metrics_store: &wanaku_infra::metrics::MetricsStore,
 ) -> Vec<Box<dyn Feature>> {
+    let mut action_policy = wanaku_feature_action_policy::ActionPolicyFeature::new();
+    if let Some(backend) =
+        wanaku_feature_action_policy::revision_persistence::FileRevisionPersistence::from_config()
+    {
+        info!("action policy revision persistence enabled");
+        action_policy = action_policy.with_revision_persistence(backend);
+    }
     let mut evaluator = wanaku_feature_evaluator::EvaluatorFeature::new()
         .with_metrics(metrics_store.clone());
     if let Some(backend) =
@@ -161,7 +168,7 @@ fn build_features(
         Box::new(wanaku_feature_metrics::MetricsFeature::new(metrics_store.clone())),
         Box::new(wanaku_feature_intercept::InterceptFeature::new()),
         Box::new(wanaku_feature_mcp_metadata::McpMetadataFeature::new()),
-        Box::new(wanaku_feature_action_policy::ActionPolicyFeature::new()),
+        Box::new(action_policy),
         Box::new(evaluator),
         Box::new(wanaku_feature_plugins::PluginsFeature::new(args.plugins_path.as_deref())),
     ]

--- a/tests/e2e/ui/pages/action-policies.page.ts
+++ b/tests/e2e/ui/pages/action-policies.page.ts
@@ -1,0 +1,20 @@
+import { type Locator, type Page } from "@playwright/test";
+import { BasePage } from "./base.page";
+
+export class ActionPoliciesPage extends BasePage {
+  constructor(page: Page, baseUrl: string) {
+    super(page, baseUrl);
+  }
+
+  async goto() {
+    await this.navigateTo("/action-policies");
+  }
+
+  activePolicy(): Locator {
+    return this.page.getByRole("region", { name: "Active policy" });
+  }
+
+  revisionHistory(): Locator {
+    return this.page.getByRole("region", { name: "Revision history" });
+  }
+}

--- a/tests/e2e/ui/tests/action-policies.spec.ts
+++ b/tests/e2e/ui/tests/action-policies.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { ActionPoliciesPage } from "../pages/action-policies.page";
+
+const routerUrl = process.env.WANAKU_ROUTER_URL ?? "http://localhost:8080";
+const activeRevision = {
+  id: 1,
+  created_at: "2026-08-27T10:00:00Z",
+  activated_at: "2026-08-27T10:00:00Z",
+  status: "active",
+  checksum: "test-checksum",
+  origin: "startup",
+  actor: null,
+  failure_reason: null,
+};
+const policy = {
+  rules: [{
+    id: "protect-production",
+    description: "Protect production services",
+    effect: "deny",
+    selectors: { operation: "tools/call", target_type: "tool", target_name: { matcher: "glob", value: "restart*" } },
+    predicates: [{ operator: "equals", pointer: "/arguments/service", value: "production" }],
+    reason_code: "production_restart_denied",
+    message: "Production restarts are not permitted.",
+    metadata: { owner: "platform" },
+  }],
+};
+
+test.describe("Action Policies", () => {
+  let policies: ActionPoliciesPage;
+
+  test.beforeEach(async ({ page }) => {
+    policies = new ActionPoliciesPage(page, `${routerUrl}/admin/`);
+  });
+
+  test("displays the active policy and revision history", async ({ page }) => {
+    await page.route("**/api/v1/action-policies", (route) => route.fulfill({ json: { data: { revision: activeRevision, policy } } }));
+    await page.route("**/api/v1/action-policies/revisions", (route) => route.fulfill({ json: { data: [activeRevision] } }));
+    await page.route("**/api/v1/action-policies/revisions/1", (route) => route.fulfill({ json: { data: { revision: activeRevision, policy } } }));
+    await policies.goto();
+    await expect.poll(() => policies.getPageTitle()).toBe("Action Policies");
+    await expect(policies.activePolicy()).toContainText("Revision");
+    await expect(policies.activePolicy()).toContainText("Rules");
+    await expect(policies.revisionHistory()).toBeVisible();
+    await policies.activePolicy().getByRole("button", { name: /protect-production/ }).click();
+    await expect(policies.activePolicy()).toContainText("production_restart_denied");
+    await expect(policies.activePolicy()).toContainText("/arguments/service");
+  });
+
+  test("displays rejected revisions when no policy is active", async ({ page }) => {
+    const rejectedRevision = {
+      ...activeRevision,
+      id: 2,
+      activated_at: null,
+      status: "rejected",
+      failure_reason: "rule selectors must not be empty",
+    };
+    await page.route("**/api/v1/action-policies", (route) => route.fulfill({ status: 404, json: { error: "no action policy revision found" } }));
+    await page.route("**/api/v1/action-policies/revisions", (route) => route.fulfill({ json: { data: [rejectedRevision] } }));
+    await page.route("**/api/v1/action-policies/revisions/2", (route) => route.fulfill({ json: { data: { revision: rejectedRevision, policy } } }));
+
+    await policies.goto();
+
+    await expect(policies.activePolicy()).toContainText("No active policy");
+    await expect(policies.revisionHistory()).toContainText("Revision 2 — rejected");
+    await policies.revisionHistory().getByRole("button", { name: /Revision 2/ }).click();
+    await expect(policies.revisionHistory()).toContainText("rule selectors must not be empty");
+    await expect(policies.revisionHistory()).toContainText("protect-production");
+  });
+});

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod mcp;
 pub mod metadata;
 pub mod persistence;
 pub mod registry;
+pub mod revision;
 pub mod time;
 
 pub use metadata::{MCP_ID_KEY, MCP_METHOD_KEY, MCP_NAME_KEY, NAMESPACE_METADATA_KEY};

--- a/types/src/revision.rs
+++ b/types/src/revision.rs
@@ -1,0 +1,398 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+pub type RevisionId = u64;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RevisionOrigin {
+    Startup,
+    Api,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivationStatus {
+    Active,
+    Superseded,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevisionMetadata {
+    pub id: RevisionId,
+    pub created_at: String,
+    pub activated_at: Option<String>,
+    pub status: ActivationStatus,
+    pub checksum: String,
+    pub origin: RevisionOrigin,
+    pub actor: Option<String>,
+    pub failure_reason: Option<String>,
+}
+
+pub trait RevisionRecord: Clone {
+    fn metadata(&self) -> &RevisionMetadata;
+    fn metadata_mut(&mut self) -> &mut RevisionMetadata;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "R: Serialize", deserialize = "R: Deserialize<'de>"))]
+pub struct RevisionSnapshot<R> {
+    #[serde(default)]
+    pub revisions: Vec<R>,
+    #[serde(default)]
+    pub active_id: Option<RevisionId>,
+    #[serde(default)]
+    pub next_id: RevisionId,
+}
+
+impl<R> Default for RevisionSnapshot<R> {
+    fn default() -> Self {
+        Self {
+            revisions: Vec::new(),
+            active_id: None,
+            next_id: 0,
+        }
+    }
+}
+
+/// Persistence contract for one independent revision stream.
+pub trait RevisionPersistence<R>: Send + Sync {
+    type Error;
+
+    fn load(&self) -> Result<RevisionSnapshot<R>, Self::Error>;
+    fn save(&self, snapshot: &RevisionSnapshot<R>) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevisionHistoryError<E> {
+    Conflict {
+        expected: RevisionId,
+        actual: RevisionId,
+    },
+    Build(E),
+    Lock,
+}
+
+#[derive(Clone)]
+pub struct RevisionHistory<R> {
+    inner: Arc<RwLock<RevisionHistoryInner<R>>>,
+}
+
+struct RevisionHistoryInner<R> {
+    revisions: Vec<R>,
+    active_id: Option<RevisionId>,
+    max_history: usize,
+    next_id: RevisionId,
+}
+
+impl<R: RevisionRecord> RevisionHistory<R> {
+    #[must_use]
+    pub fn new(max_history: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(RevisionHistoryInner {
+                revisions: Vec::new(),
+                active_id: None,
+                max_history,
+                next_id: 1,
+            })),
+        }
+    }
+
+    pub fn restore(&self, snapshot: RevisionSnapshot<R>) -> Result<(), RevisionHistoryError<()>> {
+        let mut guard = self.inner.write().map_err(|_| RevisionHistoryError::Lock)?;
+        let max_id = snapshot
+            .revisions
+            .iter()
+            .map(|revision| revision.metadata().id)
+            .max()
+            .unwrap_or(0);
+        guard.next_id = snapshot.next_id.max(max_id.saturating_add(1)).max(1);
+        guard.revisions = snapshot.revisions;
+        guard.active_id = snapshot.active_id;
+        trim_history(&mut guard);
+        Ok(())
+    }
+
+    pub fn snapshot(&self) -> Result<RevisionSnapshot<R>, RevisionHistoryError<()>> {
+        let guard = self.inner.read().map_err(|_| RevisionHistoryError::Lock)?;
+        Ok(RevisionSnapshot {
+            revisions: guard.revisions.clone(),
+            active_id: guard.active_id,
+            next_id: guard.next_id,
+        })
+    }
+
+    pub fn commit<E>(
+        &self,
+        expected: Option<RevisionId>,
+        activate: bool,
+        build: impl FnOnce(RevisionId) -> Result<R, E>,
+    ) -> Result<R, RevisionHistoryError<E>> {
+        let mut guard = self.inner.write().map_err(|_| RevisionHistoryError::Lock)?;
+        check_concurrency(&guard, expected)?;
+        let id = guard.next_id;
+        let mut revision = build(id).map_err(RevisionHistoryError::Build)?;
+        revision.metadata_mut().id = id;
+        revision.metadata_mut().status = if activate {
+            ActivationStatus::Active
+        } else {
+            ActivationStatus::Rejected
+        };
+        guard.next_id = id.saturating_add(1);
+        if activate {
+            mark_previous_superseded(&mut guard);
+            guard.active_id = Some(id);
+        }
+        guard.revisions.push(revision.clone());
+        trim_history(&mut guard);
+        Ok(revision)
+    }
+
+    pub fn check_concurrency(
+        &self,
+        expected: Option<RevisionId>,
+    ) -> Result<(), RevisionHistoryError<()>> {
+        let guard = self.inner.read().map_err(|_| RevisionHistoryError::Lock)?;
+        check_concurrency(&guard, expected)
+    }
+
+    #[must_use]
+    pub fn active_revision(&self) -> Option<R> {
+        let guard = self.inner.read().ok()?;
+        let active_id = guard.active_id?;
+        guard
+            .revisions
+            .iter()
+            .find(|revision| revision.metadata().id == active_id)
+            .cloned()
+    }
+
+    #[must_use]
+    pub fn active_revision_id(&self) -> Option<RevisionId> {
+        self.inner.read().ok().and_then(|guard| guard.active_id)
+    }
+
+    #[must_use]
+    pub fn list_metadata(&self) -> Vec<RevisionMetadata> {
+        self.inner
+            .read()
+            .map(|guard| {
+                let mut metadata: Vec<_> = guard
+                    .revisions
+                    .iter()
+                    .map(|revision| revision.metadata().clone())
+                    .collect();
+                metadata.sort_by_key(|entry| std::cmp::Reverse(entry.id));
+                metadata
+            })
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn get(&self, id: RevisionId) -> Option<R> {
+        self.inner.read().ok().and_then(|guard| {
+            guard
+                .revisions
+                .iter()
+                .find(|revision| revision.metadata().id == id)
+                .cloned()
+        })
+    }
+}
+
+fn check_concurrency<R, E>(
+    history: &RevisionHistoryInner<R>,
+    expected: Option<RevisionId>,
+) -> Result<(), RevisionHistoryError<E>> {
+    if let Some(expected) = expected {
+        let actual = history.active_id.unwrap_or(0);
+        if actual != expected {
+            return Err(RevisionHistoryError::Conflict { expected, actual });
+        }
+    }
+    Ok(())
+}
+
+fn mark_previous_superseded<R: RevisionRecord>(history: &mut RevisionHistoryInner<R>) {
+    if let Some(active_id) = history.active_id
+        && let Some(previous) = history
+            .revisions
+            .iter_mut()
+            .find(|revision| revision.metadata().id == active_id)
+    {
+        previous.metadata_mut().status = ActivationStatus::Superseded;
+    }
+}
+
+fn trim_history<R: RevisionRecord>(history: &mut RevisionHistoryInner<R>) {
+    while history.revisions.len() > history.max_history {
+        let active_is_oldest = history.active_id == Some(history.revisions[0].metadata().id);
+        if active_is_oldest && history.revisions.len() <= history.max_history.saturating_add(1) {
+            break;
+        }
+        if active_is_oldest {
+            history.revisions.remove(1);
+        } else {
+            history.revisions.remove(0);
+        }
+    }
+}
+
+/// Compute the checksum used by all revision streams.
+pub fn checksum<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    let json = serde_json::to_string(value)?;
+    let mut hasher = DefaultHasher::new();
+    json.hash(&mut hasher);
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestRevision {
+        metadata: RevisionMetadata,
+        value: String,
+    }
+
+    impl RevisionRecord for TestRevision {
+        fn metadata(&self) -> &RevisionMetadata {
+            &self.metadata
+        }
+
+        fn metadata_mut(&mut self) -> &mut RevisionMetadata {
+            &mut self.metadata
+        }
+    }
+
+    fn build(id: RevisionId, value: &str, active: bool) -> TestRevision {
+        TestRevision {
+            metadata: RevisionMetadata {
+                id,
+                created_at: String::new(),
+                activated_at: None,
+                status: if active {
+                    ActivationStatus::Active
+                } else {
+                    ActivationStatus::Rejected
+                },
+                checksum: value.to_owned(),
+                origin: RevisionOrigin::Api,
+                actor: None,
+                failure_reason: None,
+            },
+            value: value.to_owned(),
+        }
+    }
+
+    #[test]
+    fn commit_is_bounded_and_supersedes_previous() {
+        let history = RevisionHistory::new(2);
+        for value in ["one", "two", "three"] {
+            assert!(
+                history
+                    .commit(None, true, |id| Ok::<_, ()>(build(id, value, true)))
+                    .is_ok()
+            );
+        }
+        let entries = history.list_metadata();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].status, ActivationStatus::Active);
+        assert_eq!(entries[1].status, ActivationStatus::Superseded);
+    }
+
+    #[test]
+    fn concurrency_and_restore_keep_ids_monotonic() {
+        let history = RevisionHistory::new(5);
+        let first = history
+            .commit(None, true, |id| Ok::<_, ()>(build(id, "one", true)))
+            .ok();
+        let Some(first) = first else {
+            return;
+        };
+        assert!(matches!(
+            history.check_concurrency(Some(first.metadata.id + 1)),
+            Err(RevisionHistoryError::Conflict { .. })
+        ));
+        let snapshot = history.snapshot().ok();
+        let Some(snapshot) = snapshot else {
+            return;
+        };
+        let restored = RevisionHistory::new(5);
+        assert!(restored.restore(snapshot).is_ok());
+        let next = restored
+            .commit(None, true, |id| Ok::<_, ()>(build(id, "two", true)))
+            .ok();
+        assert!(next.is_some_and(|entry| entry.metadata.id > first.metadata.id));
+    }
+
+    #[test]
+    fn lookup_and_checksum_are_stable() {
+        let history = RevisionHistory::new(5);
+        let revision = history
+            .commit(None, true, |id| Ok::<_, ()>(build(id, "value", true)))
+            .ok();
+        let Some(revision) = revision else {
+            return;
+        };
+        assert_eq!(
+            history.get(revision.metadata.id).map(|entry| entry.value),
+            Some("value".to_owned())
+        );
+        let first_checksum = checksum(&vec!["value"]);
+        let second_checksum = checksum(&vec!["value"]);
+        assert!(matches!(
+            (first_checksum, second_checksum),
+            (Ok(first), Ok(second)) if first == second
+        ));
+    }
+
+    #[test]
+    fn commit_corrects_builder_owned_id_and_status() {
+        let history = RevisionHistory::new(5);
+        let active = history
+            .commit(None, true, |id| {
+                let mut revision = build(id + 99, "active", false);
+                revision.metadata.status = ActivationStatus::Superseded;
+                Ok::<_, ()>(revision)
+            })
+            .ok();
+        assert!(active.is_some_and(|revision| {
+            revision.metadata.id == 1 && revision.metadata.status == ActivationStatus::Active
+        }));
+
+        let rejected = history
+            .commit(None, false, |id| {
+                Ok::<_, ()>(build(id + 99, "rejected", true))
+            })
+            .ok();
+        assert!(rejected.is_some_and(|revision| {
+            revision.metadata.id == 2 && revision.metadata.status == ActivationStatus::Rejected
+        }));
+    }
+
+    #[test]
+    fn histories_have_independent_ids_and_active_state() {
+        let first = RevisionHistory::new(5);
+        let second = RevisionHistory::new(5);
+        let first_revision = first
+            .commit(None, true, |id| Ok::<_, ()>(build(id, "first", true)))
+            .ok();
+        let second_revision = second
+            .commit(None, false, |id| Ok::<_, ()>(build(id, "second", false)))
+            .ok();
+
+        assert_eq!(first_revision.map(|revision| revision.metadata.id), Some(1));
+        assert_eq!(
+            second_revision.map(|revision| revision.metadata.id),
+            Some(1)
+        );
+        assert_eq!(first.active_revision_id(), Some(1));
+        assert_eq!(second.active_revision_id(), None);
+    }
+}

--- a/ui/admin/src/Pages/ActionPolicies/ActionPoliciesPage.scss
+++ b/ui/admin/src/Pages/ActionPolicies/ActionPoliciesPage.scss
@@ -1,0 +1,39 @@
+@use "@carbon/react/scss/spacing" as *;
+@use "@carbon/react/scss/theme" as *;
+
+.action-policies {
+  padding: $spacing-07;
+
+  h2 { margin-bottom: $spacing-05; }
+  h4 { margin: $spacing-05 0 $spacing-03; }
+}
+
+.action-policies__notification { padding: 0 $spacing-07; }
+
+.action-policies__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: $spacing-03;
+  margin-bottom: $spacing-06;
+
+  .cds--tile { display: flex; flex-direction: column; gap: $spacing-03; }
+  span { color: $text-secondary; }
+  strong { overflow-wrap: anywhere; }
+}
+
+.action-policies__history { margin-top: $spacing-08; }
+.policy-rule { padding-bottom: $spacing-05; }
+.policy-rule__tags { display: flex; flex-wrap: wrap; gap: $spacing-03; margin-bottom: $spacing-04; }
+.policy-empty { padding: $spacing-05; color: $text-secondary; }
+.policy-json { padding: $spacing-05; overflow-x: auto; background: $layer-02; }
+
+.revision-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: $spacing-05;
+  margin-bottom: $spacing-06;
+
+  div { display: flex; flex-direction: column; align-items: flex-start; gap: $spacing-03; min-width: 0; }
+  span { color: $text-secondary; }
+  code { overflow-wrap: anywhere; }
+}

--- a/ui/admin/src/Pages/ActionPolicies/ActionPoliciesPage.tsx
+++ b/ui/admin/src/Pages/ActionPolicies/ActionPoliciesPage.tsx
@@ -1,0 +1,105 @@
+import { Accordion, AccordionItem, InlineNotification, Tag, Tile } from "@carbon/react";
+import { useCallback, useEffect, useState } from "react";
+import { PageSkeleton } from "../../components/PageSkeleton";
+import { useActionPolicies, type ActionPolicyRevision } from "../../hooks/api/use-action-policies";
+import { PolicyDetails } from "./PolicyDetails";
+import "./ActionPoliciesPage.scss";
+
+type PageState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; active?: ActionPolicyRevision; revisions: ActionPolicyRevision[] };
+
+const formatDate = (value?: string): string => value ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value)) : "Not activated";
+
+const statusTagType = (status: ActionPolicyRevision["revision"]["status"]): "green" | "gray" | "red" => {
+  if (status === "active") return "green";
+  if (status === "rejected") return "red";
+  return "gray";
+};
+
+export const ActionPoliciesPage = () => {
+  const { getActivePolicy, listRevisions, getRevision } = useActionPolicies();
+  const [state, setState] = useState<PageState>({ status: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const revisionsResponse = await listRevisions();
+      let active: ActionPolicyRevision | undefined;
+      try {
+        active = (await getActivePolicy()).data;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to load the active action policy";
+        if (!message.includes("no action policy revision found")) throw error;
+      }
+      const details = await Promise.all(revisionsResponse.data.map(({ id }) => getRevision(id)));
+      setState({ status: "success", active, revisions: details.map(({ data }) => data) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load action policies";
+      setState({ status: "error", message });
+    }
+  }, [getActivePolicy, getRevision, listRevisions]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  if (state.status === "loading") return <PageSkeleton title="Action Policies" />;
+
+  return (
+    <div>
+      <h1 className="title">Action Policies</h1>
+      <p className="description">Review the active policy and its revision history. Policies are read-only in the admin UI.</p>
+
+      {state.status === "error" ? (
+        <div className="action-policies__notification">
+          <InlineNotification kind="error" title="Action policies are unavailable" subtitle={state.message} lowContrast hideCloseButton />
+        </div>
+      ) : (
+        <div id="page-content" className="action-policies">
+          <section aria-labelledby="active-policy-heading">
+            <h2 id="active-policy-heading">Active policy</h2>
+            {state.active ? (
+              <>
+                <div className="action-policies__summary">
+                  <Tile><span>Revision</span><strong>{state.active.revision.id}</strong></Tile>
+                  <Tile><span>Status</span><Tag type={statusTagType(state.active.revision.status)}>{state.active.revision.status}</Tag></Tile>
+                  <Tile><span>Rules</span><strong>{state.active.policy.rules.length}</strong></Tile>
+                  <Tile><span>Activated</span><strong>{formatDate(state.active.revision.activated_at)}</strong></Tile>
+                </div>
+                <PolicyDetails policy={state.active.policy} />
+              </>
+            ) : (
+              <Tile>
+                <h3>No active policy</h3>
+                <p>No policy revision is currently active.</p>
+              </Tile>
+            )}
+          </section>
+
+          <section aria-labelledby="revision-history-heading" className="action-policies__history">
+            <h2 id="revision-history-heading">Revision history</h2>
+            {state.revisions.length === 0 ? <Tile>No policy revisions are available.</Tile> : (
+              <Accordion align="start">
+                {state.revisions.map(({ revision, policy }) => (
+                  <AccordionItem key={revision.id} title={`Revision ${revision.id} — ${revision.status}`}>
+                    <div className="revision-details">
+                      <div><span>Status</span><Tag type={statusTagType(revision.status)}>{revision.status}</Tag></div>
+                      <div><span>Origin</span><strong>{revision.origin}</strong></div>
+                      <div><span>Created</span><strong>{formatDate(revision.created_at)}</strong></div>
+                      <div><span>Activated</span><strong>{formatDate(revision.activated_at)}</strong></div>
+                      <div><span>Checksum</span><code>{revision.checksum}</code></div>
+                      {revision.actor && <div><span>Actor</span><strong>{revision.actor}</strong></div>}
+                      {revision.failure_reason && <div><span>Failure reason</span><strong>{revision.failure_reason}</strong></div>}
+                    </div>
+                    <h4>Policy rules</h4>
+                    <PolicyDetails policy={policy} />
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/admin/src/Pages/ActionPolicies/PolicyDetails.tsx
+++ b/ui/admin/src/Pages/ActionPolicies/PolicyDetails.tsx
@@ -1,0 +1,80 @@
+import { Accordion, AccordionItem, StructuredListBody, StructuredListCell, StructuredListRow, StructuredListWrapper, Tag } from "@carbon/react";
+import type { ActionPolicy, ActionPolicyRule, JsonValue, PolicyPredicate } from "../../hooks/api/use-action-policies";
+
+interface PolicyDetailsProps {
+  policy: ActionPolicy;
+}
+
+const displayJson = (value: JsonValue | undefined): string => value === undefined ? "—" : JSON.stringify(value);
+
+const selectorEntries = (rule: ActionPolicyRule): Array<[string, string]> => {
+  const { selectors } = rule;
+  const entries: Array<[string, string]> = [];
+  if (selectors.namespace) entries.push(["Namespace", selectors.namespace]);
+  if (selectors.operation) entries.push(["Operation", selectors.operation]);
+  if (selectors.target_type) entries.push(["Target type", selectors.target_type]);
+  if (selectors.target_name) entries.push(["Target name", `${selectors.target_name.matcher}: ${selectors.target_name.value}`]);
+  if (selectors.uri) entries.push(["URI", `${selectors.uri.matcher}: ${selectors.uri.value}`]);
+  Object.entries(selectors.labels ?? {}).forEach(([key, value]) => entries.push([`Label: ${key}`, value]));
+  return entries;
+};
+
+const predicateValue = (predicate: PolicyPredicate): string =>
+  predicate.values ? displayJson(predicate.values) : displayJson(predicate.value);
+
+const RuleDetails = ({ rule }: { rule: ActionPolicyRule }) => (
+  <div className="policy-rule">
+    <div className="policy-rule__tags">
+      <Tag type={rule.effect === "deny" ? "red" : "green"}>{rule.effect}</Tag>
+      {rule.reason_code && <Tag type="gray">{rule.reason_code}</Tag>}
+    </div>
+    {rule.description && <p>{rule.description}</p>}
+    {rule.message && <p><strong>Caller message:</strong> {rule.message}</p>}
+
+    <h4>Selectors</h4>
+    <StructuredListWrapper aria-label={`Selectors for ${rule.id}`}>
+      <StructuredListBody>
+        {selectorEntries(rule).map(([name, value]) => (
+          <StructuredListRow key={name}>
+            <StructuredListCell>{name}</StructuredListCell>
+            <StructuredListCell>{value}</StructuredListCell>
+          </StructuredListRow>
+        ))}
+      </StructuredListBody>
+    </StructuredListWrapper>
+
+    <h4>Predicates</h4>
+    {(rule.predicates ?? []).length === 0 ? <p>None</p> : (
+      <StructuredListWrapper aria-label={`Predicates for ${rule.id}`}>
+        <StructuredListBody>
+          {(rule.predicates ?? []).map((predicate, index) => (
+            <StructuredListRow key={`${predicate.pointer}-${index}`}>
+              <StructuredListCell>{predicate.pointer}</StructuredListCell>
+              <StructuredListCell>{predicate.operator}</StructuredListCell>
+              <StructuredListCell>{predicateValue(predicate)}</StructuredListCell>
+            </StructuredListRow>
+          ))}
+        </StructuredListBody>
+      </StructuredListWrapper>
+    )}
+
+    <h4>Metadata</h4>
+    {Object.keys(rule.metadata ?? {}).length === 0 ? <p>None</p> : (
+      <pre className="policy-json">{JSON.stringify(rule.metadata, null, 2)}</pre>
+    )}
+  </div>
+);
+
+export const PolicyDetails = ({ policy }: PolicyDetailsProps) => {
+  if (policy.rules.length === 0) return <p className="policy-empty">This policy has no rules.</p>;
+
+  return (
+    <Accordion align="start">
+      {policy.rules.map((rule) => (
+        <AccordionItem key={rule.id} title={`${rule.id} — ${rule.effect}`}>
+          <RuleDetails rule={rule} />
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+};

--- a/ui/admin/src/Pages/ActionPolicies/index.ts
+++ b/ui/admin/src/Pages/ActionPolicies/index.ts
@@ -1,0 +1,1 @@
+export * from "./router-exports";

--- a/ui/admin/src/Pages/ActionPolicies/router-exports.tsx
+++ b/ui/admin/src/Pages/ActionPolicies/router-exports.tsx
@@ -1,0 +1,3 @@
+import { ActionPoliciesPage } from "./ActionPoliciesPage";
+
+export const Component = ActionPoliciesPage;

--- a/ui/admin/src/hooks/api/use-action-policies.ts
+++ b/ui/admin/src/hooks/api/use-action-policies.ts
@@ -1,0 +1,81 @@
+import { useCallback } from "react";
+import { customFetch } from "../../custom-fetch";
+
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export interface MatchExpression {
+  matcher: "exact" | "glob" | "prefix";
+  value: string;
+}
+
+export interface PolicySelectors {
+  namespace?: string;
+  operation?: string;
+  target_type?: "tool" | "resource" | "prompt";
+  target_name?: MatchExpression;
+  labels?: Record<string, string>;
+  uri?: MatchExpression;
+}
+
+export interface PolicyPredicate {
+  operator: "exists" | "equals" | "not_equals" | "one_of" | "not_one_of";
+  pointer: string;
+  value?: JsonValue;
+  values?: JsonValue[];
+}
+
+export interface ActionPolicyRule {
+  id: string;
+  description?: string;
+  effect: "allow" | "deny";
+  selectors: PolicySelectors;
+  predicates?: PolicyPredicate[];
+  reason_code?: string;
+  message?: string;
+  metadata?: Record<string, JsonValue>;
+}
+
+export interface ActionPolicy {
+  rules: ActionPolicyRule[];
+}
+
+export interface RevisionMetadata {
+  id: number;
+  created_at: string;
+  activated_at?: string;
+  status: "active" | "superseded" | "rejected";
+  checksum: string;
+  origin: "startup" | "api";
+  actor?: string;
+  failure_reason?: string;
+}
+
+export interface ActionPolicyRevision {
+  revision: RevisionMetadata;
+  policy: ActionPolicy;
+}
+
+interface ApiResponse<T> {
+  status: number;
+  data: T;
+  headers: Headers;
+}
+
+export const useActionPolicies = () => {
+  const getActivePolicy = useCallback(
+    () => customFetch<ApiResponse<ActionPolicyRevision>>("/api/v1/action-policies", { method: "GET" }),
+    [],
+  );
+
+  const listRevisions = useCallback(
+    () => customFetch<ApiResponse<RevisionMetadata[]>>("/api/v1/action-policies/revisions", { method: "GET" }),
+    [],
+  );
+
+  const getRevision = useCallback(
+    (id: number) => customFetch<ApiResponse<ActionPolicyRevision>>(`/api/v1/action-policies/revisions/${id}`, { method: "GET" }),
+    [],
+  );
+
+  return { getActivePolicy, listRevisions, getRevision };
+};

--- a/ui/admin/src/navigation/core-nav-items.ts
+++ b/ui/admin/src/navigation/core-nav-items.ts
@@ -12,6 +12,7 @@ export const CORE_NAV_ITEMS: NavItem[] = [
   { id: "namespaces", label: "Namespaces", route: Links.Namespaces, source: "core", order: 60 },
   { id: "forwards", label: "Forwards", route: Links.Forwards, source: "core", order: 70 },
   { id: "evaluators", label: "Evaluators", route: Links.Evaluators, source: "core", order: 80 },
+  { id: "action-policies", label: "Action Policies", route: Links.ActionPolicies, source: "core", section: "Admin", order: 89 },
   { id: "plugins", label: "Installed Plugins", route: Links.Plugins, source: "core", section: "Admin", order: 90 },
 
   { id: "downloads", label: "CLI Downloads", route: Links.Downloads, source: "core", order: 100 },

--- a/ui/admin/src/router.tsx
+++ b/ui/admin/src/router.tsx
@@ -66,6 +66,10 @@ export function buildRouter(pluginPages: PluginPage[]) {
           lazy: async () => import("./Pages/Evaluators"),
         },
         {
+          path: Links.ActionPolicies,
+          lazy: async () => import("./Pages/ActionPolicies"),
+        },
+        {
           path: Links.Plugins,
           lazy: async () => import("./Pages/Plugins"),
         },

--- a/ui/admin/src/router/links.models.ts
+++ b/ui/admin/src/router/links.models.ts
@@ -9,6 +9,7 @@ export const enum Links {
   Namespaces = "/namespaces",
   Forwards = "/forwards",
   Evaluators = "/evaluators",
+  ActionPolicies = "/action-policies",
   Plugins = "/plugins-admin",
   Downloads = "/downloads",
   Logout = "/logout"


### PR DESCRIPTION
## Summary

- add an extensible action-policy schema, selector matcher interface, and typed JSON predicates
- add deterministic deny-overrides evaluation and fallible MCP request views
- enforce policies before the evaluator for tools/call, resources/read, and prompts/get
- add independent revision history, persistence, and management API routes
- add a read-only Admin UI for active policy details and revision history
- document the policy model, current fail-closed posture, deferred integrations, and API

## Validation

- cargo build
- cargo test
- yarn build (ui/admin)
- focused Action Policies ESLint and TypeScript checks
- Playwright Action Policies suite (2 tests)
- git diff --check upstream/main..HEAD

Closes #1870
Closes #1900
Closes #1901
Closes #1902
Closes #1903
Closes #1904
Closes #1905
Closes #1906

Related to #1869, #383, #1872, #1875, #503, and #1331.

Generated by Codex via OSS Helper