### PR TITLE
Fix #1872: add governance posture model

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Contributors working on the project may want to refer to the development documen
 - [Plugin Development](docs/plugin-development-guide.md) - Guide for writing new feature crates
 - [Evaluator Engine](docs/evaluator-engine.md) - WASM-based evaluator
 - [Action Policies](docs/action-policies.md) - Deterministic MCP action rules
+- [Governance Posture](docs/governance-posture.md) - Enforcement modes and fail-safe behavior
 - [Contributing](CONTRIBUTING.md) - Contribution guidelines
 - [Security](SECURITY.md) - Security policy
 

--- a/docs/action-policies.md
+++ b/docs/action-policies.md
@@ -2,6 +2,8 @@
 
 Action policies give Wanaku a deterministic authorization layer for MCP actions. They complement the evaluator. Use action policies for rules that depend on known names, labels, URIs, and structured request values. Use evaluators for contextual or semantic decisions.
 
+The [Governance Posture](./governance-posture.md) model defines the planned behavior for unmatched actions, policy failures, audit-only evaluation, and disabled scopes. The current action-policy filter does not apply this posture model yet.
+
 ## Configure a policy
 
 Add one `action_policy` object to `wanaku.yaml`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,6 +380,8 @@ Wanaku loads these top-level sections from `wanaku.yaml`:
 - `action_policy` — declarative action-policy rules
 - `plugins` — plugin service mappings owned by the plugins feature
 
+The shared [Governance Posture](./governance-posture.md) model defines fail-safe defaults and namespace overrides. Runtime loading of the `governance` section is not implemented yet.
+
 Wanaku discovers tools, resources, and prompts from the configured forwards.
 
 **Evaluator configuration** (see [Evaluator Engine](./evaluator-engine.md) for full details):

