### PR TITLE
[1794][UI] Extract shared error notification hook

### DIFF
--- a/ui/admin/src/Pages/Dashboard/DashboardPage.tsx
+++ b/ui/admin/src/Pages/Dashboard/DashboardPage.tsx
@@ -5,7 +5,6 @@ import {
   Grid,
   Tile,
   ClickableTile,
-  InlineNotification,
   SkeletonText,
   SkeletonPlaceholder,
   DataTable,
@@ -40,13 +39,15 @@ interface SystemStatistics {
   dataStoresCount?: number;
 }
 import "./DashboardPage.scss";
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 export const DashboardPage: React.FC = () => {
   const navigate = useNavigate();
   const [statistics, setStatistics] = useState<SystemStatistics | null>(null);
   const [metrics, setMetrics] = useState<MetricsSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const { getStatistics } = useStatistics();
   const { getMetrics } = useMetrics();
 
@@ -82,18 +83,6 @@ export const DashboardPage: React.FC = () => {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
-
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => {
-        setErrorMessage(null);
-      }, 10_000);
-
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-  }, [errorMessage]);
 
   const filterEntries = metrics
     ? Object.entries(metrics.filters).sort(([a], [b]) => a.localeCompare(b))
@@ -188,13 +177,9 @@ export const DashboardPage: React.FC = () => {
   return (
     <div className="dashboard-page">
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <div className="dashboard-header">

--- a/ui/admin/src/Pages/Evaluators/EvaluatorsPage.tsx
+++ b/ui/admin/src/Pages/Evaluators/EvaluatorsPage.tsx
@@ -6,6 +6,8 @@ import { EvaluatorsTable } from "./EvaluatorsTable";
 import { EvaluatorModal } from "./EvaluatorModal";
 import { BindingsTable, BindingEntry } from "./BindingsTable";
 import { BindingModal } from "./BindingModal";
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 const EvaluatorsPage: React.FC = () => {
   const [evaluators, setEvaluators] = useState<EvaluatorDef[]>([]);
@@ -13,7 +15,7 @@ const EvaluatorsPage: React.FC = () => {
   const [bindings, setBindings] = useState<BindingEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isMutating, setIsMutating] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const [isEvaluatorModalOpen, setIsEvaluatorModalOpen] = useState(false);
@@ -72,13 +74,6 @@ const EvaluatorsPage: React.FC = () => {
   useEffect(() => {
     Promise.all([fetchEvaluators(), fetchConnections(), fetchBindings()]).finally(() => setIsLoading(false));
   }, [fetchEvaluators, fetchConnections, fetchBindings]);
-
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => setErrorMessage(null), 10_000);
-      return () => clearTimeout(timer);
-    }
-  }, [errorMessage]);
 
   useEffect(() => {
     if (successMessage) {
@@ -175,13 +170,9 @@ const EvaluatorsPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       {successMessage && (

--- a/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
+++ b/ui/admin/src/Pages/Forwards/ForwardsPage.tsx
@@ -1,12 +1,11 @@
-import {
-  InlineNotification
-} from "@carbon/react"
 import {useEffect, useState} from "react"
 import {addForward, updateForward, listForwards, refreshForward, removeForward} from "../../hooks/api/use-forwards"
 import {ForwardEntry} from "../../models"
 import {ForwardDetailModal} from "./ForwardDetailModal.tsx"
 import {ForwardModal} from "./ForwardModal.tsx"
 import {ForwardsTable} from "./ForwardsTable.tsx"
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 const ForwardsPage = () => {
 
@@ -14,7 +13,7 @@ const ForwardsPage = () => {
   const [isModalOpen, setModalOpen] = useState(false)
   const [openedForward, setOpenedForward] = useState<ForwardEntry>()
   const [detailForward, setDetailForward] = useState<ForwardEntry>()
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const { errorMessage, setErrorMessage } = useErrorNotification()
 
   function fetchForwards() {
     listForwards().then((response) => {
@@ -120,13 +119,9 @@ const ForwardsPage = () => {
         A list of forwards registered in the system.
       </p>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <div id="page-content">

--- a/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
+++ b/ui/admin/src/Pages/LLMChat/LLMChatPage.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useState} from "react"
+import React, {useState} from "react"
 import {LLMSetup} from "./LLMSetup.tsx"
 import {LLMTools} from "./LLMTools.tsx"
 import {LLMChatArea} from "./LLMChatArea"
-import {Column, Grid, InlineNotification} from "@carbon/react"
+import {Column, Grid} from "@carbon/react"
 import {
   isConfigStoredInLocalStorage,
   LLM_CONFIG,
@@ -11,20 +11,15 @@ import {
   persistConfig,
   STORE_IN_LOCAL_STORAGE
 } from "./config"
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 
 export const LLMChatPage: React.FC = () => {
   
   const [isStoredInLocalStorage, setStoreInLocalStorage] = useState(isConfigStoredInLocalStorage())
   const [config, setConfig] = useState<LlmConfig>(loadConfig())
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => setErrorMessage(null), 10000);
-      return () => clearTimeout(timer);
-    }
-  }, [errorMessage]);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   
   
   function applyConfigChange(config: LlmConfig) {
@@ -37,13 +32,9 @@ export const LLMChatPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <h1 className="title">LLM Chat for testing</h1>

--- a/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
+++ b/ui/admin/src/Pages/Namespaces/NamespacesPage.tsx
@@ -1,4 +1,3 @@
-import {InlineNotification} from "@carbon/react";
 import {PageSkeleton} from "../../components/PageSkeleton";
 import React, {useCallback, useEffect, useState} from "react";
 import {NamespaceEntry} from "../../models";
@@ -6,13 +5,15 @@ import {NamespaceTable} from "./NamespacesTable";
 import {NamespaceModal} from "./NamespaceModal";
 import {useNamespaces} from "../../hooks/api/use-namespaces";
 import {sortedNamespaces} from "./namespaces"
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 export const NamespacesPage: React.FC = () => {
   const [namespaces, setNamespaces] = useState<NamespaceEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [openedNamespace, setOpenedNamespace] = useState<NamespaceEntry>();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const { listNamespaces, createNamespace, updateNamespace, removeNamespace } = useNamespaces();
 
   const refreshNamespaces = useCallback(async () => {
@@ -30,15 +31,6 @@ export const NamespacesPage: React.FC = () => {
   useEffect(() => {
     refreshNamespaces();
   }, [refreshNamespaces]);
-
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => {
-        setErrorMessage(null);
-      }, 10_000);
-      return () => clearTimeout(timer);
-    }
-  }, [errorMessage]);
 
   if (isLoading) return <PageSkeleton title="Namespaces" />;
 
@@ -92,13 +84,9 @@ export const NamespacesPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <h1 className="title">Namespaces</h1>

--- a/ui/admin/src/Pages/Plugins/PluginsPage.tsx
+++ b/ui/admin/src/Pages/Plugins/PluginsPage.tsx
@@ -1,15 +1,16 @@
-import { InlineNotification } from "@carbon/react";
 import { PageSkeleton } from "../../components/PageSkeleton";
 import React, { useCallback, useEffect, useState } from "react";
 import type { PluginManifest } from "../../plugins/types";
 import { usePlugins } from "../../hooks/api/use-plugins";
 import { PluginsTable } from "./PluginsTable";
 import { PluginDetailModal } from "./PluginDetailModal";
+import {ErrorNotification} from "../../components/ErrorNotification"
+import {useErrorNotification} from "../../hooks/error-notifications"
 
 const PluginsPage: React.FC = () => {
   const [plugins, setPlugins] = useState<PluginManifest[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const [selectedPlugin, setSelectedPlugin] = useState<PluginManifest | null>(null);
 
   const { listPlugins } = usePlugins();
@@ -32,13 +33,6 @@ const PluginsPage: React.FC = () => {
     fetchPlugins().finally(() => setIsLoading(false));
   }, [fetchPlugins]);
 
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => setErrorMessage(null), 10_000);
-      return () => clearTimeout(timer);
-    }
-  }, [errorMessage]);
-
   const handleView = (plugin: PluginManifest) => {
     setSelectedPlugin(plugin);
   };
@@ -52,13 +46,9 @@ const PluginsPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
 

--- a/ui/admin/src/Pages/Prompts/PromptsPage.tsx
+++ b/ui/admin/src/Pages/Prompts/PromptsPage.tsx
@@ -1,15 +1,16 @@
-import {InlineNotification} from "@carbon/react";
 import {PageSkeleton} from "../../components/PageSkeleton";
 import React, {useCallback, useEffect, useState} from "react";
 import {usePrompts} from "../../hooks/api/use-prompts";
 import {PromptEntry} from "../../models";
 import {PromptsTable} from "./PromptsTable";
 import {unwrapData} from "../../utils/api-response";
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 export const PromptsPage: React.FC = () => {
   const [fetchedData, setFetchedData] = useState<PromptEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const { listPrompts, removePrompt } = usePrompts();
 
   const updatePrompts = useCallback(async () => {
@@ -30,18 +31,6 @@ export const PromptsPage: React.FC = () => {
     updatePrompts();
   }, [updatePrompts]);
 
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => {
-        setErrorMessage(null);
-      }, 10_000);
-
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-  }, [errorMessage]);
-
   if (isLoading) return <PageSkeleton title="Prompts" />;
 
   const handleDeletePrompt = async (promptName?: string) => {
@@ -56,13 +45,9 @@ export const PromptsPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <h1 className="title">Prompts</h1>

--- a/ui/admin/src/Pages/Resources/ResourcesPage.tsx
+++ b/ui/admin/src/Pages/Resources/ResourcesPage.tsx
@@ -1,15 +1,16 @@
-import {InlineNotification} from "@carbon/react"
 import {ResourceModal} from "./ResourceModal"
 import {RefreshHandle, ResourcesTable} from "./ResourcesTable"
 import React, {useRef, useState} from "react"
 import {ResourceEntry} from "../../models"
 import {useResources} from "../../hooks/api/use-resources"
 import {getErrorMessage} from "../../utils/error"
+import {ErrorNotification} from "../../components/ErrorNotification"
+import {useErrorNotification} from "../../hooks/error-notifications"
 
 
 export const ResourcesPage: React.FC = () => {
 
-  const [errorMessage, setErrorMessage] = useState<string>()
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const [isModalOpen, setModalOpen] = useState(false)
   const [openedResource, setOpenedResource] = useState<ResourceEntry>()
   const { updateResource, removeResource } = useResources()
@@ -49,13 +50,9 @@ export const ResourcesPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(undefined)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <h1 className="title">Resources</h1>

--- a/ui/admin/src/Pages/ToolCalls/ToolCallsPage.tsx
+++ b/ui/admin/src/Pages/ToolCalls/ToolCallsPage.tsx
@@ -1,6 +1,8 @@
 import React, {useEffect, useRef, useState} from "react";
-import {Accordion, AccordionItem, Button, InlineNotification, Search, Tag, Toggle,} from "@carbon/react";
+import {Accordion, AccordionItem, Button, Search, Tag, Toggle,} from "@carbon/react";
 import {Download, TrashCan} from "@carbon/icons-react";
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 const enum ToolCallEventType {
   STARTED = "STARTED",
   COMPLETED = "COMPLETED",
@@ -54,7 +56,7 @@ const ToolCallsPage: React.FC = () => {
     errorCategory: "",
   });
   const [autoScroll, setAutoScroll] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const eventSourceRef = useRef<EventSource | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -204,25 +206,12 @@ const ToolCallsPage: React.FC = () => {
     }
   }, [filteredEvents, autoScroll]);
 
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => {
-        setErrorMessage(null);
-      }, 10000);
-      return () => clearTimeout(timer);
-    }
-  }, [errorMessage]);
-
   return (
     <div style={{ padding: "2rem" }}>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Connection Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
 

--- a/ui/admin/src/Pages/Tools/ToolsPage.tsx
+++ b/ui/admin/src/Pages/Tools/ToolsPage.tsx
@@ -1,4 +1,3 @@
-import {InlineNotification} from "@carbon/react";
 import {PageSkeleton} from "../../components/PageSkeleton";
 import React, {useCallback, useEffect, useState} from "react";
 import {useTools} from "../../hooks/api/use-tools";
@@ -6,6 +5,8 @@ import {ToolEntry} from "../../models";
 import {ToolsTable} from "./ToolsTable";
 import {ToolModal} from "./ToolModal"
 import {unwrapData} from "../../utils/api-response";
+import {useErrorNotification} from "../../hooks/error-notifications"
+import {ErrorNotification} from "../../components/ErrorNotification"
 
 
 export const ToolsPage: React.FC = () => {
@@ -13,7 +14,7 @@ export const ToolsPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [openedTool, setOpenedTool] = useState<ToolEntry>()
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { errorMessage, setErrorMessage } = useErrorNotification()
   const { listTools, updateTool, removeTool } = useTools();
 
   const updateTools = useCallback(async () => {
@@ -33,18 +34,6 @@ export const ToolsPage: React.FC = () => {
   useEffect(() => {
     updateTools();
   }, [updateTools]);
-
-  useEffect(() => {
-    if (errorMessage) {
-      const timer = setTimeout(() => {
-        setErrorMessage(null);
-      }, 10_000);
-
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-  }, [errorMessage]);
 
   if (isLoading) return <PageSkeleton title="Tools" />;
 
@@ -78,13 +67,9 @@ export const ToolsPage: React.FC = () => {
   return (
     <div>
       {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-          lowContrast
-          hideCloseButton={false}
+        <ErrorNotification
+          errorMessage={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
       <h1 className="title">Tools</h1>

--- a/ui/admin/src/components/ErrorNotification.tsx
+++ b/ui/admin/src/components/ErrorNotification.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import {InlineNotification} from "@carbon/react"
+
+
+interface ErrorNotificationProps {
+  errorMessage: string
+  onClose: () => void
+}
+
+
+export const ErrorNotification: React.FC<ErrorNotificationProps> = ({ errorMessage, onClose }) => {
+  return (
+    <InlineNotification
+      kind="error"
+      title="Error"
+      subtitle={errorMessage}
+      onCloseButtonClick={onClose}
+      lowContrast
+      hideCloseButton={false}
+    />
+  )
+}

--- a/ui/admin/src/hooks/error-notifications.ts
+++ b/ui/admin/src/hooks/error-notifications.ts
@@ -1,0 +1,15 @@
+import {useEffect, useState} from "react"
+
+
+export function useErrorNotification(timeout: number = 10_000) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  
+  useEffect(() => {
+    if (errorMessage) {
+      const timer = setTimeout(() => setErrorMessage(null), timeout)
+      return () => clearTimeout(timer)
+    }
+  }, [errorMessage, timeout])
+  
+  return { errorMessage, setErrorMessage }
+}


### PR DESCRIPTION
Issue: https://github.com/wanaku-ai/wanaku/issues/1794

I've extracted both the error state and the `InlineNotification` used for displaying errors into separate files for better resuse.

## Summary by Sourcery

Extract shared error notification handling and presentation for consistent reuse across the admin UI.

Enhancements:
- Centralize error message state, automatic dismissal, and error notification rendering in reusable hook and component.
- Update dashboard and resource-management pages to use the shared error notification behavior.