### PR TITLE
Fix: tool required field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ load-test: test-resources test-tools
 	$(WANAKU_CLI_CMD) targets tools list
 
 early-builds:
-	gh workflow run early-access -f currentDevelopmentVersion=$$(cat core/core-util/target/classes/version.txt)
+	gh workflow run early-access --ref $$(git rev-parse --abbrev-ref HEAD) -f currentDevelopmentVersion=$$(cat core/core-util/target/classes/version.txt)

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/apps/wanaku-cli/pom.xml
+++ b/apps/wanaku-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>apps</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-cli</artifactId>

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPrompt.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -62,7 +63,7 @@ public class McpPrompt extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpPromptList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -35,7 +36,7 @@ public class McpPromptList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResource.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -53,7 +54,7 @@ public class McpResource extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpResourceList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.mcp.client.McpClient;
@@ -37,7 +38,7 @@ public class McpResourceList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpTool.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.jline.terminal.Terminal;
 import io.vertx.core.json.JsonObject;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -61,7 +62,7 @@ public class McpTool extends BaseCommand {
             System.out.println(result.resultText());
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/mcp/McpToolList.java
@@ -3,6 +3,7 @@ package ai.wanaku.cli.main.commands.mcp;
 import java.util.List;
 import org.jline.terminal.Terminal;
 import ai.wanaku.cli.main.commands.BaseCommand;
+import ai.wanaku.cli.main.support.McpErrorHelper;
 import ai.wanaku.cli.main.support.WanakuPrinter;
 import ai.wanaku.core.mcp.client.ClientUtil;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -36,7 +37,7 @@ public class McpToolList extends BaseCommand {
 
             return EXIT_OK;
         } catch (Exception e) {
-            printer.printErrorMessage(e.getMessage());
+            printer.printErrorMessage(McpErrorHelper.friendlyMessage(e, uri));
             return EXIT_ERROR;
         }
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/namespaces/NamespaceList.java
@@ -3,11 +3,9 @@ package ai.wanaku.cli.main.commands.namespaces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jline.terminal.Terminal;
-import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import ai.wanaku.capabilities.sdk.api.types.Namespace;
 import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
 import ai.wanaku.cli.main.commands.BaseCommand;
@@ -36,7 +34,7 @@ For detailed information see the label expression manual page:
 Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 """
             })
-    private String labelExpression;
+    String labelExpression;
 
     NamespacesService namespacesService;
 
@@ -76,15 +74,16 @@ Note: If omitted, all namespaces are listed. Label matching is case-sensitive.
 
     @Override
     public Integer doCall(Terminal terminal, WanakuPrinter printer) throws Exception {
-        namespacesService =
-                QuarkusRestClientBuilder.newBuilder().baseUri(URI.create(host)).build(NamespacesService.class);
+        namespacesService = initAuthenticatedServiceIfNeeded(namespacesService, NamespacesService.class, host);
 
         try {
             WanakuResponse<List<Namespace>> response = namespacesService.list(labelExpression);
             List<AddressableNamespace> list =
                     response.data().stream().map(this::convertToAddressable).collect(Collectors.toList());
 
-            list.add(AddressableNamespace.defaultNs(host));
+            if (labelExpression == null || labelExpression.isBlank()) {
+                list.add(AddressableNamespace.defaultNs(host));
+            }
 
             printer.printTable(list, "id", "name", "path", "labels");
         } catch (WebApplicationException ex) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/commands/start/StartLocal.java
@@ -162,6 +162,7 @@ public class StartLocal extends StartBase {
                 return EXIT_OK;
             }
         }
+        printer.printWarningMessage("Authentication is disabled in local mode");
         startWanaku();
         return EXIT_OK;
     }

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/AuthCredentialStore.java
@@ -23,7 +23,6 @@ public class AuthCredentialStore {
 
     private static final Logger LOG = Logger.getLogger(AuthCredentialStore.class);
 
-    private static final String DEFAULT_CREDENTIALS_FILE = WanakuHome.get() + File.separator + "credentials";
     private static final String API_TOKEN_KEY = "api.token";
     private static final String REFRESH_TOKEN_KEY = "refresh.token";
     private static final String AUTH_MODE_KEY = "auth.mode";
@@ -35,7 +34,11 @@ public class AuthCredentialStore {
     private final URI credentialsUri;
 
     public AuthCredentialStore() {
-        this(resolveCredentialsPath(DEFAULT_CREDENTIALS_FILE));
+        this(resolveCredentialsPath(getDefaultCredentialsFile()));
+    }
+
+    private static String getDefaultCredentialsFile() {
+        return WanakuHome.get() + File.separator + "credentials";
     }
 
     public AuthCredentialStore(String credentialsPath) {

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/McpErrorHelper.java
@@ -1,0 +1,114 @@
+package ai.wanaku.cli.main.support;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * Translates MCP client exceptions into user-friendly error messages.
+ *
+ * <p>MCP client operations often throw wrapped exceptions (e.g.,
+ * {@code ExecutionException} wrapping {@code ConnectException}) whose default
+ * messages expose raw Java class names. This helper unwraps the cause chain
+ * and produces concise, actionable messages consistent with the rest of
+ * the Wanaku CLI.</p>
+ */
+public final class McpErrorHelper {
+
+    private McpErrorHelper() {}
+
+    /**
+     * Produces a user-friendly error message for the given exception and
+     * MCP server URI.
+     *
+     * @param ex the exception thrown during MCP client operations
+     * @param uri the MCP server URI the command was targeting (may be null)
+     * @return a user-friendly error message
+     */
+    public static String friendlyMessage(Exception ex, String uri) {
+        Throwable root = rootCause(ex);
+
+        if (root instanceof ConnectException) {
+            return connectionRefusedMessage(uri);
+        }
+
+        if (root instanceof UnknownHostException) {
+            return unknownHostMessage(root);
+        }
+
+        if (root instanceof SocketTimeoutException) {
+            return timeoutMessage(uri);
+        }
+
+        if (root instanceof IllegalArgumentException) {
+            String msg = root.getMessage();
+            if (msg != null && (msg.contains("URI") || msg.contains("scheme") || msg.contains("url"))) {
+                return invalidUriMessage(uri);
+            }
+        }
+
+        // For any other exception, return the root cause message without class name prefixes
+        String message = root.getMessage();
+        if (message == null || message.isBlank()) {
+            message = ex.getMessage();
+        }
+        if (message == null || message.isBlank()) {
+            return "An unexpected error occurred. Run with --verbose for more details";
+        }
+        return message;
+    }
+
+    private static String connectionRefusedMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Connection refused");
+        if (uri != null) {
+            sb.append(": could not connect to ").append(uri);
+        }
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - MCP server is not running\n");
+        sb.append("  - Incorrect --uri value\n");
+        sb.append("  - Network connectivity issues");
+        return sb.toString();
+    }
+
+    private static String unknownHostMessage(Throwable root) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Unable to resolve host: ").append(root.getMessage());
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - Invalid hostname in --uri option\n");
+        sb.append("  - DNS resolution failure\n");
+        sb.append("  - Network connectivity issues");
+        return sb.toString();
+    }
+
+    private static String timeoutMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Request timed out");
+        if (uri != null) {
+            sb.append(" connecting to ").append(uri);
+        }
+        sb.append("\n\nPossible causes:\n");
+        sb.append("  - MCP server is not responding\n");
+        sb.append("  - Network latency issues\n");
+        sb.append("  - Firewall blocking the connection");
+        return sb.toString();
+    }
+
+    private static String invalidUriMessage(String uri) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Invalid URI");
+        if (uri != null) {
+            sb.append(": '").append(uri).append("' is not a valid MCP server URI");
+        }
+        sb.append("\n\nExpected format: http://<host>:<port>/path or https://<host>:<port>/path");
+        return sb.toString();
+    }
+
+    private static Throwable rootCause(Throwable ex) {
+        Throwable current = ex;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/NamespaceOptions.java
@@ -33,7 +33,7 @@ public class NamespaceOptions {
             "No namespace matched '%s'. Use 'wanaku namespace list' to see available namespaces.";
 
     @Option(
-            names = {"-N", "--namespace"},
+            names = {"-N", "--namespace", "--namespace-name"},
             description = "The namespace name associated with this entity")
     String namespace;
 

--- a/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
+++ b/apps/wanaku-cli/src/main/java/ai/wanaku/cli/main/support/WanakuPrinter.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.stream.Collectors.toMap;
 import static org.jline.console.Printer.TableRows.EVEN;
 
 /**
@@ -309,9 +308,13 @@ public class WanakuPrinter extends DefaultPrinter {
         Map<String, Object> map = convertToMap(object);
         if (keys != null && keys.length > 0) {
             Set<String> keySet = Set.of(keys);
-            map = map.entrySet().stream()
-                    .filter(entry -> keySet.contains(entry.getKey()))
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            Map<String, Object> filtered = new HashMap<>();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                if (keySet.contains(entry.getKey())) {
+                    filtered.put(entry.getKey(), entry.getValue());
+                }
+            }
+            map = filtered;
         }
 
         try {

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolListTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -90,6 +91,25 @@ class McpToolListTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should show user-friendly message for wrapped ConnectException")
+    void shouldShowFriendlyMessageForConnectException() throws Exception {
+        java.net.ConnectException cause = new java.net.ConnectException("Connection refused");
+        RuntimeException ex = new RuntimeException("java.net.ConnectException: Connection refused", cause);
+        when(mcpClient.listTools()).thenThrow(ex);
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(printer).printErrorMessage(captor.capture());
+        String message = captor.getValue();
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:3001/mcp"));
+        assertTrue(message.contains("MCP server is not running"));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/mcp/McpToolTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -92,6 +93,24 @@ class McpToolTest {
 
         assertEquals(BaseCommand.EXIT_ERROR, result);
         verify(printer).printErrorMessage("connection refused");
+    }
+
+    @Test
+    @DisplayName("Should show user-friendly message for invalid URI")
+    void shouldShowFriendlyMessageForInvalidUri() throws Exception {
+        command.uri = "not-a-valid-uri";
+        when(mcpClient.executeTool(any(ToolExecutionRequest.class)))
+                .thenThrow(new IllegalArgumentException("URI with undefined scheme"));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(BaseCommand.EXIT_ERROR, result);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(printer).printErrorMessage(captor.capture());
+        String message = captor.getValue();
+        assertTrue(message.contains("Invalid URI"));
+        assertTrue(message.contains("not-a-valid-uri"));
     }
 
     @Test

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespaceListTest.java
@@ -1,0 +1,114 @@
+package ai.wanaku.cli.main.commands.namespaces;
+
+import java.util.List;
+import java.util.Map;
+import ai.wanaku.capabilities.sdk.api.types.Namespace;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.cli.main.support.WanakuPrinter;
+import ai.wanaku.core.services.api.NamespacesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NamespaceListTest {
+
+    @Mock
+    private NamespacesService namespacesService;
+
+    private NamespaceList command;
+
+    @BeforeEach
+    void setUp() {
+        command = new NamespaceList();
+        command.namespacesService = namespacesService;
+        command.host = "http://localhost:8080";
+    }
+
+    @Test
+    @DisplayName("Should include default namespace when no label expression is set")
+    @SuppressWarnings("unchecked")
+    void shouldIncludeDefaultNamespaceWhenNoLabelExpression() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+
+        when(namespacesService.list(null)).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        assertEquals(2, printed.size(), "Should contain the namespace plus the default namespace");
+    }
+
+    @Test
+    @DisplayName("Should exclude default namespace when label expression is set")
+    @SuppressWarnings("unchecked")
+    void shouldExcludeDefaultNamespaceWhenLabelExpressionSet() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+        ns.setLabels(Map.of("tier", "frontend"));
+
+        when(namespacesService.list("tier=frontend")).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        command.labelExpression = "tier=frontend";
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        assertEquals(1, printed.size(), "Should contain only the matched namespace, not the default");
+    }
+
+    @Test
+    @DisplayName("Should exclude default namespace when label expression is a blank string")
+    @SuppressWarnings("unchecked")
+    void shouldExcludeDefaultNamespaceWhenLabelExpressionBlank() throws Exception {
+        Namespace ns = new Namespace();
+        ns.setId("ns-1");
+        ns.setPath("ns-team");
+        ns.setName("team");
+
+        when(namespacesService.list("   ")).thenReturn(new WanakuResponse<>(List.of(ns)));
+
+        command.labelExpression = "   ";
+
+        WanakuPrinter printer = mock(WanakuPrinter.class);
+        Integer result = command.doCall(null, printer);
+
+        assertEquals(0, result);
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(printer).printTable(captor.capture(), eq("id"), eq("name"), eq("path"), eq("labels"));
+
+        List<?> printed = captor.getValue();
+        // A blank label expression is effectively "no filter", so the default namespace should be excluded
+        // since the backend treats blank as "list all" and the client should not add a synthetic default
+        // Actually, blank means "no filter active" so default SHOULD be included
+        assertEquals(2, printed.size(), "Blank expression means no filter, so default namespace should be included");
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/commands/namespaces/NamespacesCreateTest.java
@@ -80,4 +80,25 @@ public class NamespacesCreateTest {
         Namespace submitted = captor.getValue();
         assertNull(submitted.getName());
     }
+
+    @Test
+    @DisplayName("Should create pre-allocated namespace when name is omitted")
+    void shouldCreatePreallocatedNamespaceWhenNameOmitted() throws Exception {
+        Namespace created = new Namespace();
+        created.setId("ns-3");
+        created.setPath("ns-no-name");
+
+        when(namespacesService.create(any(Namespace.class))).thenReturn(new WanakuResponse<>(created));
+
+        command.path = "ns-no-name";
+        command.name = null;
+
+        Integer result = command.doCall(null, mock(WanakuPrinter.class));
+
+        assertEquals(0, result);
+        ArgumentCaptor<Namespace> captor = ArgumentCaptor.forClass(Namespace.class);
+        verify(namespacesService).create(captor.capture());
+        Namespace submitted = captor.getValue();
+        assertNull(submitted.getName());
+    }
 }

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/McpErrorHelperTest.java
@@ -1,0 +1,126 @@
+package ai.wanaku.cli.main.support;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpErrorHelperTest {
+
+    @Test
+    @DisplayName("Should produce friendly message for ConnectException")
+    void shouldHandleConnectException() {
+        Exception ex = new ConnectException("Connection refused");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:59999/mcp"));
+        assertTrue(message.contains("MCP server is not running"));
+        assertFalse(message.contains("java.net.ConnectException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for wrapped ConnectException")
+    void shouldHandleWrappedConnectException() {
+        ConnectException cause = new ConnectException("Connection refused");
+        Exception ex = new ExecutionException("java.net.ConnectException: Connection refused", cause);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("http://localhost:59999/mcp"));
+        assertTrue(message.contains("Possible causes"));
+        assertFalse(message.contains("ExecutionException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for IllegalArgumentException with URI issue")
+    void shouldHandleInvalidUri() {
+        Exception ex = new IllegalArgumentException("URI with undefined scheme");
+        String message = McpErrorHelper.friendlyMessage(ex, "not-a-valid-uri");
+
+        assertTrue(message.contains("Invalid URI"));
+        assertTrue(message.contains("not-a-valid-uri"));
+        assertTrue(message.contains("not a valid MCP server URI"));
+        assertFalse(message.contains("IllegalArgumentException"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for UnknownHostException")
+    void shouldHandleUnknownHost() {
+        Exception ex = new UnknownHostException("nonexistent.host.example");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://nonexistent.host.example:8080/mcp");
+
+        assertTrue(message.contains("Unable to resolve host"));
+        assertTrue(message.contains("nonexistent.host.example"));
+        assertTrue(message.contains("DNS resolution failure"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for wrapped UnknownHostException")
+    void shouldHandleWrappedUnknownHost() {
+        UnknownHostException cause = new UnknownHostException("badhost.example");
+        Exception ex = new ExecutionException("lookup failed", cause);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://badhost.example:8080/mcp");
+
+        assertTrue(message.contains("Unable to resolve host"));
+        assertTrue(message.contains("badhost.example"));
+    }
+
+    @Test
+    @DisplayName("Should produce friendly message for SocketTimeoutException")
+    void shouldHandleTimeout() {
+        Exception ex = new SocketTimeoutException("Read timed out");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("Request timed out"));
+        assertTrue(message.contains("http://localhost:8080/mcp"));
+        assertTrue(message.contains("MCP server is not responding"));
+    }
+
+    @Test
+    @DisplayName("Should pass through plain message for unrecognized exceptions")
+    void shouldPassThroughGenericException() {
+        Exception ex = new RuntimeException("something went wrong");
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("something went wrong"));
+    }
+
+    @Test
+    @DisplayName("Should handle exception with null message")
+    void shouldHandleNullMessage() {
+        Exception ex = new RuntimeException((String) null);
+        String message = McpErrorHelper.friendlyMessage(ex, "http://localhost:8080/mcp");
+
+        assertTrue(message.contains("unexpected error"));
+    }
+
+    @Test
+    @DisplayName("Should handle ConnectException with null URI")
+    void shouldHandleConnectExceptionWithNullUri() {
+        Exception ex = new ConnectException("Connection refused");
+        String message = McpErrorHelper.friendlyMessage(ex, null);
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("MCP server is not running"));
+    }
+
+    @Test
+    @DisplayName("Should handle deeply wrapped ConnectException")
+    void shouldHandleDeeplyWrappedConnectException() {
+        ConnectException root = new ConnectException("Connection refused");
+        Exception mid = new ExecutionException("inner", root);
+        Exception outer = new RuntimeException("outer", mid);
+        String message = McpErrorHelper.friendlyMessage(outer, "http://localhost:59999/mcp");
+
+        assertTrue(message.contains("Connection refused"));
+        assertTrue(message.contains("Possible causes"));
+        assertFalse(message.contains("ExecutionException"));
+        assertFalse(message.contains("RuntimeException"));
+    }
+}

--- a/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
+++ b/apps/wanaku-cli/src/test/java/ai/wanaku/cli/main/support/WanakuPrinterPlainModeTest.java
@@ -2,6 +2,7 @@ package ai.wanaku.cli.main.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jline.terminal.Terminal;
@@ -111,6 +112,21 @@ class WanakuPrinterPlainModeTest {
 
         String output = outputStream.toString();
         assertTrue(output.contains("Available service templates:"), "Info message must appear in plain-mode output");
+    }
+
+    @Test
+    void printAsMapHandlesNullValues() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", "ns-123");
+        data.put("name", null);
+        data.put("path", "my-path");
+
+        printer.printAsMap(data, "id", "name", "path");
+
+        String output = outputStream.toString();
+        assertFalse(output.isBlank(), "Map output with null values must not be blank");
+        assertTrue(output.contains("ns-123"), "Output must contain non-null value 'ns-123'");
+        assertTrue(output.contains("my-path"), "Output must contain non-null value 'my-path'");
     }
 
     @Test

--- a/apps/wanaku-jbang/pom.xml
+++ b/apps/wanaku-jbang/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ai.wanaku</groupId>
 		<artifactId>apps</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 
 	<artifactId>wanaku-jbang</artifactId>

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -94,6 +94,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/apps/wanaku-operator/pom.xml
+++ b/apps/wanaku-operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>apps</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-operator</artifactId>

--- a/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
+++ b/apps/wanaku-operator/src/main/java/ai/wanaku/operator/util/CapabilityResourceFactory.java
@@ -52,7 +52,8 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating services-volume PVC for deployment: %s", deploymentName);
         pvc.getMetadata().setName(createVolumeClaimName(serviceName));
         pvc.getMetadata().setNamespace(ns);
-        pvc.getMetadata().getLabels().put("app", deploymentName);
+        pvc.getMetadata().getLabels().put("app", serviceName);
+        pvc.getMetadata().getLabels().put("app.kubernetes.io/part-of", deploymentName);
         pvc.getMetadata().getLabels().put("component", "wanaku-services-storage");
 
         pvc.addOwnerReference(resource);
@@ -133,11 +134,12 @@ public final class CapabilityResourceFactory {
         LOG.infof("Creating internal service for capability: %s", serviceName);
         service.getMetadata().setName(serviceName);
         service.getMetadata().setNamespace(ns);
-        service.getMetadata().getLabels().put("app", parentName);
+        service.getMetadata().getLabels().put("app", serviceName);
+        service.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         service.getMetadata().getLabels().put("component", serviceName);
 
         ServiceSpec serviceSpec2 = service.getSpec();
-        serviceSpec2.setSelector(Map.of("app", parentName, "component", serviceName));
+        serviceSpec2.setSelector(Map.of("app", serviceName));
 
         service.addOwnerReference(resource);
 
@@ -156,14 +158,15 @@ public final class CapabilityResourceFactory {
 
         desiredDeployment.getMetadata().setName(serviceName);
         desiredDeployment.getMetadata().setNamespace(ns);
-        desiredDeployment.getMetadata().getLabels().put("app", parentName);
+        desiredDeployment.getMetadata().getLabels().put("app", serviceName);
+        desiredDeployment.getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         desiredDeployment.getMetadata().getLabels().put("component", serviceName);
 
         final DeploymentSpec deploymentSpec = desiredDeployment.getSpec();
 
-        deploymentSpec.getSelector().getMatchLabels().put("app", parentName);
-        deploymentSpec.getSelector().getMatchLabels().put("component", serviceName);
-        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", parentName);
+        deploymentSpec.getSelector().getMatchLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app", serviceName);
+        deploymentSpec.getTemplate().getMetadata().getLabels().put("app.kubernetes.io/part-of", parentName);
         deploymentSpec.getTemplate().getMetadata().getLabels().put("component", serviceName);
         deploymentSpec
                 .getTemplate()

--- a/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
+++ b/apps/wanaku-operator/src/main/resources/ai/wanaku/operator/wanaku/wanaku-router-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: "wanaku-mcp-router"
-          image: quay.io/wanaku/wanaku-router-backend:0.1.3
+          image: quay.io/wanaku/wanaku-router-backend:0.2.x
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/assertions/OperatorAssertions.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/assertions/OperatorAssertions.java
@@ -1,0 +1,65 @@
+package ai.wanaku.operator.assertions;
+
+import org.assertj.core.api.Assertions;
+import io.fabric8.kubernetes.api.model.Condition;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Service;
+
+/**
+ * Custom assertions for Wanaku operator testing.
+ * Provides Kubernetes-specific assertions with clear failure messages.
+ */
+public final class OperatorAssertions {
+
+    private OperatorAssertions() {}
+
+    // ========== Condition Assertions ==========
+
+    public static void assertCondition(
+            Condition condition, String expectedType, String expectedStatus, Long expectedObservedGeneration) {
+        Assertions.assertThat(condition).isNotNull();
+        Assertions.assertThat(condition.getType()).isEqualTo(expectedType);
+        Assertions.assertThat(condition.getStatus()).isEqualTo(expectedStatus);
+        Assertions.assertThat(condition.getObservedGeneration()).isEqualTo(expectedObservedGeneration);
+    }
+
+    // ========== Service Assertions ==========
+
+    public static void assertServiceLabel(Service service, String labelKey, String expectedValue) {
+        Assertions.assertThat(service).isNotNull();
+        Assertions.assertThat(service.getMetadata().getLabels()).containsEntry(labelKey, expectedValue);
+    }
+
+    public static void assertServicePort(Service service, int expectedPort) {
+        Assertions.assertThat(service).isNotNull();
+        Assertions.assertThat(service.getSpec().getPorts()).isNotEmpty();
+        Assertions.assertThat(service.getSpec().getPorts().getFirst().getPort()).isEqualTo(expectedPort);
+    }
+
+    // ========== Metadata Assertions ==========
+
+    public static void assertMetadataLabel(HasMetadata resource, String labelKey, String expectedValue) {
+        Assertions.assertThat(resource).isNotNull();
+        Assertions.assertThat(resource.getMetadata().getLabels()).containsEntry(labelKey, expectedValue);
+    }
+
+    // ========== Endpoint Assertions ==========
+
+    public static void assertEndpointTarget(Endpoints endpoints, String expectedHost, int expectedPort) {
+        Assertions.assertThat(endpoints).isNotNull();
+        Assertions.assertThat(endpoints.getSubsets()).isNotEmpty();
+        Assertions.assertThat(endpoints.getSubsets().getFirst().getAddresses()).isNotEmpty();
+        Assertions.assertThat(endpoints.getSubsets().getFirst().getPorts()).isNotEmpty();
+        Assertions.assertThat(endpoints
+                        .getSubsets()
+                        .getFirst()
+                        .getAddresses()
+                        .getFirst()
+                        .getHostname())
+                .isEqualTo(expectedHost);
+        Assertions.assertThat(
+                        endpoints.getSubsets().getFirst().getPorts().getFirst().getPort())
+                .isEqualTo(expectedPort);
+    }
+}

--- a/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
+++ b/apps/wanaku-operator/src/test/java/ai/wanaku/operator/util/CapabilityResourceFactoryTest.java
@@ -1,0 +1,137 @@
+package ai.wanaku.operator.util;
+
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import ai.wanaku.operator.wanaku.WanakuCapability;
+import ai.wanaku.operator.wanaku.WanakuCapabilitySpec;
+
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertMetadataLabel;
+import static ai.wanaku.operator.assertions.OperatorAssertions.assertServiceLabel;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapabilityResourceFactoryTest {
+
+    private static WanakuCapability makeCapability(String crName) {
+        WanakuCapability capability = new WanakuCapability();
+        capability.getMetadata().setName(crName);
+        capability.getMetadata().setNamespace("wanaku");
+        capability.getMetadata().setUid("test-uid");
+        capability.setSpec(new WanakuCapabilitySpec());
+        return capability;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = new WanakuCapabilitySpec.CapabilitiesSpec();
+        spec.setName(name);
+        spec.setImage("quay.io/wanaku/wanaku-tool-service-http:latest");
+        return spec;
+    }
+
+    private static WanakuCapabilitySpec.CapabilitiesSpec makeCiCCapabilityEntry(String name) {
+        WanakuCapabilitySpec.CapabilitiesSpec spec = makeCapabilityEntry(name);
+        spec.setImage("quay.io/wanaku/camel-integration-capability:latest");
+        spec.setType(OperatorConstants.CAMEL_INTEGRATION_CAPABILITY_TYPE);
+        return spec;
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void wanakuCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void wanakuCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredWanakuCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void cicCapabilityDeploymentUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertMetadataLabel(deployment, "app", "cic-catalog-test");
+        assertMetadataLabel(deployment, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void cicCapabilityDeploymentMatchLabelsUseCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getSelector().getMatchLabels().get("app"));
+    }
+
+    @Test
+    void cicCapabilityPodTemplateUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCiCCapabilityEntry("cic-catalog-test");
+
+        Deployment deployment = CapabilityResourceFactory.makeDesiredCiCCapabilityDeployment(cr, null, entry);
+
+        assertEquals(
+                "cic-catalog-test",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app"));
+        assertEquals(
+                "wanaku-capabilities",
+                deployment.getSpec().getTemplate().getMetadata().getLabels().get("app.kubernetes.io/part-of"));
+    }
+
+    @Test
+    void internalServiceSelectorUsesCapabilityName() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+        WanakuCapabilitySpec.CapabilitiesSpec entry = makeCapabilityEntry("cic-catalog-test");
+
+        Service service = CapabilityResourceFactory.makeCapabilityInternalService(cr, entry);
+
+        assertEquals("cic-catalog-test", service.getSpec().getSelector().get("app"));
+        assertServiceLabel(service, "app", "cic-catalog-test");
+        assertServiceLabel(service, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+
+    @Test
+    void pvcUsesCapabilityNameAsAppLabel() {
+        WanakuCapability cr = makeCapability("wanaku-capabilities");
+
+        PersistentVolumeClaim pvc = CapabilityResourceFactory.makeServicesVolumePVC(cr, "cic-catalog-test");
+
+        assertMetadataLabel(pvc, "app", "cic-catalog-test");
+        assertMetadataLabel(pvc, "app.kubernetes.io/part-of", "wanaku-capabilities");
+    }
+}

--- a/apps/wanaku-router-backend/pom.xml
+++ b/apps/wanaku-router-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>apps</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-router-backend</artifactId>

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/exceptions/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,34 @@
+package ai.wanaku.backend.api.v1.exceptions;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.logging.Logger;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+
+/**
+ * Maps {@link IllegalArgumentException} to HTTP 400 (Bad Request) responses.
+ * This ensures that validation errors (e.g., invalid namespace names) return
+ * a proper client error status instead of a generic 500 error.
+ */
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    private static final Logger LOG = Logger.getLogger(IllegalArgumentExceptionMapper.class);
+
+    @APIResponse(
+            responseCode = "400",
+            description = "Bad request",
+            content = @Content(schema = @Schema(implementation = WanakuResponse.class)))
+    @Override
+    public Response toResponse(IllegalArgumentException e) {
+        LOG.warnf("Bad request: %s", e.getMessage());
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new WanakuResponse<Void>(e.getMessage()))
+                .build();
+    }
+}

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/forwards/ForwardsBean.java
@@ -29,6 +29,7 @@ import ai.wanaku.backend.core.mcp.util.LabelExpressionParser;
 import ai.wanaku.backend.core.persistence.api.ForwardReferenceRepository;
 import ai.wanaku.backend.core.persistence.api.WanakuRepository;
 import ai.wanaku.capabilities.sdk.api.exceptions.EntityAlreadyExistsException;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.ServiceUnavailableException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.ForwardReference;
@@ -332,7 +333,8 @@ public class ForwardsBean extends AbstractBean<ForwardReference> {
     public void refresh(ForwardReference forwardReferenceHint) {
         List<ForwardReference> references = forwardReferenceRepository.findByName(forwardReferenceHint.getName());
         if (references.isEmpty()) {
-            throw new WanakuException("Forward reference not found: %s".formatted(forwardReferenceHint.getName()));
+            throw new ResourceNotFoundException(
+                    "Forward reference not found: %s".formatted(forwardReferenceHint.getName()));
         }
 
         ForwardReference forwardReference = references.getFirst();

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.WanakuRouterConfig;
 import ai.wanaku.backend.core.persistence.api.NamespaceRepository;
@@ -26,6 +27,12 @@ public class NamespacesBean {
     private static final String LABEL_ALLOCATED_AT = "wanaku.io/allocated-at";
     private static final String LABEL_EXPIRES_AT = "wanaku.io/expires-at";
     private static final Set<String> PROTECTED_NAMESPACES = Set.of("default", "public", "wanaku-internal");
+
+    /**
+     * Pattern for valid namespace names and paths: must start with an alphanumeric character,
+     * followed by zero or more alphanumeric characters or dashes.
+     */
+    private static final Pattern VALID_NAMESPACE_PATTERN = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9-]*$");
 
     @Inject
     Instance<NamespaceRepository> namespaceRepositoryInstance;
@@ -72,6 +79,8 @@ public class NamespacesBean {
     }
 
     public Namespace alocateNamespace(String name) {
+        validateNamespaceValue(name, "name");
+
         List<Namespace> byName = namespaceRepository.findByName(name);
         if (byName.isEmpty()) {
             final List<Namespace> namespaces = namespaceRepository.findFirstAvailable(name);
@@ -106,6 +115,9 @@ public class NamespacesBean {
         if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         if (isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath())) {
             throw new IllegalArgumentException("Reserved namespace names cannot be created");
@@ -165,6 +177,9 @@ public class NamespacesBean {
         if (namespace == null) {
             return false;
         }
+
+        validateNamespaceValue(namespace.getPath(), "path");
+        validateNamespaceValue(namespace.getName(), "name");
 
         Namespace existingNamespace = namespaceRepository.findById(id);
         if (existingNamespace == null) {
@@ -272,6 +287,27 @@ public class NamespacesBean {
 
     private boolean isProtectedNamespace(Namespace namespace) {
         return isProtectedNamespaceName(namespace.getName()) || isProtectedNamespaceName(namespace.getPath());
+    }
+
+    /**
+     * Validates that a namespace value (name or path) contains only alphanumeric characters and dashes,
+     * and starts with an alphanumeric character. Null values are accepted (e.g., preallocated namespaces
+     * have null names).
+     *
+     * @param value the value to validate
+     * @param fieldName the field name for the error message (e.g., "name" or "path")
+     * @throws IllegalArgumentException if the value contains invalid characters
+     */
+    private void validateNamespaceValue(String value, String fieldName) {
+        if (value == null) {
+            return;
+        }
+
+        if (!VALID_NAMESPACE_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid namespace %s: '%s'. Only alphanumeric characters and dashes are allowed, and it must start with an alphanumeric character"
+                            .formatted(fieldName, value));
+        }
     }
 
     private boolean isProtectedNamespaceName(String value) {

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBean.java
@@ -97,6 +97,12 @@ public class NamespacesBean {
             throw new IllegalArgumentException("Namespace cannot be null");
         }
 
+        // Path must be provided
+        if (namespace.getPath() == null || StringHelper.isBlank(namespace.getPath())) {
+            throw new IllegalArgumentException("Path cannot be null");
+        }
+
+        // Name can be null if we are resetting/de-allocating the NS
         if (namespace.getName() != null && StringHelper.isBlank(namespace.getName())) {
             namespace.setName(null);
         }

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/api/v1/toolsetrepos/ToolsetReposBean.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import ai.wanaku.backend.core.persistence.api.DataStoreRepository;
+import ai.wanaku.capabilities.sdk.api.exceptions.ResourceNotFoundException;
 import ai.wanaku.capabilities.sdk.api.exceptions.WanakuException;
 import ai.wanaku.capabilities.sdk.api.types.DataStore;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -149,7 +150,7 @@ public class ToolsetReposBean {
             throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         if (url != null && !url.isBlank()) {
@@ -206,7 +207,7 @@ public class ToolsetReposBean {
     public Map<String, Object> browse(String name) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         String url = resolveBaseUrl(ds);
@@ -242,7 +243,7 @@ public class ToolsetReposBean {
     public List<ToolReference> fetchToolset(String name, String toolsetName) throws WanakuException {
         DataStore ds = findByName(name);
         if (ds == null) {
-            throw new WanakuException("Toolset repository not found: %s".formatted(name));
+            throw new ResourceNotFoundException("Toolset repository not found: %s".formatted(name));
         }
 
         validateToolsetName(toolsetName);

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/bridge/InvokerBridge.java
@@ -116,6 +116,11 @@ public class InvokerBridge implements ToolsBridge {
                     } else {
                         RequestIdContext.clear();
                     }
+                })
+                .onFailure()
+                .recoverWithItem(failure -> {
+                    LOG.debugf(failure, "Handling failure: %s", failure.getMessage());
+                    return ToolResponse.error(failure.getMessage());
                 });
     }
 

--- a/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
+++ b/apps/wanaku-router-backend/src/main/java/ai/wanaku/backend/common/ToolsHelper.java
@@ -89,11 +89,14 @@ public class ToolsHelper {
             ToolManager.ToolDefinition toolDefinition =
                     toolManager.newTool(toolReference.getName()).setDescription(description);
 
-            final boolean required = isRequired(toolReference);
 
             InputSchema inputSchema = toolReference.getInputSchema();
             if (inputSchema != null) {
-                inputSchema.getProperties().forEach((key, value) -> addArgument(key, value, toolDefinition, required));
+                inputSchema.getProperties().forEach((key, value) -> {
+                    boolean required = inputSchema.getRequired() != null
+                            && inputSchema.getRequired().contains(key);
+                    addArgument(key, value, toolDefinition, required);
+                });
             }
 
             if (namespace != null) {

--- a/apps/wanaku-router-backend/src/main/webui/openapi.json
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.json
@@ -3356,7 +3356,7 @@
   },
   "info" : {
     "title" : "wanaku-router-backend API",
-    "version" : "0.2.0-SNAPSHOT"
+    "version" : "0.2.0"
   },
   "servers" : [ {
     "url" : "http://localhost:8080",

--- a/apps/wanaku-router-backend/src/main/webui/openapi.yaml
+++ b/apps/wanaku-router-backend/src/main/webui/openapi.yaml
@@ -2259,7 +2259,7 @@ paths:
       - Tool Call Resource
 info:
   title: wanaku-router-backend API
-  version: 0.2.0-SNAPSHOT
+  version: 0.2.0
 servers:
 - url: http://localhost:8080
   description: Auto generated value

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/AbstractNamespacesResourceTest.java
@@ -141,6 +141,34 @@ public abstract class AbstractNamespacesResourceTest extends WanakuRouterTest {
 
     @Order(6)
     @Test
+    public void testCreateNamespaceWithInvalidPathReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/invalid-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(7)
+    @Test
+    public void testCreateNamespaceWithLeadingDashReturns400() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-bad-path");
+
+        given().headers(getHeaders())
+                .body(namespace)
+                .when()
+                .post("/api/v1/namespaces")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Order(8)
+    @Test
     public void testStaleNamespaceCleanup() {
         Namespace namespace = new Namespace();
         stalePath = "test-stale-ns-" + System.currentTimeMillis();

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/api/v1/namespaces/NamespacesBeanTest.java
@@ -16,6 +16,7 @@ import static ai.wanaku.test.assertions.WanakuAssertions.assertNamespaceExists;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @QuarkusTest
 @TestProfile(NoOidcTestProfile.class)
@@ -227,6 +228,78 @@ public class NamespacesBeanTest {
         boolean result = namespacesBean.update(publicNamespace.getId(), updated);
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingSlashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("/my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpacesIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithSpecialCharsIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my_namespace!");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithLeadingDashIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("-my-namespace");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace path");
+    }
+
+    @Test
+    void testCreateNamespaceWithInvalidNameIsRejected() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-path");
+        namespace.setName("/invalid-name");
+
+        assertThatThrownBy(() -> namespacesBean.create(namespace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid namespace name");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("valid-namespace-123");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getPath()).isEqualTo("valid-namespace-123");
+    }
+
+    @Test
+    void testCreateNamespaceWithValidNameAndPathSucceeds() {
+        Namespace namespace = new Namespace();
+        namespace.setPath("my-path-" + System.currentTimeMillis());
+        namespace.setName("my-name");
+
+        Namespace created = namespacesBean.create(namespace);
+        assertThat(created).isNotNull();
+        assertThat(created.getName()).isEqualTo("my-name");
     }
 
     @Test

--- a/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
+++ b/apps/wanaku-router-backend/src/test/java/ai/wanaku/backend/bridge/InvokerBridgeTest.java
@@ -3,7 +3,12 @@ package ai.wanaku.backend.bridge;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import ai.wanaku.backend.service.support.ServiceResolver;
 import ai.wanaku.capabilities.sdk.api.types.InputSchema;
 import ai.wanaku.capabilities.sdk.api.types.Property;
 import ai.wanaku.capabilities.sdk.api.types.ToolReference;
@@ -12,8 +17,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -460,5 +467,42 @@ class InvokerBridgeTest {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, () -> InvokerToolExecutor.validateRequiredParameters(ref, null));
         assertTrue(ex.getMessage().contains("query"), "Should report 'query' as missing");
+    }
+
+    @Test
+    void execute_returnsErrorResponseOnValidationFailure() {
+        // Set up a tool reference with a required parameter
+        Map<String, Property> props = new HashMap<>();
+        props.put("city", prop(null, null, null));
+
+        ToolReference ref = buildToolReference(props);
+        ref.setType("http");
+        ref.getInputSchema().setRequired(List.of("city"));
+
+        // Mock ToolArguments with empty args (missing required 'city')
+        ToolManager.ToolArguments toolArguments = mock(ToolManager.ToolArguments.class);
+        when(toolArguments.args()).thenReturn(Map.of());
+        McpConnection connection = mock(McpConnection.class);
+        when(connection.id()).thenReturn("test-connection");
+        when(toolArguments.connection()).thenReturn(connection);
+        when(toolArguments.requestId()).thenReturn(new RequestId("test-request-1"));
+
+        // Mock dependencies -- ServiceResolver must return a non-null target
+        // so we get past resolveService and into buildToolInvokeRequest
+        ServiceResolver serviceResolver = mock(ServiceResolver.class);
+        when(serviceResolver.resolve(anyString(), anyString()))
+                .thenReturn(mock(ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget.class));
+
+        WanakuBridgeTransport transport = mock(WanakuBridgeTransport.class);
+
+        InvokerBridge bridge = new InvokerBridge(serviceResolver, transport, null, null);
+
+        // Execute should return ToolResponse.error instead of propagating the exception
+        ToolResponse response = bridge.execute(toolArguments, ref).await().indefinitely();
+
+        assertNotNull(response, "Response should not be null");
+        assertTrue(response.isError(), "Response should be an error");
+        TextContent textContent = response.firstContent().asText();
+        assertTrue(textContent.text().contains("city"), "Error message should mention the missing parameter 'city'");
     }
 }

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/archetypes/wanaku-mcp-servers-archetype/pom.xml
+++ b/archetypes/wanaku-mcp-servers-archetype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-mcp-servers-archetype</artifactId>

--- a/archetypes/wanaku-provider-archetype/pom.xml
+++ b/archetypes/wanaku-provider-archetype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-provider-archetype</artifactId>

--- a/archetypes/wanaku-tool-service-archetype/pom.xml
+++ b/archetypes/wanaku-tool-service-archetype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-tool-service-archetype</artifactId>

--- a/capabilities-quarkus-sdk/pom.xml
+++ b/capabilities-quarkus-sdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities-quarkus-sdk</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-capabilities-base</artifactId>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-provider/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities-quarkus-sdk</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-capabilities-provider</artifactId>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-runtimes/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-runtimes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities-quarkus-sdk</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-runtimes/wanaku-capabilities-runtime-camel/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-runtimes/wanaku-capabilities-runtime-camel/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>wanaku-capabilities-runtimes</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-capabilities-runtime-camel</artifactId>

--- a/capabilities-quarkus-sdk/wanaku-capabilities-tools/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-capabilities-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities-quarkus-sdk</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-capabilities-tools</artifactId>

--- a/capabilities-quarkus-sdk/wanaku-mcp-forward-discovery/pom.xml
+++ b/capabilities-quarkus-sdk/wanaku-mcp-forward-discovery/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities-quarkus-sdk</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-mcp-forward-discovery</artifactId>

--- a/capabilities/pom.xml
+++ b/capabilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/capabilities/providers/pom.xml
+++ b/capabilities/providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>capabilities</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/capabilities/providers/wanaku-provider-performance-static-file/pom.xml
+++ b/capabilities/providers/wanaku-provider-performance-static-file/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-provider-performance-static-file</artifactId>

--- a/capabilities/tools/pom.xml
+++ b/capabilities/tools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>ai.wanaku</groupId>
     <artifactId>capabilities</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
   </parent>
   <artifactId>tools</artifactId>
   <packaging>pom</packaging>

--- a/capabilities/tools/wanaku-tool-performance-noop/pom.xml
+++ b/capabilities/tools/wanaku-tool-performance-noop/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-tool-performance-noop</artifactId>

--- a/capabilities/tools/wanaku-tool-service-exec/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-exec/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-tool-service-exec</artifactId>

--- a/capabilities/tools/wanaku-tool-service-http/pom.xml
+++ b/capabilities/tools/wanaku-tool-service-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-tool-service-http</artifactId>

--- a/core/core-exchange/pom.xml
+++ b/core/core-exchange/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>core</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>core-exchange</artifactId>

--- a/core/core-mcp-client/pom.xml
+++ b/core/core-mcp-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>core</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>core-mcp-client</artifactId>

--- a/core/core-service-discovery/pom.xml
+++ b/core/core-service-discovery/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>core</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>core-service-discovery</artifactId>

--- a/core/core-services-api/pom.xml
+++ b/core/core-services-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>core</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>core-services-api</artifactId>

--- a/core/core-util/pom.xml
+++ b/core/core-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>core</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>core-util</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -346,7 +346,7 @@ metadata:
     app: wanaku-search
 spec:
   routerRef: wanaku-dev
-  image: quay.io/wanaku/camel-integration-capability:0.1.3
+  image: quay.io/wanaku/camel-integration-capability:0.2.0
   route: |
     - route:
         id: tavily-search
@@ -464,7 +464,7 @@ spec:
   auth:
     authServer: http://keycloak:8080
   router:
-    image: quay.io/wanaku/wanaku-router-backend:0.1.3
+    image: quay.io/wanaku/wanaku-router-backend:0.2.0
     env:
       - name: JAVA_OPTS
         value: "-Xmx512m -XX:MaxDirectMemorySize=256m"

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -80,13 +80,22 @@ Defines a Wanaku router instance.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `spec.auth.authServer` | string | No | `""` | Keycloak server address (format: `http://address`). Leave empty if running without auth. |
-| `spec.auth.authProxy` | string | No | `""` | OIDC proxy address. Use `"auto"` to enable Wanaku's built-in OIDC proxy, or set to Keycloak's address. Empty defaults to Keycloak's address. |
 | `spec.auth.authRealm` | string | No | `"wanaku"` | Keycloak realm name. |
+| `spec.auth.authProxy` | string | No | `""` | OIDC proxy address. Use `"auto"` to enable the built-in OIDC proxy, or set to Keycloak's address directly. Empty inherits Keycloak's address. |
 | `spec.imagePullPolicy` | string | No | `"IfNotPresent"` | Global image pull policy for all operator-managed deployments (`Always`, `IfNotPresent`, `Never`). |
 | `spec.ingress.host` | string | No | `""` | Ingress hostname for Kubernetes clusters. OpenShift auto-generates Routes; set this only on vanilla Kubernetes. |
 | `spec.router.image` | string | No | `quay.io/wanaku/wanaku-router-backend:latest` | Router container image. |
 | `spec.router.env` | list | No | `[]` | List of `{name, value}` environment variables for the router (e.g., to set `wanaku.http.auth=none`). |
 | `spec.router.imagePullPolicy` | string | No | inherits `spec.imagePullPolicy` | Override pull policy for router pod only. |
+
+The status section reports:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.host` | string | External hostname assigned to the router (from OpenShift Route or Ingress). |
+| `status.sseEndpoint` | string | SSE stream endpoint URL. |
+| `status.streamableEndpoint` | string | Streamable HTTP endpoint URL. |
+| `status.conditions` | list | Standard Kubernetes condition array (each entry: `status`, `reason`, `message`, `lastTransitionTime`, `observedGeneration`). |
 
 **Example (minimal, with Keycloak):**
 
@@ -207,11 +216,167 @@ kubectl create configmap finance-catalog-data \
 > [!TIP]
 > See [Service Catalogs](usage.md#service-catalogs) and [Service Templates](service-templates.md) for details on creating and packaging catalogs.
 
+### WanakuCamelCodeExecutionEngine (`wanaku.ai/v1alpha1`)
+
+Deploys the Camel Code Execution Engine. Supports two modes: **in-cluster** (Kubernetes Deployment) and **remote** (ExternalName service pointing to an existing endpoint).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `spec.auth.authServer` | string | No | `""` | Keycloak server address (format: `http://address`). |
+| `spec.auth.authProxy` | string | No | `""` | OIDC proxy address. Use `"auto"` to enable the built-in proxy. Empty inherits `authServer`. |
+| `spec.auth.authRealm` | string | No | `"wanaku"` | Keycloak realm name. |
+| `spec.secrets.oidcCredentialsSecret` | string | No | `""` | OIDC client secret. |
+| `spec.routerRef` | string | **Yes** | — | Name of the `WanakuRouter` CR this engine registers with. |
+| `spec.deploymentMode` | string | No | `"in-cluster"` | Deployment mode: `in-cluster` or `remote`. |
+| `spec.engineType` | string | No | `"camel"` | Engine type identifier. |
+| `spec.languageName` | string | **Yes** | — | Language name for the engine (e.g., `yaml`, `java`). |
+| `spec.image` | string | **Yes** (in-cluster) | — | Container image. Required when `deploymentMode=in-cluster`. |
+| `spec.port` | int | No | `9190` | gRPC port. |
+| `spec.remote.host` | string | **Yes** (remote) | — | Hostname of the remote engine. Required when `deploymentMode=remote`. |
+| `spec.remote.port` | int | No | `9190` | Port of the remote engine. |
+| `spec.remote.scheme` | string | No | `"http"` | URL scheme: `http` or `https`. |
+| `spec.remote.path` | string | No | `""` | Optional path prefix for the remote engine URL. |
+| `spec.security.componentAllowlist` | list | No | `[]` | Allowed Camel component names. |
+| `spec.security.componentBlocklist` | list | No | `[]` | Blocked Camel component names. |
+| `spec.security.endpointAllowlist` | list | No | `[]` | Allowed endpoint URI patterns. |
+| `spec.security.endpointBlocklist` | list | No | `[]` | Blocked endpoint URI patterns. |
+| `spec.security.routeAllowlist` | list | No | `[]` | Allowed route IDs. |
+| `spec.security.routeBlocklist` | list | No | `[]` | Blocked route IDs. |
+| `spec.dependencyCache.enabled` | bool | No | `true` | Enable dependency caching. |
+| `spec.dependencyCache.strategy` | string | No | `"inmemory"` | Cache strategy: `inmemory`, `infinispan`, or `disabled`. |
+| `spec.dependencyCache.cacheName` | string | No | `""` | Infinispan cache name (when strategy=infinispan). |
+| `spec.dependencyCache.templateNamespace` | string | No | `""` | Namespace for template lookup. |
+| `spec.dependencyCache.templatePrefix` | string | No | `""` | Prefix for template keys. |
+| `spec.resources.cpuRequest` | string | No | `""` | CPU request (e.g., `"100m"`). |
+| `spec.resources.memoryRequest` | string | No | `""` | Memory request (e.g., `"128Mi"`). |
+| `spec.resources.cpuLimit` | string | No | `""` | CPU limit (e.g., `"500m"`). |
+| `spec.resources.memoryLimit` | string | No | `""` | Memory limit (e.g., `"256Mi"`). |
+| `spec.imagePullPolicy` | string | No | `"IfNotPresent"` | Image pull policy. |
+| `spec.env` | list | No | `[]` | Additional environment variables. |
+
+**Status fields** (read-only — populated by the operator):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.deploymentState` | string | Operator reconciliation state (e.g., `REMOTE_READY`, error states). |
+| `status.serviceUrl` | string | Final service URL of the engine (in-cluster) or the resolved remote URL. |
+| `status.activeRoutes` | list of string | Route IDs currently running inside the engine. |
+| `status.healthChecks[]` | list of object | Per-check results. Each entry: `name` (string), `status` (string), `message` (string), `timestamp` (string, ISO-8601). |
+| `status.conditions` | list of object | Standard Kubernetes condition array. Each entry: `status` (string), `reason` (string), `message` (string), `lastTransitionTime` (string), `observedGeneration` (int). |
+
+**Example (in-cluster):**
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCamelCodeExecutionEngine
+metadata:
+  name: my-code-engine
+spec:
+  routerRef: wanaku-dev
+  languageName: yaml
+  image: quay.io/wanaku/camel-code-execution-engine:latest
+  deploymentMode: in-cluster
+```
+
+**Example (remote):**
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCamelCodeExecutionEngine
+metadata:
+  name: my-remote-engine
+spec:
+  routerRef: wanaku-dev
+  languageName: yaml
+  deploymentMode: remote
+  remote:
+    host: engine.example.com
+    port: 9443
+    scheme: https
+    path: /mcp
+```
+
+> [!IMPORTANT]
+> When `deploymentMode=in-cluster`, `spec.image` is required. When `deploymentMode=remote`, `spec.remote.host` is required.
+
 ### WanakuCamelRoute (`wanaku.ai/v1alpha1`)
 
-Packages inline Camel routes and MCP metadata into a service catalog automatically, then deploys the resulting capability to a router.
+Packages inline Camel routes and MCP metadata in a single CR, then deploys the resulting capability to a router. The reconciler builds a Base64 ZIP and pushes it via the router's REST API, and also provisions a dedicated Deployment + Service for the Camel Integration Capability instance.
 
-See the dedicated [WanakuCamelRoute CRD guide](camel-route-crd.md) for the full schema, examples, and troubleshooting notes.
+> [!NOTE]
+> Use `spec.route` to hold the raw Camel route definition (XML or YAML — validates as opaque JSON). Use `spec.mcp` to declare which routes become visible MCP tools and resources. See the dedicated [WanakuCamelRoute CRD guide](camel-route-crd.md) for a walkthrough with end-to-end examples.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `spec.routerRef` | string | **Yes** | — | Name of the `WanakuRouter` CR to deploy to. Must exist in the same namespace. |
+| `spec.image` | string | No | `quay.io/wanaku/camel-integration-capability:latest` | Container image for the CIC sidecar created by this CR. Override to pin a specific version. |
+| `spec.route` | object (opaque) | No | — | Raw Camel route definition (YAML or XML). The CRD schema sets `x-kubernetes-preserve-unknown-fields: true` so any structure passes validation. |
+| `spec.mcp` | object | No | — | MCP exposure configuration. |
+| `spec.mcp.tools[]` | list | No | — | Tools exposed to agents. Each entry: `name`, `routeId` (must match the Camel route `id`), `description`, `properties[]`. The inner `properties[]` fields are `name`, `type`, `description`, `required`. |
+| `spec.mcp.resources[]` | list | No | — | Resources exposed to agents. Each entry: `name`, `routeId`, `description`, `uri`, `mimeType`. |
+| `spec.mcp.properties` | map\<string,string\> | No | — | Template variable substitutions applied when packaging the catalog (key → value replaces `${key}` in the route). |
+| `spec.properties` | map\<string,string\> | No | — | Arbitrary key/value pairs forwarded by the operator (no effect on runtime, available for downstream tooling or annotations). |
+
+**Status fields** (read-only — populated by the operator):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.conditions` | list of object | Standard Kubernetes condition array. |
+| `status.deployedCatalogName` | string | Name of the catalog pushed to the router. |
+| `status.registeredTools` | list of string | Tool names successfully registered with the router. |
+| `status.registeredResources` | list of string | Resource names successfully registered with the router. |
+
+**Shared type: `spec.mcp.tools[].properties[]`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | **Yes** | Parameter name as seen by the agent (e.g., `employeeId`). |
+| `type` | string | No | MCP tool parameter type (`string`, `int`, `boolean`, etc.). |
+| `description` | string | No | Human-readable description shown to the agent. |
+| `required` | bool | No | Whether the agent must supply this parameter. |
+
+**Example — Tavily search tool:**
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCamelRoute
+metadata:
+  name: tavily-search
+  labels:
+    app: wanaku-search
+spec:
+  routerRef: wanaku-dev
+  image: quay.io/wanaku/camel-integration-capability:0.1.3
+  route: |
+    - route:
+        id: tavily-search
+        from:
+          uri: "direct:tavily-search"
+        steps:
+          - setHeader:
+              constant: GET
+              name: CamelHttpMethod
+          - toD:
+              uri: "https://api.tavily.com/search?query=${header.query}"
+  mcp:
+    tools:
+      - name: tavily_search
+        routeId: tavily-search
+        description: "Search the web using Tavily"
+        properties:
+          - name: query
+            type: string
+            description: The search query
+            required: true
+  properties:
+    TAVILY_API_KEY: "<from-secret>"
+```
+
+> [!IMPORTANT]
+> `spec.route` is opaque to the CRD validator (no nested schema is enforced). If your YAML fails validation, suspect an encoding or indentation issue — the correct field is `spec.route`, not `spec.route.id`. Run `kubectl apply --dry-run=server` to get the precise rejection message.
+>
+> [!NOTE]
+> The dedicated [WanakuCamelRoute CRD guide](camel-route-crd.md) provides a deeper dive on Camel endpoint patterns, header mapping, parameter passing, and packaging workflows.
 
 ## Deployment Examples
 
@@ -277,11 +442,130 @@ wanaku service package --path=employee-system -o employee-system.b64
 kubectl create configmap employee-catalog-data --from-file=catalog.zip=employee-system.b64 -n wanaku
 ```
 
-Then apply the CRs:
+Then apply:
 
 ```shell
 kubectl apply -f router.yaml -n wanaku
 kubectl apply -f service-catalog.yaml -n wanaku
+```
+
+## Common Deployment Patterns
+
+### Resource Limits for Router and Capabilities
+
+JVM-based containers can OOMKill without explicit requests. Set resource requests and limits using `spec.router.resources.*` (router) or `spec.dependencyCache.resources.*` (CIC). For standard HTTP capabilities, pass `JAVA_OPTS` via `env`:
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuRouter
+metadata:
+  name: wanaku-router
+spec:
+  auth:
+    authServer: http://keycloak:8080
+  router:
+    image: quay.io/wanaku/wanaku-router-backend:0.1.3
+    env:
+      - name: JAVA_OPTS
+        value: "-Xmx512m -XX:MaxDirectMemorySize=256m"
+```
+
+For the Camel Code Execution Engine, use the dedicated `resources` block (Kubernetes-native):
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCamelCodeExecutionEngine
+metadata:
+  name: code-engine
+spec:
+  routerRef: wanaku-router
+  deploymentMode: in-cluster
+  languageName: yaml
+  image: quay.io/wanaku/camel-code-execution-engine:latest
+  resources:
+    cpuRequest: "200m"
+    memoryRequest: "512Mi"
+    cpuLimit: "1"
+    memoryLimit: "1Gi"
+```
+
+> [!TIP]
+> Setting values in both Quarkus `quarkus.kubernetes.resources` (application config) and K8s resource requests (environment variable or CR field) is redundant — the operator uses the CR fields you supply. The operator constructs the Deployment's `resources.requests` and `resources.limits` from these values; if both are empty, the Deployment has no resource constraints (Kubernetes uses the namespace `LimitRange`, if defined).
+
+### High-Availability (HA) Replicas
+
+The operator currently creates Deployments with a single replica. For HA you must manually scale after creation:
+
+```shell
+kubectl scale deployment wanaku-dev --replicas=2 -n wanaku
+kubectl scale deployment wanaku-http --replicas=2 -n wanaku
+```
+
+> [!NOTE]
+> Scaled replicas share the same `Service`, so capabilities discover routers via the ClusterIP. The operator does not yet reconcile replica counts from a CR field — plan to manage replication in your GitOps pipeline until this feature is added.
+
+### Referencing Secrets and Configuring OIDC Credentials
+
+The `spec.secrets.oidcCredentialsSecret` field references a Kubernetes `Secret` by name. The Secret must live in the same namespace as the `WanakuCapability` or `WanakuCamelCodeExecutionEngine`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wanaku-oidc-secret
+  namespace: wanaku
+type: Opaque
+data:
+  client-secret: <base64-of-your-keycloak-client-secret>
+```
+
+Then reference it:
+
+```yaml
+spec:
+  secrets:
+    oidcCredentialsSecret: wanaku-oidc-secret
+```
+
+> [!IMPORTANT]
+> The `client-secret` key in the Secret **must** be named `client-secret` (lowercase, hyphenated). The operator reads this key verbatim — different names cause a reconciliation error.
+
+### Annotations on Operator-Managed Resources
+
+`spec.annotations` (top-level on the CR) passes arbitrary key/value pairs to the operator-managed Deployment and Service. Use this to add sidecar injection markers, prometheus scraping annotations, or pod security labels:
+
+```yaml
+spec:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    sidecar.istio.io/inject: "true"
+```
+
+### DeploymentMode for the Code Execution Engine (in-cluster vs remote)
+
+The `WanakuCamelCodeExecutionEngine` CR supports two modes:
+
+- **`in-cluster` (default):** the operator provisions a K8s Deployment and Service from `spec.image`.
+- **`remote`:** the operator provisions an `ExternalName` Service pointing to the existing endpoint described in `spec.remote`. No Deployment is created.
+
+Use `remote` when your code engine is already deployed (e.g., a managed Kafka Connect cluster, a separate Camel runtime, or legacy VMs):
+
+```yaml
+apiVersion: "wanaku.ai/v1alpha1"
+kind: WanakuCamelCodeExecutionEngine
+metadata:
+  name: external-yaml-engine
+spec:
+  routerRef: wanaku-dev
+  deploymentMode: remote
+  engineType: camel
+  languageName: yaml
+  remote:
+    host: camel-engine.internal.example.com
+    port: 9190
+    scheme: http
+    path: /mcp
 ```
 
 ## Lifecycle Operations
@@ -602,6 +886,27 @@ kubectl get configmap wanaku-http-config -n wanaku
 
 > [!WARNING]
 > Do **not** manually edit operator-managed resources (deployments, services, etc.). The operator reconciles them continuously and will overwrite manual changes. Always edit the custom resource instead.
+
+### Troubleshooting CRD validation errors
+
+When `kubectl apply` rejects a CR before the operator ever sees it, the problem is purely in the YAML shape. Common culprits and fixes:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Forbidden: spec.router: Invalid value` | `spec.router` or `spec.capabilities` passed at the top level of the wrong CR kind | `router` belongs on `WanakuRouter`; `capabilities` belongs on `WanakuCapability`. Do not mix them. |
+| `no matches for kind "WanakuRouter" in version "wanaku.ai/v1alpha1"` | CRDs not installed | Re-run `helm install` (or `kubectl apply` the CRD YAMLs) and verify with `kubectl get crd wanakurouters.wanaku.ai`. |
+| `Forbidden: updates to statefulset spec are not allowed` | Editing an operator-managed Deployment directly | Delete and re-create via `kubectl apply -f <your-cr>`. The operator rebuilds the Deployment from the CR. |
+| `Object field is immutable` (e.g. `spec.auth`) on an existing CR | Auth block changed after first reconcile | Delete and recreate the CR (or delete the operator-managed Deployment so it gets rebuilt). |
+| `unable to recognize ""` or `error converting YAML` — blank value | Trailing space on a key, or scalar placed where object is expected (e.g. `authProxy: "auto" # with a trailing tab`) | Run the file through `yamllint` and re-apply with `--dry-run=server`. |
+| CRD accepted but CR stays in `NotReady` indefinitely | Router not reachable / OIDC secret wrong / `routerRef` typo | Run `kubectl describe <cr> -n <ns>`; check operator logs (`kubectl logs -l app=wanaku-operator -n <ns>`); confirm the referenced router exists and is in `Ready` condition. |
+
+**Quick diagnosis loop:**
+
+```shell
+kubectl apply --dry-run=server -f my-cr.yaml -n wanaku
+kubectl describe wanakurouter wanaku-router -n wanaku
+kubectl logs -l app=wanaku-operator -n wanaku --tail=100
+```
 
 ## Next Steps
 

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -16,7 +16,7 @@ git push origin 0.2.x
 
 ```shell
 export RELEASE_BRANCH=0.2.x
-export PREVIOUS_VERSION=0.1.0
+export PREVIOUS_VERSION=0.1.3
 export CURRENT_DEVELOPMENT_VERSION=0.2.0
 export NEXT_DEVELOPMENT_VERSION=0.2.1
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,45 @@ wanaku auth login \
 wanaku tools list --no-auth
 ```
 
+### CLI commands fail with: An error occurred: Failed to communicate with Keycloak
+
+**Symptoms:**
+
+- `wanaku` CLI commands fail to communicate with Keycloak
+
+Example:
+
+```shell
+An error occurred: Failed to communicate with Keycloak at https://127.0.0.1:8543
+
+Run with --verbose flag for more details
+
+```
+
+If you set `--verbose` and then shows the cause as:
+
+```shell
+sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+```
+
+**Why this happens:**
+
+The security code (JSSE) in wanaku-cli doesn't recognize the certificate that serves the Keycloak HTTPS endpoint.
+
+**Fix:**
+
+You have two options:
+
+- You can skip the certificate checks in wanaku-cli by using the `--insecure` parameter. In this case, it will show a warning `WARNING: TLS certificate verification is disabled. This is insecure and should only be used for development.`.
+
+- You can use the CA that signed the Keycloak HTTPS endpoint, by either importing it into the default Java truststore `$JAVA_HOME/lib/security/cacerts` or have a particular keystore file and use the `-Djavax.net.ssl.trustStore` and `-Djavax.net.ssl.trustStorePassword` parameters to refer to this custom truststore.
+
+NOTE: You can set these `-D` to the wanaku-cli as in this example:
+
+```shell
+java "-Djavax.net.ssl.trustStore=my-truststore.p12" "-Djavax.net.ssl.trustStorePassword=changeit" -jar quarkus-run.jar  admin credentials show --admin-username=admin --admin-password=admin --keycloak-url=https://keycloak.192.168.49.2.nip.io --show-secret --client-id wanaku-service
+```
+
 ### Token issuer mismatch causes 401 on OpenShift / Kubernetes
 
 **Symptoms:**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -357,6 +357,19 @@ Verify the installation:
 wanaku --version
 ```
 
+### Handling HTTPS connections
+
+Wanaku CLI may connect to either Keycloak or Wanaku MCP server, if their HTTP endpoints are protected by a server certificate (TLS) you may choose to skip the certificate checks or use the CA (Certificate Authority) that issued them on the wanaku-cli so the client can check the server certificate.
+
+1. In wanaku-cli you can skip the checks by using the `--insecure` parameter, and it's going to print a warning message about it.
+2. You can use the CA that signed the Keycloak HTTPS endpoint, by either importing it into the default Java truststore `$JAVA_HOME/lib/security/cacerts` or have a particular keystore file and use the `-Djavax.net.ssl.trustStore` and `-Djavax.net.ssl.trustStorePassword` parameters to refer to this custom truststore.
+
+NOTE: You can set these `-D` to the wanaku-cli as in this example:
+
+```shell
+java "-Djavax.net.ssl.trustStore=my-truststore.p12" "-Djavax.net.ssl.trustStorePassword=changeit" -jar quarkus-run.jar  admin credentials show --admin-username=admin --admin-password=admin --keycloak-url=https://keycloak.192.168.49.2.nip.io --show-secret --client-id wanaku-service
+```
+
 ## Installing and Running the Router
 
 There are three ways to run the router. They work similarly, with the distinction that some of them may come with more

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
         <annotations-api.version>6.0.53</annotations-api.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
-        <wanaku-capabilities-sdk.version>0.2.1</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.2.2-SNAPSHOT</wanaku-capabilities-sdk.version>
         <forage.version>1.5.0</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
         <annotations-api.version>6.0.53</annotations-api.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
-        <wanaku-capabilities-sdk.version>0.2.0</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.2.1</wanaku-capabilities-sdk.version>
         <forage.version>1.5.0</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
         <wanaku-capabilities-sdk.version>0.2.0</wanaku-capabilities-sdk.version>
-        <forage.version>1.3</forage.version>
+        <forage.version>1.5.0</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <operator-framework.version>5.3.4</operator-framework.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
         <annotations-api.version>6.0.53</annotations-api.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
-        <wanaku-capabilities-sdk.version>0.2.0-SNAPSHOT</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.2.0</wanaku-capabilities-sdk.version>
         <forage.version>1.3</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>wanaku</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
         <annotations-api.version>6.0.53</annotations-api.version>
         <quarkus-operator-sdk.version>7.7.4</quarkus-operator-sdk.version>
         <quarkus-helm.version>1.4.1</quarkus-helm.version>
-        <wanaku-capabilities-sdk.version>0.2.2-SNAPSHOT</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.2.2</wanaku-capabilities-sdk.version>
         <forage.version>1.5.0</forage.version>
         <commonmark.version>0.29.0</commonmark.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/wanaku-ai/wanaku</url>
     <description>Wanaku MCP Router</description>
 
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
 
     <developers>
@@ -27,7 +27,7 @@
         <connection>scm:git:https://github.com/wanaku-ai/wanaku.git</connection>
         <developerConnection>scm:git:https://github.com/wanaku-ai/wanaku.git</developerConnection>
         <url>https://github.com/wanaku-ai/wanaku</url>
-        <tag>HEAD</tag>
+        <tag>wanaku-0.2.0</tag>
     </scm>
 
     <licenses>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/services/service-templates/pom.xml
+++ b/services/service-templates/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>services</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>service-templates</artifactId>

--- a/tests/mcp-servers/pom.xml
+++ b/tests/mcp-servers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>tests</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>test-mcp-servers</artifactId>

--- a/tests/mcp-servers/wanaku-performance-test-mock-mcp/pom.xml
+++ b/tests/mcp-servers/wanaku-performance-test-mock-mcp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>test-mcp-servers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>wanaku-performance-test-mock-mcp</artifactId>

--- a/tests/plans/camel-integration-capability.md
+++ b/tests/plans/camel-integration-capability.md
@@ -1494,6 +1494,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
   | grep -iv "this-configmap-does-not-exist" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1509,6 +1510,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
     | grep -iv "this-configmap-does-not-exist" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"

--- a/tests/plans/operator-camel-route.md
+++ b/tests/plans/operator-camel-route.md
@@ -1267,6 +1267,7 @@ UNEXPECTED_ERRORS=$(oc logs "${OPERATOR_POD}" -n "${WANAKU_NAMESPACE}" \
   | grep -iv "not found in namespace" \
   | grep -iv "non-existent-router" \
   | grep -iv "Failed to remove service catalog" \
+  | grep -v "\-XX:" \
   | wc -l | tr -d ' ')
 
 echo "unexpected-error-count=${UNEXPECTED_ERRORS}"
@@ -1281,6 +1282,7 @@ if [ "${UNEXPECTED_ERRORS}" -gt 0 ]; then
     | grep -iv "not found in namespace" \
     | grep -iv "non-existent-router" \
     | grep -iv "Failed to remove service catalog" \
+    | grep -v "\-XX:" \
     | tail -10
 else
   echo "PASS: no unexpected errors in operator logs"

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
When listing the tool, the required field is blank [].

via /public/mcp/sse

## Summary by Sourcery

Correct MCP tool required-parameter reporting while improving CLI error handling, namespace validation, operator resource labeling, release metadata, and supporting documentation.

New Features:
- Report required MCP tool parameters from each tool’s input schema so they are correctly exposed when listing tools.
- Provide clearer CLI feedback for MCP connection, timeout, hostname, and URI errors.
- Validate namespace names and paths and return invalid requests as HTTP 400 responses.
- Support authenticated namespace service access, namespace-name option aliases, and conditional inclusion of the default namespace.
- Return tool execution failures as MCP error responses instead of propagating exceptions.

Bug Fixes:
- Fix MCP tool listings so the required field reflects the parameters actually marked as required.
- Correct Kubernetes capability resource labels and selectors to target individual capabilities.
- Prevent null-valued map entries from producing blank CLI output.

Enhancements:
- Improve operator-managed Kubernetes resource metadata and update the bundled router image reference.
- Expand operator, namespace, MCP, and CLI test coverage.
- Improve operator and CLI documentation, including Camel execution engine, route configuration, TLS, troubleshooting, and deployment guidance.

Build:
- Finalize the project and module Maven versions at 0.2.0 and update released dependency versions.

CI:
- Adjust integration test log filtering to ignore JVM option lines.

Documentation:
- Document operator status fields, Camel execution engine and route configuration, resource and HA patterns, secret usage, deployment modes, and troubleshooting guidance.

Tests:
- Add coverage for required MCP parameters, friendly MCP errors, namespace behavior and validation, tool execution failures, null map output, and Kubernetes resource labels.

Chores:
- Update the SCM release tag and related release metadata.