--- a/docs/governance-posture.md
+++ b/docs/governance-posture.md
@@ -1,0 +1,95 @@
+# Governance Posture
+
+Governance posture defines how Wanaku handles policy decisions, unmatched actions, and evaluation failures. The model keeps these controls separate. This separation makes the effective behavior explicit for each namespace.
+
+> [!IMPORTANT]
+> The current implementation provides the shared posture types, default values, namespace resolution, and configuration validation. It does not load this model from `wanaku.yaml` or apply it in the action-policy and evaluator filters yet. Do not use the example configuration in production until runtime integration is complete.
+
+## Posture settings
+
+Each posture has four independent settings.
+
+| Setting | Values | Default | Purpose |
+| --- | --- | --- | --- |
+| `mode` | `enforce`, `audit`, `disabled` | `enforce` | Controls whether governance decisions affect traffic. |
+| `no_match` | `allow`, `deny` | `deny` | Controls the result when no policy or evaluator matches an action. |
+| `on_failure` | `allow`, `deny` | `deny` | Controls the result when governance cannot produce a decision. |
+| `audit_level` | `basic`, `full` | `basic` | Controls whether audit mode calls an LLM. |
+
+The defaults are fail-safe. Wanaku denies an unmatched action or a failed governance decision unless the operator explicitly selects `allow`.
+
+### Enforcement modes
+
+`enforce` applies governance decisions to traffic.
+
+`audit` observes traffic without enforcement. The `basic` audit level does not call an LLM. The `full` audit level permits LLM calls so that Wanaku can produce complete would-be decisions. Full audit is an explicit opt-in because it adds LLM cost and latency.
+
+`disabled` intentionally bypasses governance for the applicable scope. A disabled posture must include a non-empty `disabled_reason`. Validation rejects a disabled posture without this reason.
+
+### No-match behavior
+
+`allow` permits an action when no rule or evaluator matches it.
+
+`deny` rejects an action when no rule or evaluator matches it. This value is the default.
+
+The decision model keeps an explicit allow separate from an allow that comes from the no-match behavior. Audit events and metrics can use this distinction after runtime integration is complete.
+
+### Failure behavior
+
+`allow` permits an action when governance cannot produce a decision.
+
+`deny` rejects an action when governance cannot produce a decision. This value is the default.
+
+The failure behavior is for unavailable or invalid policy state and evaluation failures. Runtime integration will apply it to LLM, schema, processor, WASM, registry, and internal failures.
+
+## Global posture and namespace overrides
+
+The model contains one global posture and a map of namespace overrides. An override changes only the fields that it specifies. All other fields inherit the global value.
+
+Namespace resolution uses the namespace name as the map key. It does not use declaration order. One request resolves one posture value for its namespace.
+
+The following example shows the configuration shape that the shared types accept:
+
+```yaml
+governance:
+  default:
+    mode: enforce
+    no_match: deny
+    on_failure: deny
+    audit_level: basic
+
+  namespaces:
+    sandbox:
+      mode: audit
+      no_match: allow
+      audit_level: full
+
+    maintenance:
+      mode: disabled
+      disabled_reason: Scheduled maintenance window
+```
+
+The effective `sandbox` posture uses `on_failure: deny` from the global posture. The effective `maintenance` posture inherits the global no-match, failure, and audit settings.
+
+Unknown fields cause deserialization to fail. An empty namespace name causes validation to fail.
+
+## Current implementation boundary
+
+The shared model is in `types/src/governance.rs`. It provides:
+
+- Serializable posture enums and structures.
+- Fail-safe default values.
+- Global-to-namespace resolution.
+- Validation for namespace names and disabled-scope reasons.
+- OpenAPI schema derivation when the `openapi` feature is enabled.
+
+The following work remains for complete runtime support:
+
+- Load and validate `governance` from `wanaku.yaml`.
+- Capture the effective posture in an immutable request snapshot.
+- Apply the posture in the action-policy and evaluator filters.
+- Suppress evaluator side effects in audit mode.
+- Add readiness status, audit events, and bounded metrics.
+
+See [issue #1872](https://github.com/wanaku-ai/wanaku/issues/1872) for the complete acceptance criteria.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ All in a single binary with no runtime dependencies (except libc).
 - **[Configuration](./configuration.md)** — all environment variables and YAML config options
 - **[Authentication](./auth.md)** — set up oauth2-proxy with Keycloak
 - **[Management API](./management-api.md)** — REST API reference for tools, resources, etc.
+- **[Governance Posture](./governance-posture.md)** — enforcement modes, fail-safe defaults, and namespace resolution
 - **[Action Policies](./action-policies.md)** — deterministic rules for MCP actions
 - **[FAQ](./faq.md)** — common issues and troubleshooting
 

--- a/types/src/governance.rs
+++ b/types/src/governance.rs
@@ -1,0 +1,228 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Controls whether governance decisions affect traffic.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum EnforcementMode {
+    #[default]
+    Enforce,
+    Audit,
+    Disabled,
+}
+
+/// Controls the result when no governance rule matches an action.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum NoMatchBehavior {
+    Allow,
+    #[default]
+    Deny,
+}
+
+/// Controls the result when governance cannot produce a decision.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum FailureBehavior {
+    Allow,
+    #[default]
+    Deny,
+}
+
+/// Controls whether audit mode invokes configured LLM evaluators.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum AuditLevel {
+    /// Record traffic and deterministic policy decisions without invoking LLMs.
+    #[default]
+    Basic,
+    /// Run the full evaluator pipeline, including configured LLM calls.
+    Full,
+}
+
+/// The effective governance settings for one namespace.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(default, deny_unknown_fields)]
+pub struct GovernancePosture {
+    pub mode: EnforcementMode,
+    pub no_match: NoMatchBehavior,
+    pub on_failure: FailureBehavior,
+    pub audit_level: AuditLevel,
+    /// Required when governance is intentionally disabled.
+    pub disabled_reason: Option<String>,
+}
+
+/// A namespace override. Omitted fields inherit the global posture.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(default, deny_unknown_fields)]
+pub struct GovernancePostureOverride {
+    pub mode: Option<EnforcementMode>,
+    pub no_match: Option<NoMatchBehavior>,
+    pub on_failure: Option<FailureBehavior>,
+    pub audit_level: Option<AuditLevel>,
+    pub disabled_reason: Option<String>,
+}
+
+/// Global governance posture and namespace-specific overrides.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(default, deny_unknown_fields)]
+pub struct GovernanceConfig {
+    pub default: GovernancePosture,
+    pub namespaces: BTreeMap<String, GovernancePostureOverride>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum GovernanceConfigError {
+    #[error("disabled governance scope '{scope}' requires a reason")]
+    DisabledReasonRequired { scope: String },
+    #[error("governance namespace must not be empty")]
+    EmptyNamespace,
+}
+
+impl GovernanceConfig {
+    /// Resolve one immutable posture without depending on declaration order.
+    #[must_use]
+    pub fn resolve(&self, namespace: &str) -> GovernancePosture {
+        let Some(override_posture) = self.namespaces.get(namespace) else {
+            return self.default.clone();
+        };
+        GovernancePosture {
+            mode: override_posture.mode.unwrap_or(self.default.mode),
+            no_match: override_posture.no_match.unwrap_or(self.default.no_match),
+            on_failure: override_posture
+                .on_failure
+                .unwrap_or(self.default.on_failure),
+            audit_level: override_posture
+                .audit_level
+                .unwrap_or(self.default.audit_level),
+            disabled_reason: override_posture
+                .disabled_reason
+                .clone()
+                .or_else(|| self.default.disabled_reason.clone()),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), GovernanceConfigError> {
+        validate_posture("global", &self.default)?;
+        for namespace in self.namespaces.keys() {
+            if namespace.trim().is_empty() {
+                return Err(GovernanceConfigError::EmptyNamespace);
+            }
+            validate_posture(namespace, &self.resolve(namespace))?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_posture(scope: &str, posture: &GovernancePosture) -> Result<(), GovernanceConfigError> {
+    if posture.mode == EnforcementMode::Disabled
+        && posture
+            .disabled_reason
+            .as_deref()
+            .is_none_or(|reason| reason.trim().is_empty())
+    {
+        return Err(GovernanceConfigError::DisabledReasonRequired {
+            scope: scope.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_fail_safe() {
+        let posture = GovernanceConfig::default().resolve("default");
+
+        assert_eq!(posture.mode, EnforcementMode::Enforce);
+        assert_eq!(posture.no_match, NoMatchBehavior::Deny);
+        assert_eq!(posture.on_failure, FailureBehavior::Deny);
+        assert_eq!(posture.audit_level, AuditLevel::Basic);
+    }
+
+    #[test]
+    fn namespace_override_inherits_unspecified_global_values() {
+        let config: GovernanceConfig = serde_yaml::from_str(
+            r#"
+default:
+  mode: enforce
+  no_match: deny
+  on_failure: deny
+namespaces:
+  sandbox:
+    mode: audit
+    no_match: allow
+    audit_level: full
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.resolve("sandbox"),
+            GovernancePosture {
+                mode: EnforcementMode::Audit,
+                no_match: NoMatchBehavior::Allow,
+                on_failure: FailureBehavior::Deny,
+                audit_level: AuditLevel::Full,
+                disabled_reason: None,
+            }
+        );
+        assert_eq!(config.resolve("production"), config.default);
+    }
+
+    #[test]
+    fn disabled_scope_requires_non_empty_reason() {
+        let mut config = GovernanceConfig::default();
+        config.namespaces.insert(
+            "maintenance".to_owned(),
+            GovernancePostureOverride {
+                mode: Some(EnforcementMode::Disabled),
+                ..GovernancePostureOverride::default()
+            },
+        );
+
+        assert_eq!(
+            config.validate(),
+            Err(GovernanceConfigError::DisabledReasonRequired {
+                scope: "maintenance".to_owned(),
+            })
+        );
+
+        config
+            .namespaces
+            .get_mut("maintenance")
+            .unwrap()
+            .disabled_reason = Some("scheduled maintenance".to_owned());
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    #[test]
+    fn explicit_global_disabled_scope_requires_reason() {
+        let config = GovernanceConfig {
+            default: GovernancePosture {
+                mode: EnforcementMode::Disabled,
+                disabled_reason: Some(" ".to_owned()),
+                ..GovernancePosture::default()
+            },
+            namespaces: BTreeMap::new(),
+        };
+
+        assert_eq!(
+            config.validate(),
+            Err(GovernanceConfigError::DisabledReasonRequired {
+                scope: "global".to_owned(),
+            })
+        );
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod correlation;
 pub mod feature;
+pub mod governance;
 pub mod http_response;
 pub mod interactions;
 pub mod mcp;


### PR DESCRIPTION
## Summary

- add shared governance enforcement, no-match, and failure behavior types
- use fail-safe defaults and deterministic global/namespace override resolution
- model basic audit and opt-in full LLM audit
- require an explicit reason for disabled governance scopes
- add focused unit tests for defaults, inheritance, and validation
- document the posture settings, configuration shape, resolution rules, defaults, and current implementation boundary

## Status

This is an early draft for review. It establishes and documents the reusable posture model. Filter integration, readiness/status APIs, metrics, audit events, and the remaining issue acceptance criteria are not implemented yet.

## Validation

- `rustfmt --edition 2024 --check types/src/governance.rs`
- `git diff --check`
- documentation links and repository references checked locally
- `cargo test -p wanaku-types governance` could not complete because CMake is not installed; the transitive `libz-ng-sys` build requires it

Generated by Codex via OSS Helper

## Summary by Sourcery

Establish the shared governance posture model and document its configuration and resolution behavior.

New Features:
- Add a reusable governance posture model covering enforcement, no-match, failure, and audit behavior with global defaults and namespace overrides.

Enhancements:
- Provide fail-safe defaults, deterministic posture resolution, and validation requiring reasons for disabled governance scopes.
- Expose governance types through the shared types crate with optional OpenAPI schemas.

Documentation:
- Document governance posture settings, configuration shape, inheritance rules, defaults, and current runtime integration boundaries.

Tests:
- Add unit tests covering fail-safe defaults, namespace inheritance, and disabled-scope validation.