### PR TITLE
Update Keycloak image version to 26.7.2

### DIFF
--- a/deploy/auth/docker-compose-auth.yml
+++ b/deploy/auth/docker-compose-auth.yml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.6.1
+    image: quay.io/keycloak/keycloak:26.7.2
     command: ["start-dev", "--import-realm"]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update the deployed Keycloak container to version 26.7.2.