### PR TITLE
Fix #1892: Add a CLI downloads page to the web UI

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ docker pull quay.io/wanaku/wanaku-server-headless:early-access
 
 ### 2. Download the CLI
 
-The Wanaku CLI is a separate package. Download the latest `wanaku` binary from the [wanaku-barn early access release page](https://github.com/wanaku-ai/wanaku-barn/releases/tag/early-access).
+The Wanaku CLI is a separate package. Download the latest `wanaku` binary from the [wanaku-barn early access release page](https://github.com/wanaku-ai/wanaku-barn/releases/tag/early-access), or use the **CLI Downloads** page in the admin UI (`http://localhost:8080/admin`) to pick the right package for your platform.
 
 ```bash
 chmod +x wanaku

--- a/tests/e2e/ui/pages/cli-downloads.page.ts
+++ b/tests/e2e/ui/pages/cli-downloads.page.ts
@@ -1,0 +1,24 @@
+import { type Page, type Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class CliDownloadsPage extends BasePage {
+  constructor(page: Page, baseUrl: string) {
+    super(page, baseUrl);
+  }
+
+  async goto() {
+    await this.navigateTo('/cli-downloads');
+  }
+
+  sectionHeading(label: string): Locator {
+    return this.page.locator('.cli-package-section-heading', { hasText: label });
+  }
+
+  packageTile(name: string): Locator {
+    return this.page.locator('.cli-package-tile', { hasText: name });
+  }
+
+  downloadLink(tile: Locator): Locator {
+    return tile.locator('a:has-text("Download")');
+  }
+}

--- a/tests/e2e/ui/tests/cli-downloads.spec.ts
+++ b/tests/e2e/ui/tests/cli-downloads.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { CliDownloadsPage } from '../pages/cli-downloads.page';
+
+const routerUrl = process.env.WANAKU_ROUTER_URL ?? 'http://localhost:8080';
+
+test.describe('CLI Downloads', () => {
+  let cliDownloads: CliDownloadsPage;
+
+  test.beforeEach(async ({ page }) => {
+    cliDownloads = new CliDownloadsPage(page, `${routerUrl}/admin/`);
+    await cliDownloads.goto();
+  });
+
+  test('displays page title and description', async () => {
+    const title = await cliDownloads.getPageTitle();
+    expect(title).toBe('CLI Downloads');
+
+    const description = await cliDownloads.getPageDescription();
+    expect(description).toContain('Wanaku CLI');
+  });
+
+  test('distinguishes native and Java packages', async () => {
+    await expect(cliDownloads.sectionHeading('Native Binaries')).toBeVisible();
+    await expect(cliDownloads.sectionHeading('Java Packages')).toBeVisible();
+  });
+
+  test('provides a working download link for each package', async () => {
+    const tile = cliDownloads.packageTile('Wanaku CLI').first();
+    await expect(tile).toBeVisible();
+
+    const link = cliDownloads.downloadLink(tile);
+    await expect(link).toHaveAttribute('href', /.+/);
+    await expect(link).toHaveAttribute('target', '_blank');
+  });
+});

--- a/ui/admin/src/Pages/CliDownloads/CliDownloadsPage.scss
+++ b/ui/admin/src/Pages/CliDownloads/CliDownloadsPage.scss
@@ -1,0 +1,57 @@
+@use '@carbon/react/scss/spacing' as *;
+@use '@carbon/react/scss/theme' as *;
+
+.cli-downloads-page {
+  .cli-package-section {
+    margin-top: $spacing-06;
+  }
+
+  .cli-package-section-heading {
+    font-size: 1rem;
+    font-weight: 600;
+    color: $text-primary;
+    margin-bottom: $spacing-04;
+  }
+
+  .cli-package-grid {
+    margin: 0;
+  }
+
+  .cli-package-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: $spacing-03;
+    height: 100%;
+    margin-bottom: $spacing-05;
+  }
+
+  .cli-package-tile-header {
+    display: flex;
+    align-items: center;
+    gap: $spacing-03;
+
+    h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: $text-primary;
+    }
+  }
+
+  .cli-package-requirement {
+    font-size: 0.75rem;
+    color: $text-secondary;
+  }
+
+  .cli-package-description {
+    font-size: 0.875rem;
+    color: $text-secondary;
+    flex-grow: 1;
+  }
+
+  .cli-downloads-footer {
+    margin-top: $spacing-06;
+    font-size: 0.875rem;
+    color: $text-secondary;
+  }
+}

--- a/ui/admin/src/Pages/CliDownloads/CliDownloadsPage.tsx
+++ b/ui/admin/src/Pages/CliDownloads/CliDownloadsPage.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Column, Grid, Link as CarbonLink, Tag, Tile } from "@carbon/react";
+import { Chip, Download, Java } from "@carbon/icons-react";
+import {
+  CLI_PACKAGE_TYPE_LABELS,
+  CLI_PACKAGES,
+  CLI_RELEASES_URL,
+  type CliPackage,
+  type CliPackageType,
+} from "../../constants/cli-packages";
+import "./CliDownloadsPage.scss";
+
+const PACKAGE_TYPE_ICONS: Record<CliPackageType, React.ComponentType<{ size?: number }>> = {
+  native: Chip,
+  java: Java,
+};
+
+function groupByType(packages: CliPackage[]): Map<CliPackageType, CliPackage[]> {
+  const groups = new Map<CliPackageType, CliPackage[]>();
+  for (const pkg of packages) {
+    const existing = groups.get(pkg.packageType) ?? [];
+    existing.push(pkg);
+    groups.set(pkg.packageType, existing);
+  }
+  return groups;
+}
+
+export const CliDownloadsPage: React.FC = () => {
+  const groups = groupByType(CLI_PACKAGES);
+
+  return (
+    <div className="cli-downloads-page">
+      <h1 className="title">CLI Downloads</h1>
+      <p className="description">
+        Download the Wanaku CLI to manage tools, resources, forwards, and namespaces from
+        the command line. The CLI works with both the Java-based Classic router and this
+        Rust-based router.
+      </p>
+
+      <div id="page-content">
+        {Array.from(groups.entries()).map(([packageType, packages]) => {
+          const Icon = PACKAGE_TYPE_ICONS[packageType];
+          return (
+            <section className="cli-package-section" key={packageType}>
+              <h2 className="cli-package-section-heading">
+                {CLI_PACKAGE_TYPE_LABELS[packageType]}
+              </h2>
+              <Grid className="cli-package-grid" narrow>
+                {packages.map((pkg) => (
+                  <Column lg={4} md={4} sm={4} key={pkg.id}>
+                    <Tile className="cli-package-tile">
+                      <div className="cli-package-tile-header">
+                        <Icon size={24} />
+                        <h3>{pkg.name}</h3>
+                      </div>
+                      <Tag type="cool-gray">{pkg.platform}</Tag>
+                      {pkg.requirement && (
+                        <p className="cli-package-requirement">{pkg.requirement}</p>
+                      )}
+                      <p className="cli-package-description">{pkg.description}</p>
+                      <CarbonLink
+                        href={pkg.downloadUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        renderIcon={Download}
+                      >
+                        Download
+                      </CarbonLink>
+                    </Tile>
+                  </Column>
+                ))}
+              </Grid>
+            </section>
+          );
+        })}
+      </div>
+
+      <p className="cli-downloads-footer">
+        Looking for a different platform? Browse all published assets on the{" "}
+        <CarbonLink href={CLI_RELEASES_URL} target="_blank" rel="noreferrer">
+          releases page
+        </CarbonLink>
+        .
+      </p>
+    </div>
+  );
+};

--- a/ui/admin/src/Pages/CliDownloads/index.ts
+++ b/ui/admin/src/Pages/CliDownloads/index.ts
@@ -1,0 +1,1 @@
+export * from './router-exports';

--- a/ui/admin/src/Pages/CliDownloads/router-exports.tsx
+++ b/ui/admin/src/Pages/CliDownloads/router-exports.tsx
@@ -1,0 +1,3 @@
+import { CliDownloadsPage } from './CliDownloadsPage';
+
+export const element = <CliDownloadsPage />;

--- a/ui/admin/src/constants/cli-packages.ts
+++ b/ui/admin/src/constants/cli-packages.ts
@@ -1,0 +1,57 @@
+/**
+ * Static catalog of Wanaku CLI packages available for download.
+ *
+ * The Wanaku CLI is published from the wanaku-barn repository and works with
+ * both the Java-based "Classic" router and this Rust-based router. New
+ * package types (e.g. additional native platforms) can be added here without
+ * touching the page component.
+ */
+
+export type CliPackageType = "native" | "java";
+
+export interface CliPackage {
+  /** Stable identifier, used as the React list key. */
+  id: string;
+  /** Display name shown on the card. */
+  name: string;
+  /** Distinguishes native binaries from Java archives that need a JVM. */
+  packageType: CliPackageType;
+  /** Supported platform(s) or runtime for this package. */
+  platform: string;
+  /** Extra runtime requirement, if any (e.g. "Requires Java 17 or later"). */
+  requirement?: string;
+  /** Where to download the package or view release assets. */
+  downloadUrl: string;
+  /** Short description of the package. */
+  description: string;
+}
+
+export const CLI_PACKAGE_TYPE_LABELS: Record<CliPackageType, string> = {
+  native: "Native Binaries",
+  java: "Java Packages",
+};
+
+export const CLI_RELEASES_URL =
+  "https://github.com/wanaku-ai/wanaku-barn/releases/tag/early-access";
+
+export const CLI_PACKAGES: CliPackage[] = [
+  {
+    id: "cli-native-linux-x86_64",
+    name: "Wanaku CLI",
+    packageType: "native",
+    platform: "Linux (x86_64)",
+    downloadUrl: CLI_RELEASES_URL,
+    description:
+      "Self-contained native binary. Does not require a Java runtime.",
+  },
+  {
+    id: "cli-java",
+    name: "Wanaku CLI",
+    packageType: "java",
+    platform: "Linux, macOS, Windows",
+    requirement: "Requires Java 17 or later",
+    downloadUrl: CLI_RELEASES_URL,
+    description:
+      "Cross-platform archive. Runs anywhere a compatible JVM is installed.",
+  },
+];

--- a/ui/admin/src/navigation/core-nav-items.ts
+++ b/ui/admin/src/navigation/core-nav-items.ts
@@ -13,4 +13,5 @@ export const CORE_NAV_ITEMS: NavItem[] = [
   { id: "forwards", label: "Forwards", route: Links.Forwards, source: "core", order: 70 },
   { id: "evaluators", label: "Evaluators", route: Links.Evaluators, source: "core", order: 80 },
   { id: "plugins", label: "Installed Plugins", route: Links.Plugins, source: "core", section: "Admin", order: 90 },
+  { id: "cli-downloads", label: "CLI Downloads", route: Links.CliDownloads, source: "core", order: 95 },
 ];

--- a/ui/admin/src/router.tsx
+++ b/ui/admin/src/router.tsx
@@ -69,6 +69,10 @@ export function buildRouter(pluginPages: PluginPage[]) {
           path: Links.Plugins,
           lazy: async () => import("./Pages/Plugins"),
         },
+        {
+          path: Links.CliDownloads,
+          lazy: async () => import("./Pages/CliDownloads"),
+        },
         ...pluginRoutes,
       ],
     },

--- a/ui/admin/src/router/links.models.ts
+++ b/ui/admin/src/router/links.models.ts
@@ -10,6 +10,7 @@ export const enum Links {
   Forwards = "/forwards",
   Evaluators = "/evaluators",
   Plugins = "/plugins-admin",
+  CliDownloads = "/cli-downloads",
   Logout = "/logout"
 }
 


### PR DESCRIPTION
## Summary

- Adds a "CLI Downloads" page to the admin UI listing the available Wanaku CLI packages, distinguishing native binaries from Java archives (which require a JVM), with platform info and a download link for each.
- Package data lives in a small typed array (`src/constants/cli-packages.ts`) so future package types (e.g. additional native platforms) can be added without touching the page component.
- Adds a visible "CLI Downloads" nav entry and registers the `/cli-downloads` route.
- Adds Playwright E2E coverage for the new page.
- Points the getting-started guide at the new page.

Fixes #1892

## Test plan

- [x] `cd ui/admin && yarn run build` (type-checks and builds)
- [x] `cd ui/admin && yarn run lint` (no new issues)
- [x] `cargo build --release` and ran the server with `WANAKU_UI_PATH` pointing at the built UI
- [x] `cd tests/e2e/ui && npx playwright test cli-downloads.spec.ts` against the running server (3/3 passing)
- [x] Manually verified the "CLI Downloads" link is visible in the admin UI nav

## Summary by Sourcery

Add an admin UI page for discovering and downloading Wanaku CLI packages.

New Features:
- Add an admin UI page that lists available Wanaku CLI packages with platform, runtime, and download information.
- Expose the CLI Downloads page through the admin navigation and `/cli-downloads` route.

Enhancements:
- Organize CLI package metadata in a typed catalog that can be extended independently of the page UI.

Documentation:
- Update the getting-started guide to reference the admin UI CLI Downloads page.

Tests:
- Add Playwright coverage for page content, package categories, and download links.