### PR TITLE
feat(ui): add CLI downloads page to the web UI

### DIFF
--- a/tests/e2e/ui/pages/downloads.page.ts
+++ b/tests/e2e/ui/pages/downloads.page.ts
@@ -1,0 +1,20 @@
+import { type Page, type Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class DownloadsPage extends BasePage {
+  constructor(page: Page, baseUrl: string) {
+    super(page, baseUrl);
+  }
+
+  async goto() {
+    await this.navigateTo('/downloads');
+  }
+
+  downloadButtons(): Locator {
+    return this.page.getByRole('link', { name: 'Download' });
+  }
+
+  viewAllPackagesLink(): Locator {
+    return this.page.getByRole('link', { name: /View all packages/ });
+  }
+}

--- a/tests/e2e/ui/tests/downloads.spec.ts
+++ b/tests/e2e/ui/tests/downloads.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import { DownloadsPage } from '../pages/downloads.page';
+
+const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
+
+test.describe('CLI Downloads', () => {
+  let downloads: DownloadsPage;
+
+  test.beforeEach(async ({ page }) => {
+    downloads = new DownloadsPage(page, `${routerUrl}/admin/`);
+  });
+
+  test('displays page title', async () => {
+    await downloads.goto();
+    const title = await downloads.getPageTitle();
+    expect(title).toBe('CLI Downloads');
+  });
+
+  test('lists CLI packages with download links', async () => {
+    await downloads.goto();
+    await expect(downloads.downloadButtons().first()).toBeVisible({ timeout: 5_000 });
+    expect(await downloads.downloadButtons().count()).toBeGreaterThan(0);
+  });
+
+  test('links to the full release page', async () => {
+    await downloads.goto();
+    await expect(downloads.viewAllPackagesLink()).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/ui/admin/src/Pages/Downloads/DownloadsPage.tsx
+++ b/ui/admin/src/Pages/Downloads/DownloadsPage.tsx
@@ -1,0 +1,55 @@
+import {Button, Column, Grid, Link} from "@carbon/react";
+import {Launch} from "@carbon/icons-react";
+import React from "react";
+import {CLI_DOWNLOADS, CLI_RELEASE_PAGE, CLI_RELEASE_TAG} from "./downloads";
+import {DownloadsTable} from "./DownloadsTable";
+
+export const DownloadsPage: React.FC = () => {
+  return (
+    <div>
+      <h1 className="title">CLI Downloads</h1>
+      <p className="description">
+        Wanaku provides its command line interface (CLI) in multiple packages.
+        Some packages are portable Java packages that run on any operating system
+        with a compatible Java runtime, while others are self-contained native
+        binaries built for a specific platform. Pick the package that matches your
+        environment and follow the accompanying instructions to install it.
+      </p>
+      <div id="page-content">
+        <Grid narrow>
+          <Column lg={16} md={8} sm={4}>
+            <DownloadsTable downloads={CLI_DOWNLOADS} />
+          </Column>
+          <Column lg={16} md={8} sm={4} style={{marginTop: "1rem"}}>
+            <p style={{color: "var(--cds-text-secondary)", marginBottom: "0.5rem"}}>
+              Looking for a different platform or an older version? Browse every
+              published artifact on the release page.
+            </p>
+            <Button
+              kind="ghost"
+              size="sm"
+              renderIcon={Launch}
+              href={CLI_RELEASE_PAGE}
+              target="_blank"
+              rel="noopener noreferrer"
+              as="a"
+            >
+              View all packages ({CLI_RELEASE_TAG})
+            </Button>
+            <p style={{color: "var(--cds-text-secondary)", marginTop: "1rem", fontSize: "0.75rem"}}>
+              After downloading, verify the file against the{" "}
+              <Link
+                href={`${CLI_RELEASE_PAGE.replace("/tag/", "/download/")}/checksums_sha256.txt`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                published checksums
+              </Link>
+              .
+            </p>
+          </Column>
+        </Grid>
+      </div>
+    </div>
+  );
+};

--- a/ui/admin/src/Pages/Downloads/DownloadsTable.tsx
+++ b/ui/admin/src/Pages/Downloads/DownloadsTable.tsx
@@ -1,0 +1,84 @@
+import {Download} from "@carbon/icons-react";
+import {
+  Button,
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tag,
+} from "@carbon/react";
+import {FunctionComponent} from "react";
+import {CliDownload} from "./downloads";
+import {TableEmptyState} from "../EmptyTableState";
+
+interface DownloadsTableProps {
+  downloads: CliDownload[];
+}
+
+export const DownloadsTable: FunctionComponent<DownloadsTableProps> = ({downloads}) => {
+  const headers = [
+    {key: "name", header: "Package"},
+    {key: "kind", header: "Type"},
+    {key: "platform", header: "Platform"},
+    {key: "runtime", header: "Runtime"},
+    {key: "notes", header: "Notes"},
+    {key: "download", header: "Download"},
+  ];
+
+  return (
+    <DataTable headers={headers} rows={downloads.map((entry) => ({...entry, id: entry.id}))}>
+      {({getTableProps, getHeaderProps, getRowProps, headers}) => (
+        <TableContainer>
+          <Table {...getTableProps()}>
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableHeader {...getHeaderProps({header})}>{header.header}</TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {downloads.map((entry) => (
+                <TableRow {...getRowProps({row: {id: entry.id} as never})} key={entry.id}>
+                  <TableCell>{entry.name}</TableCell>
+                  <TableCell>
+                    <Tag type={entry.kind === "java" ? "purple" : "blue"} size="sm">
+                      {entry.kind === "java" ? "Java" : "Native"}
+                    </Tag>
+                  </TableCell>
+                  <TableCell>{entry.platform}</TableCell>
+                  <TableCell>{entry.runtime}</TableCell>
+                  <TableCell>{entry.notes ?? "—"}</TableCell>
+                  <TableCell>
+                    <Button
+                      kind="tertiary"
+                      size="sm"
+                      renderIcon={Download}
+                      href={entry.downloadUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      as="a"
+                    >
+                      Download
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {downloads.length === 0 && (
+                <TableEmptyState
+                  colSpan={headers.length}
+                  title="No CLI packages available"
+                  body="Check the release page for the latest packages"
+                />
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+  );
+};

--- a/ui/admin/src/Pages/Downloads/downloads.ts
+++ b/ui/admin/src/Pages/Downloads/downloads.ts
@@ -39,13 +39,34 @@ export interface CliDownload {
 export const CLI_REPO = "wanaku-ai/wanaku-barn";
 
 /**
- * Release tag the downloads point at. The `early-access` tag always tracks the
- * latest published build, which keeps the links stable across releases.
+ * The version of the CLI packages. Keep this in sync with the Wanaku project
+ * version (see the workspace `Cargo.toml` and `ui/admin/package.json`).
  */
-export const CLI_RELEASE_TAG = "early-access";
+export const CLI_VERSION = "0.3.0";
 
-/** The version of the CLI packages currently published under the release tag. */
-export const CLI_VERSION = "0.3.0-SNAPSHOT";
+/**
+ * The release channel the downloads point at.
+ *
+ * - `early-access` tracks the latest pre-release build. It is published under
+ *   the fixed `early-access` tag, and its artifacts carry the `-SNAPSHOT`
+ *   suffix (for example `wanaku-cli-0.3.0-SNAPSHOT.zip`).
+ * - `stable` points at the tagged release for {@link CLI_VERSION}. It is
+ *   published under the `v<version>` tag (for example `v0.3.0`), and its
+ *   artifacts use the plain version (for example `wanaku-cli-0.3.0.zip`).
+ */
+export type ReleaseChannel = "early-access" | "stable";
+export const CLI_RELEASE_CHANNEL: ReleaseChannel = "early-access";
+
+const isEarlyAccess = CLI_RELEASE_CHANNEL === "early-access";
+
+/**
+ * Release tag the downloads point at. Derived from the selected channel so the
+ * links stay correct for both early-access and stable releases.
+ */
+export const CLI_RELEASE_TAG = isEarlyAccess ? "early-access" : `v${CLI_VERSION}`;
+
+/** The artifact version used in the published file names for the channel. */
+const ARTIFACT_VERSION = isEarlyAccess ? `${CLI_VERSION}-SNAPSHOT` : CLI_VERSION;
 
 /** Page that lists every asset of the referenced release. */
 export const CLI_RELEASE_PAGE = `https://github.com/${CLI_REPO}/releases/tag/${CLI_RELEASE_TAG}`;
@@ -66,8 +87,8 @@ export const CLI_DOWNLOADS: CliDownload[] = [
     kind: "java",
     runtime: "Java 21+",
     platform: "Any (JVM)",
-    fileName: `wanaku-cli-${CLI_VERSION}.zip`,
-    downloadUrl: downloadUrl(`wanaku-cli-${CLI_VERSION}.zip`),
+    fileName: `wanaku-cli-${ARTIFACT_VERSION}.zip`,
+    downloadUrl: downloadUrl(`wanaku-cli-${ARTIFACT_VERSION}.zip`),
     notes: "Portable package. Requires a Java 21+ runtime installed on your machine.",
   },
   {
@@ -76,8 +97,8 @@ export const CLI_DOWNLOADS: CliDownload[] = [
     kind: "native",
     runtime: "Native (no runtime required)",
     platform: "Linux x86_64",
-    fileName: `wanaku-cli-${CLI_VERSION}-linux-x86_64.zip`,
-    downloadUrl: downloadUrl(`wanaku-cli-${CLI_VERSION}-linux-x86_64.zip`),
+    fileName: `wanaku-cli-${ARTIFACT_VERSION}-linux-x86_64.zip`,
+    downloadUrl: downloadUrl(`wanaku-cli-${ARTIFACT_VERSION}-linux-x86_64.zip`),
     notes: "Self-contained binary. Unzip, make it executable and move it into your PATH.",
   },
 ];

--- a/ui/admin/src/Pages/Downloads/downloads.ts
+++ b/ui/admin/src/Pages/Downloads/downloads.ts
@@ -1,0 +1,83 @@
+/**
+ * Static, front-end model of the CLI packages that Wanaku publishes.
+ *
+ * Wanaku ships its CLI in more than one flavour: a self-contained native
+ * binary for a specific platform and a portable Java package that runs on any
+ * operating system that has a compatible JVM installed. A single download link
+ * cannot represent all of those options, so the page below lists every package
+ * and lets the user pick the one that matches their environment.
+ *
+ * The CLI is released from the companion `wanaku-barn` repository. The entries
+ * are intentionally kept as a plain, extensible array: adding support for new
+ * platforms (for example native macOS or Linux aarch64 builds) is just a matter
+ * of adding new objects to {@link CLI_DOWNLOADS}.
+ */
+
+/** Distinguishes portable Java packages from platform-specific native binaries. */
+export type CliPackageKind = "native" | "java";
+
+export interface CliDownload {
+  /** Stable identifier, also used as the table row id and in tests. */
+  id: string;
+  /** Human friendly package name. */
+  name: string;
+  /** Whether the package is a native binary or a Java (JVM) package. */
+  kind: CliPackageKind;
+  /** The runtime the package needs, e.g. "Native (no runtime required)". */
+  runtime: string;
+  /** The supported operating system / architecture. */
+  platform: string;
+  /** The name of the artifact as published in the release. */
+  fileName: string;
+  /** Direct download URL for the artifact. */
+  downloadUrl: string;
+  /** Optional extra guidance shown to the user. */
+  notes?: string;
+}
+
+/** The GitHub repository that publishes the Wanaku CLI packages. */
+export const CLI_REPO = "wanaku-ai/wanaku-barn";
+
+/**
+ * Release tag the downloads point at. The `early-access` tag always tracks the
+ * latest published build, which keeps the links stable across releases.
+ */
+export const CLI_RELEASE_TAG = "early-access";
+
+/** The version of the CLI packages currently published under the release tag. */
+export const CLI_VERSION = "0.3.0-SNAPSHOT";
+
+/** Page that lists every asset of the referenced release. */
+export const CLI_RELEASE_PAGE = `https://github.com/${CLI_REPO}/releases/tag/${CLI_RELEASE_TAG}`;
+
+const downloadUrl = (fileName: string): string =>
+  `https://github.com/${CLI_REPO}/releases/download/${CLI_RELEASE_TAG}/${fileName}`;
+
+/**
+ * The list of CLI packages available for download.
+ *
+ * Add new native builds (macOS, Linux aarch64, Windows, ...) here as they
+ * become available in the release.
+ */
+export const CLI_DOWNLOADS: CliDownload[] = [
+  {
+    id: "java-universal",
+    name: "Wanaku CLI (Java)",
+    kind: "java",
+    runtime: "Java 21+",
+    platform: "Any (JVM)",
+    fileName: `wanaku-cli-${CLI_VERSION}.zip`,
+    downloadUrl: downloadUrl(`wanaku-cli-${CLI_VERSION}.zip`),
+    notes: "Portable package. Requires a Java 21+ runtime installed on your machine.",
+  },
+  {
+    id: "native-linux-x86_64",
+    name: "Wanaku CLI (native)",
+    kind: "native",
+    runtime: "Native (no runtime required)",
+    platform: "Linux x86_64",
+    fileName: `wanaku-cli-${CLI_VERSION}-linux-x86_64.zip`,
+    downloadUrl: downloadUrl(`wanaku-cli-${CLI_VERSION}-linux-x86_64.zip`),
+    notes: "Self-contained binary. Unzip, make it executable and move it into your PATH.",
+  },
+];

--- a/ui/admin/src/Pages/Downloads/index.ts
+++ b/ui/admin/src/Pages/Downloads/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/ui/admin/src/Pages/Downloads/router-exports.tsx
+++ b/ui/admin/src/Pages/Downloads/router-exports.tsx
@@ -1,0 +1,3 @@
+import {DownloadsPage} from './DownloadsPage';
+
+export const element = <DownloadsPage />;

--- a/ui/admin/src/navigation/core-nav-items.ts
+++ b/ui/admin/src/navigation/core-nav-items.ts
@@ -13,4 +13,6 @@ export const CORE_NAV_ITEMS: NavItem[] = [
   { id: "forwards", label: "Forwards", route: Links.Forwards, source: "core", order: 70 },
   { id: "evaluators", label: "Evaluators", route: Links.Evaluators, source: "core", order: 80 },
   { id: "plugins", label: "Installed Plugins", route: Links.Plugins, source: "core", section: "Admin", order: 90 },
+
+  { id: "downloads", label: "CLI Downloads", route: Links.Downloads, source: "core", order: 100 },
 ];

--- a/ui/admin/src/router.tsx
+++ b/ui/admin/src/router.tsx
@@ -69,6 +69,10 @@ export function buildRouter(pluginPages: PluginPage[]) {
           path: Links.Plugins,
           lazy: async () => import("./Pages/Plugins"),
         },
+        {
+          path: Links.Downloads,
+          lazy: async () => import("./Pages/Downloads"),
+        },
         ...pluginRoutes,
       ],
     },

--- a/ui/admin/src/router/links.models.ts
+++ b/ui/admin/src/router/links.models.ts
@@ -10,6 +10,7 @@ export const enum Links {
   Forwards = "/forwards",
   Evaluators = "/evaluators",
   Plugins = "/plugins-admin",
+  Downloads = "/downloads",
   Logout = "/logout"
 }
 


### PR DESCRIPTION
Closes #1892

## Summary

Wanaku ships its CLI in more than one flavour — a portable **Java** package and platform-specific **native** binaries — so a single download link cannot represent every option. This PR adds a dedicated **CLI Downloads** page to the admin web UI that lists the available packages and helps users pick the right one for their environment, using the OpenShift CLI downloads page as UX inspiration.

## Changes

- **Route constant** — added `Downloads = "/downloads"` in `ui/admin/src/router/links.models.ts`.
- **Route registration** — registered the lazy `/downloads` route in `ui/admin/src/router.tsx`.
- **Navigation** — added a visible **CLI Downloads** nav item in `ui/admin/src/navigation/core-nav-items.ts`.
- **Page** — created `ui/admin/src/Pages/Downloads/` following the established three-file pattern (`index.ts`, `router-exports.tsx`, page component), mirroring `Pages/Tools`:
  - `downloads.ts` — an **extensible front-end array** of CLI packages. Each entry carries `kind` (Java vs native), `runtime`, `platform`, `fileName` and a `downloadUrl`. Adding a new platform is just a matter of appending an object.
  - `DownloadsTable.tsx` — a Carbon `DataTable` that clearly distinguishes Java packages from native binaries (via a `Tag`) and exposes a download button per row.
  - `DownloadsPage.tsx` — the page with a title/description, the table, a link to the full release page (all published artifacts) and a link to the checksums.
- **E2E tests** — added a Playwright page object (`tests/e2e/ui/pages/downloads.page.ts`) and spec (`tests/e2e/ui/tests/downloads.spec.ts`) verifying the page title, the presence of download links, and the "view all packages" link.

## Data source & defaults

The CLI is published from the companion **`wanaku-ai/wanaku-barn`** repository. The current `early-access` release provides:

- `wanaku-cli-<version>.zip` → modelled as the **Java** package (any OS, requires Java 21+)
- `wanaku-cli-<version>-linux-x86_64.zip` → modelled as the **native** Linux x86_64 binary

Sensible defaults were chosen for the two open questions raised during analysis:

1. **Server binaries?** The issue is specifically about *CLI* downloads, so this page lists only CLI packages (not `wanaku-server`). Those remain covered by `get-wanaku.sh` / the getting-started guide.
2. **Versioned vs release-tag links?** Links point at the stable `early-access` release tag so they keep working across releases. A single `CLI_VERSION`/`CLI_RELEASE_TAG` constant makes it trivial to switch to versioned links later.

## Verification

- `tsc -b` — passes
- `eslint` — passes
- `vite build` — succeeds

## Summary by Sourcery

Add an admin UI page for discovering and downloading Wanaku CLI packages across supported environments.

New Features:
- Add a dedicated CLI Downloads page to the admin UI with downloadable Java and native CLI packages, release links, and checksum verification guidance.

Enhancements:
- Expose the downloads page through the admin navigation and lazy-loaded routing.

Tests:
- Add Playwright coverage for the downloads page title, package download links, and full release link.