### PR TITLE
Drop unnecessary String clone when reading the request URI

### DIFF
--- a/filters/src/prompt_get.rs
+++ b/filters/src/prompt_get.rs
@@ -39,11 +39,8 @@ impl PromptGetFilter {
         let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
         let parsed = parse_body(body, json_rpc_id);
 
-        let prompt_name = match &parsed.name {
-            Some(n) => n.clone(),
-            None => {
-                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INVALID_PARAMS, "missing name in prompts/get"));
-            }
+        let Some(prompt_name) = parsed.name.as_deref() else {
+            return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INVALID_PARAMS, "missing name in prompts/get"));
         };
 
         trace!(prompt = %prompt_name, namespace = %namespace, "handling MCP prompts/get request");
@@ -53,7 +50,7 @@ impl PromptGetFilter {
             return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INTERNAL_ERROR, "internal error: registry unavailable"));
         };
 
-        let Some(prompt) = registry.get_prompt_in_namespace(namespace, &prompt_name) else {
+        let Some(prompt) = registry.get_prompt_in_namespace(namespace, prompt_name) else {
             warn!(prompt = %prompt_name, "prompt not found in registry");
             return Ok(crate::response::json_rpc_error(
                 &parsed.id,
@@ -64,7 +61,7 @@ impl PromptGetFilter {
 
         if prompt.messages.is_empty()
             && let Some(ref uri) = prompt.configuration_uri {
-                return self.handle_forwarded_get(uri, &prompt_name, &parsed).await;
+                return self.handle_forwarded_get(uri, prompt_name, &parsed).await;
             }
 
         let messages: Vec<serde_json::Value> = prompt

--- a/filters/src/resource_read.rs
+++ b/filters/src/resource_read.rs
@@ -74,11 +74,8 @@ impl ResourceReadFilter {
         let json_rpc_id = crate::response::json_rpc_id_from_metadata(ctx.get_metadata(crate::MCP_ID_KEY));
         let parsed = parse_body(body, json_rpc_id);
 
-        let resource_uri = match &parsed.uri {
-            Some(u) => u.clone(),
-            None => {
-                return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INVALID_PARAMS, "missing uri in resources/read"));
-            }
+        let Some(resource_uri) = parsed.uri.as_deref() else {
+            return Ok(crate::response::json_rpc_error(&parsed.id, crate::response::JSONRPC_INVALID_PARAMS, "missing uri in resources/read"));
         };
 
         let namespace = ctx
@@ -94,7 +91,7 @@ impl ResourceReadFilter {
 
         let resources = registry.list_resources_in_namespace(namespace);
         let resource = resources.iter().find(|r| !r.is_template() && r.location == resource_uri)
-            .or_else(|| resources.iter().find(|r| r.is_template() && matches_uri_template(&r.location, &resource_uri)));
+            .or_else(|| resources.iter().find(|r| r.is_template() && matches_uri_template(&r.location, resource_uri)));
 
         let resource = match resource {
             Some(r) => r.clone(),
@@ -109,7 +106,7 @@ impl ResourceReadFilter {
         };
 
         if resource.is_mcp_forward() {
-            return self.handle_forwarded_read(&resource, &resource_uri, &parsed).await;
+            return self.handle_forwarded_read(&resource, resource_uri, &parsed).await;
         }
 
         warn!(uri = %resource_uri, resource_type = %resource.type_, "unsupported resource type — only MCP-forwarded resources are supported");


### PR DESCRIPTION
## Summary

Removes an unnecessary `String` clone when reading the request URI (and prompt name) in the MCP body filters, as described in #1912.

Previously, `resource_read.rs` and `prompt_get.rs` matched on the optional owned `String` in `ParsedBody` and called `.clone()` in the `Some` branch. Since the value is only ever read (never mutated or stored), we can borrow it directly.

## Changes

- **`filters/src/resource_read.rs`**: Collapse the `match &parsed.uri { ... }` into a `let-else` using `parsed.uri.as_deref()`, making `resource_uri` a `&str`. Drop the now-redundant leading `&` at the `matches_uri_template(...)` and `handle_forwarded_read(...)` call sites.
- **`filters/src/prompt_get.rs`**: Apply the identical pattern to `parsed.name`, making `prompt_name` a `&str`, and drop the `&` at the `get_prompt_in_namespace(...)` and `handle_forwarded_get(...)` call sites.

## Behavior

No behavioral change. Both branches (present / missing) remain covered by the existing `parse_body_*` tests.

## Testing

- `cargo build -p wanaku-filters` ✅
- `cargo test -p wanaku-filters` ✅ (68 passed)
- `cargo clippy -p wanaku-filters` ✅ (only a pre-existing unrelated `too_many_arguments` warning in `tool_call.rs`)

Fixes #1912

## Summary by Sourcery

Enhancements:
- Avoid cloning request URI and prompt name strings when processing MCP body filters by borrowing them directly.