### PR TITLE
Replace method-call closures with function references in intercept filter

### DIFF
--- a/features/intercept/src/filter.rs
+++ b/features/intercept/src/filter.rs
@@ -43,10 +43,10 @@ const ID_PREFIX: &str = "wk-";
 
 fn find_existing_id(messages: &[serde_json::Value]) -> Option<String> {
     for msg in messages {
-        if msg.get("role").and_then(|r| r.as_str()) != Some("system") {
+        if msg.get("role").and_then(serde_json::Value::as_str) != Some("system") {
             continue;
         }
-        let content = msg.get("content").and_then(|c| c.as_str())?;
+        let content = msg.get("content").and_then(serde_json::Value::as_str)?;
         if let Some(pos) = content.find(ID_PREFIX) {
             let start = pos;
             let id: String = content[start..]
@@ -66,7 +66,7 @@ fn inject_system_prompt(body_bytes: &[u8], conversation_id: &str) -> (Option<Byt
         return (None, conversation_id.to_owned());
     };
 
-    let Some(messages) = parsed.get_mut("messages").and_then(|m| m.as_array_mut()) else {
+    let Some(messages) = parsed.get_mut("messages").and_then(serde_json::Value::as_array_mut) else {
         return (None, conversation_id.to_owned());
     };
 


### PR DESCRIPTION
## Summary

Fixes the `clippy::redundant_closure_for_method_calls` lints in `features/intercept/src/filter.rs` by replacing three method-call closures with direct function references.

## Changes

- Line 46 (`find_existing_id`): `.and_then(|r| r.as_str())` → `.and_then(serde_json::Value::as_str)`
- Line 49 (`find_existing_id`): `.and_then(|c| c.as_str())` → `.and_then(serde_json::Value::as_str)`
- Line 69 (`inject_system_prompt`): `.and_then(|m| m.as_array_mut())` → `.and_then(serde_json::Value::as_array_mut)`

This is a low-risk, behavior-preserving cleanup. `filters/src/json_rpc.rs` was intentionally left untouched as it is out of scope for this issue.

## Verification

- `cargo clippy -p wanaku-feature-intercept` — no warnings for the intercept crate
- `cargo build -p wanaku-feature-intercept` — builds successfully

Fixes #1915

## Summary by Sourcery

Enhancements:
- Replace redundant method-call closures with direct `serde_json::Value` function references in the intercept filter.