### PR TITLE
Fix #1872: apply posture to action policies

### DIFF
--- a/docs/action-policies.md
+++ b/docs/action-policies.md
@@ -2,7 +2,7 @@
 
 Action policies give Wanaku a deterministic authorization layer for MCP actions. They complement the evaluator. Use action policies for rules that depend on known names, labels, URIs, and structured request values. Use evaluators for contextual or semantic decisions.
 
-The [Governance Posture](./governance-posture.md) model defines the planned behavior for unmatched actions, policy failures, audit-only evaluation, and disabled scopes. The current action-policy filter does not apply this posture model yet.
+The [Governance Posture](./governance-posture.md) model defines the behavior for unmatched actions, policy failures, audit-only evaluation, and disabled scopes. The action-policy filter resolves the global posture and namespace override before it evaluates a request.
 
 ## Configure a policy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -378,9 +378,10 @@ Wanaku loads these top-level sections from `wanaku.yaml`:
 - `llm_connections` — named LLM connections (model/url/api_key) for evaluators; config-only, never exposed via the management API
 - `evaluators` — evaluator feature configuration
 - `action_policy` — declarative action-policy rules
+- `governance` — global governance posture and namespace overrides
 - `plugins` — plugin service mappings owned by the plugins feature
 
-The shared [Governance Posture](./governance-posture.md) model defines fail-safe defaults and namespace overrides. Runtime loading of the `governance` section is not implemented yet.
+The [Governance Posture](./governance-posture.md) model defines fail-safe defaults and namespace overrides. Wanaku validates the section during startup. Invalid governance configuration stops startup.
 
 Wanaku discovers tools, resources, and prompts from the configured forwards.
 

--- a/docs/governance-posture.md
+++ b/docs/governance-posture.md
@@ -3,7 +3,7 @@
 Governance posture defines how Wanaku handles policy decisions, unmatched actions, and evaluation failures. The model keeps these controls separate. This separation makes the effective behavior explicit for each namespace.
 
 > [!IMPORTANT]
-> The current implementation provides the shared posture types, default values, namespace resolution, and configuration validation. It does not load this model from `wanaku.yaml` or apply it in the action-policy and evaluator filters yet. Do not use the example configuration in production until runtime integration is complete.
+> Wanaku applies the posture model to action policies. Evaluator integration is not complete. The evaluator still uses its current error policy and execution behavior.
 
 ## Posture settings
 
@@ -40,7 +40,7 @@ The decision model keeps an explicit allow separate from an allow that comes fro
 
 `deny` rejects an action when governance cannot produce a decision. This value is the default.
 
-The failure behavior is for unavailable or invalid policy state and evaluation failures. Runtime integration will apply it to LLM, schema, processor, WASM, registry, and internal failures.
+The failure behavior applies to unavailable or invalid action-policy state and missing runtime state. Evaluator integration will apply it to LLM, schema, processor, WASM, registry, and internal failures.
 
 ## Global posture and namespace overrides
 
@@ -48,7 +48,7 @@ The model contains one global posture and a map of namespace overrides. An overr
 
 Namespace resolution uses the namespace name as the map key. It does not use declaration order. One request resolves one posture value for its namespace.
 
