### PR TITLE
Remove redundant variable rebinding in intercept filter

### DIFF
--- a/features/intercept/src/filter.rs
+++ b/features/intercept/src/filter.rs
@@ -48,8 +48,7 @@ fn find_existing_id(messages: &[serde_json::Value]) -> Option<String> {
         }
         let content = msg.get("content").and_then(|c| c.as_str())?;
         if let Some(pos) = content.find(ID_PREFIX) {
-            let start = pos;
-            let id: String = content[start..]
+            let id: String = content[pos..]
                 .chars()
                 .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
                 .collect();


### PR DESCRIPTION
## Summary

Removes a redundant single-use variable rebinding in `features/intercept/src/filter.rs`.

Inside `find_existing_id`, the line `let start = pos;` simply aliased `pos` and was only used once in the slice index `content[start..]`. This change removes the rebinding and uses `pos` directly.

```rust
if let Some(pos) = content.find(ID_PREFIX) {
    let id: String = content[pos..]
        .chars()
        .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
        .collect();
    ...
}
```

The unrelated `start` struct field (`Instant`) elsewhere in the file was left untouched.

## Testing

- `cargo build` in `features/intercept` — passes
- `cargo clippy` in `features/intercept` — clean (remaining warnings are pre-existing and belong to the unrelated `wanaku-types` crate)

This is a behavior-preserving cleanup.

Fixes #1913

## Summary by Sourcery

Enhancements:
- Remove redundant variable rebinding when extracting an existing intercept ID.