### PR TITLE
Fix #1916: Use dynamic version resolution for serverInfo in handle_initialize

### DIFF
--- a/filters/src/mcp_init.rs
+++ b/filters/src/mcp_init.rs
@@ -44,15 +44,24 @@ impl McpInitFilter {
                         "listChanged": false
                     }
                 },
-                "serverInfo": {
-                    "name": "wanaku-server",
-                    "version": "0.3.0"
-                }
+                "serverInfo": Self::server_info()
             }
         });
 
         let response_body = Bytes::from(response.to_string());
         Ok(FilterAction::Reject(crate::response::json_response(response_body)))
+    }
+
+    /// Builds the `serverInfo` object advertised to MCP clients during initialization.
+    ///
+    /// The `name` is kept as the fixed literal `wanaku-server` (the client-visible
+    /// server name), while the `version` is resolved dynamically at compile time from
+    /// the crate version so it never drifts out of sync with releases.
+    fn server_info() -> serde_json::Value {
+        serde_json::json!({
+            "name": "wanaku-server",
+            "version": env!("CARGO_PKG_VERSION"),
+        })
     }
 
     fn handle_notification() -> Result<FilterAction, FilterError> {
@@ -71,5 +80,26 @@ impl McpInitFilter {
 
         let response_body = Bytes::from(response.to_string());
         Ok(FilterAction::Reject(crate::response::json_response(response_body)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_info_name_is_wanaku_server() {
+        // The client-visible server name must remain `wanaku-server` regardless of the
+        // crate name (`wanaku-filters`), so this must stay a fixed literal.
+        let info = McpInitFilter::server_info();
+        assert_eq!(info["name"], "wanaku-server");
+    }
+
+    #[test]
+    fn server_info_version_matches_crate_version() {
+        // The version is resolved dynamically at compile time and inherits the
+        // workspace version, so it stays in sync with releases automatically.
+        let info = McpInitFilter::server_info();
+        assert_eq!(info["version"], env!("CARGO_PKG_VERSION"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1916.

`handle_initialize` in `filters/src/mcp_init.rs` previously hardcoded the `serverInfo.version` (`0.3.0`), which drifts out of sync with the crate version on every release. This PR resolves the version dynamically at compile time via `env!("CARGO_PKG_VERSION")` so it always matches the workspace/crate version automatically.

## Approach (corrected)

- **Version is now dynamic**: `env!("CARGO_PKG_VERSION")`. This is safe because the `filters` crate inherits the workspace version (`0.3.0`) via `version.workspace = true`.
- **Name stays a fixed literal `"wanaku-server"`**: `mcp_init.rs` lives in the `wanaku-filters` crate, so using `env!("CARGO_PKG_NAME")` would resolve to `wanaku-filters` and cause a client-visible regression. The issue's "Note" explicitly calls this out, so only the version is made dynamic.

The `serverInfo` construction was extracted into a small `server_info()` helper to make it unit-testable.

## Tests

Added regression tests guarding the intended behaviour:

- `server_info_name_is_wanaku_server` — asserts the client-visible name stays `wanaku-server`.
- `server_info_version_matches_crate_version` — asserts the version matches the crate version.

```
running 2 tests
test mcp_init::tests::server_info_name_is_wanaku_server ... ok
test mcp_init::tests::server_info_version_matches_crate_version ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 68 filtered out
```

## Summary by Sourcery

Ensure MCP initialization advertises the correct crate version while preserving the established server name.

Bug Fixes:
- Keep the MCP serverInfo version synchronized with the crate version by resolving it dynamically at compile time instead of hardcoding it.

Enhancements:
- Extract serverInfo construction into a reusable helper while preserving the client-visible server name as wanaku-server.

Tests:
- Add regression tests verifying the advertised server name and version.