-The following example shows the configuration shape that the shared types accept:
+Add the `governance` section to `wanaku.yaml`:
 
 ```yaml
 governance:
@@ -73,6 +73,21 @@ The effective `sandbox` posture uses `on_failure: deny` from the global posture.
 
 Unknown fields cause deserialization to fail. An empty namespace name causes validation to fail.
 
+Wanaku validates this configuration during startup. Wanaku stops startup if the configuration is invalid. If the section is absent, Wanaku uses the fail-safe defaults.
+
+## Action-policy behavior
+
+The action-policy filter applies the effective namespace posture as follows:
+
+| Condition | `enforce` | `audit` | `disabled` |
+| --- | --- | --- | --- |
+| Explicit allow | Allow | Record and allow | Skip evaluation |
+| Explicit deny | Deny | Record and allow | Skip evaluation |
+| No matching rule | Apply `no_match` | Record and allow | Skip evaluation |
+| Invalid or unavailable policy | Apply `on_failure` | Record and allow | Skip evaluation |
+
+Basic and full audit levels have the same result for deterministic action policies. Action-policy evaluation does not call an LLM and does not have evaluator side effects.
+
 ## Current implementation boundary
 
 The shared model is in `types/src/governance.rs`. It provides:
@@ -85,11 +100,8 @@ The shared model is in `types/src/governance.rs`. It provides:
 
 The following work remains for complete runtime support:
 
-- Load and validate `governance` from `wanaku.yaml`.
-- Capture the effective posture in an immutable request snapshot.
-- Apply the posture in the action-policy and evaluator filters.
+- Apply the posture in the evaluator filter.
 - Suppress evaluator side effects in audit mode.
 - Add readiness status, audit events, and bounded metrics.
 
 See [issue #1872](https://github.com/wanaku-ai/wanaku/issues/1872) for the complete acceptance criteria.
-

--- a/features/action-policy/src/filter.rs
+++ b/features/action-policy/src/filter.rs
@@ -4,6 +4,9 @@ use bytes::Bytes;
 use praxis_filter::{FilterAction, FilterError, HttpFilterContext};
 use wanaku_filters::json_rpc::{McpRequestView, RequestViewError};
 use wanaku_infra::registry::InMemoryRegistry;
+use wanaku_types::governance::{
+    EnforcementMode, FailureBehavior, GovernanceConfig, GovernancePosture, NoMatchBehavior,
+};
 use wanaku_types::registry::{DEFAULT_NAMESPACE, ToolRegistry};
 
 use crate::{
@@ -16,6 +19,8 @@ const INVALID_ACTION_REASON_CODE: &str = "invalid_action_request";
 const INVALID_ACTION_MESSAGE: &str = "The action request is invalid.";
 const INVALID_POLICY_REASON_CODE: &str = "action_policy_invalid";
 const INVALID_POLICY_MESSAGE: &str = "The action policy is unavailable.";
+const NO_MATCH_REASON_CODE: &str = "governance_no_match";
+const NO_MATCH_MESSAGE: &str = "No governance policy permits this action.";
 
 wanaku_filters::body_filter_boilerplate!(ActionPolicyFilter, "wanaku_action_policy");
 
@@ -35,15 +40,34 @@ impl ActionPolicyFilter {
         let id = wanaku_filters::response::json_rpc_id_from_metadata(
             ctx.get_metadata(wanaku_filters::MCP_ID_KEY),
         );
+        let namespace = ctx
+            .get_metadata(wanaku_types::NAMESPACE_METADATA_KEY)
+            .unwrap_or(DEFAULT_NAMESPACE);
+        let posture = ctx
+            .extensions
+            .get::<GovernanceConfig>()
+            .cloned()
+            .unwrap_or_default()
+            .resolve(namespace);
+        if posture.mode == EnforcementMode::Disabled {
+            tracing::warn!(
+                namespace,
+                reason = posture.disabled_reason.as_deref().unwrap_or("unspecified"),
+                "governance is disabled for namespace"
+            );
+            return Ok(FilterAction::Continue);
+        }
         let Some(state) = ctx.extensions.get::<ActionPolicyState>() else {
-            return Ok(policy_error(
-                &id,
-                INVALID_POLICY_REASON_CODE,
-                INVALID_POLICY_MESSAGE,
-            ));
+            return Ok(apply_failure(&posture, &id));
         };
         let snapshot = state.snapshot();
-        Ok(evaluate_snapshot(ctx, body.as_ref(), snapshot, &id))
+        Ok(evaluate_snapshot(
+            ctx,
+            body.as_ref(),
+            snapshot,
+            &posture,
+            &id,
+        ))
     }
 }
 
@@ -51,17 +75,16 @@ fn evaluate_snapshot(
     ctx: &HttpFilterContext<'_>,
     body: Option<&Bytes>,
     snapshot: PolicySnapshot,
+    posture: &GovernancePosture,
     id: &serde_json::Value,
 ) -> FilterAction {
     let policy = match snapshot {
         PolicySnapshot::Valid(policy) => policy,
-        PolicySnapshot::Unconfigured => return FilterAction::Continue,
-        PolicySnapshot::Invalid => {
-            return policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE);
-        }
+        PolicySnapshot::Unconfigured => return apply_no_match(posture, id),
+        PolicySnapshot::Invalid => return apply_failure(posture, id),
     };
     let Some(registry) = ctx.extensions.get::<InMemoryRegistry>() else {
-        return policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE);
+        return apply_failure(posture, id);
     };
     evaluate_request(RequestEvaluation {
         method: ctx
@@ -72,6 +95,7 @@ fn evaluate_snapshot(
             .unwrap_or(DEFAULT_NAMESPACE),
         body,
         policy: &policy,
+        posture,
         registry,
         id,
     })
@@ -87,6 +111,7 @@ struct RequestEvaluation<'a> {
     namespace: &'a str,
     body: Option<&'a Bytes>,
     policy: &'a crate::CompiledPolicy,
+    posture: &'a GovernancePosture,
     registry: &'a InMemoryRegistry,
     id: &'a serde_json::Value,
 }
@@ -97,6 +122,7 @@ fn evaluate_request(input: RequestEvaluation<'_>) -> FilterAction {
         namespace,
         body,
         policy,
+        posture,
         registry,
         id,
     } = input;
@@ -107,6 +133,14 @@ fn evaluate_request(input: RequestEvaluation<'_>) -> FilterAction {
         return policy_error(id, INVALID_ACTION_REASON_CODE, INVALID_ACTION_MESSAGE);
     };
     let decision = PolicyEngine::evaluate(PolicyState::Available(policy), &context);
+    if posture.mode == EnforcementMode::Audit {
+        tracing::info!(
+            namespace,
+            decision = ?decision,
+            "action-policy decision recorded in audit mode"
+        );
+        return FilterAction::Continue;
+    }
     match &decision {
         PolicyDecision::ExplicitDeny { .. } => policy_error(
             id,
@@ -117,8 +151,31 @@ fn evaluate_request(input: RequestEvaluation<'_>) -> FilterAction {
                 .deny_message()
                 .unwrap_or(crate::DEFAULT_DENY_MESSAGE),
         ),
-        PolicyDecision::ExplicitAllow { .. } | PolicyDecision::NoMatch => FilterAction::Continue,
+        PolicyDecision::ExplicitAllow { .. } => FilterAction::Continue,
+        PolicyDecision::NoMatch => apply_no_match(posture, id),
         PolicyDecision::PolicyUnavailable | PolicyDecision::PolicyInvalid => {
+            apply_failure(posture, id)
+        }
+    }
+}
+
+fn apply_no_match(posture: &GovernancePosture, id: &serde_json::Value) -> FilterAction {
+    if posture.mode == EnforcementMode::Audit {
+        return FilterAction::Continue;
+    }
+    match posture.no_match {
+        NoMatchBehavior::Allow => FilterAction::Continue,
+        NoMatchBehavior::Deny => policy_error(id, NO_MATCH_REASON_CODE, NO_MATCH_MESSAGE),
+    }
+}
+
+fn apply_failure(posture: &GovernancePosture, id: &serde_json::Value) -> FilterAction {
+    if posture.mode == EnforcementMode::Audit {
+        return FilterAction::Continue;
+    }
+    match posture.on_failure {
+        FailureBehavior::Allow => FilterAction::Continue,
+        FailureBehavior::Deny => {
             policy_error(id, INVALID_POLICY_REASON_CODE, INVALID_POLICY_MESSAGE)
         }
     }
@@ -218,6 +275,7 @@ fn policy_error(id: &serde_json::Value, reason_code: &str, message: &str) -> Fil
 mod tests {
     use super::*;
     use crate::DEFAULT_DENY_REASON_CODE;
+    use wanaku_types::TOOLS_CALL;
     use wanaku_types::registry::{
         PromptEntry, PromptRegistry, ResourceEntry, ResourceRegistry, ToolEntry,
     };
@@ -261,6 +319,7 @@ mod tests {
     #[expect(clippy::too_many_lines, reason = "three governed MCP method fixtures")]
     fn denies_tool_resource_and_prompt_actions() {
         let registry = InMemoryRegistry::new();
+        let posture = GovernancePosture::default();
         registry.register_tool(ToolEntry {
             name: "delete".to_owned(),
             description: String::new(),
@@ -334,6 +393,7 @@ mod tests {
                 namespace: DEFAULT_NAMESPACE,
                 body: Some(&body),
                 policy: &policy,
+                posture: &posture,
                 registry: &registry,
                 id: &id,
             });
@@ -344,6 +404,10 @@ mod tests {
     #[test]
     fn explicit_allow_and_no_match_continue() {
         let registry = InMemoryRegistry::new();
+        let posture = GovernancePosture {
+            no_match: NoMatchBehavior::Allow,
+            ..GovernancePosture::default()
+        };
         let policy = compile_policy(&serde_json::json!({
             "id": "allow", "effect": "allow",
             "selectors": {"operation": "tools/call"}
@@ -356,6 +420,7 @@ mod tests {
                 namespace: DEFAULT_NAMESPACE,
                 body: Some(&body),
                 policy: &policy,
+                posture: &posture,
                 registry: &registry,
                 id: &id,
             }),
@@ -369,6 +434,7 @@ mod tests {
                 namespace: DEFAULT_NAMESPACE,
                 body: Some(&body),
                 policy: &policy,
+                posture: &posture,
                 registry: &registry,
                 id: &id,
             }),
@@ -383,6 +449,10 @@ mod tests {
     )]
     fn resource_name_comes_from_registry_and_tool_uri_is_not_exposed() {
         let registry = InMemoryRegistry::new();
+        let posture = GovernancePosture {
+            no_match: NoMatchBehavior::Allow,
+            ..GovernancePosture::default()
+        };
         registry.register_resource(ResourceEntry {
             name: "registered-name".to_owned(),
             description: String::new(),
@@ -426,6 +496,7 @@ mod tests {
                 namespace: DEFAULT_NAMESPACE,
                 body: Some(&resource_body),
                 policy: &resource_policy,
+                posture: &posture,
                 registry: &registry,
                 id: &id,
             }),
@@ -449,6 +520,7 @@ mod tests {
                 namespace: DEFAULT_NAMESPACE,
                 body: Some(&tool_body),
                 policy: &tool_uri_policy,
+                posture: &posture,
                 registry: &registry,
                 id: &id,
             }),
@@ -459,6 +531,7 @@ mod tests {
     #[test]
     fn malformed_governed_request_is_safely_rejected() {
         let registry = InMemoryRegistry::new();
+        let posture = GovernancePosture::default();
         let policy = compile_policy(&serde_json::json!({
             "id": "deny", "effect": "deny", "selectors": {"operation": "tools/call"}
         }));
@@ -469,10 +542,75 @@ mod tests {
             namespace: DEFAULT_NAMESPACE,
             body: Some(&malformed),
             policy: &policy,
+            posture: &posture,
             registry: &registry,
             id: &id,
         });
         assert_denied(action, INVALID_ACTION_REASON_CODE);
+    }
+
+    #[test]
+    fn posture_behaviors_are_applied() {
+        let id = serde_json::json!(7);
+        let permissive = GovernancePosture {
+            no_match: NoMatchBehavior::Allow,
+            on_failure: FailureBehavior::Allow,
+            ..GovernancePosture::default()
+        };
+
+        assert!(matches!(
+            apply_no_match(&permissive, &id),
+            FilterAction::Continue
+        ));
+        assert!(matches!(
+            apply_failure(&permissive, &id),
+            FilterAction::Continue
+        ));
+        assert_denied(
+            apply_no_match(&GovernancePosture::default(), &id),
+            NO_MATCH_REASON_CODE,
+        );
+        assert_denied(
+            apply_failure(&GovernancePosture::default(), &id),
+            INVALID_POLICY_REASON_CODE,
+        );
+
+        let audit = GovernancePosture {
+            mode: EnforcementMode::Audit,
+            ..GovernancePosture::default()
+        };
+        assert!(matches!(
+            apply_no_match(&audit, &id),
+            FilterAction::Continue
+        ));
+        assert!(matches!(apply_failure(&audit, &id), FilterAction::Continue));
+    }
+
+    #[test]
+    fn audit_mode_does_not_enforce_policy_denial() {
+        let registry = InMemoryRegistry::new();
+        let policy = compile_policy(&serde_json::json!({
+            "id": "deny", "effect": "deny", "selectors": {"operation": TOOLS_CALL}
+        }));
+        let posture = GovernancePosture {
+            mode: EnforcementMode::Audit,
+            ..GovernancePosture::default()
+        };
+        let body = request(TOOLS_CALL, &serde_json::json!({"name": "unsafe"}));
+        let id = serde_json::json!(7);
+
+        assert!(matches!(
+            evaluate_request(RequestEvaluation {
+                method: TOOLS_CALL,
+                namespace: DEFAULT_NAMESPACE,
+                body: Some(&body),
+                policy: &policy,
+                posture: &posture,
+                registry: &registry,
+                id: &id,
+            }),
+            FilterAction::Continue
+        ));
     }
 
     #[test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,6 +17,7 @@ use tracing::info;
 use wanaku_infra::persistence::FilePersistence;
 use wanaku_infra::registry::InMemoryRegistry;
 use wanaku_types::feature::Feature;
+use wanaku_types::governance::GovernanceConfig;
 use wanaku_types::registry::{ForwardEntry, ForwardRegistry};
 
 #[expect(clippy::too_many_lines, reason = "server bootstrap")]
@@ -43,9 +44,11 @@ fn main() {
     // Paired with InterceptFeature: adds x-request-id to tool schemas for conversation tracking
     wanaku_registry.enable_request_id_injection();
 
+    let wanaku_config = load_wanaku_yaml(&args.wanaku_config);
+    let governance = load_governance_config(wanaku_config.as_ref()).unwrap_or_else(|e| fatal(&e));
     let features: Vec<Box<dyn Feature>> = build_features(&args, &metrics_store);
 
-    load_config(&args, &wanaku_registry, &features);
+    load_config(wanaku_config.as_ref(), &wanaku_registry, &features);
 
     let mut filter_registry = wanaku_server::build_full_registry();
     for feature in &features {
@@ -56,6 +59,7 @@ fn main() {
         health_registry: build_health_registry(&config.clusters),
         kv_stores: praxis_core::kv::KvStoreRegistry::new(),
         mgmt_registry: wanaku_registry.clone(),
+        governance,
         features,
     };
 
@@ -77,6 +81,7 @@ fn build_pipelines(config: &Config, wanaku_registry: &InMemoryRegistry, filter_r
         &service_deps.health_registry,
         &service_deps.kv_stores,
         wanaku_registry,
+        &service_deps.governance,
         &service_deps.features,
     );
     wanaku_server::pipelines::resolve_pipelines(config, &pipeline_deps)
@@ -87,12 +92,16 @@ struct ServiceDeps {
     health_registry: praxis_core::health::HealthRegistry,
     kv_stores: praxis_core::kv::KvStoreRegistry,
     mgmt_registry: InMemoryRegistry,
+    governance: GovernanceConfig,
     features: Vec<Box<dyn Feature>>,
 }
 
-fn load_config(args: &ServerArgs, wanaku_registry: &InMemoryRegistry, features: &[Box<dyn Feature>]) {
-    let wanaku_config = load_wanaku_yaml(&args.wanaku_config);
-    if let Some(ref yaml) = wanaku_config {
+fn load_config(
+    wanaku_config: Option<&serde_yaml::Value>,
+    wanaku_registry: &InMemoryRegistry,
+    features: &[Box<dyn Feature>],
+) {
+    if let Some(yaml) = wanaku_config {
         load_core_config(yaml, wanaku_registry);
         for feature in features {
             feature.load_yaml_config(yaml);
@@ -102,6 +111,21 @@ fn load_config(args: &ServerArgs, wanaku_registry: &InMemoryRegistry, features: 
     for feature in features {
         feature.load_env_config();
     }
+}
+
+fn load_governance_config(
+    root: Option<&serde_yaml::Value>,
+) -> Result<GovernanceConfig, String> {
+    let config = root
+        .and_then(|value| value.get("governance"))
+        .map(|value| serde_yaml::from_value::<GovernanceConfig>(value.clone()))
+        .transpose()
+        .map_err(|error| format!("invalid governance configuration: {error}"))?
+        .unwrap_or_default();
+    config
+        .validate()
+        .map_err(|error| format!("invalid governance configuration: {error}"))?;
+    Ok(config)
 }
 
 #[expect(clippy::too_many_lines, reason = "service registration is sequential")]
@@ -282,4 +306,59 @@ fn load_core_config(config: &serde_yaml::Value, registry: &InMemoryRegistry) {
 fn fatal(err: &dyn std::fmt::Display) -> ! {
     eprintln!("fatal: {err}");
     std::process::exit(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_governance_config;
+    use wanaku_types::governance::{
+        AuditLevel, EnforcementMode, FailureBehavior, NoMatchBehavior,
+    };
+
+    #[test]
+    fn absent_governance_config_uses_fail_safe_defaults() {
+        let config = load_governance_config(None).unwrap();
+        let posture = config.resolve("default");
+
+        assert_eq!(posture.mode, EnforcementMode::Enforce);
+        assert_eq!(posture.no_match, NoMatchBehavior::Deny);
+        assert_eq!(posture.on_failure, FailureBehavior::Deny);
+        assert_eq!(posture.audit_level, AuditLevel::Basic);
+    }
+
+    #[test]
+    fn governance_config_loads_namespace_overrides() {
+        let root: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+governance:
+  namespaces:
+    sandbox:
+      mode: audit
+      no_match: allow
+"#,
+        )
+        .unwrap();
+        let config = load_governance_config(Some(&root)).unwrap();
+        let posture = config.resolve("sandbox");
+
+        assert_eq!(posture.mode, EnforcementMode::Audit);
+        assert_eq!(posture.no_match, NoMatchBehavior::Allow);
+        assert_eq!(posture.on_failure, FailureBehavior::Deny);
+    }
+
+    #[test]
+    fn governance_config_rejects_disabled_scope_without_reason() {
+        let root: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+governance:
+  namespaces:
+    maintenance:
+      mode: disabled
+"#,
+        )
+        .unwrap();
+
+        let error = load_governance_config(Some(&root)).unwrap_err();
+        assert!(error.contains("requires a reason"));
+    }
 }

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use wanaku_infra::registry::InMemoryRegistry;
 use wanaku_types::feature::Feature;
+use wanaku_types::governance::GovernanceConfig;
 
 /// Dependencies needed to build filter pipelines for all listeners.
 ///
@@ -23,6 +24,8 @@ pub struct PipelineDeps<'a> {
     pub kv_stores: &'a praxis_core::kv::KvStoreRegistry,
     /// Wanaku in-memory registry (tools, resources, prompts, namespaces, forwards).
     pub wanaku_registry: &'a InMemoryRegistry,
+    /// Immutable governance posture configuration.
+    pub governance: &'a GovernanceConfig,
     /// Wanaku feature crates that provide pipeline extensions and filters.
     pub features: &'a [Box<dyn Feature>],
 }
@@ -35,14 +38,32 @@ impl<'a> PipelineDeps<'a> {
         health_registry: &'a praxis_core::health::HealthRegistry,
         kv_stores: &'a praxis_core::kv::KvStoreRegistry,
         wanaku_registry: &'a InMemoryRegistry,
+        governance: &'a GovernanceConfig,
         features: &'a [Box<dyn Feature>],
     ) -> Self {
-        Self { filter_registry, health_registry, kv_stores, wanaku_registry, features }
+        Self {
+            filter_registry,
+            health_registry,
+            kv_stores,
+            wanaku_registry,
+            governance,
+            features,
+        }
     }
 }
 
 struct RegistryExtension {
     registry: InMemoryRegistry,
+}
+
+struct GovernanceExtension {
+    config: GovernanceConfig,
+}
+
+impl PipelineExtension for GovernanceExtension {
+    fn prepare(&self, extensions: &mut RequestExtensions) {
+        extensions.insert(self.config.clone());
+    }
 }
 
 impl PipelineExtension for RegistryExtension {
@@ -99,6 +120,9 @@ pub fn resolve_pipelines(
 
         pipeline.add_pipeline_extension(Box::new(RegistryExtension {
             registry: deps.wanaku_registry.clone(),
+        }));
+        pipeline.add_pipeline_extension(Box::new(GovernanceExtension {
+            config: deps.governance.clone(),
         }));
 
         for feature in deps.features {

--- a/types/src/governance.rs
+++ b/types/src/governance.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    feature = "openapi",
+    allow(
+        clippy::large_stack_frames,
+        reason = "utoipa::ToSchema generates large schema implementations"
+    )
+)]
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/wanaku.yaml
+++ b/wanaku.yaml
@@ -6,6 +6,15 @@ forwards:
     address: "http://localhost:8181/mcp"
     namespace: "test-ns"
 
+# Governance uses fail-safe defaults. Namespace entries override only the
+# fields that they specify. See docs/governance-posture.md.
+governance:
+  default:
+    mode: enforce
+    no_match: deny
+    on_failure: deny
+    audit_level: basic
+
 # Sample evaluator configuration. See docs/evaluator-engine.md for the full guide.
 # LLM connections are config-only: they can't be set or read through the
 # management API, only here.


### PR DESCRIPTION
## Summary

- load and validate governance posture configuration during startup
- inject one immutable governance configuration into each request pipeline
- apply enforce, audit, disabled, no-match, and failure behavior to action policies
- use fail-safe defaults when no governance section is present
- update the governance, action-policy, and configuration documentation
- add focused posture and startup configuration tests

## Scope

This continuation applies posture to deterministic action policies. Evaluator integration, audit side-effect suppression, readiness APIs, audit events, and posture metrics remain for later reviewable slices.

## Validation

- `cargo +1.96.0 test -p wanaku-types governance`
- `cargo +1.96.0 test -p wanaku-feature-action-policy`
- `cargo +1.96.0 test -p wanaku-server governance_config`
- `git diff --check`
- parsed `wanaku.yaml` successfully

The focused action-policy Clippy run reaches pre-existing unfulfilled lint expectations in `wanaku-infra/src/mcp_client.rs` and `wanaku-infra/src/llm.rs`.

Generated by Codex via OSS Helper

## Summary by Sourcery

Apply validated governance posture configuration to action-policy authorization behavior.

New Features:
- Apply governance posture modes and namespace-specific overrides to deterministic action-policy decisions.
- Load, validate, and propagate immutable governance configuration through request pipelines, with fail-safe defaults when omitted.

Bug Fixes:
- Honor configured no-match and policy-failure behavior instead of treating unmatched or unavailable action policies as implicitly allowed or generically denied.

Enhancements:
- Add audit and disabled handling for action-policy evaluation while preserving evaluator integration for a later change.
- Clarify governance, action-policy, and configuration documentation and provide a sample governance configuration.

Documentation:
- Document startup validation, fail-safe defaults, namespace overrides, and action-policy posture behavior.

Tests:
- Add coverage for governance configuration defaults, namespace overrides, invalid disabled scopes, posture behavior, and audit-mode policy handling.