### PR TITLE
Move CLI Downloads under Developer navigation

### DIFF
--- a/tests/e2e/ui/tests/downloads.spec.ts
+++ b/tests/e2e/ui/tests/downloads.spec.ts
@@ -16,6 +16,14 @@ test.describe('CLI Downloads', () => {
     expect(title).toBe('CLI Downloads');
   });
 
+  test('lists CLI Downloads in the Developer menu', async ({ page }) => {
+    await downloads.goto();
+    const headerNavigation = page.getByRole('navigation', { name: 'Wanaku' });
+    await headerNavigation.getByRole('link', { name: 'Developer', exact: true }).click();
+
+    await expect(headerNavigation.getByRole('link', { name: 'CLI Downloads' })).toBeVisible();
+  });
+
   test('lists CLI packages with download links', async () => {
     await downloads.goto();
     await expect(downloads.downloadButtons().first()).toBeVisible({ timeout: 5_000 });

--- a/ui/admin/src/navigation/core-nav-items.ts
+++ b/ui/admin/src/navigation/core-nav-items.ts
@@ -15,5 +15,5 @@ export const CORE_NAV_ITEMS: NavItem[] = [
   { id: "action-policies", label: "Action Policies", route: Links.ActionPolicies, source: "core", section: "Admin", order: 89 },
   { id: "plugins", label: "Installed Plugins", route: Links.Plugins, source: "core", section: "Admin", order: 90 },
 
-  { id: "downloads", label: "CLI Downloads", route: Links.Downloads, source: "core", order: 100 },
+  { id: "downloads", label: "CLI Downloads", route: Links.Downloads, source: "core", section: "Developer", order: 42 },
 ];


### PR DESCRIPTION
## Summary

- place CLI Downloads in the Developer navigation group
- keep it after the existing developer tools
- verify the nested desktop navigation with Playwright

## Validation

- yarn build
- Playwright CLI Downloads suite (4 tests)
- scoped ESLint and TypeScript checks
- git diff --check

Generated by Codex via OSS Helper

## Summary by Sourcery

Organize CLI Downloads under the Developer navigation and verify its nested menu placement.

Enhancements:
- Move CLI Downloads into the Developer navigation section while preserving its position after the existing developer tools.

Tests:
- Add Playwright coverage confirming CLI Downloads appears in the expanded Developer navigation menu.