### PR TITLE
[1953] Harden LLM Chat correctness, security, and accessibility

### DIFF
--- a/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
+++ b/ui/admin/src/Pages/LLMChat/LLMChatArea.tsx
@@ -14,6 +14,8 @@ import {getInferenceUrl} from "../../custom-fetch"
 import {getErrorMessage} from "../../utils/error"
 import {selectedToolsJson} from "./utils"
 import {connectMCPClient} from "./mcp"
+import {listModels} from "../../hooks/api/use-models"
+import {validateExtraLlmParameters} from "./extra-llm-parameters"
 
 
 interface ChatMessage {
@@ -27,13 +29,15 @@ interface ChatMessage {
 interface LLMChatAreaProps {
   config: LlmConfig
   onSystemPromptChange: (systemPrompt: string) => void
+  onError: (error: string) => void
 }
 
-export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPromptChange }) => {
+export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPromptChange, onError }) => {
   
   const [userPrompt, setUserPrompt] = useState("")
   const [displayedMessages, setDisplayedMessages] = useState<ChatMessage[]>([])
   const [isRunning, setIsRunning] = useState(false)
+  const [sendDisabled, setSendDisabled] = useState(isSendUnavailable())
   
   const chatHistory = useRef<ChatMessage[]>([])
   const abortController = useRef(new AbortController())
@@ -50,15 +54,42 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
       || message.role === "tool")
   }
   
