### PR TITLE
Fix #1914: Use function references instead of method-call closures in json_rpc filter

### DIFF
--- a/filters/src/json_rpc.rs
+++ b/filters/src/json_rpc.rs
@@ -25,11 +25,11 @@ impl JsonRpcParams {
             return Self::default();
         };
 
-        let name = params.get("name").and_then(|n| n.as_str()).map(str::to_owned);
-        let uri = params.get("uri").and_then(|u| u.as_str()).map(str::to_owned);
+        let name = params.get("name").and_then(serde_json::Value::as_str).map(str::to_owned);
+        let uri = params.get("uri").and_then(serde_json::Value::as_str).map(str::to_owned);
         let arguments = params
             .get("arguments")
-            .and_then(|a| a.as_object())
+            .and_then(serde_json::Value::as_object)
             .cloned()
             .unwrap_or_default();
 


### PR DESCRIPTION
## Summary

Resolves #1914.

In `filters/src/json_rpc.rs`, several closures merely forwarded to a method and triggered clippy's `redundant_closure_for_method_calls` lint. This replaces them with direct function references.

## Changes

- `params.get("name").and_then(|n| n.as_str())` → `and_then(serde_json::Value::as_str)`
- `params.get("uri").and_then(|u| u.as_str())` → `and_then(serde_json::Value::as_str)`
- `params.get("arguments").and_then(|a| a.as_object())` → `and_then(serde_json::Value::as_object)`

`serde_json::Value` is already fully-qualified in this file, so no new `use` was needed.

## Rationale

Pure clippy cleanup — no behavioral change. Function references are more concise and idiomatic than closures that only forward to a method.

## Testing

- `cargo clippy -p wanaku-filters --all-targets` — compiles cleanly with no new warnings.
- `cargo test -p wanaku-filters json_rpc` — all tests pass.

## Summary by Sourcery

Enhancements:
- Replace redundant method-forwarding closures in JSON-RPC parameter parsing with direct function references.