+  function isSendUnavailable(): boolean {
+    return !userPrompt.length
+      || !config.selectedModel
+      || !config.apiKey
+  }
+  
+  async function validateSelectedModel(): Promise<boolean> {
+    const models = await listModels(config.apiKey!)
+    return models.includes(config.selectedModel)
+  }
+  
   async function runPrompt(signal: AbortSignal) {
+    if (!userPrompt) {
+      throw new Error("User prompt cannot be empty")
+    }
+    if (!config.apiKey) {
+      throw new Error("API key is required")
+    }
+    if (!config.selectedModel) {
+      throw new Error("Model is required")
+    }
+    const selectedModelValid = await validateSelectedModel()
+    if (! selectedModelValid) {
+       throw new Error("Selected model is not valid")
+    }
+    validateExtraLlmParameters(config.extraLlmParams)
     try {
       chatHistory.current.push({ role: "user", content: userPrompt })
       setDisplayedMessages(chatHistory.current)
       setIsRunning(true)
+      setSendDisabled(true)
       
       async function send(): Promise<Response> {
         const extraLlmParams = config.extraLlmParams ? JSON.parse(config.extraLlmParams) : {}
         return await fetch(getInferenceUrl("/v1/chat/completions"), {
+          signal,
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -116,7 +147,19 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
                   name: toolName,
                   arguments: toolArgs
                 })
-                const toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
+                const toolResultType = (toolResult.content as any).type
+                let toolResultText = ""
+                if (toolResultType === "text") {
+                  toolResultText = (toolResult.content as Array<{ text: string }>)[0].text
+                } else if (toolResultType === "image") {
+                  toolResultText = "[image]"
+                } else if (toolResultType === "audio") {
+                  toolResultText = "[audio]"
+                } else if (toolResultType === "resource") {
+                  toolResultText = "[resource]"
+                } else {
+                  toolResultText = `Unknown type: ${toolResultType}`
+                }
                 chatHistory.current.push({
                   role: "tool",
                   name: toolName,
@@ -151,6 +194,7 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
       }
     } finally {
       setIsRunning(false)
+      setSendDisabled(isSendUnavailable())
     }
   }
   
@@ -163,9 +207,13 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
             size="lg"
             renderIcon={Send}
             iconDescription="Send"
-            disabled={isRunning}
+            disabled={sendDisabled}
             onClick={() => {
-              runPrompt(abortController.current.signal)
+              runPrompt(abortController.current.signal).catch((error)=>  {
+                if (error instanceof Error) {
+                  onError(error.message)
+                }
+              })
             }}>
             Send
           </Button>
@@ -209,7 +257,9 @@ export const LLMChatArea: React.FC<LLMChatAreaProps> = ({ config, onSystemPrompt
             placeholder="Type your prompt here..."
             value={userPrompt}
             onChange={(event) => {
-              setUserPrompt(event.target.value)
+              const userPrompt = event.target.value
+              setUserPrompt(userPrompt)
+              setSendDisabled(userPrompt.length === 0)
             }}
             rows={4}
           />

--- a/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -77,6 +77,9 @@ export const LLMChatPage: React.FC = () => {
         <Column lg={12}>
           <LLMChatArea
             config={config}
+            onError={(error: string) => {
+              setErrorMessage(error)
+            }}
             onSystemPromptChange={(systemPrompt) => {
               applyConfigChange({ ...config, systemPrompt })
             }}

--- a/ui/admin/src/Pages/LLMChat/LLMTools.tsx
+++ b/ui/admin/src/Pages/LLMChat/LLMTools.tsx
@@ -119,7 +119,7 @@ export const LLMTools: React.FC<LLMToolsProps> = ({
             checked={isAllSelected()}
             indeterminate={isSomeSelected()}
             onChange={(_, { checked }) => {
-              const selection = checked ? [...tools] : []
+              const selection = checked ? [...filteredTools()] : []
               onSelectionChange(namespace, selection)
             }}
           />

--- a/ui/admin/src/Pages/LLMChat/extra-llm-parameters.ts
+++ b/ui/admin/src/Pages/LLMChat/extra-llm-parameters.ts
@@ -1,0 +1,127 @@
+/**
+ *
+ * @throws  SyntaxError - Thrown if the string to parse is not valid JSON.
+ *
+ * @throws  TypeError - Thrown if the JSON object contains invalid types.
+ *
+ * @throws  RangeError - Thrown if the JSON object contains invalid values.
+ */
+export function validateExtraLlmParameters(extraLlmParameters: string) {
+  if (extraLlmParameters.trim().length === 0) {
+    return
+  }
+  const parameters = JSON.parse(extraLlmParameters) as Record<string, unknown>
+  
+  if ("top_k" in parameters) {
+    assertIsInteger("top_k", parameters)
+    const top_k = parameters.top_k as number
+    if (top_k < 0 && top_k !== -1) {
+      throw new RangeError("Parameter 'top_k' must be positive number, greater than zero");
+    }
+  }
+  assertNumberIfPresent("top_p", parameters)
+  assertNumberIfPresent("min_p", parameters)
+  assertNumberIfPresent("temperature", parameters)
+  assertNumberIfPresent("presence_penalty", parameters)
+  assertNumberIfPresent("frequency_penalty", parameters)
+  assertNumberIfPresent("repetition_penalty", parameters)
+  assertNumberIfPresent("typical_p", parameters)
+  assertIntegerIfPresent("mirostat_mode", parameters)
+  assertNumberIfPresent("mirostat_tau", parameters)
+  assertNumberIfPresent("mirostat_eta", parameters)
+  assertIntegerIfPresent("max_tokens", parameters)
+  assertIntegerIfPresent("max_completion_tokens", parameters)
+  assertStringOrStringArrayIfPresent("stop", parameters)
+  assertIntegerIfPresent("n", parameters)
+  assertIntegerOrNullIfPresent("seed", parameters)
+  assertObjectIfPresent ("response_format", parameters)
+  assertObjectIfPresent ("logit_bias", parameters)
+  assertBooleanIfPresent("logprobs", parameters)
+  assertIntegerIfPresent("top_logprobs", parameters)
+  assertStringConstantIfPresent("reasoning_effort", ["low", "medium", "high"], parameters)
+  assertBooleanIfPresent("stream", parameters)
+  assertObjectIfPresent("stream_options", parameters)
+  assertStringIfPresent("user", parameters)
+}
+
+function assertNumberIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (typeof parameters[parameter] !== "number") {
+      throw new TypeError(`Parameter '${parameter}' must be a number`)
+    }
+  }
+}
+
+function assertIntegerIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    assertIsInteger(parameter, parameters)
+  }
+}
+
+function assertIntegerOrNullIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (!isIntegerOrNull(parameters[parameter])) {
+      throw new TypeError(`Parameter ${parameter} must be an integer or null`)
+    }
+  }
+}
+
+function assertStringIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (typeof parameters[parameter] !== "string") {
+      throw new TypeError(`Parameter '${parameter}' must be a string`)
+    }
+  }
+}
+
+function assertStringConstantIfPresent(parameter: string, expected: string[], parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (!expected.includes(parameters[parameter] as string)) {
+      throw new TypeError(`Parameter '${parameter}' must be one of: ${expected.join(", ")}`)
+    }
+  }
+}
+
+function assertBooleanIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (typeof parameters[parameter] !== "boolean") {
+      throw new TypeError(`Parameter '${parameter}' must be a boolean`)
+    }
+  }
+}
+
+function assertStringOrStringArrayIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (!isStringOrStringArray(parameters[parameter])) {
+      throw new TypeError(`Parameter ${parameter} must be a string or an array of strings`)
+    }
+  }
+}
+
+function assertObjectIfPresent(parameter: string, parameters: Record<string, unknown>) {
+  if (parameter in parameters) {
+    if (typeof parameters[parameter] !== "object") {
+      throw new TypeError(`Parameter '${parameter}' must be an object`)
+    }
+  }
+}
+
+function assertIsInteger(parameter: string, parameters: Record<string, unknown>) {
+  if (!Number.isInteger(parameters[parameter])) {
+    throw new TypeError(`Parameter '${parameter}' must be a number`)
+  }
+}
+
+function isStringOrStringArray(value: unknown): value is string | string[] {
+  if (typeof value === "string") {
+    return true
+  }
+  if (Array.isArray(value)) {
+    return value.every((item) => typeof item === 'string')
+  }
+  return false
+}
+
+function isIntegerOrNull(value: unknown): value is number | null {
+  return (value === null) ? true : Number.isInteger(value)
+}

--- a/ui/admin/src/hooks/api/use-models.ts
+++ b/ui/admin/src/hooks/api/use-models.ts
@@ -1,0 +1,29 @@
+import {getInferenceUrl} from "../../custom-fetch.ts"
+
+
+interface ModelCache {
+  models: string[]
+}
+
+let cache: ModelCache | null = null
+
+
+export async function listModels(apiKey: string): Promise<string[]> {
+  if (cache) {
+    return cache.models
+  }
+  if (!apiKey) {
+    throw new Error("API key is required")
+  }
+  const response = await fetch(getInferenceUrl("/v1/models"), {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  })
+  if (response.ok) {
+    const body: { data: { id: string }[] } = await response.json()
+    const models = body.data.map(model => model.id)
+    cache = { models }
+    return models
+  } else {
+    throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`)
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1953

- Inference and MCP responses use explicit TypeScript types.
  > @opiske not sure what you meant
- Empty prompts and invalid model or tool setup cannot start a request.
  > fixed
- Invalid extra-parameter JSON produces an inline validation message.
  > fixed
- AbortSignal reaches inference and tool-execution requests.
  > fixed
- Cancellation stops execution predictably.
  > @opiske not sure what you meant
- Multi-part and non-text MCP results render correctly.
  > @opiske not sure about multi-part, but I 've added non-text responses. Currently displays only the type, later we could    improve it by displaying the image, audio etc.
- Tool responses do not use unsafe HTML rendering.
  > @opiske should alread work. If not, please provide an example
- Tool and namespace selection remains internally consistent.
  > @opiske should lready work. There was a problem that namespace stored if the local storage might not be valid anymore. Selecting a different one should help fix it. Alternatively, try to delete the local storage.
- Transcript markup and execution status are accessible to screen readers.
  > @opiske not sure what you meant
- Playwright tests cover errors, cancellation, keyboard operation, and rendering.
  > @opiske not sure what you meant

## Summary by Sourcery

Harden the LLM chat experience by validating request configuration, handling cancellation and MCP responses safely, and keeping tool selection state consistent.

New Features:
- Validate selected models against the inference service before sending chat requests.
- Support non-text MCP tool results with type-aware transcript placeholders.

Bug Fixes:
- Prevent invalid chat requests caused by empty prompts, missing credentials or models, invalid model selections, and malformed extra parameters.
- Keep tool namespace and select-all behavior synchronized with the currently available tools.

Enhancements:
- Propagate request cancellation signals to inference calls and improve send-button state management.
- Surface chat validation and execution errors through the page-level error display.